### PR TITLE
fix(infra): redirects should contain the plugin name

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -361,7 +361,17 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   from = "/docs/platform-ui-link/vcluster/vcluster-yaml/:version"
   to = "/docs/vcluster/:version/configure/vcluster-yaml/"
 
-## Redirect old deploy structure to new locations
+## Redirect paths missing /vcluster/ to correct locations with /vcluster/
+# This handles cases where links are generated without the /vcluster/ prefix
+
+[[redirects]]
+  from = "/docs/deploy/*"
+  to = "/docs/vcluster/deploy/:splat"
+  status = 301
+  force = true
+
+## Redirect OLD deploy structure to NEW locations
+# For current/main docs only - versions 0.26.0 and below keep their old structure
 
 [[redirects]]
   from = "/docs/vcluster/deploy/basics"
@@ -370,8 +380,8 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/*/deploy/basics"
-  to = "/docs/vcluster/deploy/control-plane/container/basics"
+  from = "/docs/vcluster/deploy/basics/*"
+  to = "/docs/vcluster/deploy/control-plane/container/basics/:splat"
   status = 301
   force = true
 
@@ -382,19 +392,13 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/*/deploy/flux"
-  to = "/docs/vcluster/deploy/control-plane/container/flux"
+  from = "/docs/vcluster/deploy/flux/*"
+  to = "/docs/vcluster/deploy/control-plane/container/flux/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "/docs/vcluster/deploy/environment/*"
-  to = "/docs/vcluster/deploy/control-plane/container/environment/:splat"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/docs/vcluster/*/deploy/environment/*"
   to = "/docs/vcluster/deploy/control-plane/container/environment/:splat"
   status = 301
   force = true
@@ -406,19 +410,7 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/*/deploy/security/*"
-  to = "/docs/vcluster/deploy/control-plane/container/security/:splat"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/docs/vcluster/deploy/topologies/high-availability"
-  to = "/docs/vcluster/deploy/control-plane/container/high-availability"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/docs/vcluster/*/deploy/topologies/high-availability"
   to = "/docs/vcluster/deploy/control-plane/container/high-availability"
   status = 301
   force = true
@@ -430,19 +422,7 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/*/deploy/topologies/air-gapped"
-  to = "/docs/vcluster/deploy/control-plane/container/security/air-gapped"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/docs/vcluster/deploy/topologies/isolated-control-plane"
-  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-control-plane"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/docs/vcluster/*/deploy/topologies/isolated-control-plane"
   to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-control-plane"
   status = 301
   force = true
@@ -454,8 +434,8 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/*/deploy/topologies/isolated-workloads"
-  to = "/docs/vcluster/deploy/worker-nodes/host-nodes/isolated-workloads"
+  from = "/docs/vcluster/deploy/topologies/*"
+  to = "/docs/vcluster/deploy/worker-nodes/:splat"
   status = 301
   force = true
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-907

