### PR TITLE
fix(infra): bump node version on netlify and add memory logs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,16 @@ base = "/"
 publish = "public/"
 command = """
     set -e
+    node --version
     export NODE_OPTIONS="--max_old_space_size=8192"
+    node -e "console.log('Max memory:', process.memoryUsage())"
     mkdir -p public/
     npm run build
     mv build/ public/docs/
   """
+
+[build.environment]
+  NODE_VERSION = "20"
 
 [[redirects]]
   from = "/docs/architecture/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,9 @@ base = "/"
 publish = "public/"
 command = """
     set -e
+    echo "NODE_OPTIONS: $NODE_OPTIONS"
     node --version
-    export NODE_OPTIONS="--max_old_space_size=8192"
-    node -e "console.log('Max memory:', process.memoryUsage())"
+    node -e "console.log('Heap limit:', require('v8').getHeapStatistics().heap_size_limit / 1024 / 1024 / 1024, 'GB')"
     mkdir -p public/
     npm run build
     mv build/ public/docs/
@@ -13,6 +13,7 @@ command = """
 
 [build.environment]
   NODE_VERSION = "20"
+  NODE_OPTIONS = "--max-old-space-size=8192"
 
 [[redirects]]
   from = "/docs/architecture/*"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

