### PR TITLE
Add section for sync.toHost.rewriteHosts

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
@@ -8,7 +8,6 @@ description: Configuration for ...
 import DisableResourceWarning from '../../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
 import Patches from '../../../../../../_fragments/patches.mdx'
 import SyncPods from '../../../../../../_partials/config/sync/toHost/pods.mdx'
-import Admonition from '@theme/Admonition';
 
 By default, this is enabled.
 
@@ -82,6 +81,14 @@ sync:
 ## Use secrets for ServiceAccount tokens
 
 A host Pod requires a ServiceAccount token to communicate with the virtual clusters API. If you don't want to create these secrets in the host cluster, disable this option. vCluster then adds annotations to the pods.
+
+## Rewrite hosts
+
+Applies only to Pods that have the field `spec.subdomain` set.
+In such Pods, the fqdn hostname (`hostname -f`) is constructed based on the host cluster namespace the vCluster runs in.
+This is usually not what applications expect as they are unaware of the host cluster.
+
+If this option is enabled, vCluster injects an initContainer to override the Pod's `/etc/hosts` file to change the fqdn hostname to match the expected domain.
 
 :::note Configuration change
 In vCluster version `0.27.0`, the `rewriteHosts.initContainer.image` configuration changed from a string to an object format. This change provides granular control over the registry, repository, and tag of the image.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Fixes flow by adding a section, so the previously added note has some context.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-7954
