### PR TITLE
fix(infra): exclude 3 EOL versions from the build settings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -184,6 +184,7 @@ const config = {
           `https://github.com/loft-sh/vcluster-docs/edit/main/${versionDocsDirPath}/${docPath}`,
         editCurrentVersion: true,
         lastVersion: "0.27.0",
+        onlyIncludeVersions: ["current", "0.27.0", "0.26.0", "0.25.0", "0.24.0", "0.23.0"],
         versions: {
           current: {
             label: "main 🚧",


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

This helps reduce memory build footprint and pass netlify builds.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-897

