### PR TITLE
fix(platform): remove recursive link in allowed templates

### DIFF
--- a/platform/understand/what-are-templates.mdx
+++ b/platform/understand/what-are-templates.mdx
@@ -23,4 +23,4 @@ Templates can include settings such as:
 
 Templates are created at a global level, but to use a template, they need to be given permission to be allowed in a given project.
 
-Read more about how to [allow templates in a project](../understand/what-are-templates.mdx).
+Read more about how to [allow templates in a project](../administer/templates/create-templates#management-access).

--- a/platform_versioned_docs/version-4.2.0/understand/what-are-templates.mdx
+++ b/platform_versioned_docs/version-4.2.0/understand/what-are-templates.mdx
@@ -19,8 +19,8 @@ Templates can include settings such as:
 - Kubernetes objects (including CRDs for virtual clusters). This could include development tooling, pre-populated databases with test data, or any other useful resources.
 - Custom defined [Apps](what-are-apps.mdx)
 
-## Allowing Templates in Projects
+## Allow templates in projects
 
-Templates are created at a global level, but in order to use a template, they need to be given permission to be allowed in a given project.
+Templates are created at a global level, but to use a template, they need to be given permission to be allowed in a given project.
 
-Read more about how to [allow templates in a project](../understand/what-are-templates.mdx).
+Read more about how to [allow templates in a project](../administer/projects/allowed/templates).

--- a/platform_versioned_docs/version-4.3.0/understand/what-are-templates.mdx
+++ b/platform_versioned_docs/version-4.3.0/understand/what-are-templates.mdx
@@ -23,4 +23,4 @@ Templates can include settings such as:
 
 Templates are created at a global level, but to use a template, they need to be given permission to be allowed in a given project.
 
-Read more about how to [allow templates in a project](../understand/what-are-templates.mdx).
+Read more about how to [allow templates in a project](../administer/templates/create-templates#management-access).


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-1054--vcluster-docs-site.netlify.app/docs/platform/understand/what-are-templates

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-902

