### PR TITLE
Update list-helm-versions.mdx

### DIFF
--- a/platform/_partials/install/list-helm-versions.mdx
+++ b/platform/_partials/install/list-helm-versions.mdx
@@ -2,6 +2,6 @@
 To retrieve all available versions of the platform Helm chart, run the following command:
 
 ```bash title="List available platform versions"
-helm search repo loft-sh/vcluster-platform
+helm search repo loft/vcluster-platform
 ```
 :::


### PR DESCRIPTION
Invalid repo name.

# Content Description
The helm search repo command referred to an incorrect repo name.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

