### PR TITLE
feat(platform): acccess metrics endpoint in vcluster platform

### DIFF
--- a/platform/administer/monitoring/metrics.mdx
+++ b/platform/administer/monitoring/metrics.mdx
@@ -83,27 +83,36 @@ When `serviceMonitor.enabled=true`, the platform exposes metrics on port `8080`.
 
 ### Access the metrics endpoint directly without a ServiceMonitor
 
-vCluster Platform exposes its internal metrics at 
+When collecting metrics directly without a ServiceMonitor, it's important to understand that vCluster Platform typically runs with multiple replicas for high availability. To get complete metrics coverage, you need to collect metrics from all platform pods rather than through a single endpoint.
+
+#### Collect metrics from all platform pods
+
+Each vCluster Platform pod exposes metrics on port `8080` at the `/metrics` endpoint. Your metrics collection tool should scrape metrics from all replicas to ensure complete coverage.
+
+The platform pods can be identified using the following Kubernetes labels:
+- `app=loft` - Identifies vCluster Platform pods
+- `component=loft` - Component label for the platform
+- `release=loft` - Helm release name (may vary based on your installation)
+
+By default, vCluster Platform requires an `Authorization` HTTP header field with a Kubernetes bearer token that has access to the non-resource 
 <!-- vale off -->
-`https://my-loft-subdomain.my-url.com/metrics`
+URL `/metrics`
 <!-- vale on -->
-.
-By default vCluster Platform requires an `Authorization` http header field with a kubernetes bearer token that has access to the non resource 
-<!-- vale off -->
-url `/metrics`
-<!-- vale on -->
- in the kubernetes cluster where vCluster Platform is installed.
+ in the Kubernetes cluster where vCluster Platform is installed.
 If the header is not provided, vCluster Platform denies the request.
 
-:::info Disable metrics authentication
-If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
+:::info Turn off metrics authentication
+If you wish to scrape metrics without authentication, you can turn it off via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
-If you have kubernetes service account token that has the appropriate rights, you can access the metrics via curl:
+Example of accessing metrics from a specific pod using port-forward:
 
 ```bash
-# Add an optional --insecure, if your vCluster Platform instance is using an untrusted certificate
-$ curl https://my-vcluster-platform-subdomain.my-url.com/metrics -H "Authorization: Bearer eyJhbGci..."
+# Port-forward to a specific platform pod
+kubectl port-forward -n vcluster-platform loft-xxxx 8080:8080
+
+# Access metrics with authentication token
+curl http://localhost:8080/metrics -H "Authorization: Bearer eyJhbGci..."
 
 # HELP apiserver_audit_event_total [ALPHA] Counter of audit events generated and sent to the audit backend.
 # TYPE apiserver_audit_event_total counter

--- a/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
+++ b/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
@@ -83,27 +83,36 @@ When `serviceMonitor.enabled=true`, the platform exposes metrics on port `8080`.
 
 ### Access the metrics endpoint directly without a ServiceMonitor
 
-vCluster Platform exposes its internal metrics at 
+When collecting metrics directly without a ServiceMonitor, it's important to understand that vCluster Platform typically runs with multiple replicas for high availability. To get complete metrics coverage, you need to collect metrics from all platform pods rather than through a single endpoint.
+
+#### Collect metrics from all platform pods
+
+Each vCluster Platform pod exposes metrics on port `8080` at the `/metrics` endpoint. Your metrics collection tool should scrape metrics from all replicas to ensure complete coverage.
+
+The platform pods can be identified using the following Kubernetes labels:
+- `app=loft` - Identifies vCluster Platform pods
+- `component=loft` - Component label for the platform
+- `release=loft` - Helm release name (may vary based on your installation)
+
+By default, vCluster Platform requires an `Authorization` HTTP header field with a Kubernetes bearer token that has access to the non-resource 
 <!-- vale off -->
-`https://my-loft-subdomain.my-url.com/metrics`
+URL `/metrics`
 <!-- vale on -->
