### PR TITLE
Add custom schedulers example

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -49,17 +49,24 @@ sync:
         team: backend
 ```
 
+:::tip Example
+
+Checkout [this guide](../../../../../../learn-how-to/control-plane/container/use-custom-schedulers) that shows how to deploy
+custom host and virtual schedulers and use them with Hybrid scheduling.
+
+:::
+
 ## Use host schedulers
 
 `sync.toHost.pods.hybridScheduling.hostSchedulers` specifies a list of schedulers available on the host cluster that virtual cluster pods can use.
 
-The default Kubernetes scheduler on the host cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.  
+The default Kubernetes scheduler on the host cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.
 
 A default scheduler can be used in two ways: by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`. In both cases, the default Kubernetes scheduler running on the host cluster schedules the pod.
 
 ### Use custom host schedulers
 
-The following hybrid scheduling configuration allows virtual cluster pods to use the host cluster's custom schedulers my-custom-scheduler and my-gpu-scheduler. 
+The following hybrid scheduling configuration allows virtual cluster pods to use the host cluster's custom schedulers my-custom-scheduler and my-gpu-scheduler.
 
 :::note
 This example omits the full vCluster configuration to highlight the relevant hybrid scheduling settings.
@@ -102,7 +109,7 @@ spec:
 
 ## Use custom virtual schedulers
 
-Virtual cluster pods can use a custom scheduler that runs inside the virtual cluster.  
+Virtual cluster pods can use a custom scheduler that runs inside the virtual cluster.
 To ensure these pods are scheduled correctly, **do not** include virtual schedulers in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list in your vCluster configuration.
 
 The following example shows the hybrid scheduling configuration and a pod that uses the `my-virtual-ai-scheduler` running in the virtual cluster.

