### PR TITLE
feat(config): add  error handling to skip missing schema paths 

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -977,7 +977,11 @@ spec:
 	// fmt.Println(paths)
 	for _, p := range paths {
 		p := strings.TrimPrefix(p, "/")
-		util.GenerateFromPath(schema, util.BasePath+"/config", p, nil)
+		err := util.GenerateFromPathWithError(schema, util.BasePath+"/config", p, nil)
+		if err != nil {
+			fmt.Printf("Warning: Skipping path %q: %v\n", p, err)
+			continue
+		}
 	}
 }
 

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -316,6 +316,13 @@ func GenerateObjectOverview(information *ObjectInformation) {
 }
 
 func GenerateFromPath(schema *jsonschema.Schema, basePath string, schemaPath string, defaults map[string]interface{}) {
+	err := GenerateFromPathWithError(schema, basePath, schemaPath, defaults)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func GenerateFromPathWithError(schema *jsonschema.Schema, basePath string, schemaPath string, defaults map[string]interface{}) error {
 	splittedSchemaPath := strings.Split(schemaPath, "/")
 
 	fieldSchema := schema
@@ -325,7 +332,7 @@ func GenerateFromPath(schema *jsonschema.Schema, basePath string, schemaPath str
 		lastProperty = property
 		fieldSchema, ok = fieldSchema.Properties.Get(property)
 		if !ok {
-			panic("Couldn't find schema path '" + schemaPath + "' at '" + property + "'")
+			return fmt.Errorf("couldn't find schema path '%s' at '%s'", schemaPath, property)
 		}
 
 		if i+1 == len(splittedSchemaPath) {
@@ -354,7 +361,7 @@ func GenerateFromPath(schema *jsonschema.Schema, basePath string, schemaPath str
 			refSplit := strings.Split(ref, "/")
 			fieldSchema, ok = schema.Definitions[refSplit[len(refSplit)-1]]
 			if !ok {
-				panic("Couldn't find schema definition " + refSplit[len(refSplit)-1])
+				return fmt.Errorf("couldn't find schema definition %s", refSplit[len(refSplit)-1])
 			}
 		}
 	}
@@ -374,8 +381,9 @@ func GenerateFromPath(schema *jsonschema.Schema, basePath string, schemaPath str
 	_ = os.MkdirAll(path.Dir(filePath), 0o777)
 	err := os.WriteFile(filePath, []byte(content), os.ModePerm)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to write file: %w", err)
 	}
+	return nil
 }
 
 func GenerateResource(schema *jsonschema.Schema, basePath string, subResource bool) error {

--- a/hack/vcluster/partials/README.md
+++ b/hack/vcluster/partials/README.md
@@ -9,12 +9,14 @@ go run hack/vcluster/partials/main.go <schema-dir> <output-dir>
 ```
 
 ### Arguments
+
 - `<schema-dir>`: Directory containing `vcluster.schema.json` and `default_values.yaml`
 - `<output-dir>`: Directory where MDX partials are generated
 
 ### Examples
 
 Generate partials for a specific version:
+
 ```bash
 # For vCluster 0.21
 go run hack/vcluster/partials/main.go configsrc/v0.21/ vcluster_versioned_docs/version-0.21.0/_partials/config
@@ -25,16 +27,22 @@ go run hack/vcluster/partials/main.go configsrc/main/ vcluster/_partials/config
 
 ## Version compatibility
 
-The partials generation tool is designed to work across different vCluster versions. When generating partials for older versions, the tool:
+The partials generation tool is designed to work across different
+vCluster versions. When generating partials for older versions, the tool:
 
-1. **Skips missing schema paths**: If a path exists in the code but not in the schema (e.g., `integrations/istio` in v0.24), it is skipped with a warning
+1. **Skips missing schema paths**: If a path exists in the code but not in the
+   schema (e.g., `integrations/istio` in v0.24), it is skipped with a warning
 2. **Continues processing**: The generation does not fail due to missing paths
-3. **Logs warnings**: Missing paths are logged to help identify version differences
+3. **Logs warnings**: Missing paths are logged to help identify version
+   differences
 
 ### Example output
-```
-Warning: Skipping path "integrations/istio": couldn't find schema path 'integrations/istio' at 'istio'
-Warning: Skipping path "logging": couldn't find schema path 'logging' at 'logging'
+
+```text
+Warning: Skipping path "integrations/istio": couldn't find schema path 
+  'integrations/istio' at 'istio'
+Warning: Skipping path "logging": couldn't find schema path 'logging' at 
+  'logging'
 ```
 
 ## Add new paths
@@ -47,11 +55,14 @@ When adding new configuration paths to vCluster:
 
 ## CI integration
 
-The partials generation is triggered by the `sync-config-schema.yaml` workflow in the vCluster repository when:
+The partials generation is triggered by the `sync-config-schema.yaml` workflow
+in the vCluster repository when:
+
 - A new release is published
 - Manual workflow dispatch is triggered
 
 The CI workflow:
+
 1. Generates schema files from the vCluster release
 2. Runs this partials generation tool
 3. Creates a PR with the updated documentation
@@ -59,7 +70,11 @@ The CI workflow:
 ## Troubleshoot common issues
 
 ### Panic: "Couldn't find schema path"
-If you encounter this error with older code, update to the latest version that includes error handling for missing paths.
+
+If you encounter this error with older code, update to the latest version that
+includes error handling for missing paths.
 
 ### Check for missing partials
-Check the warnings output to see which paths were skipped due to version differences.
+
+Check the warnings output to see which paths were skipped due to version
+differences.

--- a/hack/vcluster/partials/README.md
+++ b/hack/vcluster/partials/README.md
@@ -1,0 +1,65 @@
+# vCluster partials generation
+
+This tool generates MDX documentation partials from vCluster JSON schema files.
+
+## Usage
+
+```bash
+go run hack/vcluster/partials/main.go <schema-dir> <output-dir>
+```
+
+### Arguments
+- `<schema-dir>`: Directory containing `vcluster.schema.json` and `default_values.yaml`
+- `<output-dir>`: Directory where MDX partials are generated
+
+### Examples
+
+Generate partials for a specific version:
+```bash
+# For vCluster 0.21
+go run hack/vcluster/partials/main.go configsrc/v0.21/ vcluster_versioned_docs/version-0.21.0/_partials/config
+
+# For current development version
+go run hack/vcluster/partials/main.go configsrc/main/ vcluster/_partials/config
+```
+
+## Version compatibility
+
+The partials generation tool is designed to work across different vCluster versions. When generating partials for older versions, the tool:
+
+1. **Skips missing schema paths**: If a path exists in the code but not in the schema (e.g., `integrations/istio` in v0.24), it is skipped with a warning
+2. **Continues processing**: The generation does not fail due to missing paths
+3. **Logs warnings**: Missing paths are logged to help identify version differences
+
+### Example output
+```
+Warning: Skipping path "integrations/istio": couldn't find schema path 'integrations/istio' at 'istio'
+Warning: Skipping path "logging": couldn't find schema path 'logging' at 'logging'
+```
+
+## Add new paths
+
+When adding new configuration paths to vCluster:
+
+1. Add the path to the `paths` array in `hack/vcluster/partials/main.go`
+2. The path is included in future versions
+3. Older versions without this path skip it automatically
+
+## CI integration
+
+The partials generation is triggered by the `sync-config-schema.yaml` workflow in the vCluster repository when:
+- A new release is published
+- Manual workflow dispatch is triggered
+
+The CI workflow:
+1. Generates schema files from the vCluster release
+2. Runs this partials generation tool
+3. Creates a PR with the updated documentation
+
+## Troubleshoot common issues
+
+### Panic: "Couldn't find schema path"
+If you encounter this error with older code, update to the latest version that includes error handling for missing paths.
+
+### Check for missing partials
+Check the warnings output to see which paths were skipped due to version differences.

--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -88,6 +88,7 @@ var paths = []string{
 	"controlPlane/hostPathMapper",
 	"controlPlane/distro/k8s",
 	"controlPlane/distro/k3s",
+	"controlPlane/distro/k0s",
 	"controlPlane/distro",
 	"controlPlane/coredns",
 	"controlPlane/backingStore/etcd/embedded",
@@ -114,7 +115,6 @@ func main() {
 		panic(fmt.Errorf("failed to read default values from %q: %w", defaultValues, err))
 	}
 	outputDir := os.Args[2]
-	_ = os.RemoveAll(outputDir)
 	defaults := map[string]interface{}{}
 	err = yaml.Unmarshal(values, &defaults)
 	if err != nil {
@@ -130,6 +130,10 @@ func main() {
 		panic(fmt.Errorf("failed to parse schema JSON: %w", err))
 	}
 	for _, path := range paths {
-		util.GenerateFromPath(schema, outputDir, path, defaults)
+		err := util.GenerateFromPathWithError(schema, outputDir, path, defaults)
+		if err != nil {
+			fmt.Printf("Warning: Skipping path %q: %v\n", path, err)
+			continue
+		}
 	}
 }

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -26,7 +26,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -38,7 +38,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -53,7 +53,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 Version specifies k8s components (scheduler, kube-controller-manager & apiserver) version.
 It is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,
@@ -77,7 +77,7 @@ value from controlPlane.distro.k8s.(controlPlane-component).image.tag will be us
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -89,7 +89,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -104,7 +104,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-image}
 
 Image is the distro image
 
@@ -116,7 +116,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -132,7 +132,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -147,7 +147,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -165,7 +165,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -180,7 +180,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -195,7 +195,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -213,7 +213,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -225,7 +225,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -240,7 +240,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-image}
 
 Image is the distro image
 
@@ -252,7 +252,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -268,7 +268,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -283,7 +283,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -301,7 +301,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -316,7 +316,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -331,7 +331,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -349,7 +349,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -361,7 +361,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-image}
 
 Image is the distro image
 
@@ -373,7 +373,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -389,7 +389,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -404,7 +404,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -422,7 +422,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -437,7 +437,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -452,7 +452,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -470,7 +470,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -485,7 +485,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -500,7 +500,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -518,7 +518,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s}
+#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s}
 
 K3S holds K3s relevant configuration.
 
@@ -530,7 +530,7 @@ K3S holds K3s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -545,7 +545,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-token}
+##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -560,7 +560,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -575,7 +575,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -590,7 +590,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -605,7 +605,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image}
 
 Image is the distro image
 
@@ -617,7 +617,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -633,7 +633,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -648,7 +648,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -666,7 +666,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -681,7 +681,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -696,7 +696,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -714,7 +714,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s}
+#### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s}
 
 K0S holds k0s relevant configuration.
 
@@ -726,7 +726,7 @@ K0S holds k0s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -741,7 +741,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-config}
+##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -756,7 +756,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -771,7 +771,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-resources}
 
 Resources for the distro init container
 
@@ -786,7 +786,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -801,7 +801,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image}
 
 Image is the distro image
 
@@ -813,7 +813,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -829,7 +829,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -844,7 +844,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -862,7 +862,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -877,7 +877,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -892,7 +892,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -913,7 +913,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore}
+### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -925,7 +925,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd}
+#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -937,7 +937,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -949,7 +949,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -964,7 +964,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -982,7 +982,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy}
+##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -994,7 +994,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -1009,7 +1009,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -1021,7 +1021,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -1036,7 +1036,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -1051,7 +1051,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -1063,7 +1063,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -1079,7 +1079,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -1094,7 +1094,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -1112,7 +1112,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -1127,7 +1127,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -1142,7 +1142,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -1157,7 +1157,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -1169,7 +1169,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -1184,7 +1184,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -1202,7 +1202,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -1214,7 +1214,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1229,7 +1229,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -1247,7 +1247,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -1259,7 +1259,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -1277,7 +1277,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -1289,7 +1289,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -1304,7 +1304,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -1319,7 +1319,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -1334,7 +1334,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -1349,7 +1349,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -1364,7 +1364,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -1382,7 +1382,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -1394,7 +1394,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -1409,7 +1409,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -1427,7 +1427,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -1439,7 +1439,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -1451,7 +1451,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -1466,7 +1466,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -1481,7 +1481,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -1496,7 +1496,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -1511,7 +1511,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -1529,7 +1529,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -1544,7 +1544,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -1559,7 +1559,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -1571,7 +1571,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -1586,7 +1586,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -1602,7 +1602,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -1618,7 +1618,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -1634,7 +1634,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -1652,7 +1652,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -1676,7 +1676,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1691,7 +1691,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -1709,7 +1709,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -1721,7 +1721,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -1736,7 +1736,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -1754,7 +1754,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -1766,7 +1766,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -1790,7 +1790,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database}
+#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1802,7 +1802,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1814,7 +1814,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1829,7 +1829,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1847,7 +1847,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1862,7 +1862,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1877,7 +1877,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1895,7 +1895,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external}
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1907,7 +1907,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1922,7 +1922,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1940,7 +1940,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1955,7 +1955,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1970,7 +1970,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1985,7 +1985,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.
@@ -2012,7 +2012,7 @@ This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns}
+### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -2024,7 +2024,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -2039,7 +2039,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -2054,7 +2054,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -2066,7 +2066,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-spec}
+##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -2081,7 +2081,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2096,7 +2096,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2114,7 +2114,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment}
+#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -2126,7 +2126,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -2141,7 +2141,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -2156,7 +2156,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -2171,7 +2171,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2186,7 +2186,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2201,7 +2201,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -2213,7 +2213,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2228,7 +2228,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2246,7 +2246,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -2258,7 +2258,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2273,7 +2273,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -2291,7 +2291,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2306,7 +2306,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -2321,7 +2321,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -2339,7 +2339,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteConfig}
+#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -2354,7 +2354,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteManifests}
+#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -2369,7 +2369,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 
@@ -2387,7 +2387,7 @@ PriorityClassName specifies the priority class name for the CoreDNS pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy}
+### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -2399,7 +2399,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-bindAddress}
+#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -2414,7 +2414,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-port}
+#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -2429,7 +2429,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-extraSANs}
+#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 
@@ -2447,7 +2447,7 @@ ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper}
+### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -2459,7 +2459,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -2474,7 +2474,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-central}
+#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 
@@ -2492,7 +2492,7 @@ Central specifies if the central host path mapper will be used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress}
+### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -2504,7 +2504,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -2519,7 +2519,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -2534,7 +2534,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-pathType}
+#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -2549,7 +2549,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -2564,7 +2564,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2579,7 +2579,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
 
 Labels are extra labels for this resource.
 
@@ -2597,7 +2597,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -2609,7 +2609,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -2624,7 +2624,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -2639,7 +2639,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-kubeletNodePort}
+#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -2654,7 +2654,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-httpsNodePort}
+#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -2669,7 +2669,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2684,7 +2684,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2702,7 +2702,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -2714,7 +2714,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -2726,7 +2726,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -2741,7 +2741,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -2756,7 +2756,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -2771,7 +2771,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -2789,7 +2789,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -2801,7 +2801,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2816,7 +2816,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2834,7 +2834,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -2846,7 +2846,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -2861,7 +2861,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2876,7 +2876,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2891,7 +2891,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -2906,7 +2906,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -2921,7 +2921,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -2939,7 +2939,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -2951,7 +2951,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -2966,7 +2966,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -2984,7 +2984,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes}
+#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -2996,7 +2996,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe}
+##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -3008,7 +3008,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3026,7 +3026,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe}
+##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -3038,7 +3038,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3056,7 +3056,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe}
+##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -3068,7 +3068,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3089,7 +3089,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -3101,7 +3101,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -3113,7 +3113,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -3129,7 +3129,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -3144,7 +3144,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -3159,7 +3159,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -3174,7 +3174,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -3192,7 +3192,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -3207,7 +3207,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-dataVolume}
+##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -3222,7 +3222,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-binariesVolume}
+##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -3239,7 +3239,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -3254,7 +3254,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -3266,7 +3266,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -3281,7 +3281,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -3297,7 +3297,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -3313,7 +3313,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -3329,7 +3329,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -3347,7 +3347,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -3371,7 +3371,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -3386,7 +3386,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3401,7 +3401,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -3416,7 +3416,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -3428,7 +3428,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3443,7 +3443,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -3461,7 +3461,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 
@@ -3473,7 +3473,7 @@ Image is the image for the controlPlane statefulSet container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
 
 Configure the registry of the container image, e.g. my-registry.com or ghcr.io
 It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
@@ -3489,7 +3489,7 @@ It defaults to ghcr.io and can be overriding either by using this field or contr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
 
 Configure the repository of the container image, e.g. my-repo/my-image.
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -3506,7 +3506,7 @@ If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -3524,7 +3524,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -3539,7 +3539,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-workingDir}
+#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -3554,7 +3554,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -3569,7 +3569,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-args}
+#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -3584,7 +3584,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -3599,7 +3599,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsPolicy}
+#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -3614,7 +3614,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig}
+#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -3626,7 +3626,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -3643,7 +3643,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-searches}
+##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -3660,7 +3660,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options}
+##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -3675,7 +3675,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -3690,7 +3690,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
 
 
 
@@ -3714,7 +3714,7 @@ Required.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor}
+### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -3726,7 +3726,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -3741,7 +3741,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -3756,7 +3756,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 
@@ -3774,7 +3774,7 @@ Annotations are the extra annotations to add to the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -3786,7 +3786,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-defaultImageRegistry}
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -3802,7 +3802,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler}
+#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -3814,7 +3814,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3832,7 +3832,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -3844,7 +3844,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -3859,7 +3859,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -3874,7 +3874,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -3886,7 +3886,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -3904,7 +3904,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3919,7 +3919,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -3937,7 +3937,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount}
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -3949,7 +3949,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -3964,7 +3964,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -3979,7 +3979,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -3991,7 +3991,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4009,7 +4009,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4024,7 +4024,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4042,7 +4042,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService}
+#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -4054,7 +4054,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4069,7 +4069,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -4087,7 +4087,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata}
+#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -4099,7 +4099,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -42,7 +42,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -60,7 +60,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -72,7 +72,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -87,7 +87,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -102,7 +102,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -114,7 +114,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -132,7 +132,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -147,7 +147,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -165,7 +165,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -177,7 +177,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -192,7 +192,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -207,7 +207,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -219,7 +219,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -237,7 +237,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -252,7 +252,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -270,7 +270,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -282,7 +282,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -297,7 +297,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -315,7 +315,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata}
+### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -327,7 +327,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -14,7 +14,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -71,7 +71,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -83,7 +83,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -98,7 +98,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -110,7 +110,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -125,7 +125,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -140,7 +140,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -152,7 +152,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -168,7 +168,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -183,7 +183,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -201,7 +201,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -216,7 +216,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -231,7 +231,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -246,7 +246,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -258,7 +258,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -273,7 +273,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -291,7 +291,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -303,7 +303,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -318,7 +318,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -336,7 +336,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -348,7 +348,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -366,7 +366,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -378,7 +378,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -393,7 +393,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -408,7 +408,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -423,7 +423,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -438,7 +438,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -453,7 +453,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -471,7 +471,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -483,7 +483,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -498,7 +498,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -516,7 +516,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -528,7 +528,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -540,7 +540,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -555,7 +555,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -570,7 +570,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -585,7 +585,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -600,7 +600,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -618,7 +618,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -633,7 +633,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -648,7 +648,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -660,7 +660,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -675,7 +675,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -691,7 +691,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -707,7 +707,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -723,7 +723,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -741,7 +741,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -765,7 +765,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -780,7 +780,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -798,7 +798,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -810,7 +810,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -825,7 +825,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -843,7 +843,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -855,7 +855,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -879,7 +879,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -891,7 +891,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -903,7 +903,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -918,7 +918,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -936,7 +936,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -951,7 +951,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -966,7 +966,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -984,7 +984,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -996,7 +996,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1011,7 +1011,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1029,7 +1029,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1044,7 +1044,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1059,7 +1059,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1074,7 +1074,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.17-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -56,7 +56,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -71,7 +71,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -86,7 +86,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -104,7 +104,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -116,7 +116,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -131,7 +131,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -146,7 +146,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -203,7 +203,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -218,7 +218,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -236,7 +236,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -248,7 +248,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -263,7 +263,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -281,7 +281,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -296,7 +296,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -311,7 +311,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -329,7 +329,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -344,7 +344,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -359,7 +359,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro}
+## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 Version specifies k8s components (scheduler, kube-controller-manager & apiserver) version.
 It is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,
@@ -65,7 +65,7 @@ value from controlPlane.distro.k8s.(controlPlane-component).image.tag will be us
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -77,7 +77,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -92,7 +92,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-image}
 
 Image is the distro image
 
@@ -104,7 +104,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -120,7 +120,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -135,7 +135,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -153,7 +153,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -168,7 +168,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -183,7 +183,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -201,7 +201,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -213,7 +213,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -228,7 +228,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-image}
 
 Image is the distro image
 
@@ -240,7 +240,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -256,7 +256,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -271,7 +271,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -289,7 +289,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -304,7 +304,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -319,7 +319,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -337,7 +337,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -349,7 +349,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-image}
 
 Image is the distro image
 
@@ -361,7 +361,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -377,7 +377,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -392,7 +392,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -410,7 +410,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -425,7 +425,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -440,7 +440,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -458,7 +458,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -473,7 +473,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -488,7 +488,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -506,7 +506,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s}
+### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s}
 
 K3S holds K3s relevant configuration.
 
@@ -518,7 +518,7 @@ K3S holds K3s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -533,7 +533,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-token}
+#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -548,7 +548,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -563,7 +563,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -578,7 +578,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -593,7 +593,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image}
 
 Image is the distro image
 
@@ -605,7 +605,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -621,7 +621,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -636,7 +636,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -654,7 +654,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -669,7 +669,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -684,7 +684,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -702,7 +702,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s}
+### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s}
 
 K0S holds k0s relevant configuration.
 
@@ -714,7 +714,7 @@ K0S holds k0s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -729,7 +729,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-config}
+#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -744,7 +744,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -759,7 +759,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-resources}
 
 Resources for the distro init container
 
@@ -774,7 +774,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -789,7 +789,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-image}
 
 Image is the distro image
 
@@ -801,7 +801,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -817,7 +817,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#distro-k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -832,7 +832,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#distro-k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -850,7 +850,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -865,7 +865,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -880,7 +880,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k0s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k0s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s}
+## `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s}
 
 K0S holds k0s relevant configuration.
 
@@ -14,7 +14,7 @@ K0S holds k0s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -44,7 +44,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -59,7 +59,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k0s-resources}
 
 Resources for the distro init container
 
@@ -74,7 +74,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -89,7 +89,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-image}
 
 Image is the distro image
 
