### PR TITLE
Remove centos stream 10 support from matrix

### DIFF
--- a/vcluster/deploy/worker-nodes/private-nodes/node-requirements.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/node-requirements.mdx
@@ -35,7 +35,6 @@ Security-Enhanced Linux (SELinux) is currently not supported.
 | Ubuntu | 22.04 | |
 | RHEL (RedHat Enterprise Linux) | 10 | Disable SElinux |
 | RHEL (RedHat Enterprise Linux) | 9 | Disable SElinux |
-| CentOS Stream | 10 | Disable SElinux and install `iptables`|
 | CentOS Stream | 9 | Disable SElinux and install `iptables` |
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-7410