--- a/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
+++ b/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
@@ -387,7 +387,7 @@ pod-uses-host-scheduler      my-host-scheduler
 pod-uses-virtual-scheduler   my-virtual-scheduler
 ```
 
-## Troubleshooting
+## Troubleshoot
 
 - No nodes in the virtual cluster:
   - Ensure `sync.fromHost.nodes.enabled` is `true` and that your host cluster has Ready nodes.

--- a/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
+++ b/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
@@ -1,0 +1,325 @@
+---
+title: Use custom schedulers with Hybrid Scheduling
+sidebar_label: Use custom schedulers
+sidebar_position: 6
+description: How to deploy and use custom schedulers in both host and virtual cluster
+---
+
+import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+
+<TenancySupport hostNodes="true" />
+
+This guide shows how to deploy custom schedulers in both host and virtual cluster, and then use both of them in your
+virtual cluster, by enabling Hybrid Scheduling.
+
+## Prerequisites
+
+Before you begin, ensure you have installed:
+- kind,
+- vcluster CLI.
+
+## Create host and virtual cluster
+
+Create kind host cluster:
+
+```shell
+kind create cluster --name scheduler-demo
+```
+
+Next, create vCluster config file which enables and configures Hybrid Scheduling:
+
+```shell
+cat > my-vcluster.yaml <<EOF
+sync:
+  toHost:
+    pods:
+      hybridScheduling:
+        enabled: true
+        hostSchedulers:
+          - my-host-scheduler
+  fromHost:
+    nodes:
+      enabled: true
+EOF
+```
+
+Finally, create virtual cluster with Hybrid Scheduling enabled:
+
+```shell
+vcluster create -n my-vcluster my-vcluster --values my-vcluster.yaml
+```
+
+## Deploy custom host scheduler
+
+Create file `custom-host-scheduler.yaml` with the following Kubernetes manifests:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-scheduler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-scheduler-as-kube-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-scheduler-as-volume-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-scheduler-extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-scheduler-config
+  namespace: kube-system
+data:
+  my-scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: my-host-scheduler
+    leaderElection:
+      leaderElect: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: my-kube-scheduler
+    tier: control-plane
+  name: my-kube-scheduler
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      component: my-kube-scheduler
+      tier: control-plane
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: my-kube-scheduler
+        tier: control-plane
+    spec:
+      serviceAccountName: my-scheduler
+      containers:
+        - command:
+            - kube-scheduler
+            - --config=/etc/kubernetes/my-scheduler/my-scheduler-config.yaml
+          image: registry.k8s.io/kube-scheduler:v1.33.4
+          imagePullPolicy: IfNotPresent
+          name: kube-scheduler
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/kubernetes/my-scheduler
+          securityContext:
+            privileged: false
+      volumes:
+        - name: config-volume
+          configMap:
+            name: my-scheduler-config
+```
+
+Apply manifests to host cluster:
+
+```shell
+kubectl --context=kind-scheduler-demo apply -f custom-host-scheduler.yaml
+```
+
+## Deploy custom host scheduler
+
+Create file `custom-virtual-scheduler.yaml` with the following Kubernetes manifests:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-scheduler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-scheduler-as-kube-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: my-scheduler-as-volume-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-scheduler-extension-apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: my-scheduler
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-scheduler-config
+  namespace: kube-system
+data:
+  my-scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: my-virtual-scheduler
+    leaderElection:
+      leaderElect: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: my-kube-scheduler
+    tier: control-plane
+  name: my-kube-scheduler
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      component: my-kube-scheduler
+      tier: control-plane
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: my-kube-scheduler
+        tier: control-plane
+    spec:
+      serviceAccountName: my-scheduler
+      containers:
+        - command:
+            - kube-scheduler
+            - --config=/etc/kubernetes/my-scheduler/my-scheduler-config.yaml
+          image: registry.k8s.io/kube-scheduler:v1.33.4
+          imagePullPolicy: IfNotPresent
+          name: kube-scheduler
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/kubernetes/my-scheduler
+          securityContext:
+            privileged: false
+      volumes:
+        - name: config-volume
+          configMap:
+            name: my-scheduler-config
+```
+
+Apply manifests to virtual cluster:
+
+```shell
+kubectl --context=vcluster_my-vcluster_my-vcluster_kind-scheduler-demo apply -f custom-virtual-scheduler.yaml
+```
+
+## Deploy pods that use custom schedulers
+
+Now, create the following `pods.yaml` manifest with pods that are using different schedulers - one pod is using the
+default scheduler, one pod is using the custom host scheduler, and one pod is using the custom virtual scheduler.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-uses-default-scheduler
+spec:
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.9
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-uses-virtual-scheduler
+spec:
+  schedulerName: my-virtual-scheduler
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.9
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-uses-host-scheduler
+spec:
+  schedulerName: my-host-scheduler
+  containers:
+    - name: pause
+      image: registry.k8s.io/pause:3.9
+```
+
+Create pods:
+
+```
+kubectl --context=vcluster_my-vcluster_my-vcluster_kind-scheduler-demo apply -f pods.yaml
+```
+
+Wait until all created pods are running.
+
+Finally, you can confirm that the created pods have been scheduled with correct schedulers, by checking Kubernetes
+events:
+
+```shell
+kubectl get events -n default --field-selector reason=Scheduled -o custom-columns=POD:.involvedObject.name,SCHEDULER:.reportingComponent
+POD                          SCHEDULER
+pod-uses-default-scheduler   default-scheduler
+pod-uses-host-scheduler      my-host-scheduler
+pod-uses-virtual-scheduler   my-virtual-scheduler
+```

--- a/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
+++ b/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
@@ -16,7 +16,7 @@ virtual cluster, by enabling Hybrid Scheduling.
 
 Before you begin, ensure you have installed:
 - kind,
-- vcluster CLI.
+- vCluster CLI.
 
 ## Create host and virtual cluster
 

--- a/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
+++ b/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
@@ -5,17 +5,36 @@ sidebar_position: 6
 description: How to deploy and use custom schedulers in both host and virtual cluster
 ---
 
-import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+This guide shows how to:
+- Run a custom scheduler in the host cluster.
+- Run a custom scheduler in the virtual cluster.
+- Use vCluster Hybrid scheduling, so Pods from the virtual cluster can use schedulers from both host and virtual cluster.
 
-<TenancySupport hostNodes="true" />
+How pods are scheduled with Hybrid scheduling enabled:
+- Pods without `spec.schedulerName` use the default scheduler inside the virtual cluster.
+- Pods whose `spec.schedulerName` matches any scheduler from `sync.toHost.pods.hybridScheduling.hostSchedulers` in your
+  vCluster config are scheduled by that matching host scheduler.
+- Pods whose `spec.schedulerName` matches a scheduler running inside the virtual cluster are scheduled by that virtual
+  scheduler.
 