-.
-By default vCluster Platform requires an `Authorization` http header field with a Kubernetes bearer token that has access to the non resource 
-<!-- vale off -->
-url `/metrics`
-<!-- vale on -->
- in the kubernetes cluster where vCluster Platform is installed.
+ in the Kubernetes cluster where vCluster Platform is installed.
 If the header is not provided, vCluster Platform denies the request.
 
-:::info Disable metrics authentication
-If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
+:::info Turn off metrics authentication
+If you wish to scrape metrics without authentication, you can turn it off via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
-If you have kubernetes service account token that has the appropriate rights, you can access the metrics via curl:
+Example of accessing metrics from a specific pod using port-forward:
 
 ```bash
-# Add an optional --insecure, if your vCluster Platform instance is using an untrusted certificate
-$ curl https://my-vcluster-platform-subdomain.my-url.com/metrics -H "Authorization: Bearer eyJhbGci..."
+# Port-forward to a specific platform pod
+kubectl port-forward -n vcluster-platform loft-xxxx 8080:8080
+
+# Access metrics with authentication token
+curl http://localhost:8080/metrics -H "Authorization: Bearer eyJhbGci..."
 
 # HELP apiserver_audit_event_total [ALPHA] Counter of audit events generated and sent to the audit backend.
 # TYPE apiserver_audit_event_total counter

--- a/platform_versioned_docs/version-4.3.0/administer/monitoring/metrics.mdx
+++ b/platform_versioned_docs/version-4.3.0/administer/monitoring/metrics.mdx
@@ -83,27 +83,36 @@ When `serviceMonitor.enabled=true`, the platform exposes metrics on port `8080`.
 
 ### Access the metrics endpoint directly without a ServiceMonitor
 
-vCluster Platform exposes its internal metrics at 
+When collecting metrics directly without a ServiceMonitor, it's important to understand that vCluster Platform typically runs with multiple replicas for high availability. To get complete metrics coverage, you need to collect metrics from all platform pods rather than through a single endpoint.
+
+#### Collect metrics from all platform pods
+
+Each vCluster Platform pod exposes metrics on port `8080` at the `/metrics` endpoint. Your metrics collection tool should scrape metrics from all replicas to ensure complete coverage.
+
+The platform pods can be identified using the following Kubernetes labels:
+- `app=loft` - Identifies vCluster Platform pods
+- `component=loft` - Component label for the platform
+- `release=loft` - Helm release name (may vary based on your installation)
+
+By default, vCluster Platform requires an `Authorization` HTTP header field with a Kubernetes bearer token that has access to the non-resource 
 <!-- vale off -->
-`https://my-loft-subdomain.my-url.com/metrics`
+URL `/metrics`
 <!-- vale on -->
-.
-By default vCluster Platform requires an `Authorization` http header field with a kubernetes bearer token that has access to the non resource 
-<!-- vale off -->
-url `/metrics`
-<!-- vale on -->
- in the kubernetes cluster where vCluster Platform is installed.
+ in the Kubernetes cluster where vCluster Platform is installed.
 If the header is not provided, vCluster Platform denies the request.
 
-:::info Disable metrics authentication
-If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
+:::info Turn off metrics authentication
+If you wish to scrape metrics without authentication, you can turn it off via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
-If you have kubernetes service account token that has the appropriate rights, you can access the metrics via curl:
+Example of accessing metrics from a specific pod using port-forward:
 
 ```bash
-# Add an optional --insecure, if your vCluster Platform instance is using an untrusted certificate
-$ curl https://my-vcluster-platform-subdomain.my-url.com/metrics -H "Authorization: Bearer eyJhbGci..."
+# Port-forward to a specific platform pod
+kubectl port-forward -n vcluster-platform loft-xxxx 8080:8080
+
+# Access metrics with authentication token
+curl http://localhost:8080/metrics -H "Authorization: Bearer eyJhbGci..."
 
 # HELP apiserver_audit_event_total [ALPHA] Counter of audit events generated and sent to the audit backend.
 # TYPE apiserver_audit_event_total counter


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-1019--vcluster-docs-site.netlify.app/docs/platform/administer/monitoring/metrics

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-534