@@ -101,7 +101,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -117,7 +117,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -132,7 +132,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -150,7 +150,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -165,7 +165,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k3s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k3s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s}
+## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s}
 
 K3S holds K3s relevant configuration.
 
@@ -14,7 +14,7 @@ K3S holds K3s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-token}
+### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -44,7 +44,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -59,7 +59,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k3s-resources}
 
 Resources for the distro init container
 
@@ -74,7 +74,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -89,7 +89,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image}
 
 Image is the distro image
 
@@ -101,7 +101,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -117,7 +117,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -132,7 +132,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -150,7 +150,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -165,7 +165,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 Version specifies k8s components (scheduler, kube-controller-manager & apiserver) version.
 It is a shortcut for controlPlane.distro.k8s.apiServer.image.tag,
@@ -53,7 +53,7 @@ value from controlPlane.distro.k8s.(controlPlane-component).image.tag will be us
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -65,7 +65,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -80,7 +80,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer-image}
 
 Image is the distro image
 
@@ -92,7 +92,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#k8s-apiServer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -108,7 +108,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-apiserver</span> <span className="config-field-enum"></span> {#k8s-apiServer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -123,7 +123,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#k8s-apiServer-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -141,7 +141,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -156,7 +156,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -171,7 +171,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -189,7 +189,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -201,7 +201,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -216,7 +216,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager-image}
 
 Image is the distro image
 
@@ -228,7 +228,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#k8s-controllerManager-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -244,7 +244,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-controller-manager</span> <span className="config-field-enum"></span> {#k8s-controllerManager-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -259,7 +259,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#k8s-controllerManager-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -277,7 +277,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -292,7 +292,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -307,7 +307,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -325,7 +325,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -337,7 +337,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler-image}
 
 Image is the distro image
 
@@ -349,7 +349,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#k8s-scheduler-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -365,7 +365,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">kube-scheduler</span> <span className="config-field-enum"></span> {#k8s-scheduler-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -380,7 +380,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#k8s-scheduler-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -398,7 +398,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -413,7 +413,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -428,7 +428,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -446,7 +446,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -461,7 +461,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -476,7 +476,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/service.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service}
+## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -326,7 +326,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -338,7 +338,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -356,7 +356,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -368,7 +368,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -389,7 +389,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -401,7 +401,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -413,7 +413,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -429,7 +429,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -444,7 +444,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -459,7 +459,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -474,7 +474,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -492,7 +492,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -507,7 +507,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -522,7 +522,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -539,7 +539,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -554,7 +554,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -566,7 +566,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -581,7 +581,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -597,7 +597,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -613,7 +613,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -629,7 +629,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -647,7 +647,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -671,7 +671,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -686,7 +686,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -701,7 +701,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -716,7 +716,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -728,7 +728,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -743,7 +743,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -761,7 +761,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 
@@ -773,7 +773,7 @@ Image is the image for the controlPlane statefulSet container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Configure the registry of the container image, e.g. my-registry.com or ghcr.io
 It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
@@ -789,7 +789,7 @@ It defaults to ghcr.io and can be overriding either by using this field or contr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Configure the repository of the container image, e.g. my-repo/my-image.
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -806,7 +806,7 @@ If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -824,7 +824,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -839,7 +839,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -854,7 +854,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -869,7 +869,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -884,7 +884,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -899,7 +899,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -914,7 +914,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -926,7 +926,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -943,7 +943,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -960,7 +960,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -975,7 +975,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -990,7 +990,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-disableSync}
+#### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-syncSettings-disableSync}
 
 DisableSync will not sync any resources and disable most control plane functionality.
 
@@ -356,7 +356,7 @@ DisableSync will not sync any resources and disable most control plane functiona
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-rewriteKubernetesService}
+#### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-syncSettings-rewriteKubernetesService}
 
 RewriteKubernetesService will rewrite the Kubernetes service to point to the vCluster service if disableSync is enabled
 
@@ -371,7 +371,7 @@ RewriteKubernetesService will rewrite the Kubernetes service to point to the vCl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-targetNamespace}
+#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -386,7 +386,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -401,7 +401,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -416,7 +416,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -434,7 +434,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync}
+### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -446,7 +446,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-version}
 
 Version is the config version
 
@@ -461,7 +461,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export}
+#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -473,7 +473,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -488,7 +488,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -503,7 +503,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-optional}
 
 
 
@@ -518,7 +518,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -534,7 +534,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -547,7 +547,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -562,7 +562,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -577,7 +577,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -592,7 +592,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -607,7 +607,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -622,7 +622,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -637,7 +637,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -654,7 +654,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -667,7 +667,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -682,7 +682,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -697,7 +697,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -712,7 +712,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -727,7 +727,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -745,7 +745,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -760,7 +760,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -773,7 +773,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-secret}
 
 
 
@@ -788,7 +788,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-configmap}
 
 
 
@@ -809,7 +809,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -822,7 +822,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -837,7 +837,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -852,7 +852,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -867,7 +867,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -882,7 +882,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -897,7 +897,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -912,7 +912,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -929,7 +929,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -942,7 +942,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -957,7 +957,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -972,7 +972,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -987,7 +987,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1002,7 +1002,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1020,7 +1020,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1035,7 +1035,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1048,7 +1048,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -1063,7 +1063,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -1084,7 +1084,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -1097,7 +1097,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -1118,7 +1118,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import}
+#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -1130,7 +1130,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1145,7 +1145,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -1160,7 +1160,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-optional}
 
 
 
@@ -1175,7 +1175,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -1191,7 +1191,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -1204,7 +1204,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -1219,7 +1219,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1234,7 +1234,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -1249,7 +1249,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1264,7 +1264,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1279,7 +1279,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1294,7 +1294,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1311,7 +1311,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1324,7 +1324,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1339,7 +1339,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1354,7 +1354,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1369,7 +1369,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1384,7 +1384,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1402,7 +1402,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1417,7 +1417,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1430,7 +1430,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-secret}
 
 
 
@@ -1445,7 +1445,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-configmap}
 
 
 