-This guide shows how to deploy custom schedulers in both host and virtual cluster, and then use both of them in your
-virtual cluster, by enabling Hybrid Scheduling.
+See [Hybrid scheduling](../../../configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling) docs for more details.
+
+<div className="enterprise-feature">
+:::info Enterprise feature with node synced from host to virtual
+
+Hybrid scheduling feature that is used in this guide is an Enterprise feature that is available in vCluster v0.26.0 and
+newer. It requires shared host nodes and host nodes have to be synced into the virtual cluster. This guide enables node
+syncing in the above vCluster config.
+
+:::
+</div>
 
 ## Prerequisites
 
-Before you begin, ensure you have installed:
+Before you begin, ensure you have:
 - kind,
+- container runtime that kind can use (e.g. Docker),
+- kubectl,
 - vCluster CLI.
 
 ## Create host and virtual cluster
@@ -26,7 +45,7 @@ Create kind host cluster:
 kind create cluster --name scheduler-demo
 ```
 
-Next, create vCluster config file which enables and configures Hybrid Scheduling:
+Create a vCluster config file with Hybrid scheduling enabled and node syncing from the host:
 
 ```shell
 cat > my-vcluster.yaml <<EOF
@@ -43,15 +62,25 @@ sync:
 EOF
 ```
 
-Finally, create virtual cluster with Hybrid Scheduling enabled:
+Create the virtual cluster:
 
 ```shell
 vcluster create -n my-vcluster my-vcluster --values my-vcluster.yaml
 ```
 
+Set environment variables for the kube contexts to reduce copy/paste errors:
+
+```shell
+# Host context provided by kind
+export HOST_CONTEXT=kind-scheduler-demo
+
+# vCluster context usually follows this pattern; confirm via `kubectl config get-contexts`
+export VCLUSTER_CONTEXT=vcluster_my-vcluster_my-vcluster_kind-scheduler-demo
+```
+
 ## Deploy custom host scheduler
 
-Create file `custom-host-scheduler.yaml` with the following Kubernetes manifests:
+Create `custom-host-scheduler.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -153,15 +182,30 @@ spec:
             name: my-scheduler-config
 ```
 
-Apply manifests to host cluster:
+:::tip
+Use a kube-scheduler image tag compatible with your cluster’s Kubernetes version (minor version should match). The
+example above uses tag `v1.33.4` (the latest GA version at the time of writing); adjust if your control plane is on a
+different minor version.
+:::
+
+:::caution
+`leaderElection` is disabled for simplicity (a single replica). For high availability setup, enable leader election and
+run multiple replicas.
+:::
+
+Apply manifests in the host cluster:
 
 ```shell
-kubectl --context=kind-scheduler-demo apply -f custom-host-scheduler.yaml
+# deploy custom host scheduler
+kubectl --context="${HOST_CONTEXT}" apply -f custom-host-scheduler.yaml
+
+# check the status of the deployment
+kubectl --context="${HOST_CONTEXT}" -n kube-system rollout status deploy/my-kube-scheduler
 ```
 
-## Deploy custom host scheduler
+## Deploy custom virtual scheduler
 
-Create file `custom-virtual-scheduler.yaml` with the following Kubernetes manifests:
+Create `custom-virtual-scheduler.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -263,16 +307,22 @@ spec:
             name: my-scheduler-config
 ```
 
-Apply manifests to virtual cluster:
+Apply manifests in the virtual cluster:
 
 ```shell
-kubectl --context=vcluster_my-vcluster_my-vcluster_kind-scheduler-demo apply -f custom-virtual-scheduler.yaml
+# deploy custom virtual scheduler
+kubectl --context="${VCLUSTER_CONTEXT}" apply -f custom-virtual-scheduler.yaml
+
+# check the status of the deployment
+kubectl --context="${VCLUSTER_CONTEXT}" -n kube-system rollout status deploy/my-kube-scheduler
 ```
 
-## Deploy pods that use custom schedulers
+## Deploy pods that use different schedulers
 
-Now, create the following `pods.yaml` manifest with pods that are using different schedulers - one pod is using the
-default scheduler, one pod is using the custom host scheduler, and one pod is using the custom virtual scheduler.
+Now, create `pods.yaml` with pods that are using different schedulers:
+- one pod is using the default scheduler,
+- one pod is using the custom host scheduler, and
+- one pod is using the custom virtual scheduler.
 
 ```yaml
 apiVersion: v1
