### PR TITLE
fix: use empty object for dedicated access key

### DIFF
--- a/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -177,7 +177,7 @@ The `vcluster.yaml` file is typically stored locally in your project folder or p
 
     ```yaml title="vcluster.yaml"
     external:
-      platform:
+      platform: {}
     ```
 
 :::note
@@ -256,7 +256,7 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 
     ```yaml title="Dedicated access key example"
     external:
-      platform:
+      platform: {}
     ```
 
   </TabItem>

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -173,7 +173,7 @@ The `vcluster.yaml` file is typically stored locally in your project folder or p
 
     ```yaml title="vcluster.yaml"
     external:
-      platform:
+      platform: {}
     ```
 
 :::note
@@ -252,7 +252,7 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 
     ```yaml title="Dedicated access key example"
     external:
-      platform:
+      platform: {}
     ```
 
   </TabItem>

--- a/vcluster_versioned_docs/version-0.25.0/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -173,7 +173,7 @@ The `vcluster.yaml` file is typically stored locally in your project folder or p
 
     ```yaml title="vcluster.yaml"
     external:
-      platform:
+      platform: {}
     ```
 
 :::note
@@ -252,7 +252,7 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 
     ```yaml title="Dedicated access key example"
     external:
-      platform:
+      platform: {}
     ```
 
   </TabItem>

--- a/vcluster_versioned_docs/version-0.26.0/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -173,7 +173,7 @@ The `vcluster.yaml` file is typically stored locally in your project folder or p
 
     ```yaml title="vcluster.yaml"
     external:
-      platform:
+      platform: {}
     ```
 
 :::note
@@ -252,7 +252,7 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 
     ```yaml title="Dedicated access key example"
     external:
-      platform:
+      platform: {}
     ```
 
   </TabItem>

--- a/vcluster_versioned_docs/version-0.27.0/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster_versioned_docs/version-0.27.0/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -177,7 +177,7 @@ The `vcluster.yaml` file is typically stored locally in your project folder or p
 
     ```yaml title="vcluster.yaml"
     external:
-      platform:
+      platform: {}
     ```
 
 :::note
@@ -256,7 +256,7 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 
     ```yaml title="Dedicated access key example"
     external:
-      platform:
+      platform: {}
     ```
 
   </TabItem>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

