### PR TITLE
chore(infra): redirect old docs to a dedicated standalone versions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -225,7 +225,7 @@ const config = {
             badge: true,
           },
           "0.20.0": {
-            label: "v0.20 (EOL)",
+            label: "v0.20 (EOL) ↗",
             banner: "unmaintained",
             badge: true,
           },

--- a/src/theme/DocSidebar/Desktop/Content/index.js
+++ b/src/theme/DocSidebar/Desktop/Content/index.js
@@ -23,8 +23,28 @@ export default function ContentWrapper(props) {
     <>
       {shouldShowVClusterVersioning && <VersionSelector docsPluginId={"vcluster"} dropdownItemsAfter={[
         {
+          to: "https://vcluster.com/docs/v0.24",
+          label: "v0.24 (EOL) ↗"
+        },
+        {
+          to: "https://vcluster.com/docs/v0.23",
+          label: "v0.23 (EOL) ↗"
+        },
+        {
+          to: "https://vcluster.com/docs/v0.22",
+          label: "v0.22 (EOL) ↗"
+        },
+        {
+          to: "https://vcluster.com/docs/v0.21",
+          label: "v0.21 (EOL) ↗"
+        },
+        {
+          to: "https://vcluster.com/docs/v0.20",
+          label: "v0.20 (EOL) ↗"
+        },
+        {
           to: "https://vcluster.com/docs/v0.19",
-          label: "v0.19 (EOL)"
+          label: "v0.19 (EOL) ↗"
         }
       ]} />}
       {shouldShowPlatformVersioning && <VersionSelector docsPluginId={"platform"} dropdownItemsAfter={[


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-897