@@ -1466,7 +1466,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1479,7 +1479,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1494,7 +1494,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1509,7 +1509,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1524,7 +1524,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1539,7 +1539,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1554,7 +1554,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1569,7 +1569,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1586,7 +1586,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1599,7 +1599,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1614,7 +1614,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1629,7 +1629,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1644,7 +1644,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1659,7 +1659,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1677,7 +1677,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1692,7 +1692,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1705,7 +1705,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1720,7 +1720,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1744,7 +1744,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks}
+#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1756,7 +1756,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual}
+##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1768,7 +1768,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1783,7 +1783,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1798,7 +1798,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1813,7 +1813,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1825,7 +1825,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1840,7 +1840,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1855,7 +1855,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1870,7 +1870,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1885,7 +1885,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1900,7 +1900,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1915,7 +1915,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1932,7 +1932,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1945,7 +1945,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1960,7 +1960,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1975,7 +1975,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1990,7 +1990,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2005,7 +2005,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2023,7 +2023,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2038,7 +2038,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2051,7 +2051,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -2066,7 +2066,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -2090,7 +2090,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost}
+##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -2102,7 +2102,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -2117,7 +2117,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -2132,7 +2132,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -2147,7 +2147,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -2159,7 +2159,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -2174,7 +2174,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -2189,7 +2189,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -2204,7 +2204,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -2219,7 +2219,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -2234,7 +2234,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -2249,7 +2249,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -2266,7 +2266,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -2279,7 +2279,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -2294,7 +2294,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -2309,7 +2309,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -2324,7 +2324,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2339,7 +2339,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2357,7 +2357,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2372,7 +2372,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2385,7 +2385,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -2400,7 +2400,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -2427,7 +2427,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole}
 
 
 
@@ -2439,7 +2439,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole-extraRules}
 
 
 
@@ -2457,7 +2457,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-role}
 
 
 
@@ -2469,7 +2469,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-role-extraRules}
 
 
 
@@ -2490,7 +2490,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `multiNamespaceMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode}
+### `multiNamespaceMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode}
 
 MultiNamespaceMode tells virtual cluster to sync to multiple namespaces instead of a single one. This will map each virtual cluster namespace to a single namespace in the host cluster.
 
@@ -2502,7 +2502,7 @@ MultiNamespaceMode tells virtual cluster to sync to multiple namespaces instead 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode-enabled}
 
 Enabled specifies if multi namespace mode should get enabled
 
@@ -2517,7 +2517,7 @@ Enabled specifies if multi namespace mode should get enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaceLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode-namespaceLabels}
+#### `namespaceLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode-namespaceLabels}
 
 NamespaceLabels are extra labels that will be added by vCluster to each created namespace.
 
@@ -2535,7 +2535,7 @@ NamespaceLabels are extra labels that will be added by vCluster to each created 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane}
+### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -2547,7 +2547,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -2562,7 +2562,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-headless}
+#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -2577,7 +2577,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -2592,7 +2592,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -2607,7 +2607,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 
@@ -2625,7 +2625,7 @@ Service is the vCluster service in the remote cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -2637,7 +2637,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -2652,7 +2652,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -2667,7 +2667,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -2682,7 +2682,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -2697,7 +2697,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -2715,7 +2715,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -2727,7 +2727,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -2742,7 +2742,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -2759,7 +2759,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -2773,7 +2773,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -2788,7 +2788,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -2803,7 +2803,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2818,7 +2818,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -2833,7 +2833,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -2853,7 +2853,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.
@@ -2872,7 +2872,7 @@ Impersonation attempts on these users will still be subjected to the checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `reuseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-reuseNamespace}
+### `reuseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-reuseNamespace}
 
 ReuseNamespace allows reusing the same namespace to create multiple vClusters.
 This flag is deprecated, as this scenario will be removed entirely in upcoming releases.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/genericSync.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/genericSync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync}
+## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -14,7 +14,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-version}
 
 Version is the config version
 
@@ -29,7 +29,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export}
+### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -41,7 +41,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -56,7 +56,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -71,7 +71,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-optional}
 
 
 
@@ -86,7 +86,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -102,7 +102,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -115,7 +115,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -130,7 +130,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -145,7 +145,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -160,7 +160,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -175,7 +175,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -190,7 +190,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -205,7 +205,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -222,7 +222,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -235,7 +235,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -250,7 +250,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -265,7 +265,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -280,7 +280,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -295,7 +295,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -313,7 +313,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -328,7 +328,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -341,7 +341,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-secret}
 
 
 
@@ -356,7 +356,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-configmap}
 
 
 
@@ -377,7 +377,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -390,7 +390,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -405,7 +405,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -420,7 +420,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -435,7 +435,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -450,7 +450,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -465,7 +465,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -480,7 +480,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -497,7 +497,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -510,7 +510,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -525,7 +525,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -540,7 +540,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -555,7 +555,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -570,7 +570,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -588,7 +588,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -603,7 +603,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -616,7 +616,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -631,7 +631,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -652,7 +652,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -665,7 +665,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -686,7 +686,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import}
+### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -698,7 +698,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -713,7 +713,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -728,7 +728,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-optional}
 
 
 
@@ -743,7 +743,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -759,7 +759,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -772,7 +772,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -787,7 +787,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -802,7 +802,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -817,7 +817,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -832,7 +832,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -847,7 +847,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -862,7 +862,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -879,7 +879,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -892,7 +892,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -907,7 +907,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -922,7 +922,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -937,7 +937,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -952,7 +952,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -970,7 +970,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -985,7 +985,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -998,7 +998,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-secret}
 
 
 
@@ -1013,7 +1013,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-configmap}
 
 
 
@@ -1034,7 +1034,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1047,7 +1047,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1062,7 +1062,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1077,7 +1077,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1092,7 +1092,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1107,7 +1107,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1122,7 +1122,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1137,7 +1137,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1154,7 +1154,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1167,7 +1167,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1182,7 +1182,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1197,7 +1197,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1212,7 +1212,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1227,7 +1227,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1245,7 +1245,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1260,7 +1260,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1273,7 +1273,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1288,7 +1288,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1312,7 +1312,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks}
+### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1324,7 +1324,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual}
+#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1336,7 +1336,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1351,7 +1351,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1366,7 +1366,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1381,7 +1381,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1393,7 +1393,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1408,7 +1408,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1423,7 +1423,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1438,7 +1438,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1453,7 +1453,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1468,7 +1468,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1483,7 +1483,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1500,7 +1500,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1513,7 +1513,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1528,7 +1528,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1543,7 +1543,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1558,7 +1558,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1573,7 +1573,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1591,7 +1591,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1606,7 +1606,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1619,7 +1619,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -1634,7 +1634,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -1658,7 +1658,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost}
+#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -1670,7 +1670,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1685,7 +1685,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -1700,7 +1700,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1715,7 +1715,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1727,7 +1727,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -1742,7 +1742,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1757,7 +1757,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -1772,7 +1772,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1787,7 +1787,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1802,7 +1802,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1817,7 +1817,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1834,7 +1834,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1847,7 +1847,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1862,7 +1862,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1877,7 +1877,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1892,7 +1892,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1907,7 +1907,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1925,7 +1925,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1940,7 +1940,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1953,7 +1953,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -1968,7 +1968,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -1995,7 +1995,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-clusterRole}
 
 
 
@@ -2007,7 +2007,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-clusterRole-extraRules}
 
 
 
@@ -2025,7 +2025,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-role}
 
 
 
@@ -2037,7 +2037,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-role-extraRules}
 
 
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/isolatedControlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/isolatedControlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane}
+## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -14,7 +14,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-headless}
+### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -44,7 +44,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -59,7 +59,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -74,7 +74,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-disableSync}
+### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#syncSettings-disableSync}
 
 DisableSync will not sync any resources and disable most control plane functionality.
 
@@ -29,7 +29,7 @@ DisableSync will not sync any resources and disable most control plane functiona
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-rewriteKubernetesService}
+### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#syncSettings-rewriteKubernetesService}
 
 RewriteKubernetesService will rewrite the Kubernetes service to point to the vCluster service if disableSync is enabled
 
@@ -44,7 +44,7 @@ RewriteKubernetesService will rewrite the Kubernetes service to point to the vCl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-targetNamespace}
+### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -59,7 +59,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -74,7 +74,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -89,7 +89,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -14,7 +14,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -29,7 +29,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -44,7 +44,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -59,7 +59,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -74,7 +74,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/exportKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
 
@@ -491,7 +491,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -506,7 +506,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -518,7 +518,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -536,7 +536,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -548,7 +548,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines whether to sync external secrets or not
 
@@ -560,7 +560,7 @@ ExternalSecrets defines whether to sync external secrets or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -578,7 +578,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores}
 
 Stores defines whether to sync stores or not
 
@@ -590,7 +590,7 @@ Stores defines whether to sync stores or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -608,7 +608,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores}
 
 ClusterStores defines whether to sync cluster stores or not
 
@@ -620,7 +620,7 @@ ClusterStores defines whether to sync cluster stores or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -635,7 +635,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -647,7 +647,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -674,7 +674,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -688,7 +688,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -703,7 +703,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -715,7 +715,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -727,7 +727,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -739,7 +739,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -757,7 +757,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -769,7 +769,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -790,7 +790,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -802,7 +802,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -814,7 +814,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -829,7 +829,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -841,7 +841,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/certManager.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -29,7 +29,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -41,7 +41,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -59,7 +59,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -71,7 +71,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets}
+#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines whether to sync external secrets or not
 
@@ -83,7 +83,7 @@ ExternalSecrets defines whether to sync external secrets or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -101,7 +101,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores}
+#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores}
 
 Stores defines whether to sync stores or not
 
@@ -113,7 +113,7 @@ Stores defines whether to sync stores or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -131,7 +131,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores}
+#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores}
 
 ClusterStores defines whether to sync cluster stores or not
 
@@ -143,7 +143,7 @@ ClusterStores defines whether to sync cluster stores or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -158,7 +158,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -170,7 +170,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/networking.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/networking.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking}
+## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
@@ -14,7 +14,7 @@ Networking options related to the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -26,7 +26,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -40,7 +40,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -55,7 +55,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -73,7 +73,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -85,7 +85,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -100,7 +100,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -121,7 +121,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -133,7 +133,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -148,7 +148,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -163,7 +163,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -178,7 +178,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -190,7 +190,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -205,7 +205,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -220,7 +220,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -235,7 +235,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -250,7 +250,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -271,7 +271,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -283,7 +283,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -298,7 +298,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -314,7 +314,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -327,7 +327,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -343,7 +343,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/replicateServices.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/plugins.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies}
+## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 
 
@@ -56,7 +56,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections}
+#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections}
 
 
 
@@ -68,7 +68,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -82,7 +82,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -98,7 +98,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -118,7 +118,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-platform}
+##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -136,7 +136,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -151,7 +151,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -169,7 +169,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -184,7 +184,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -196,7 +196,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -212,7 +212,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -227,7 +227,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -242,7 +242,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -257,7 +257,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -272,7 +272,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -290,7 +290,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -302,7 +302,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -318,7 +318,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -333,7 +333,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -348,7 +348,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -363,7 +363,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -378,7 +378,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -393,7 +393,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -411,7 +411,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -423,7 +423,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -435,7 +435,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -451,7 +451,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -468,7 +468,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -480,7 +480,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -498,7 +498,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -515,7 +515,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -534,7 +534,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -546,7 +546,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -564,7 +564,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -576,7 +576,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -593,7 +593,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -608,7 +608,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -623,7 +623,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -638,7 +638,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -654,7 +654,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -674,7 +674,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -693,7 +693,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -709,7 +709,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -725,7 +725,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -741,7 +741,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -760,7 +760,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -778,7 +778,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -793,7 +793,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -808,7 +808,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -824,7 +824,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -848,7 +848,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -860,7 +860,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -876,7 +876,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -893,7 +893,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -905,7 +905,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -923,7 +923,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -940,7 +940,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -959,7 +959,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -971,7 +971,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -987,7 +987,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1005,7 +1005,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1017,7 +1017,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1034,7 +1034,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1049,7 +1049,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -1064,7 +1064,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -1079,7 +1079,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -1095,7 +1095,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -1115,7 +1115,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -1134,7 +1134,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -1150,7 +1150,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -1166,7 +1166,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -1182,7 +1182,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -1201,7 +1201,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -1219,7 +1219,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -1234,7 +1234,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -1249,7 +1249,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -1265,7 +1265,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/limitRange.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 
 
@@ -44,7 +44,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections}
+### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections}
 
 
 
@@ -56,7 +56,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock}
+#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -70,7 +70,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -86,7 +86,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -106,7 +106,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-platform}
+#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -124,7 +124,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -139,7 +139,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/rbac.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sleepMode.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sleepMode.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode}
+## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode}
 
 SleepMode holds the native sleep mode configuration for Pro clusters
 
@@ -14,7 +14,7 @@ SleepMode holds the native sleep mode configuration for Pro clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-enabled}
 
 Enabled toggles the sleep mode functionality, allowing for disabling sleep mode without removing other config
 
@@ -29,7 +29,7 @@ Enabled toggles the sleep mode functionality, allowing for disabling sleep mode 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-timeZone}
+### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-timeZone}
 
 Timezone represents the timezone a sleep schedule should run against, defaulting to UTC if unset
 
@@ -44,7 +44,7 @@ Timezone represents the timezone a sleep schedule should run against, defaulting
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep}
 
 AutoSleep holds autoSleep details
 
@@ -56,7 +56,7 @@ AutoSleep holds autoSleep details
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automaticaly put to sleep
 
@@ -71,7 +71,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -86,7 +86,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude}
+#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -98,7 +98,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector}
 
 
 
@@ -110,7 +110,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -134,7 +134,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup}
 
 AutoWakeup holds configuration for waking the vCluster on a schedule rather than waiting for some activity.
 
