### PR TITLE
chore(infra): redirects after docs folder reorganization

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -361,6 +361,104 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   from = "/docs/platform-ui-link/vcluster/vcluster-yaml/:version"
   to = "/docs/vcluster/:version/configure/vcluster-yaml/"
 
+## Redirect old deploy structure to new locations
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/basics"
+  to = "/docs/vcluster/deploy/control-plane/container/basics"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/basics"
+  to = "/docs/vcluster/deploy/control-plane/container/basics"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/flux"
+  to = "/docs/vcluster/deploy/control-plane/container/flux"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/flux"
+  to = "/docs/vcluster/deploy/control-plane/container/flux"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/environment/*"
+  to = "/docs/vcluster/deploy/control-plane/container/environment/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/environment/*"
+  to = "/docs/vcluster/deploy/control-plane/container/environment/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/security/*"
+  to = "/docs/vcluster/deploy/control-plane/container/security/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/security/*"
+  to = "/docs/vcluster/deploy/control-plane/container/security/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/topologies/high-availability"
+  to = "/docs/vcluster/deploy/control-plane/container/high-availability"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/topologies/high-availability"
+  to = "/docs/vcluster/deploy/control-plane/container/high-availability"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/topologies/air-gapped"
+  to = "/docs/vcluster/deploy/control-plane/container/security/air-gapped"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/topologies/air-gapped"
+  to = "/docs/vcluster/deploy/control-plane/container/security/air-gapped"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/topologies/isolated-control-plane"
+  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-control-plane"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/topologies/isolated-control-plane"
+  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-control-plane"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/deploy/topologies/isolated-workloads"
+  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-workloads"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/vcluster/*/deploy/topologies/isolated-workloads"
+  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-workloads"
+  status = 301
+  force = true
+
 [[redirects]]
   from = "/docs/vcluster/0.27.0/*"
   to = "/docs/vcluster/:splat"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-1042--vcluster-docs-site.netlify.app/docs/vcluster/deploy/control-plane/container/basics

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-905

