### PR TITLE
chore(infra): switch on pretty URLs to force trailing slash

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,12 @@ command = """
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
+[build.processing]
+  skip = false
+
+[build.processing.html]
+  pretty_urls = true
+
 [[redirects]]
   from = "/docs/architecture/*"
   to = "/docs/vcluster/introduction/architecture/"
@@ -367,11 +373,6 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   to = "/docs/vcluster/deploy/:splat"
   status = 301
 
-[[redirects]]
-  from = "/docs/vcluster"
-  to = "/docs/vcluster/"
-  status = 301
-  force = false
 
 [[redirects]]
   from = "/docs/vcluster/0.27.0/*"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
To force netlify and docusarus to correctly redirect base urls and add traling / we need to enable pretty urls:

- https://docs.netlify.com/build/post-processing/overview/#post-processing-features
- https://answers.netlify.com/t/support-guide-how-can-i-alter-trailing-slash-behaviour-in-my-urls-will-enabling-pretty-urls-help/31191

> When Pretty URLs are enabled (which is the default), Netlify will:

    Redirect /about.html to /about
    Rewrite links in your HTML from /about.html to /about
    Forward /about to /about/ for directory-style navigation

> This helps avoid duplicate content and improves SEO by standardizing URLs.
You cannot use redirect rules to add or remove trailing slashes; this is handled by the Pretty URLs feature and Netlify's CDN normalization. Redirect rules will match both with and without trailing slashes, so you can't enforce one or the other using redirects alone.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-1063--vcluster-docs-site.netlify.app/

### How to test
- see if you are redirected from https://deploy-preview-1063--vcluster-docs-site.netlify.app/docs/vcluster -> https://deploy-preview-1063--vcluster-docs-site.netlify.app/docs/vcluster/
- click on regular links, menu, breadcrumbs and algolia search.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