@@ -146,7 +146,7 @@ AutoWakeup holds configuration for waking the vCluster on a schedule rather than
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup-schedule}
 
 
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync}
+## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -186,7 +186,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -198,7 +198,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -213,7 +213,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -237,7 +237,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -249,7 +249,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -264,7 +264,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -279,7 +279,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -294,7 +294,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -308,7 +308,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -323,7 +323,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -338,7 +338,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -353,7 +353,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -368,7 +368,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -383,7 +383,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -402,7 +402,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -423,7 +423,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -435,7 +435,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -450,7 +450,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -465,7 +465,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -477,7 +477,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -492,7 +492,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -507,7 +507,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -522,7 +522,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -536,7 +536,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -551,7 +551,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -566,7 +566,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -581,7 +581,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -596,7 +596,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -611,7 +611,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -630,7 +630,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -651,7 +651,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -663,7 +663,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -678,7 +678,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -693,7 +693,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -705,7 +705,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -720,7 +720,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -735,7 +735,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -750,7 +750,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -764,7 +764,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -779,7 +779,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -794,7 +794,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -809,7 +809,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -824,7 +824,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -839,7 +839,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -858,7 +858,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -879,7 +879,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -891,7 +891,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -906,7 +906,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -918,7 +918,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -933,7 +933,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -948,7 +948,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -963,7 +963,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -977,7 +977,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -992,7 +992,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1007,7 +1007,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1022,7 +1022,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1037,7 +1037,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1052,7 +1052,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1071,7 +1071,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1092,7 +1092,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1104,7 +1104,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1119,7 +1119,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1131,7 +1131,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1146,7 +1146,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1161,7 +1161,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1176,7 +1176,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1190,7 +1190,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1205,7 +1205,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1220,7 +1220,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1235,7 +1235,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1250,7 +1250,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1265,7 +1265,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1284,7 +1284,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1305,7 +1305,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1317,7 +1317,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1332,7 +1332,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1344,7 +1344,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1359,7 +1359,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1374,7 +1374,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1389,7 +1389,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1403,7 +1403,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1418,7 +1418,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1433,7 +1433,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1448,7 +1448,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1463,7 +1463,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1478,7 +1478,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1497,7 +1497,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1518,7 +1518,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1530,7 +1530,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1545,7 +1545,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1557,7 +1557,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1572,7 +1572,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1587,7 +1587,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1602,7 +1602,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1616,7 +1616,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1631,7 +1631,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1646,7 +1646,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1661,7 +1661,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1676,7 +1676,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1691,7 +1691,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1710,7 +1710,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1731,7 +1731,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1743,7 +1743,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1758,7 +1758,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1770,7 +1770,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1785,7 +1785,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1800,7 +1800,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1815,7 +1815,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1829,7 +1829,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1844,7 +1844,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1859,7 +1859,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1874,7 +1874,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1889,7 +1889,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1904,7 +1904,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1923,7 +1923,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1944,7 +1944,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -1956,7 +1956,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1971,7 +1971,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1983,7 +1983,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1998,7 +1998,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2013,7 +2013,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2028,7 +2028,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2042,7 +2042,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2057,7 +2057,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2072,7 +2072,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2087,7 +2087,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2102,7 +2102,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2117,7 +2117,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2136,7 +2136,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2157,7 +2157,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2169,7 +2169,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2184,7 +2184,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2196,7 +2196,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2211,7 +2211,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2226,7 +2226,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2241,7 +2241,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2255,7 +2255,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2270,7 +2270,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2285,7 +2285,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2300,7 +2300,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2315,7 +2315,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2330,7 +2330,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2349,7 +2349,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2370,7 +2370,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2382,7 +2382,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2397,7 +2397,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2409,7 +2409,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2424,7 +2424,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2439,7 +2439,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2454,7 +2454,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2468,7 +2468,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2483,7 +2483,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2498,7 +2498,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2513,7 +2513,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2528,7 +2528,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2543,7 +2543,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2562,7 +2562,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2583,7 +2583,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2595,7 +2595,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2610,7 +2610,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2622,7 +2622,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2637,7 +2637,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2652,7 +2652,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2667,7 +2667,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2681,7 +2681,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2696,7 +2696,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2711,7 +2711,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2726,7 +2726,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2741,7 +2741,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2756,7 +2756,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2775,7 +2775,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2796,7 +2796,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2808,7 +2808,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2823,7 +2823,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2835,7 +2835,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2850,7 +2850,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2865,7 +2865,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2880,7 +2880,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2894,7 +2894,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2909,7 +2909,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2924,7 +2924,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2939,7 +2939,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2954,7 +2954,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2969,7 +2969,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2988,7 +2988,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3009,7 +3009,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3021,7 +3021,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3036,7 +3036,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3048,7 +3048,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3063,7 +3063,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3078,7 +3078,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3093,7 +3093,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3107,7 +3107,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3122,7 +3122,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3137,7 +3137,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3152,7 +3152,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3167,7 +3167,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3182,7 +3182,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3201,7 +3201,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3222,7 +3222,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3234,7 +3234,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3249,7 +3249,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3261,7 +3261,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3276,7 +3276,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3291,7 +3291,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3306,7 +3306,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3320,7 +3320,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3335,7 +3335,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3350,7 +3350,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3365,7 +3365,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3380,7 +3380,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3395,7 +3395,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3414,7 +3414,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3435,7 +3435,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3448,7 +3448,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3463,7 +3463,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3478,7 +3478,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3490,7 +3490,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3505,7 +3505,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3520,7 +3520,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3535,7 +3535,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3549,7 +3549,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3564,7 +3564,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3579,7 +3579,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3594,7 +3594,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3609,7 +3609,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3624,7 +3624,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3643,7 +3643,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3667,7 +3667,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -3679,7 +3679,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -3691,7 +3691,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -3706,7 +3706,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -3721,7 +3721,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -3736,7 +3736,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -3748,7 +3748,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -3763,7 +3763,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -3781,7 +3781,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3793,7 +3793,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3808,7 +3808,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3823,7 +3823,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3838,7 +3838,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3852,7 +3852,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3867,7 +3867,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3882,7 +3882,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3897,7 +3897,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3912,7 +3912,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3927,7 +3927,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3946,7 +3946,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3967,7 +3967,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -3979,7 +3979,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3994,7 +3994,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4006,7 +4006,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4021,7 +4021,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4036,7 +4036,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4051,7 +4051,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4065,7 +4065,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4080,7 +4080,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4095,7 +4095,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4110,7 +4110,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4125,7 +4125,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4140,7 +4140,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4159,7 +4159,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4180,7 +4180,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4192,7 +4192,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4207,7 +4207,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4219,7 +4219,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4234,7 +4234,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4249,7 +4249,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4264,7 +4264,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4278,7 +4278,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4293,7 +4293,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4308,7 +4308,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4323,7 +4323,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4338,7 +4338,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4353,7 +4353,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4372,7 +4372,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4393,7 +4393,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4405,7 +4405,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4420,7 +4420,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4432,7 +4432,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4447,7 +4447,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4462,7 +4462,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4477,7 +4477,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4491,7 +4491,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4506,7 +4506,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4521,7 +4521,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4536,7 +4536,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4551,7 +4551,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4566,7 +4566,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4585,7 +4585,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4606,7 +4606,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4618,7 +4618,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4633,7 +4633,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4645,7 +4645,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4660,7 +4660,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4675,7 +4675,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4690,7 +4690,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4704,7 +4704,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4719,7 +4719,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4734,7 +4734,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4749,7 +4749,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4764,7 +4764,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4779,7 +4779,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4798,7 +4798,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4819,7 +4819,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -4831,7 +4831,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4846,7 +4846,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4858,7 +4858,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4873,7 +4873,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4888,7 +4888,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4903,7 +4903,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4917,7 +4917,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4932,7 +4932,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4947,7 +4947,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4962,7 +4962,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4977,7 +4977,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4992,7 +4992,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5011,7 +5011,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5032,7 +5032,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5044,7 +5044,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5059,7 +5059,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5071,7 +5071,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5086,7 +5086,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5101,7 +5101,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5116,7 +5116,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5130,7 +5130,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5145,7 +5145,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5160,7 +5160,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5175,7 +5175,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5190,7 +5190,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5205,7 +5205,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5224,7 +5224,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5245,7 +5245,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5257,7 +5257,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5272,7 +5272,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5284,7 +5284,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5299,7 +5299,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5314,7 +5314,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5329,7 +5329,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5343,7 +5343,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5358,7 +5358,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5373,7 +5373,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5388,7 +5388,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5403,7 +5403,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5418,7 +5418,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5437,7 +5437,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5458,7 +5458,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5470,7 +5470,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5485,7 +5485,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5497,7 +5497,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5512,7 +5512,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5527,7 +5527,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5542,7 +5542,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5556,7 +5556,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5571,7 +5571,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5586,7 +5586,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5601,7 +5601,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5616,7 +5616,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5631,7 +5631,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5650,7 +5650,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5671,7 +5671,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -5683,7 +5683,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5698,7 +5698,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -5713,7 +5713,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5725,7 +5725,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5740,7 +5740,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5755,7 +5755,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5770,7 +5770,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5784,7 +5784,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5799,7 +5799,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5814,7 +5814,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5829,7 +5829,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5844,7 +5844,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5859,7 +5859,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5878,7 +5878,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5896,7 +5896,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -5908,7 +5908,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -5945,7 +5945,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -5957,7 +5957,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5972,7 +5972,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5984,7 +5984,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5999,7 +5999,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6014,7 +6014,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6029,7 +6029,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6043,7 +6043,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6058,7 +6058,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6073,7 +6073,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6088,7 +6088,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6103,7 +6103,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6118,7 +6118,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6137,7 +6137,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6158,7 +6158,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -6170,7 +6170,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6185,7 +6185,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6197,7 +6197,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6212,7 +6212,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6227,7 +6227,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6242,7 +6242,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6256,7 +6256,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6271,7 +6271,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6286,7 +6286,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6301,7 +6301,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6316,7 +6316,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6331,7 +6331,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6350,7 +6350,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6368,7 +6368,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -6380,7 +6380,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -6417,7 +6417,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -6429,7 +6429,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6444,7 +6444,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6456,7 +6456,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6471,7 +6471,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6486,7 +6486,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6501,7 +6501,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6515,7 +6515,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6530,7 +6530,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6545,7 +6545,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6560,7 +6560,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6575,7 +6575,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6590,7 +6590,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6609,7 +6609,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6627,7 +6627,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -6639,7 +6639,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -728,7 +728,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -740,7 +740,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -755,7 +755,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -767,7 +767,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -782,7 +782,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -797,7 +797,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -812,7 +812,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -826,7 +826,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -841,7 +841,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -856,7 +856,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -871,7 +871,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -886,7 +886,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -901,7 +901,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -920,7 +920,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -941,7 +941,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -953,7 +953,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -968,7 +968,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -980,7 +980,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -995,7 +995,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1010,7 +1010,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1025,7 +1025,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1039,7 +1039,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1054,7 +1054,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1069,7 +1069,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1084,7 +1084,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1099,7 +1099,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1114,7 +1114,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1133,7 +1133,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1154,7 +1154,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1166,7 +1166,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1181,7 +1181,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1193,7 +1193,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1208,7 +1208,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1223,7 +1223,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1238,7 +1238,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1252,7 +1252,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1267,7 +1267,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1282,7 +1282,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1297,7 +1297,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1312,7 +1312,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1327,7 +1327,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1346,7 +1346,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1367,7 +1367,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1379,7 +1379,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1394,7 +1394,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1406,7 +1406,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1421,7 +1421,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1436,7 +1436,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1451,7 +1451,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1465,7 +1465,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1480,7 +1480,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1495,7 +1495,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1510,7 +1510,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1525,7 +1525,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1540,7 +1540,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1559,7 +1559,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1580,7 +1580,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1592,7 +1592,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1607,7 +1607,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1619,7 +1619,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1634,7 +1634,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1649,7 +1649,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1664,7 +1664,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1678,7 +1678,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1693,7 +1693,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1708,7 +1708,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1723,7 +1723,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1738,7 +1738,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1753,7 +1753,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1772,7 +1772,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1793,7 +1793,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1805,7 +1805,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1820,7 +1820,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1832,7 +1832,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1847,7 +1847,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1862,7 +1862,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1877,7 +1877,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1891,7 +1891,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1906,7 +1906,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1921,7 +1921,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1936,7 +1936,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1951,7 +1951,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1966,7 +1966,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1985,7 +1985,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2006,7 +2006,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -2018,7 +2018,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2033,7 +2033,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -2048,7 +2048,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2060,7 +2060,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2075,7 +2075,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2090,7 +2090,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2105,7 +2105,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2119,7 +2119,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2134,7 +2134,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2149,7 +2149,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2164,7 +2164,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2179,7 +2179,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2194,7 +2194,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2213,7 +2213,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2231,7 +2231,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -2243,7 +2243,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2280,7 +2280,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2292,7 +2292,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2307,7 +2307,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2319,7 +2319,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2334,7 +2334,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2349,7 +2349,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2364,7 +2364,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2378,7 +2378,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2393,7 +2393,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2408,7 +2408,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2423,7 +2423,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2438,7 +2438,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2453,7 +2453,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2472,7 +2472,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2493,7 +2493,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -2505,7 +2505,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2520,7 +2520,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2532,7 +2532,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2547,7 +2547,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2562,7 +2562,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2577,7 +2577,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2591,7 +2591,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2606,7 +2606,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2621,7 +2621,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2636,7 +2636,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2651,7 +2651,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2666,7 +2666,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2685,7 +2685,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2703,7 +2703,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -2715,7 +2715,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2752,7 +2752,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -2764,7 +2764,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2779,7 +2779,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2791,7 +2791,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2806,7 +2806,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2821,7 +2821,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2836,7 +2836,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2850,7 +2850,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2865,7 +2865,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2880,7 +2880,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2895,7 +2895,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2910,7 +2910,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2925,7 +2925,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2944,7 +2944,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2962,7 +2962,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -2974,7 +2974,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events}
+## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -174,7 +174,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -186,7 +186,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -201,7 +201,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -225,7 +225,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -237,7 +237,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -252,7 +252,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -267,7 +267,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -282,7 +282,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -296,7 +296,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -311,7 +311,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -326,7 +326,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -341,7 +341,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -356,7 +356,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -371,7 +371,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -390,7 +390,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -411,7 +411,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -423,7 +423,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -438,7 +438,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -453,7 +453,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -465,7 +465,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -480,7 +480,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -495,7 +495,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -510,7 +510,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -524,7 +524,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -539,7 +539,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -554,7 +554,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -569,7 +569,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -584,7 +584,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -599,7 +599,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -618,7 +618,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -639,7 +639,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -651,7 +651,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -666,7 +666,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -681,7 +681,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -693,7 +693,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -708,7 +708,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -723,7 +723,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -738,7 +738,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -752,7 +752,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -767,7 +767,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -782,7 +782,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -797,7 +797,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -812,7 +812,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -827,7 +827,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -846,7 +846,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -867,7 +867,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -879,7 +879,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -894,7 +894,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -906,7 +906,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -921,7 +921,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -936,7 +936,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -951,7 +951,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -965,7 +965,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -980,7 +980,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -995,7 +995,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1010,7 +1010,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1025,7 +1025,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1040,7 +1040,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1059,7 +1059,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1080,7 +1080,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1092,7 +1092,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1107,7 +1107,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1119,7 +1119,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1134,7 +1134,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1149,7 +1149,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1164,7 +1164,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1178,7 +1178,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1193,7 +1193,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1208,7 +1208,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1223,7 +1223,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1238,7 +1238,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1253,7 +1253,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1272,7 +1272,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1293,7 +1293,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1305,7 +1305,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1320,7 +1320,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1332,7 +1332,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1347,7 +1347,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1362,7 +1362,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1377,7 +1377,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1391,7 +1391,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1406,7 +1406,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1421,7 +1421,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1436,7 +1436,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1451,7 +1451,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1466,7 +1466,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1485,7 +1485,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1506,7 +1506,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1518,7 +1518,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1533,7 +1533,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1545,7 +1545,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1560,7 +1560,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1575,7 +1575,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1590,7 +1590,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1604,7 +1604,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1619,7 +1619,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1634,7 +1634,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1649,7 +1649,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1664,7 +1664,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1679,7 +1679,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1698,7 +1698,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1719,7 +1719,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1731,7 +1731,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1746,7 +1746,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1758,7 +1758,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1773,7 +1773,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1788,7 +1788,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1803,7 +1803,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1817,7 +1817,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1832,7 +1832,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1847,7 +1847,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1862,7 +1862,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1877,7 +1877,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1892,7 +1892,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1911,7 +1911,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1932,7 +1932,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -1944,7 +1944,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1959,7 +1959,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1971,7 +1971,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1986,7 +1986,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2001,7 +2001,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2016,7 +2016,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2030,7 +2030,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2045,7 +2045,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2060,7 +2060,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2075,7 +2075,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2090,7 +2090,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2105,7 +2105,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2124,7 +2124,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2145,7 +2145,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2157,7 +2157,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2172,7 +2172,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2184,7 +2184,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2199,7 +2199,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2214,7 +2214,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2229,7 +2229,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2243,7 +2243,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2258,7 +2258,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2273,7 +2273,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2288,7 +2288,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2303,7 +2303,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2318,7 +2318,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2337,7 +2337,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2358,7 +2358,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2370,7 +2370,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2385,7 +2385,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2397,7 +2397,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2412,7 +2412,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2427,7 +2427,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2442,7 +2442,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2456,7 +2456,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2471,7 +2471,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2486,7 +2486,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2501,7 +2501,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2516,7 +2516,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2531,7 +2531,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2550,7 +2550,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2571,7 +2571,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2583,7 +2583,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2598,7 +2598,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2610,7 +2610,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2625,7 +2625,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2640,7 +2640,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2655,7 +2655,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2669,7 +2669,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2684,7 +2684,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2699,7 +2699,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2714,7 +2714,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2729,7 +2729,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2744,7 +2744,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2763,7 +2763,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2784,7 +2784,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2796,7 +2796,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2811,7 +2811,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2823,7 +2823,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2838,7 +2838,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2853,7 +2853,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2868,7 +2868,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2882,7 +2882,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2897,7 +2897,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2912,7 +2912,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2927,7 +2927,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2942,7 +2942,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2957,7 +2957,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2976,7 +2976,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2997,7 +2997,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3009,7 +3009,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3024,7 +3024,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3036,7 +3036,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3051,7 +3051,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3066,7 +3066,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3081,7 +3081,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3095,7 +3095,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3110,7 +3110,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3125,7 +3125,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3140,7 +3140,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3155,7 +3155,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3170,7 +3170,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3189,7 +3189,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3210,7 +3210,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3222,7 +3222,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3237,7 +3237,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3249,7 +3249,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3264,7 +3264,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3279,7 +3279,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3294,7 +3294,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3308,7 +3308,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3323,7 +3323,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3338,7 +3338,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3353,7 +3353,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3368,7 +3368,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3383,7 +3383,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3402,7 +3402,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3423,7 +3423,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3436,7 +3436,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3451,7 +3451,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3466,7 +3466,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3478,7 +3478,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3493,7 +3493,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3508,7 +3508,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3523,7 +3523,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3537,7 +3537,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3552,7 +3552,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3567,7 +3567,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3582,7 +3582,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3597,7 +3597,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3612,7 +3612,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3631,7 +3631,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods}
+## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -162,7 +162,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -174,7 +174,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -189,7 +189,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -213,7 +213,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -225,7 +225,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -240,7 +240,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -255,7 +255,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -270,7 +270,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -284,7 +284,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -299,7 +299,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -314,7 +314,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -329,7 +329,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -344,7 +344,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -359,7 +359,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -378,7 +378,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/services.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services}
+## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/telemetry.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -26,7 +26,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -38,7 +38,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -53,7 +53,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -69,7 +69,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -81,7 +81,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -96,7 +96,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -111,7 +111,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -129,7 +129,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -141,7 +141,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -156,7 +156,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -171,7 +171,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -189,7 +189,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -201,7 +201,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -216,7 +216,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -234,7 +234,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
 
 Image is the distro image
 