@@ -305,21 +355,59 @@ spec:
       image: registry.k8s.io/pause:3.9
 ```
 
-Create pods:
-
-```
-kubectl --context=vcluster_my-vcluster_my-vcluster_kind-scheduler-demo apply -f pods.yaml
-```
-
-Wait until all created pods are running.
-
-Finally, you can confirm that the created pods have been scheduled with correct schedulers, by checking Kubernetes
-events:
+Apply the manifest in the virtual cluster:
 
 ```shell
-kubectl get events -n default --field-selector reason=Scheduled -o custom-columns=POD:.involvedObject.name,SCHEDULER:.reportingComponent
+# deploy pods
+kubectl --context="${VCLUSTER_CONTEXT}" apply -f pods.yaml
+
+# wait until all created pods are running
+kubectl --context="${VCLUSTER_CONTEXT}" get pods -w
+```
+
+## Verify which scheduler handled each pod
+
+First check which scheduler should schedule each pod:
+
+```shell
+kubectl --context="${VCLUSTER_CONTEXT}" get pods -n default -o custom-columns=NAME:.metadata.name,SCHEDULER:.spec.schedulerName
+NAME                         SCHEDULER
+pod-uses-default-scheduler   default-scheduler
+pod-uses-host-scheduler      my-host-scheduler
+pod-uses-virtual-scheduler   my-virtual-scheduler
+```
+
+Finally, confirm via events which scheduler actually scheduled the pod:
+
+```shell
+kubectl --context="${VCLUSTER_CONTEXT}" get events -n default --field-selector reason=Scheduled -o custom-columns=POD:.involvedObject.name,SCHEDULER:.reportingComponent
 POD                          SCHEDULER
 pod-uses-default-scheduler   default-scheduler
 pod-uses-host-scheduler      my-host-scheduler
 pod-uses-virtual-scheduler   my-virtual-scheduler
+```
+
+## Troubleshooting
+
+- No nodes in the virtual cluster:
+  - Ensure `sync.fromHost.nodes.enabled` is `true` and that your host cluster has Ready nodes.
+- Pod stuck in Pending:
+  - Check the scheduler’s logs:
+    - Host: `kubectl --context="${HOST_CONTEXT}" -n kube-system logs deploy/my-kube-scheduler`
+    - Virtual: `kubectl --context="${VCLUSTER_CONTEXT}" -n kube-system logs deploy/my-kube-scheduler`
+  - Ensure pod's `spec.schedulerName` (if set) matches either a virtual scheduler name or a name listed under hostSchedulers.
+- Scheduler name not set when checking events:
+  - Get events with `kubectl --context="${VCLUSTER_CONTEXT}" get events -n default -o yaml`
+    - Inspect `.reportingComponent` (for core `v1` API) or `.reportingController` (for `events.k8s.io/v1` API), as
+      scheduler name (from `KubeSchedulerConfiguration`) should be set in these fields.
+    - Inspect `.reportingInstance` where scheduler pod name should be set.
+
+## Cleanup
+
+```shell
+# Delete the virtual cluster
+vcluster delete -n my-vcluster my-vcluster
+
+# Delete the kind cluster
+kind delete cluster --name scheduler-demo
 ```

--- a/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
+++ b/vcluster/learn-how-to/control-plane/container/use-custom-schedulers.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use custom schedulers with Hybrid Scheduling
+title: Use custom schedulers with Hybrid scheduling
 sidebar_label: Use custom schedulers
 sidebar_position: 6
 description: How to deploy and use custom schedulers in both host and virtual cluster


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Add guide that shows how to deploy custom schedulers in both host and virtual cluster, and then use both of them in a virtual cluster, by enabling Hybrid Scheduling.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Custom schedulers with Hybrid scheduling example preview](https://deploy-preview-1076--vcluster-docs-site.netlify.app/docs/vcluster/next/learn-how-to/control-plane/container/use-custom-schedulers)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-725

