### PR TITLE
docs(platform): add section to explain externalURLs for airgapped deployments

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -469,6 +469,35 @@ admin:
 
 </details>
 
+<details>
+  <summary>Restrict Platform UI requests</summary>
+
+When the platform runs in an airgapped environment the pods usually don't have a connection to the outside world, but the platform UI running in your browser can still make outbound requests to external services.
+
+You can configure the platform to restrict the requests browsers will make when running the platform UI.
+
+Add this to your `vcluster-platform.yaml` as a sensible baseline:
+```yaml title="vcluster-platform.yaml"
+config:
+  uiSettings:
+    externalURLs:
+      block: true
+      allow:
+      - vcluster
+      - gtm
+      - featurebase
+```
+
+You can add any origin you need to access from the browser UI to the `allow` list. The platform uses [Content Security Policies (CSPs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) to restrict access to external URLs.
+For example, if you add custom JavaScript or CSS files from another domain, add `assets.my-domain.com/*` to the allow list.
+
+In addition to plain URLs we've bundled commonly used ones into predefined "modules". It's recommended to add them to the allow list:
+- `vcluster`: Allows the UI to make requests to `*.loft.sh` to fetch the latest license information and assets.
+- `gtm`: Allows the UI to include Google Tag Manager to improve the user experience and add in-product guides
+- `featurebase`: Allows the UI to fetch and display the changelog of new releases
+
+</details>
+
 ### Install the platform {#install-platform}
 
 It is recommended to install vCluster Platform on its own host cluster.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds a new section to the airgapped docs explaining `config.uiSettings.externalURLs` to restrict what the platform UI can access


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-594