@@ -246,7 +246,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -262,7 +262,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -277,7 +277,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -295,7 +295,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -310,7 +310,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -325,7 +325,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -340,7 +340,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -358,7 +358,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s}
+#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -370,7 +370,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -385,7 +385,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-token}
+##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -400,7 +400,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image}
 
 Image is the distro image
 
@@ -412,7 +412,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -428,7 +428,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -443,7 +443,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -461,7 +461,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -476,7 +476,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -491,7 +491,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -506,7 +506,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -521,7 +521,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -536,7 +536,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -554,7 +554,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s}
+#### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s}
 
 [Deprecated] K0S holds k0s relevant configuration.
 
@@ -566,7 +566,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -581,7 +581,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-config}
+##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -596,7 +596,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image}
 
 Image is the distro image
 
@@ -608,7 +608,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -624,7 +624,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -639,7 +639,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -657,7 +657,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -672,7 +672,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -687,7 +687,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-resources}
 
 Resources for the distro init container
 
@@ -702,7 +702,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -717,7 +717,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -732,7 +732,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k0s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -753,7 +753,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore}
+### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -765,7 +765,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd}
+#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -777,7 +777,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -789,7 +789,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -804,7 +804,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -819,7 +819,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -837,7 +837,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy}
+##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -849,7 +849,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -864,7 +864,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -876,7 +876,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -891,7 +891,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -906,7 +906,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -918,7 +918,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -934,7 +934,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -949,7 +949,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -967,7 +967,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -982,7 +982,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -997,7 +997,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -1012,7 +1012,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -1024,7 +1024,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -1039,7 +1039,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -1057,7 +1057,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -1069,7 +1069,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1084,7 +1084,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -1102,7 +1102,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -1114,7 +1114,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -1132,7 +1132,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -1144,7 +1144,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -1159,7 +1159,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -1174,7 +1174,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -1189,7 +1189,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -1204,7 +1204,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -1219,7 +1219,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -1237,7 +1237,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -1249,7 +1249,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -1264,7 +1264,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -1282,7 +1282,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -1294,7 +1294,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -1306,7 +1306,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -1321,7 +1321,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -1336,7 +1336,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -1351,7 +1351,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -1366,7 +1366,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -1384,7 +1384,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -1399,7 +1399,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -1414,7 +1414,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -1426,7 +1426,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -1441,7 +1441,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -1457,7 +1457,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -1473,7 +1473,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -1489,7 +1489,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -1507,7 +1507,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -1531,7 +1531,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1546,7 +1546,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -1564,7 +1564,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -1576,7 +1576,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -1591,7 +1591,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -1609,7 +1609,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -1621,7 +1621,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -1642,7 +1642,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external}
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -1654,7 +1654,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -1669,7 +1669,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -1684,7 +1684,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -1696,7 +1696,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -1711,7 +1711,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -1726,7 +1726,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -1750,7 +1750,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database}
+#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1762,7 +1762,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1774,7 +1774,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1789,7 +1789,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1807,7 +1807,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1822,7 +1822,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1837,7 +1837,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1855,7 +1855,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external}
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1867,7 +1867,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1882,7 +1882,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1900,7 +1900,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1915,7 +1915,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1930,7 +1930,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1945,7 +1945,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.
@@ -1972,7 +1972,7 @@ This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns}
+### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -1984,7 +1984,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -1999,7 +1999,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -2014,7 +2014,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -2026,7 +2026,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-spec}
+##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -2041,7 +2041,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2056,7 +2056,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2074,7 +2074,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment}
+#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -2086,7 +2086,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -2101,7 +2101,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -2116,7 +2116,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -2131,7 +2131,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2146,7 +2146,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2161,7 +2161,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -2173,7 +2173,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2188,7 +2188,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2206,7 +2206,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -2218,7 +2218,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2233,7 +2233,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -2251,7 +2251,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2266,7 +2266,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -2281,7 +2281,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -2299,7 +2299,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteConfig}
+#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -2314,7 +2314,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteManifests}
+#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -2329,7 +2329,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 
@@ -2347,7 +2347,7 @@ PriorityClassName specifies the priority class name for the CoreDNS pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy}
+### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -2359,7 +2359,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-bindAddress}
+#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -2374,7 +2374,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-port}
+#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -2389,7 +2389,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-extraSANs}
+#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 
@@ -2407,7 +2407,7 @@ ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper}
+### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -2419,7 +2419,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -2434,7 +2434,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-central}
+#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 
@@ -2452,7 +2452,7 @@ Central specifies if the central host path mapper will be used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress}
+### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -2464,7 +2464,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -2479,7 +2479,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -2494,7 +2494,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-pathType}
+#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -2509,7 +2509,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -2524,7 +2524,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2539,7 +2539,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
 
 Labels are extra labels for this resource.
 
@@ -2557,7 +2557,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -2569,7 +2569,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -2584,7 +2584,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -2599,7 +2599,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-kubeletNodePort}
+#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -2614,7 +2614,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-httpsNodePort}
+#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -2629,7 +2629,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2644,7 +2644,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2662,7 +2662,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -2674,7 +2674,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -2686,7 +2686,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -2701,7 +2701,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -2716,7 +2716,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -2731,7 +2731,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -2749,7 +2749,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -2761,7 +2761,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2776,7 +2776,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2794,7 +2794,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -2806,7 +2806,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -2821,7 +2821,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2836,7 +2836,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2851,7 +2851,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -2866,7 +2866,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -2881,7 +2881,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -2899,7 +2899,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -2911,7 +2911,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -2926,7 +2926,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -2944,7 +2944,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes}
+#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -2956,7 +2956,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe}
+##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -2968,7 +2968,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2986,7 +2986,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe}
+##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -2998,7 +2998,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3016,7 +3016,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe}
+##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -3028,7 +3028,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3049,7 +3049,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -3061,7 +3061,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -3073,7 +3073,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -3089,7 +3089,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -3104,7 +3104,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -3119,7 +3119,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -3134,7 +3134,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -3152,7 +3152,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -3167,7 +3167,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-dataVolume}
+##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -3182,7 +3182,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-binariesVolume}
+##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -3199,7 +3199,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -3214,7 +3214,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -3226,7 +3226,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -3241,7 +3241,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -3257,7 +3257,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -3273,7 +3273,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -3289,7 +3289,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -3307,7 +3307,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -3331,7 +3331,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -3346,7 +3346,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3361,7 +3361,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -3376,7 +3376,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -3388,7 +3388,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3403,7 +3403,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -3421,7 +3421,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 
@@ -3433,7 +3433,7 @@ Image is the image for the controlPlane statefulSet container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
 
 Configure the registry of the container image, e.g. my-registry.com or ghcr.io
 It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
@@ -3449,7 +3449,7 @@ It defaults to ghcr.io and can be overriding either by using this field or contr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
 
 Configure the repository of the container image, e.g. my-repo/my-image.
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -3466,7 +3466,7 @@ If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -3484,7 +3484,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -3499,7 +3499,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-workingDir}
+#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -3514,7 +3514,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -3529,7 +3529,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-args}
+#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -3544,7 +3544,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -3559,7 +3559,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsPolicy}
+#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -3574,7 +3574,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig}
+#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -3586,7 +3586,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -3603,7 +3603,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-searches}
+##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -3620,7 +3620,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options}
+##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -3635,7 +3635,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -3650,7 +3650,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
 
 
 
