### PR TITLE
Add version to ESO integration

### DIFF
--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -6,10 +6,12 @@ import Admonition from '@theme/Admonition';
 ### Prerequisites
 
 - `kubectl` installed
-- `external-secrets` operator installed on your host cluster. See instructions at https://external-secrets.io/v0.15.1/
+- `external-secrets` operator installed on your host cluster. See instructions at https://external-secrets.io/latest/
 
 :::warning External secrets version
-This feature is currently only compatible with CRD version `v1beta1` of the `external-secrets` operator.
+By default, vCluster uses the same CRD version as the External Secrets Operator installed on your host cluster.
+The `version` field allows you to explicitly set which CRD version to use (e.g., `v1beta1` or `v1`).
+Ensure your chosen version is supported by the External Secrets Operator on your host cluster.
 :::
 
 # External secrets integration
@@ -31,6 +33,7 @@ To enable the external secret integration, set the following fields:
 integrations:
   externalSecrets:
     enabled: true
+    version: v1 # Optional. If not specified, uses the same CRD version as your host cluster's External Secrets Operator
     sync:
       toHost:
         stores:
@@ -48,8 +51,13 @@ This enables the integration and the sync for all CRDs:
 Once the virtual cluster is up and running, you can create a `SecretStore` inside the virtual cluster.
 For this guide, you use the `fake` store type, which prefills data instead of connecting to a distant secret store.
 
+:::info API Version Compatibility
+External Secrets Operator `v0.16.2` is the last supporting `v1beta1` API version.
+For `v0.17.0+` versions, it provides exclusively `v1`.
+:::
+
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: fake
@@ -73,7 +81,7 @@ This creates a corresponding store in the host cluster.
 You can then create an `ExternalSecret` in the virtual cluster, which references the `SecretStore`.
 
 ```yaml
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: example


### PR DESCRIPTION
Add version to ESO integration

Implementation:
OSS -> https://github.com/loft-sh/vcluster/pull/3118
PRO -> https://github.com/loft-sh/vcluster-pro/pull/1065

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Document Preview](https://deploy-preview-1053--vcluster-docs-site.netlify.app/docs)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->

