### PR TITLE
fix(vcluster): add caBundle field in central admission controller

### DIFF
--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -43,6 +43,19 @@ Therefore, vCluster puts the translated pod name under the `request.options.vClu
 As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for pods.
 :::
 
+## Certificate configuration
+
+For webhooks using self-signed or private certificates, add the `caBundle` field:
+
+```bash
+# Get base64-encoded CA certificate from secret
+kubectl get secret webhook-tls-secret -n webhook-namespace -o jsonpath='{.data.ca\.crt}'
+```
+
+:::warning
+Missing `caBundle` with `failurePolicy: Fail` can make vCluster unrecoverable. Test with `failurePolicy: Ignore` first.
+:::
+
 ## Kyverno example
 
 This example ensures that all new ConfigMap resources are sent to a mutating webhook on the host cluster.
@@ -58,6 +71,8 @@ centralAdmission:
       - admissionReviewVersions:
         - v1
         clientConfig:
+          # Add caBundle for self-signed certificates
+          caBundle: LS0tLS1CRUdJTi... # Base64-encoded PEM certificate
           service:
             name: kyverno-svc
             namespace: kyverno
@@ -187,6 +202,8 @@ policies:
       - admissionReviewVersions:
         - v1
         clientConfig:
+          # Add caBundle for self-signed certificates
+          caBundle: LS0tLS1CRUdJTi... # Base64-encoded PEM certificate
           service:
             name: gatekeeper-webhook-service
             namespace: gatekeeper-system


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-1021--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/policies/admission-control

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-428