@@ -3674,7 +3674,7 @@ Required.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor}
+### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -3686,7 +3686,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -3701,7 +3701,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -3716,7 +3716,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 
@@ -3734,7 +3734,7 @@ Annotations are the extra annotations to add to the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -3746,7 +3746,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-defaultImageRegistry}
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -3762,7 +3762,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler}
+#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -3774,7 +3774,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3792,7 +3792,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -3804,7 +3804,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -3819,7 +3819,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -3834,7 +3834,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -3846,7 +3846,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -3864,7 +3864,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3879,7 +3879,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -3897,7 +3897,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount}
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -3909,7 +3909,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -3924,7 +3924,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -3939,7 +3939,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -3951,7 +3951,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -3969,7 +3969,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3984,7 +3984,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4002,7 +4002,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService}
+#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -4014,7 +4014,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4029,7 +4029,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -4047,7 +4047,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata}
+#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -4059,7 +4059,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -42,7 +42,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -60,7 +60,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -72,7 +72,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -87,7 +87,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -102,7 +102,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -114,7 +114,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -132,7 +132,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -147,7 +147,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -165,7 +165,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -177,7 +177,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -192,7 +192,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -207,7 +207,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -219,7 +219,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -237,7 +237,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -252,7 +252,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -270,7 +270,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -282,7 +282,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -297,7 +297,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -315,7 +315,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata}
+### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -327,7 +327,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 
@@ -14,7 +14,7 @@ VirtualScheduler defines if a scheduler should be used within the virtual cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -68,7 +68,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -86,7 +86,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -98,7 +98,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -113,7 +113,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -125,7 +125,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -140,7 +140,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -155,7 +155,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -167,7 +167,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -183,7 +183,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -198,7 +198,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -216,7 +216,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -231,7 +231,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -246,7 +246,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -261,7 +261,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -273,7 +273,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -288,7 +288,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -306,7 +306,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -318,7 +318,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -333,7 +333,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -351,7 +351,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -363,7 +363,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -381,7 +381,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -393,7 +393,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -408,7 +408,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -423,7 +423,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -438,7 +438,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -453,7 +453,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -468,7 +468,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -486,7 +486,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -498,7 +498,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -513,7 +513,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -531,7 +531,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -543,7 +543,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -555,7 +555,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -570,7 +570,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -585,7 +585,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -600,7 +600,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -615,7 +615,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -633,7 +633,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -648,7 +648,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -663,7 +663,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -675,7 +675,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -690,7 +690,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -706,7 +706,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -722,7 +722,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -738,7 +738,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -756,7 +756,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -780,7 +780,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -795,7 +795,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -813,7 +813,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -825,7 +825,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -840,7 +840,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -858,7 +858,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -870,7 +870,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -891,7 +891,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -903,7 +903,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -918,7 +918,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -933,7 +933,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -945,7 +945,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -960,7 +960,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -975,7 +975,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -999,7 +999,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1011,7 +1011,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1023,7 +1023,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1038,7 +1038,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1056,7 +1056,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1071,7 +1071,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1086,7 +1086,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1104,7 +1104,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1116,7 +1116,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1131,7 +1131,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1149,7 +1149,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1164,7 +1164,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1179,7 +1179,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1194,7 +1194,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -44,7 +44,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-snapshotCount}
+### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -56,7 +56,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -71,7 +71,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -86,7 +86,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -104,7 +104,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -116,7 +116,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -131,7 +131,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -146,7 +146,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -203,7 +203,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -218,7 +218,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -236,7 +236,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -248,7 +248,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -263,7 +263,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -281,7 +281,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -296,7 +296,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -311,7 +311,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -329,7 +329,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -344,7 +344,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -359,7 +359,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro}
+## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -57,7 +57,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -69,7 +69,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -84,7 +84,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -99,7 +99,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -117,7 +117,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -129,7 +129,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -144,7 +144,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -159,7 +159,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -177,7 +177,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -189,7 +189,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -204,7 +204,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -222,7 +222,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
 
 Image is the distro image
 
@@ -234,7 +234,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -250,7 +250,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -265,7 +265,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -283,7 +283,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -298,7 +298,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -313,7 +313,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -328,7 +328,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -346,7 +346,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s}
+### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -358,7 +358,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -373,7 +373,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-token}
+#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -388,7 +388,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image}
 
 Image is the distro image
 
@@ -400,7 +400,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -416,7 +416,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -431,7 +431,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -449,7 +449,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -464,7 +464,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -479,7 +479,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -494,7 +494,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -509,7 +509,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -524,7 +524,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -542,7 +542,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s}
+### `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s}
 
 [Deprecated] K0S holds k0s relevant configuration.
 
@@ -554,7 +554,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -569,7 +569,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-config}
+#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -584,7 +584,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-image}
 
 Image is the distro image
 
@@ -596,7 +596,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -612,7 +612,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#distro-k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -627,7 +627,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#distro-k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -645,7 +645,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -660,7 +660,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -675,7 +675,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-resources}
 
 Resources for the distro init container
 
@@ -690,7 +690,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -705,7 +705,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -720,7 +720,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k0s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k0s.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k0s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s}
+## `k0s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s}
 
 [Deprecated] K0S holds k0s relevant configuration.
 
@@ -14,7 +14,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k0s-enabled}
 
 Enabled specifies if the k0s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the k0s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-config}
 
 Config allows you to override the k0s config passed to the k0s binary.
 
@@ -44,7 +44,7 @@ Config allows you to override the k0s config passed to the k0s binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-image}
 
 Image is the distro image
 
@@ -56,7 +56,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -72,7 +72,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">k0sproject/k0s</span> <span className="config-field-enum"></span> {#k0s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -87,7 +87,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.30.2-k0s.0</span> <span className="config-field-enum"></span> {#k0s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -105,7 +105,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -120,7 +120,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k0s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -135,7 +135,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k0s-resources}
 
 Resources for the distro init container
 
@@ -150,7 +150,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k0s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -165,7 +165,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k0s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k0s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k0s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k3s.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k3s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s}
+## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -14,7 +14,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-token}
+### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -44,7 +44,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image}
 
 Image is the distro image
 
@@ -56,7 +56,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -72,7 +72,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -87,7 +87,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -105,7 +105,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -120,7 +120,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -135,7 +135,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k3s-resources}
 
 Resources for the distro init container
 
@@ -150,7 +150,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -165,7 +165,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -45,7 +45,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -57,7 +57,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -72,7 +72,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -87,7 +87,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -105,7 +105,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -117,7 +117,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -132,7 +132,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -147,7 +147,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -165,7 +165,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -177,7 +177,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -192,7 +192,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -210,7 +210,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
 
 Image is the distro image
 
@@ -222,7 +222,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -238,7 +238,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -253,7 +253,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -271,7 +271,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -286,7 +286,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -301,7 +301,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -316,7 +316,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/service.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service}
+## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -326,7 +326,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -338,7 +338,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -356,7 +356,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -368,7 +368,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -389,7 +389,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -401,7 +401,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -413,7 +413,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -429,7 +429,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -444,7 +444,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -459,7 +459,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -474,7 +474,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -492,7 +492,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -507,7 +507,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -522,7 +522,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -539,7 +539,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -554,7 +554,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -566,7 +566,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -581,7 +581,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -597,7 +597,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -613,7 +613,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -629,7 +629,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -647,7 +647,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -671,7 +671,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -686,7 +686,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -701,7 +701,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -716,7 +716,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -728,7 +728,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -743,7 +743,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -761,7 +761,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 
@@ -773,7 +773,7 @@ Image is the image for the controlPlane statefulSet container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Configure the registry of the container image, e.g. my-registry.com or ghcr.io
 It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
@@ -789,7 +789,7 @@ It defaults to ghcr.io and can be overriding either by using this field or contr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Configure the repository of the container image, e.g. my-repo/my-image.
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -806,7 +806,7 @@ If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -824,7 +824,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -839,7 +839,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -854,7 +854,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -869,7 +869,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -884,7 +884,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -899,7 +899,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -914,7 +914,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -926,7 +926,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -943,7 +943,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -960,7 +960,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -975,7 +975,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -990,7 +990,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-disableSync}
+#### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-syncSettings-disableSync}
 
 DisableSync will not sync any resources and disable most control plane functionality.
 
@@ -356,7 +356,7 @@ DisableSync will not sync any resources and disable most control plane functiona
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-rewriteKubernetesService}
+#### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-syncSettings-rewriteKubernetesService}
 
 RewriteKubernetesService will rewrite the Kubernetes service to point to the vCluster service if disableSync is enabled
 
@@ -371,7 +371,7 @@ RewriteKubernetesService will rewrite the Kubernetes service to point to the vCl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-targetNamespace}
+#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -386,7 +386,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -401,7 +401,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -416,7 +416,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -434,7 +434,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync}
+### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -446,7 +446,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-version}
 
 Version is the config version
 
@@ -461,7 +461,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export}
+#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -473,7 +473,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -488,7 +488,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -503,7 +503,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-optional}
 
 
 
@@ -518,7 +518,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -534,7 +534,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -547,7 +547,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -562,7 +562,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -577,7 +577,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -592,7 +592,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -607,7 +607,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -622,7 +622,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -637,7 +637,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -654,7 +654,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -667,7 +667,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -682,7 +682,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -697,7 +697,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -712,7 +712,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -727,7 +727,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -745,7 +745,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -760,7 +760,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -773,7 +773,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-secret}
 
 
 
@@ -788,7 +788,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-configmap}
 
 
 
@@ -809,7 +809,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -822,7 +822,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -837,7 +837,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -852,7 +852,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -867,7 +867,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -882,7 +882,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -897,7 +897,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -912,7 +912,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -929,7 +929,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -942,7 +942,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -957,7 +957,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -972,7 +972,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -987,7 +987,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1002,7 +1002,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1020,7 +1020,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1035,7 +1035,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1048,7 +1048,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -1063,7 +1063,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -1084,7 +1084,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -1097,7 +1097,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -1118,7 +1118,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import}
+#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -1130,7 +1130,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1145,7 +1145,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -1160,7 +1160,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-optional}
 
 
 
@@ -1175,7 +1175,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -1191,7 +1191,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -1204,7 +1204,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -1219,7 +1219,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1234,7 +1234,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -1249,7 +1249,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1264,7 +1264,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1279,7 +1279,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1294,7 +1294,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1311,7 +1311,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1324,7 +1324,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1339,7 +1339,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1354,7 +1354,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1369,7 +1369,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1384,7 +1384,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1402,7 +1402,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1417,7 +1417,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1430,7 +1430,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-secret}
 
 
 
@@ -1445,7 +1445,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-configmap}
 
 
 
@@ -1466,7 +1466,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1479,7 +1479,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1494,7 +1494,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1509,7 +1509,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1524,7 +1524,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1539,7 +1539,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1554,7 +1554,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1569,7 +1569,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1586,7 +1586,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1599,7 +1599,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1614,7 +1614,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1629,7 +1629,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1644,7 +1644,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1659,7 +1659,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1677,7 +1677,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1692,7 +1692,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1705,7 +1705,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1720,7 +1720,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1744,7 +1744,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks}
+#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1756,7 +1756,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual}
+##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1768,7 +1768,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1783,7 +1783,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1798,7 +1798,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1813,7 +1813,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1825,7 +1825,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1840,7 +1840,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1855,7 +1855,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1870,7 +1870,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1885,7 +1885,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1900,7 +1900,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1915,7 +1915,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1932,7 +1932,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1945,7 +1945,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1960,7 +1960,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1975,7 +1975,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1990,7 +1990,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2005,7 +2005,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2023,7 +2023,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2038,7 +2038,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2051,7 +2051,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -2066,7 +2066,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -2090,7 +2090,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost}
+##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -2102,7 +2102,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -2117,7 +2117,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -2132,7 +2132,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -2147,7 +2147,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -2159,7 +2159,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -2174,7 +2174,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -2189,7 +2189,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -2204,7 +2204,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -2219,7 +2219,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -2234,7 +2234,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -2249,7 +2249,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -2266,7 +2266,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -2279,7 +2279,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -2294,7 +2294,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -2309,7 +2309,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -2324,7 +2324,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2339,7 +2339,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2357,7 +2357,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2372,7 +2372,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2385,7 +2385,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -2400,7 +2400,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -2427,7 +2427,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole}
 
 
 
@@ -2439,7 +2439,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole-extraRules}
 
 
 
@@ -2457,7 +2457,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-role}
 
 
 
@@ -2469,7 +2469,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-role-extraRules}
 
 
 
@@ -2490,7 +2490,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `multiNamespaceMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode}
+### `multiNamespaceMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode}
 
 MultiNamespaceMode tells virtual cluster to sync to multiple namespaces instead of a single one. This will map each virtual cluster namespace to a single namespace in the host cluster.
 
@@ -2502,7 +2502,7 @@ MultiNamespaceMode tells virtual cluster to sync to multiple namespaces instead 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode-enabled}
 
 Enabled specifies if multi namespace mode should get enabled
 
@@ -2517,7 +2517,7 @@ Enabled specifies if multi namespace mode should get enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaceLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-multiNamespaceMode-namespaceLabels}
+#### `namespaceLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-multiNamespaceMode-namespaceLabels}
 
 NamespaceLabels are extra labels that will be added by vCluster to each created namespace.
 
@@ -2535,7 +2535,7 @@ NamespaceLabels are extra labels that will be added by vCluster to each created 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane}
+### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -2547,7 +2547,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -2562,7 +2562,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-headless}
+#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -2577,7 +2577,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -2592,7 +2592,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -2607,7 +2607,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 
@@ -2625,7 +2625,7 @@ Service is the vCluster service in the remote cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -2637,7 +2637,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -2652,7 +2652,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -2667,7 +2667,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -2682,7 +2682,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -2697,7 +2697,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -2715,7 +2715,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -2727,7 +2727,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -2742,7 +2742,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -2759,7 +2759,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -2773,7 +2773,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -2788,7 +2788,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -2803,7 +2803,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2818,7 +2818,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -2833,7 +2833,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -2853,7 +2853,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/genericSync.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/genericSync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync}
+## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -14,7 +14,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-version}
 
 Version is the config version
 
@@ -29,7 +29,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export}
+### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -41,7 +41,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -56,7 +56,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -71,7 +71,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-optional}
 
 
 
@@ -86,7 +86,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -102,7 +102,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -115,7 +115,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -130,7 +130,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -145,7 +145,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -160,7 +160,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -175,7 +175,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -190,7 +190,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -205,7 +205,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -222,7 +222,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -235,7 +235,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -250,7 +250,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -265,7 +265,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -280,7 +280,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -295,7 +295,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -313,7 +313,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -328,7 +328,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -341,7 +341,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-secret}
 
 
 
@@ -356,7 +356,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-configmap}
 
 
 
@@ -377,7 +377,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -390,7 +390,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -405,7 +405,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -420,7 +420,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -435,7 +435,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -450,7 +450,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -465,7 +465,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -480,7 +480,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -497,7 +497,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -510,7 +510,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -525,7 +525,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -540,7 +540,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -555,7 +555,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -570,7 +570,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -588,7 +588,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -603,7 +603,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -616,7 +616,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -631,7 +631,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -652,7 +652,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -665,7 +665,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -686,7 +686,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import}
+### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -698,7 +698,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -713,7 +713,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -728,7 +728,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-optional}
 
 
 
@@ -743,7 +743,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -759,7 +759,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -772,7 +772,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -787,7 +787,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -802,7 +802,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -817,7 +817,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -832,7 +832,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -847,7 +847,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -862,7 +862,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -879,7 +879,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -892,7 +892,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -907,7 +907,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -922,7 +922,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -937,7 +937,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -952,7 +952,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -970,7 +970,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -985,7 +985,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -998,7 +998,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-secret}
 
 
 
@@ -1013,7 +1013,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-configmap}
 
 
 
