### PR TITLE
fix(infra): safari renders diagrams incorreclty with htmlLabels

### DIFF
--- a/platform/index.mdx
+++ b/platform/index.mdx
@@ -24,16 +24,16 @@ section](/platform/understand/what-are-projects).
 
 vCluster Platform is installed into, and can connect to, as many physical Kubernetes clusters as you need to manage. vCluster Platform can then be used to manage workloads in each of the physical clusters, deploying spaces, virtual clusters, and apps as needed. vCluster Platform provides granular role based access control (RBAC) allowing for vCluster Platform administrators to limit which users and teams have access to which clusters, as well as much more granular control at the project, space, and virtual cluster levels. Read more about vCluster Platform integration with physical clusters in the [Clusters section ](understand/what-are-clusters.mdx).
 
-### Virtual Clusters
+### Virtual clusters
 
 Virtual clusters are _virtual_ Kubernetes clusters. These virtual clusters run inside a namespace within the "parent" or "host" physical cluster, thereby allowing administrators to effectively create many Kubernetes instance in a single instance -- ideal for development, testing, and even production workloads. See the [Virtual Clusters section](understand/what-are-virtual-clusters.mdx) for details.
 
 ### Apps
 
 Apps allow users to define applications that users can then be empowered to deploy in clusters, spaces, and virtual clusters they have appropriate access to. The idea here is nothing new, however, vCluster Platform's Apps interface allows for easily packaging applications, and critically, exposing parameters that users can then select or input at deployment time. Apps can be specified via Kubernetes Manifests,
-bash scripts, helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
+bash scripts, Helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
 
-### Cost Reduction Tools
+### Cost reduction tools
 
 vCluster Platform provides features to reduce Kubernetes costs.
 
@@ -57,18 +57,59 @@ minutes)
 
   All requests that are made through vCluster Platform count as activity in the namespace.
 
-```mermaid
-flowchart LR;
-  kubectl("<code>kubectl get pod my-pod</code>") --> Platform
-
-  Platform("vCluster Platform")
-
-  Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
-  Cluster --> Pod("apiVersion: v1<br/>kind: Pod<br/>metadata:<br/>  name: my-pod<br/>...")
-
-  class kubectl code
-  class Pod yaml
-  class Platform platform
-```
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '2em 0'}}>
+  <div style={{display: 'flex', alignItems: 'center', gap: '2em'}}>
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '14px'
+    }}>
+      $ kubectl get pod my-pod
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      vCluster Platform
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      <div style={{marginBottom: '0.5em'}}>Connected Cluster</div>
+      <div style={{fontSize: '12px'}}>Kubernetes API Server</div>
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '12px'
+    }}>
+      <div>apiVersion: v1</div>
+      <div>kind: Pod</div>
+      <div>metadata:</div>
+      <div style={{paddingLeft: '1em'}}>name: my-pod</div>
+      <div>...</div>
+    </div>
+  </div>
+</div>
 
   If your kube-context points to vCluster Platform's API server as a proxy before the actual connected cluster's API server, every `kubectl` request will be an activity and reset the inactivity timeout.

--- a/platform_versioned_docs/version-4.2.0/index.mdx
+++ b/platform_versioned_docs/version-4.2.0/index.mdx
@@ -24,16 +24,16 @@ section](/platform/understand/what-are-projects).
 
 vCluster Platform is installed into, and can connect to, as many physical Kubernetes clusters as you need to manage. vCluster Platform can then be used to manage workloads in each of the physical clusters, deploying spaces, virtual clusters, and apps as needed. vCluster Platform provides granular role based access control (RBAC) allowing for vCluster Platform administrators to limit which users and teams have access to which clusters, as well as much more granular control at the project, space, and virtual cluster levels. Read more about vCluster Platform integration with physical clusters in the [Clusters section ](understand/what-are-clusters.mdx).
 
-### Virtual Clusters
+### Virtual clusters
 
 Virtual clusters are _virtual_ Kubernetes clusters. These virtual clusters run inside a namespace within the "parent" or "host" physical cluster, thereby allowing administrators to effectively create many Kubernetes instance in a single instance -- ideal for development, testing, and even production workloads. See the [Virtual Clusters section](understand/what-are-virtual-clusters.mdx) for details.
 
 ### Apps
 
 Apps allow users to define applications that users can then be empowered to deploy in clusters, spaces, and virtual clusters they have appropriate access to. The idea here is nothing new, however, vCluster Platform's Apps interface allows for easily packaging applications, and critically, exposing parameters that users can then select or input at deployment time. Apps can be specified via Kubernetes Manifests,
-bash scripts, helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
+bash scripts, Helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
 
-### Cost Reduction Tools
+### Cost reduction tools
 
 vCluster Platform provides features to reduce Kubernetes costs.
 
@@ -57,18 +57,59 @@ minutes)
 
   All requests that are made through vCluster Platform count as activity in the namespace.
 
