### PR TITLE
Fix: Prefer 'virtual cluster' over 'vCluster' when appropriate

### DIFF
--- a/vcluster/deploy/control-plane/container/environment/netris.mdx
+++ b/vcluster/deploy/control-plane/container/environment/netris.mdx
@@ -10,7 +10,7 @@ One deployment model for vCluster is through private nodes.
 It allows for stronger isolation between the virtual clusters, since the virtual cluster Pods don't share the same Nodes.
 However, the network of a virtual cluster is not isolated from other workloads by default.
 
-This guide shows how to isolate a vCluster spanning mixed bare metal and VM private nodes that share the same underlying hardware with an exclusive network using VLAN and [Netris](https://netris.ai/).
+This guide shows how to isolate a virtual cluster spanning mixed bare metal and VM private nodes that share the same underlying hardware with an exclusive network using VLAN and [Netris](https://netris.ai/).
 
 ![Architecture](/img/netris_architecture.svg)
 
@@ -18,15 +18,15 @@ After preparing the host cluster, we will:
 
 1. Configure the VLAN membership of the switch ports with Netris
 2. Deploy the vCluster control plane on the VLAN with a load balancer
-3. Create a VM as a private node in the vCluster
-4. Provision a bare metal server as a private node in the vCluster
+3. Create a VM as a private node in the virtual cluster
+4. Provision a bare metal server as a private node in the virtual cluster
 
 Like in traditional Kubernetes clusters, Nodes share the same L2 domain.
 Instead of control plane _nodes_, the vCluster control plane runs as (multihomed) Pods in the host cluster.
-This is transparent to the vCluster, however the host cluster remains inaccessible to the vCluster.
+This is transparent to the virtual cluster, however, the host cluster remains inaccessible.
 
 This can be repeated for any number of clusters, and it's limited mainly by compute resources and VLAN ids or what the switch can handle.
-The VPCs of each vCluster may also be peered to access shared services across clusters.
+The VPCs of each virtual cluster may also be peered to access shared services across clusters.
 
 ## Netris
 
@@ -61,7 +61,7 @@ It is advisable to install Kubernetes after the network has been configured acco
 ### Configure switch fabric
 
 The host cluster gets its own VLAN, which spans all shared servers.
-In contrast to the vCluster, the VLAN traffic for the host cluster is untagged, so no special considerations are necessary in the nodes' OS.
+In contrast to the virtual cluster, the VLAN traffic for the host cluster is untagged, so no special considerations are necessary in the nodes' OS.
 
 1. Create ServerClusterTemplate in Netris
 
@@ -113,20 +113,20 @@ We have tested the following plugins:
 ### Install tooling
 
 There are a few tools we need to install in the host cluster.
-They manage interfaces on the host cluster nodes that allow adding Pods and VMs to the vCluster VLAN.
+They manage interfaces on the host cluster nodes that allow adding Pods and VMs to the virtual cluster VLAN.
 
 #### Multus
 
 See install instructions in [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni).
 
-Multus adds additional interfaces to the vCluster Pods and KubeVirt VMs to attach them to the vCluster VLAN.
+Multus adds additional interfaces to the vCluster control plane Pods and KubeVirt VMs to attach them to the virtual cluster VLAN.
 
 #### Bridge operator
 
 See install instructions in [Bridge operator](https://github.com/k8snetworkplumbingwg/bridge-operator).
 
-The Bridge operator creates an unfiltered bridge on the host for the vCluster VLAN.
-It's connected to a VLAN interface that tags any egress traffic to put it on the vCluster VLAN.
+The Bridge operator creates an unfiltered bridge on the host for the virtual cluster VLAN.
+It's connected to a VLAN interface that tags any egress traffic to put it on the virtual cluster VLAN.
 
 Multiple Pods and VMs can be connected to the same bridge on the same host.
 
@@ -134,7 +134,7 @@ Multiple Pods and VMs can be connected to the same bridge on the same host.
 
 See install instructions in [Whereabouts IPAM plugin](https://github.com/k8snetworkplumbingwg/whereabouts).
 
-The _Whereabouts_ IPAM plugin assigns well-known IPs to the vCluster Pods.
+The _Whereabouts_ IPAM plugin assigns well-known IPs to the vCluster control plane Pods.
 It tracks the allocations of the pool cluster-wide, to avoid IP conflicts across different nodes.
 
 <!-- vale off -->
@@ -160,11 +160,11 @@ vcluster platform start
 
 Provide your email address and complete the onboarding process in the browser.
 
-## Deploy a vCluster
+## Deploy vCluster
 
 The following steps can be repeated for additional vCluster deployments.
 
-### Configure switch fabric for vCluster
+### Configure switch fabric for the virtual cluster
 
 1. Create ServerClusterTemplate
 
@@ -233,7 +233,7 @@ The following steps can be repeated for additional vCluster deployments.
     ```
 
     The brigde operator creates a bridge with the name `br-vlan-3` on every Node and attach the VLAN interface on top of the default interface.
-    Egress from any (VLAN unaware) device attached to the bridge is tagged and thus part of the L2 domain of the vCluster.
+    Egress from any (VLAN unaware) device attached to the bridge is tagged and thus part of the L2 domain of the virtual cluster.
     Likewise, the tag from VLAN ingress is stripped.
 
 3. Create NetworkAttachmentDefinitions
@@ -300,7 +300,7 @@ The following steps can be repeated for additional vCluster deployments.
 
 1. Create vCluster
 
-    Use the following configuration and install a vCluster in the `vcluster-netris` namespace:
+    Use the following configuration and install vCluster in the `vcluster-netris` namespace:
 
     ```yaml title="vcluster.yaml"
     controlPlane:
@@ -321,18 +321,18 @@ The following steps can be repeated for additional vCluster deployments.
       enabled: true
     ```
 
-    Connect to the host Kubernetes cluster and create the vCluster:
+    Connect to the host Kubernetes cluster and run:
 
     ```bash
     vcluster platform create vcluster -n vcluster-netris netris --values vcluster.yaml
     ```
 
-    - The vCluster Pods get an additional interface on the VLAN.
+    - The vCluster control plane Pods get an additional interface on the VLAN.
     - The endpoint is the IP of the load balancer.
 
-2. Deploy load balancer in front of vCluster Pods
+2. Deploy load balancer in front of vCluster control plane Pods
 
-    The load balancer exposes the vCluster Pods on a single IP on the subnet.
+    The load balancer exposes the vCluster control plane Pods on a single IP on the subnet.
     A kube-vip sidecar assigns the IP on only one of the load balancer Pods at a time and provides active failover.
 
     Update the target cluster address in the following manifest to `<vcluster name>.<namespace>.svc.cluster.local`:
@@ -496,7 +496,7 @@ The following steps can be repeated for additional vCluster deployments.
     Connection to 192.168.67.253 443 port [tcp/https] succeeded!
     ```
 
-    This shows that the load balancer (Pod) is a neighbor on the vCluster VLAN subnet.
+    This shows that the load balancer (Pod) is a neighbor on the virtual cluster VLAN subnet.
 
     The Pods may reside on the same host as the load balancer, in which case the traffic would remain on the bridge and never be tagged.
     To circumvent this, pick a different Pod to run the command from.
@@ -516,9 +516,9 @@ The following steps can be repeated for additional vCluster deployments.
     bond0            UP             192.168.64.9/22 metric 10 fe80::6cb4:6fff:fedb:d0bb/64
     ```
 
-3. Obtain join token from the vCluster
+3. Obtain join token from vCluster
 
-    Connect to the vCluster and run `vcluster token create`.
+    Connect to the virtual cluster and run `vcluster token create`.
     The output should be something like this:
 
     ```bash
@@ -527,12 +527,12 @@ The following steps can be repeated for additional vCluster deployments.
 
 4. Run join command on server
 
-    This downloads the necessary Kubernetes binaries and container runtime, configures Kubelet and joins the vCluster as a new node.
+    This downloads the necessary Kubernetes binaries and container runtime, configures Kubelet and joins the virtual cluster as a new node.
 
     You may have to configure NAT so the server can reach the internet or any package mirrors.
     This depends on the operating system of your choice.
 
-5. Verify that the server joined the vCluster
+5. Verify that the server joined the virtual cluster
 
     ```bash
     $ kubectl get no
@@ -542,14 +542,14 @@ The following steps can be repeated for additional vCluster deployments.
 
 ## Join VM running in host cluster infrastructure
 
-1. Obtain join token from the vCluster
+1. Obtain join token from the virtual cluster
 
     ```bash
     $ vcluster token create
     curl -sfLk "https://192.168.67.253:443/node/join?token=tvkoek.om6n9cjltoeh9g5y" | sh -
     ```
 
-2. Create a VM in the host cluster that automatically joins the vCluster
+2. Create a VM in the host cluster that automatically joins the virtual cluster
 
     We pass the join command as a cloud-init `runCmd`, so it runs after the first boot.
 
@@ -635,9 +635,9 @@ The following steps can be repeated for additional vCluster deployments.
 
     Multus creates an additional interface attached to the bridge, which becomes the default interface in the VM.
 
-    After the OS is initialized, the join command is executed, which installs Kubernetes and joins the vCluster as a new node.
+    After the OS is initialized, the join command is executed, which installs Kubernetes and joins the virtual cluster as a new node.
 
-    After a short time, the VM shows up in the vCluster:
+    After a short time, the VM shows up in the virtual cluster:
 
     ```bash
     $ kubectl get nodes -w


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
Improves wording.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-894