@@ -1034,7 +1034,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1047,7 +1047,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1062,7 +1062,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1077,7 +1077,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1092,7 +1092,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1107,7 +1107,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1122,7 +1122,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1137,7 +1137,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1154,7 +1154,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1167,7 +1167,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1182,7 +1182,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1197,7 +1197,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1212,7 +1212,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1227,7 +1227,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1245,7 +1245,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1260,7 +1260,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1273,7 +1273,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1288,7 +1288,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1312,7 +1312,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks}
+### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1324,7 +1324,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual}
+#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1336,7 +1336,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1351,7 +1351,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1366,7 +1366,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1381,7 +1381,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1393,7 +1393,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1408,7 +1408,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1423,7 +1423,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1438,7 +1438,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1453,7 +1453,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1468,7 +1468,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1483,7 +1483,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1500,7 +1500,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1513,7 +1513,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1528,7 +1528,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1543,7 +1543,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1558,7 +1558,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1573,7 +1573,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1591,7 +1591,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1606,7 +1606,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1619,7 +1619,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -1634,7 +1634,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -1658,7 +1658,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost}
+#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -1670,7 +1670,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1685,7 +1685,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -1700,7 +1700,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1715,7 +1715,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1727,7 +1727,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -1742,7 +1742,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1757,7 +1757,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -1772,7 +1772,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1787,7 +1787,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1802,7 +1802,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1817,7 +1817,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1834,7 +1834,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1847,7 +1847,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1862,7 +1862,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1877,7 +1877,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1892,7 +1892,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1907,7 +1907,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1925,7 +1925,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1940,7 +1940,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1953,7 +1953,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -1968,7 +1968,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -1995,7 +1995,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-clusterRole}
 
 
 
@@ -2007,7 +2007,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-clusterRole-extraRules}
 
 
 
@@ -2025,7 +2025,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-role}
 
 
 
@@ -2037,7 +2037,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-role-extraRules}
 
 
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/isolatedControlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/isolatedControlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane}
+## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -14,7 +14,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-headless}
+### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -44,7 +44,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -59,7 +59,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -74,7 +74,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-disableSync}
+### `disableSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#syncSettings-disableSync}
 
 DisableSync will not sync any resources and disable most control plane functionality.
 
@@ -29,7 +29,7 @@ DisableSync will not sync any resources and disable most control plane functiona
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-rewriteKubernetesService}
+### `rewriteKubernetesService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#syncSettings-rewriteKubernetesService}
 
 RewriteKubernetesService will rewrite the Kubernetes service to point to the vCluster service if disableSync is enabled
 
@@ -44,7 +44,7 @@ RewriteKubernetesService will rewrite the Kubernetes service to point to the vCl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-targetNamespace}
+### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -59,7 +59,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -74,7 +74,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -89,7 +89,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -14,7 +14,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -29,7 +29,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -44,7 +44,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -59,7 +59,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -74,7 +74,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/exportKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -494,7 +494,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -509,7 +509,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -521,7 +521,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -539,7 +539,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -551,7 +551,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -563,7 +563,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -581,7 +581,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -593,7 +593,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -611,7 +611,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -623,7 +623,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -638,7 +638,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -650,7 +650,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -677,7 +677,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -691,7 +691,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -706,7 +706,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -718,7 +718,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -730,7 +730,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -742,7 +742,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -760,7 +760,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -772,7 +772,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -793,7 +793,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -805,7 +805,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -817,7 +817,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -832,7 +832,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -844,7 +844,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -874,7 +874,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio}
+### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -886,7 +886,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -901,7 +901,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
 
 
 
@@ -913,7 +913,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
 
 
 
@@ -925,7 +925,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
 
 
 
@@ -937,37 +937,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -985,7 +955,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
 
 
 
@@ -997,7 +967,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/certManager.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -17,7 +17,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -32,7 +32,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -44,7 +44,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -62,7 +62,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -74,7 +74,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets}
+#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -86,7 +86,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -104,7 +104,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores}
+#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -116,7 +116,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores}
+#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -146,7 +146,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -161,7 +161,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -173,7 +173,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/istio.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/istio.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio}
+## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -14,7 +14,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
 
 
 
@@ -41,7 +41,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
 
 
 
@@ -53,7 +53,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
 
 
 
@@ -65,37 +65,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -113,7 +83,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
 
 
 
@@ -125,7 +95,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/networking.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/networking.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking}
+## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
@@ -14,7 +14,7 @@ Networking options related to the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -26,7 +26,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -40,7 +40,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -55,7 +55,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -73,7 +73,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -85,7 +85,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -100,7 +100,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -121,7 +121,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -133,7 +133,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -148,7 +148,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -163,7 +163,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -178,7 +178,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -190,7 +190,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -205,7 +205,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -220,7 +220,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -235,7 +235,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -250,7 +250,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -271,7 +271,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -283,7 +283,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -298,7 +298,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -314,7 +314,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -327,7 +327,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -343,7 +343,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/replicateServices.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/plugins.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies}
+## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -56,7 +56,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections}
+#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -68,7 +68,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -82,7 +82,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -98,7 +98,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -118,7 +118,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-platform}
+##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -136,7 +136,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraControlPlaneRules}
+#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -151,7 +151,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraWorkloadRules}
+#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -166,7 +166,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -181,7 +181,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -199,7 +199,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -214,7 +214,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -226,7 +226,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -242,7 +242,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -257,7 +257,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -272,7 +272,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -287,7 +287,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -302,7 +302,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -320,7 +320,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -332,7 +332,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -348,7 +348,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -363,7 +363,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -378,7 +378,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -393,7 +393,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -408,7 +408,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -423,7 +423,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -441,7 +441,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -453,7 +453,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -465,7 +465,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -481,7 +481,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -498,7 +498,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -510,7 +510,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -528,7 +528,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -545,7 +545,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -564,7 +564,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -576,7 +576,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -594,7 +594,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -606,7 +606,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -623,7 +623,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -638,7 +638,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -653,7 +653,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -668,7 +668,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -684,7 +684,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -704,7 +704,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -723,7 +723,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -739,7 +739,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -755,7 +755,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -771,7 +771,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -790,7 +790,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -808,7 +808,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -823,7 +823,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -838,7 +838,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -854,7 +854,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -878,7 +878,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -890,7 +890,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -906,7 +906,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -923,7 +923,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -935,7 +935,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -953,7 +953,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -970,7 +970,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -989,7 +989,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -1001,7 +1001,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -1017,7 +1017,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1035,7 +1035,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1047,7 +1047,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1064,7 +1064,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1079,7 +1079,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -1094,7 +1094,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -1109,7 +1109,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -1125,7 +1125,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -1145,7 +1145,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -1164,7 +1164,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -1180,7 +1180,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -1196,7 +1196,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -1212,7 +1212,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -1231,7 +1231,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -1249,7 +1249,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -1264,7 +1264,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -1279,7 +1279,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -1295,7 +1295,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/limitRange.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -44,7 +44,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections}
+### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -56,7 +56,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock}
+#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -70,7 +70,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -86,7 +86,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -106,7 +106,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-platform}
+#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -124,7 +124,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraControlPlaneRules}
+### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -139,7 +139,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraWorkloadRules}
+### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -154,7 +154,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -169,7 +169,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/rbac.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sleepMode.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sleepMode.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode}
+## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode}
 
 SleepMode holds the native sleep mode configuration for Pro clusters
 
@@ -14,7 +14,7 @@ SleepMode holds the native sleep mode configuration for Pro clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-enabled}
 
 Enabled toggles the sleep mode functionality, allowing for disabling sleep mode without removing other config
 
@@ -29,7 +29,7 @@ Enabled toggles the sleep mode functionality, allowing for disabling sleep mode 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-timeZone}
+### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-timeZone}
 
 Timezone represents the timezone a sleep schedule should run against, defaulting to UTC if unset
 
@@ -44,7 +44,7 @@ Timezone represents the timezone a sleep schedule should run against, defaulting
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep}
 
 AutoSleep holds autoSleep details
 
@@ -56,7 +56,7 @@ AutoSleep holds autoSleep details
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automaticaly put to sleep
 
@@ -71,7 +71,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -86,7 +86,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude}
+#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -98,7 +98,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector}
 
 
 
@@ -110,7 +110,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -134,7 +134,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup}
 
 AutoWakeup holds configuration for waking the vCluster on a schedule rather than waiting for some activity.
 