-```mermaid
-flowchart LR;
-  kubectl("<code>kubectl get pod my-pod</code>") --> Platform
-
-  Platform("vCluster Platform")
-
-  Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
-  Cluster --> Pod("apiVersion: v1<br/>kind: Pod<br/>metadata:<br/>  name: my-pod<br/>...")
-
-  class kubectl code
-  class Pod yaml
-  class Platform platform
-```
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '2em 0'}}>
+  <div style={{display: 'flex', alignItems: 'center', gap: '2em'}}>
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '14px'
+    }}>
+      $ kubectl get pod my-pod
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      vCluster Platform
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      <div style={{marginBottom: '0.5em'}}>Connected Cluster</div>
+      <div style={{fontSize: '12px'}}>Kubernetes API Server</div>
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '12px'
+    }}>
+      <div>apiVersion: v1</div>
+      <div>kind: Pod</div>
+      <div>metadata:</div>
+      <div style={{paddingLeft: '1em'}}>name: my-pod</div>
+      <div>...</div>
+    </div>
+  </div>
+</div>
 
   If your kube-context points to vCluster Platform's API server as a proxy before the actual connected cluster's API server, every `kubectl` request will be an activity and reset the inactivity timeout.

--- a/platform_versioned_docs/version-4.3.0/index.mdx
+++ b/platform_versioned_docs/version-4.3.0/index.mdx
@@ -24,16 +24,16 @@ section](/platform/understand/what-are-projects).
 
 vCluster Platform is installed into, and can connect to, as many physical Kubernetes clusters as you need to manage. vCluster Platform can then be used to manage workloads in each of the physical clusters, deploying spaces, virtual clusters, and apps as needed. vCluster Platform provides granular role based access control (RBAC) allowing for vCluster Platform administrators to limit which users and teams have access to which clusters, as well as much more granular control at the project, space, and virtual cluster levels. Read more about vCluster Platform integration with physical clusters in the [Clusters section ](understand/what-are-clusters.mdx).
 
-### Virtual Clusters
+### Virtual clusters
 
 Virtual clusters are _virtual_ Kubernetes clusters. These virtual clusters run inside a namespace within the "parent" or "host" physical cluster, thereby allowing administrators to effectively create many Kubernetes instance in a single instance -- ideal for development, testing, and even production workloads. See the [Virtual Clusters section](understand/what-are-virtual-clusters.mdx) for details.
 
 ### Apps
 
 Apps allow users to define applications that users can then be empowered to deploy in clusters, spaces, and virtual clusters they have appropriate access to. The idea here is nothing new, however, vCluster Platform's Apps interface allows for easily packaging applications, and critically, exposing parameters that users can then select or input at deployment time. Apps can be specified via Kubernetes Manifests,
-bash scripts, helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
+bash scripts, Helm charts, etc. See the [Apps section](understand/what-are-apps.mdx), and be sure to learn about [versioning](administer/templates/versioning.mdx) and [parameters](administer/templates/parameters.mdx).
 
-### Cost Reduction Tools
+### Cost reduction tools
 
 vCluster Platform provides features to reduce Kubernetes costs.
 
@@ -57,18 +57,59 @@ minutes)
 
   All requests that are made through vCluster Platform count as activity in the namespace.
 
-```mermaid
-flowchart LR;
-  kubectl("<code>kubectl get pod my-pod</code>") --> Platform
-
-  Platform("vCluster Platform")
-
-  Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
-  Cluster --> Pod("apiVersion: v1<br/>kind: Pod<br/>metadata:<br/>  name: my-pod<br/>...")
-
-  class kubectl code
-  class Pod yaml
-  class Platform platform
-```
+<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '2em 0'}}>
+  <div style={{display: 'flex', alignItems: 'center', gap: '2em'}}>
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '14px'
+    }}>
+      $ kubectl get pod my-pod
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      vCluster Platform
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd'
+    }}>
+      <div style={{marginBottom: '0.5em'}}>Connected Cluster</div>
+      <div style={{fontSize: '12px'}}>Kubernetes API Server</div>
+    </div>
+    
+    <div style={{fontSize: '24px'}}>→</div>
+    
+    <div style={{
+      background: '#f0f0f0',
+      padding: '1em',
+      borderRadius: '8px',
+      border: '2px solid #ddd',
+      fontFamily: 'monospace',
+      fontSize: '12px'
+    }}>
+      <div>apiVersion: v1</div>
+      <div>kind: Pod</div>
+      <div>metadata:</div>
+      <div style={{paddingLeft: '1em'}}>name: my-pod</div>
+      <div>...</div>
+    </div>
+  </div>
+</div>
 
   If your kube-context points to vCluster Platform's API server as a proxy before the actual connected cluster's API server, every `kubectl` request will be an activity and reset the inactivity timeout.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-914

