### PR TITLE
Warn about the latest version that is compatible with vCluster integration

### DIFF
--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -6,14 +6,18 @@ import Admonition from '@theme/Admonition';
 ### Prerequisites
 
 - `kubectl` installed
-- `external-secrets` operator installed on your host cluster. See instructions at https://external-secrets.io/latest/
+- `external-secrets` operator installed on your host cluster. See instructions at https://external-secrets.io/v0.15.1/
+
+:::warning External secrets version
+This feature is currently only compatible with CRD version `v1beta1` of the `external-secrets` operator.
+:::
 
 # External secrets integration
 
 :::warning Configuration Changes
 The sync configuration for this integration has been updated.
 
-Configuration for each resource type is now defined under the relevant `toHost` or `fromHost` section.  
+Configuration for each resource type is now defined under the relevant `toHost` or `fromHost` section.
 For more information, see the [configuration reference](#config-reference).
 
 Label selectors are now supported for all resources and follow the format used by the upstream Kubernetes API.


### PR DESCRIPTION
Warn about the latest version that is compatible with vCluster integration
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