@@ -146,7 +146,7 @@ AutoWakeup holds configuration for waking the vCluster on a schedule rather than
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup-schedule}
 
 
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync}
+## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -186,7 +186,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -198,7 +198,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -213,7 +213,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -237,7 +237,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -249,7 +249,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -264,7 +264,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -279,7 +279,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -294,7 +294,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -308,7 +308,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -323,7 +323,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -338,7 +338,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -353,7 +353,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -368,7 +368,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -383,7 +383,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -402,7 +402,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -423,7 +423,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -435,7 +435,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -450,7 +450,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -465,7 +465,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -477,7 +477,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -492,7 +492,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -507,7 +507,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -522,7 +522,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -536,7 +536,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -551,7 +551,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -566,7 +566,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -581,7 +581,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -596,7 +596,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -611,7 +611,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -630,7 +630,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -651,7 +651,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -663,7 +663,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -678,7 +678,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -693,7 +693,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -705,7 +705,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -720,7 +720,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -735,7 +735,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -750,7 +750,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -764,7 +764,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -779,7 +779,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -794,7 +794,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -809,7 +809,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -824,7 +824,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -839,7 +839,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -858,7 +858,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -879,7 +879,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -891,7 +891,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -906,7 +906,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -918,7 +918,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -933,7 +933,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -948,7 +948,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -963,7 +963,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -977,7 +977,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -992,7 +992,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1007,7 +1007,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1022,7 +1022,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1037,7 +1037,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1052,7 +1052,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1071,7 +1071,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1092,7 +1092,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1104,7 +1104,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1119,7 +1119,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1131,7 +1131,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1146,7 +1146,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1161,7 +1161,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1176,7 +1176,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1190,7 +1190,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1205,7 +1205,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1220,7 +1220,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1235,7 +1235,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1250,7 +1250,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1265,7 +1265,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1284,7 +1284,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1305,7 +1305,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1317,7 +1317,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1332,7 +1332,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1344,7 +1344,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1359,7 +1359,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1374,7 +1374,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1389,7 +1389,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1403,7 +1403,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1418,7 +1418,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1433,7 +1433,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1448,7 +1448,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1463,7 +1463,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1478,7 +1478,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1497,7 +1497,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1518,7 +1518,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1530,7 +1530,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1545,7 +1545,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1557,7 +1557,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1572,7 +1572,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1587,7 +1587,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1602,7 +1602,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1616,7 +1616,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1631,7 +1631,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1646,7 +1646,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1661,7 +1661,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1676,7 +1676,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1691,7 +1691,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1710,7 +1710,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1731,7 +1731,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1743,7 +1743,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1758,7 +1758,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1770,7 +1770,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1785,7 +1785,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1800,7 +1800,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1815,7 +1815,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1829,7 +1829,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1844,7 +1844,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1859,7 +1859,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1874,7 +1874,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1889,7 +1889,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1904,7 +1904,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1923,7 +1923,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1944,7 +1944,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -1956,7 +1956,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1971,7 +1971,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1983,7 +1983,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1998,7 +1998,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2013,7 +2013,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2028,7 +2028,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2042,7 +2042,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2057,7 +2057,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2072,7 +2072,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2087,7 +2087,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2102,7 +2102,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2117,7 +2117,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2136,7 +2136,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2157,7 +2157,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2169,7 +2169,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2184,7 +2184,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2196,7 +2196,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2211,7 +2211,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2226,7 +2226,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2241,7 +2241,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2255,7 +2255,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2270,7 +2270,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2285,7 +2285,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2300,7 +2300,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2315,7 +2315,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2330,7 +2330,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2349,7 +2349,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2370,7 +2370,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2382,7 +2382,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2397,7 +2397,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2409,7 +2409,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2424,7 +2424,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2439,7 +2439,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2454,7 +2454,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2468,7 +2468,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2483,7 +2483,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2498,7 +2498,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2513,7 +2513,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2528,7 +2528,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2543,7 +2543,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2562,7 +2562,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2583,7 +2583,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2595,7 +2595,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2610,7 +2610,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2622,7 +2622,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2637,7 +2637,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2652,7 +2652,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2667,7 +2667,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2681,7 +2681,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2696,7 +2696,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2711,7 +2711,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2726,7 +2726,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2741,7 +2741,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2756,7 +2756,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2775,7 +2775,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2796,7 +2796,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2808,7 +2808,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2823,7 +2823,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2835,7 +2835,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2850,7 +2850,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2865,7 +2865,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2880,7 +2880,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2894,7 +2894,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2909,7 +2909,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2924,7 +2924,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2939,7 +2939,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2954,7 +2954,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2969,7 +2969,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2988,7 +2988,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3009,7 +3009,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3021,7 +3021,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3036,7 +3036,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3048,7 +3048,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3063,7 +3063,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3078,7 +3078,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3093,7 +3093,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3107,7 +3107,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3122,7 +3122,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3137,7 +3137,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3152,7 +3152,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3167,7 +3167,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3182,7 +3182,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3201,7 +3201,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3222,7 +3222,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3234,7 +3234,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3249,7 +3249,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3261,7 +3261,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3276,7 +3276,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3291,7 +3291,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3306,7 +3306,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3320,7 +3320,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3335,7 +3335,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3350,7 +3350,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3365,7 +3365,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3380,7 +3380,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3395,7 +3395,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3414,7 +3414,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3435,7 +3435,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3448,7 +3448,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3463,7 +3463,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3478,7 +3478,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3490,7 +3490,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3505,7 +3505,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3520,7 +3520,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3535,7 +3535,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3549,7 +3549,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3564,7 +3564,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3579,7 +3579,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3594,7 +3594,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3609,7 +3609,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3624,7 +3624,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3643,7 +3643,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3667,7 +3667,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -3679,7 +3679,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -3691,7 +3691,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -3706,7 +3706,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -3721,7 +3721,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -3736,7 +3736,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -3748,7 +3748,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -3763,7 +3763,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -3781,7 +3781,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3793,7 +3793,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3808,7 +3808,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3823,7 +3823,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3838,7 +3838,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3852,7 +3852,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3867,7 +3867,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3882,7 +3882,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3897,7 +3897,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3912,7 +3912,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3927,7 +3927,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3946,7 +3946,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3967,7 +3967,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -3979,7 +3979,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3994,7 +3994,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4006,7 +4006,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4021,7 +4021,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4036,7 +4036,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4051,7 +4051,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4065,7 +4065,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4080,7 +4080,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4095,7 +4095,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4110,7 +4110,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4125,7 +4125,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4140,7 +4140,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4159,7 +4159,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4180,7 +4180,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4192,7 +4192,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4207,7 +4207,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4219,7 +4219,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4234,7 +4234,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4249,7 +4249,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4264,7 +4264,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4278,7 +4278,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4293,7 +4293,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4308,7 +4308,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4323,7 +4323,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4338,7 +4338,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4353,7 +4353,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4372,7 +4372,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4393,7 +4393,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4405,7 +4405,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4420,7 +4420,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4432,7 +4432,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4447,7 +4447,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4462,7 +4462,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4477,7 +4477,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4491,7 +4491,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4506,7 +4506,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4521,7 +4521,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4536,7 +4536,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4551,7 +4551,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4566,7 +4566,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4585,7 +4585,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4606,7 +4606,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4618,7 +4618,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4633,7 +4633,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4645,7 +4645,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4660,7 +4660,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4675,7 +4675,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4690,7 +4690,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4704,7 +4704,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4719,7 +4719,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4734,7 +4734,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4749,7 +4749,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4764,7 +4764,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4779,7 +4779,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4798,7 +4798,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4819,7 +4819,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -4831,7 +4831,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4846,7 +4846,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4858,7 +4858,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4873,7 +4873,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4888,7 +4888,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4903,7 +4903,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4917,7 +4917,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4932,7 +4932,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4947,7 +4947,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4962,7 +4962,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4977,7 +4977,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4992,7 +4992,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5011,7 +5011,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5032,7 +5032,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5044,7 +5044,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5059,7 +5059,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5071,7 +5071,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5086,7 +5086,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5101,7 +5101,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5116,7 +5116,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5130,7 +5130,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5145,7 +5145,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5160,7 +5160,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5175,7 +5175,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5190,7 +5190,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5205,7 +5205,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5224,7 +5224,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5245,7 +5245,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5257,7 +5257,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5272,7 +5272,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5284,7 +5284,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5299,7 +5299,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5314,7 +5314,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5329,7 +5329,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5343,7 +5343,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5358,7 +5358,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5373,7 +5373,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5388,7 +5388,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5403,7 +5403,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5418,7 +5418,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5437,7 +5437,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5458,7 +5458,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5470,7 +5470,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5485,7 +5485,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5497,7 +5497,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5512,7 +5512,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5527,7 +5527,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5542,7 +5542,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5556,7 +5556,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5571,7 +5571,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5586,7 +5586,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5601,7 +5601,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5616,7 +5616,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5631,7 +5631,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5650,7 +5650,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5671,7 +5671,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -5683,7 +5683,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5698,7 +5698,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -5713,7 +5713,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5725,7 +5725,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5740,7 +5740,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5755,7 +5755,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5770,7 +5770,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5784,7 +5784,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5799,7 +5799,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5814,7 +5814,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5829,7 +5829,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5844,7 +5844,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5859,7 +5859,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5878,7 +5878,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5896,7 +5896,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -5908,7 +5908,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -5945,7 +5945,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -5957,7 +5957,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5972,7 +5972,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5984,7 +5984,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5999,7 +5999,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6014,7 +6014,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6029,7 +6029,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6043,7 +6043,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6058,7 +6058,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6073,7 +6073,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6088,7 +6088,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6103,7 +6103,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6118,7 +6118,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6137,7 +6137,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6158,7 +6158,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -6170,7 +6170,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6185,7 +6185,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6197,7 +6197,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6212,7 +6212,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6227,7 +6227,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6242,7 +6242,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6256,7 +6256,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6271,7 +6271,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6286,7 +6286,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6301,7 +6301,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6316,7 +6316,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6331,7 +6331,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6350,7 +6350,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6368,7 +6368,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -6380,7 +6380,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -6417,7 +6417,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -6429,7 +6429,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6444,7 +6444,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6456,7 +6456,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6471,7 +6471,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6486,7 +6486,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6501,7 +6501,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6515,7 +6515,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6530,7 +6530,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6545,7 +6545,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6560,7 +6560,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6575,7 +6575,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6590,7 +6590,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6609,7 +6609,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6627,7 +6627,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -6639,7 +6639,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -728,7 +728,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -740,7 +740,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -755,7 +755,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -767,7 +767,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -782,7 +782,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -797,7 +797,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -812,7 +812,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -826,7 +826,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -841,7 +841,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -856,7 +856,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -871,7 +871,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -886,7 +886,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -901,7 +901,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -920,7 +920,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -941,7 +941,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -953,7 +953,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -968,7 +968,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -980,7 +980,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -995,7 +995,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1010,7 +1010,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1025,7 +1025,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1039,7 +1039,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1054,7 +1054,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1069,7 +1069,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1084,7 +1084,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1099,7 +1099,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1114,7 +1114,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1133,7 +1133,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1154,7 +1154,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1166,7 +1166,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1181,7 +1181,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1193,7 +1193,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1208,7 +1208,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1223,7 +1223,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1238,7 +1238,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1252,7 +1252,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1267,7 +1267,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1282,7 +1282,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1297,7 +1297,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1312,7 +1312,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1327,7 +1327,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1346,7 +1346,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1367,7 +1367,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1379,7 +1379,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1394,7 +1394,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1406,7 +1406,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1421,7 +1421,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1436,7 +1436,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1451,7 +1451,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1465,7 +1465,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1480,7 +1480,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1495,7 +1495,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1510,7 +1510,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1525,7 +1525,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1540,7 +1540,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1559,7 +1559,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1580,7 +1580,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1592,7 +1592,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1607,7 +1607,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1619,7 +1619,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1634,7 +1634,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1649,7 +1649,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1664,7 +1664,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1678,7 +1678,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1693,7 +1693,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1708,7 +1708,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1723,7 +1723,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1738,7 +1738,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1753,7 +1753,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1772,7 +1772,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1793,7 +1793,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1805,7 +1805,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1820,7 +1820,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1832,7 +1832,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1847,7 +1847,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1862,7 +1862,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1877,7 +1877,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1891,7 +1891,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1906,7 +1906,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1921,7 +1921,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1936,7 +1936,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1951,7 +1951,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1966,7 +1966,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1985,7 +1985,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2006,7 +2006,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -2018,7 +2018,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2033,7 +2033,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -2048,7 +2048,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2060,7 +2060,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2075,7 +2075,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2090,7 +2090,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2105,7 +2105,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2119,7 +2119,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2134,7 +2134,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2149,7 +2149,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2164,7 +2164,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2179,7 +2179,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2194,7 +2194,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2213,7 +2213,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2231,7 +2231,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -2243,7 +2243,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2280,7 +2280,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2292,7 +2292,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2307,7 +2307,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2319,7 +2319,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2334,7 +2334,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2349,7 +2349,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2364,7 +2364,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2378,7 +2378,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2393,7 +2393,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2408,7 +2408,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2423,7 +2423,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2438,7 +2438,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2453,7 +2453,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2472,7 +2472,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2493,7 +2493,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -2505,7 +2505,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2520,7 +2520,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2532,7 +2532,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2547,7 +2547,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2562,7 +2562,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2577,7 +2577,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2591,7 +2591,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2606,7 +2606,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2621,7 +2621,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2636,7 +2636,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2651,7 +2651,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2666,7 +2666,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2685,7 +2685,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2703,7 +2703,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -2715,7 +2715,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2752,7 +2752,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -2764,7 +2764,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2779,7 +2779,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2791,7 +2791,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2806,7 +2806,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2821,7 +2821,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2836,7 +2836,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2850,7 +2850,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2865,7 +2865,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2880,7 +2880,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2895,7 +2895,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2910,7 +2910,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2925,7 +2925,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2944,7 +2944,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2962,7 +2962,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -2974,7 +2974,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events}
+## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -174,7 +174,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -186,7 +186,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -201,7 +201,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -225,7 +225,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -237,7 +237,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -252,7 +252,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -267,7 +267,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -282,7 +282,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -296,7 +296,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -311,7 +311,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -326,7 +326,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -341,7 +341,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -356,7 +356,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -371,7 +371,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -390,7 +390,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -411,7 +411,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -423,7 +423,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -438,7 +438,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -453,7 +453,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -465,7 +465,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -480,7 +480,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -495,7 +495,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -510,7 +510,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -524,7 +524,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -539,7 +539,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -554,7 +554,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -569,7 +569,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -584,7 +584,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -599,7 +599,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -618,7 +618,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -639,7 +639,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -651,7 +651,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -666,7 +666,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -681,7 +681,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -693,7 +693,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -708,7 +708,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -723,7 +723,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -738,7 +738,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -752,7 +752,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -767,7 +767,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -782,7 +782,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -797,7 +797,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -812,7 +812,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -827,7 +827,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -846,7 +846,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -867,7 +867,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -879,7 +879,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -894,7 +894,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -906,7 +906,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -921,7 +921,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -936,7 +936,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -951,7 +951,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -965,7 +965,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -980,7 +980,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -995,7 +995,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1010,7 +1010,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1025,7 +1025,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1040,7 +1040,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1059,7 +1059,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1080,7 +1080,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1092,7 +1092,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1107,7 +1107,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1119,7 +1119,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1134,7 +1134,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1149,7 +1149,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1164,7 +1164,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1178,7 +1178,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1193,7 +1193,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1208,7 +1208,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1223,7 +1223,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1238,7 +1238,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1253,7 +1253,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1272,7 +1272,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1293,7 +1293,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1305,7 +1305,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1320,7 +1320,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1332,7 +1332,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1347,7 +1347,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1362,7 +1362,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1377,7 +1377,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1391,7 +1391,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1406,7 +1406,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1421,7 +1421,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1436,7 +1436,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1451,7 +1451,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1466,7 +1466,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1485,7 +1485,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1506,7 +1506,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1518,7 +1518,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1533,7 +1533,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1545,7 +1545,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1560,7 +1560,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1575,7 +1575,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1590,7 +1590,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1604,7 +1604,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1619,7 +1619,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1634,7 +1634,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1649,7 +1649,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1664,7 +1664,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1679,7 +1679,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1698,7 +1698,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1719,7 +1719,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1731,7 +1731,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1746,7 +1746,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1758,7 +1758,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1773,7 +1773,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1788,7 +1788,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1803,7 +1803,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1817,7 +1817,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1832,7 +1832,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1847,7 +1847,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1862,7 +1862,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1877,7 +1877,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1892,7 +1892,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1911,7 +1911,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1932,7 +1932,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -1944,7 +1944,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1959,7 +1959,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1971,7 +1971,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1986,7 +1986,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2001,7 +2001,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2016,7 +2016,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2030,7 +2030,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2045,7 +2045,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2060,7 +2060,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2075,7 +2075,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2090,7 +2090,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2105,7 +2105,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2124,7 +2124,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2145,7 +2145,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2157,7 +2157,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2172,7 +2172,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2184,7 +2184,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2199,7 +2199,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2214,7 +2214,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2229,7 +2229,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2243,7 +2243,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2258,7 +2258,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2273,7 +2273,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2288,7 +2288,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2303,7 +2303,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2318,7 +2318,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2337,7 +2337,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2358,7 +2358,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2370,7 +2370,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2385,7 +2385,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2397,7 +2397,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2412,7 +2412,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2427,7 +2427,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2442,7 +2442,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2456,7 +2456,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2471,7 +2471,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2486,7 +2486,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2501,7 +2501,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2516,7 +2516,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2531,7 +2531,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2550,7 +2550,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2571,7 +2571,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2583,7 +2583,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2598,7 +2598,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2610,7 +2610,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2625,7 +2625,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2640,7 +2640,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2655,7 +2655,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2669,7 +2669,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2684,7 +2684,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2699,7 +2699,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2714,7 +2714,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2729,7 +2729,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2744,7 +2744,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2763,7 +2763,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2784,7 +2784,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2796,7 +2796,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2811,7 +2811,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2823,7 +2823,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2838,7 +2838,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2853,7 +2853,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2868,7 +2868,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2882,7 +2882,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2897,7 +2897,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2912,7 +2912,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2927,7 +2927,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2942,7 +2942,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2957,7 +2957,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2976,7 +2976,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2997,7 +2997,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3009,7 +3009,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3024,7 +3024,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3036,7 +3036,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3051,7 +3051,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3066,7 +3066,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3081,7 +3081,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3095,7 +3095,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3110,7 +3110,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3125,7 +3125,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3140,7 +3140,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3155,7 +3155,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3170,7 +3170,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3189,7 +3189,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3210,7 +3210,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3222,7 +3222,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3237,7 +3237,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3249,7 +3249,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3264,7 +3264,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3279,7 +3279,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3294,7 +3294,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3308,7 +3308,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3323,7 +3323,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3338,7 +3338,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3353,7 +3353,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3368,7 +3368,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3383,7 +3383,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3402,7 +3402,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3423,7 +3423,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3436,7 +3436,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3451,7 +3451,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3466,7 +3466,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3478,7 +3478,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3493,7 +3493,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3508,7 +3508,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3523,7 +3523,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3537,7 +3537,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3552,7 +3552,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3567,7 +3567,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3582,7 +3582,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3597,7 +3597,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3612,7 +3612,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3631,7 +3631,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods}
+## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -162,7 +162,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -174,7 +174,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -189,7 +189,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -213,7 +213,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -225,7 +225,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -240,7 +240,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -255,7 +255,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -270,7 +270,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -284,7 +284,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -299,7 +299,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -314,7 +314,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -329,7 +329,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -344,7 +344,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -359,7 +359,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -378,7 +378,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/services.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services}
+## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.25.0/_partials/config/telemetry.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- re-generate config partials for vCluster 0.24 and 0.25
- add error handling to skip missing schema paths during versioned documentation generation
  - partials generation no longer crashes when encountering version-specific schema differences
  - preserves historical features in older versions while supporting new features in newer versions
  - CI/CD pipelines can now generate documentation for any vCluster version without manual intervention

## Note for review

- ignore `vale` errors.
- spot check configuration checks (should be no `pro` labels on the right-hand side). 
- ensure that configuration that is deprecated in a specific version is indeed gone from the docs but remains in the older version (eg k0s or istio)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- https://deploy-preview-923--vcluster-docs-site.netlify.app/docs/vcluster/0.25.0/configure/vcluster-yaml/
- https://deploy-preview-923--vcluster-docs-site.netlify.app/docs/vcluster/0.24.0/configure/vcluster-yaml/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-814

