### PR TITLE
Describe cert-rotation steps for auto nodes

### DIFF
--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -13,7 +13,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 vCluster client and server certificates (also called leaf certificates) remain valid for 1 year from the initial virtual cluster creation.
 By default, vCluster uses a self-signed Certificate Authority (CA) to sign these certificates. The CA certificate remains valid for 10 years.
 
-vCluster provides commands that allow you to check details about the certificates as well as rotate them. 
+vCluster provides commands that allow you to check details about the certificates as well as rotate them.
 
 :::info
 Checking and rotating certificates is only supported for virtual clusters using the k8s distribution.
@@ -98,7 +98,7 @@ CA rotation replaces the Certificate Authority that validates all certificates i
 :::
 
 When working with virtual clusters with private nodes, there are extra steps that need to happen before doing any changes to the CA certificate and
-after making the changes to the CA certificate. 
+after making the changes to the CA certificate.
 
 
 ### Rotate the CA Certificate
@@ -171,7 +171,7 @@ Log out and perform a regular leaf [certificate rotation](#rotate-client-and-ser
 </Step>
 </Flow>
 
-## Steps required for private nodes during CA changes
+## Steps required for Private Nodes during CA changes {#private-nodes-steps}
 
 :::important
 Node deletion needs to happen before any CA cert changes whether it's rotating or restoring the cert. Otherwise, the kubelet
@@ -179,12 +179,12 @@ running on the node is not able to communicate with the apiserver running with
 the updated certificate.
 :::
 
-Before changing the CA certificate, by either rotating or restoring it, you must delete all previously joined private nodes. After the rotation, 
-you must re-join the nodes again to the virtual cluster. Each step must be performed on each private node. 
+Before changing the CA certificate, by either rotating or restoring it, you must delete all previously joined private nodes. After the rotation,
+you must re-join the nodes again to the virtual cluster. Each step must be performed on each private node.
 
 ### Steps before changing the CA certificate
 
-Before changing the CA certificate, by either rotating or restoring it, you need to delete the private nodes in the virtual cluster. 
+Before changing the CA certificate, by either rotating or restoring it, you need to delete the private nodes in the virtual cluster.
 
 <Flow>
 <Step>
@@ -201,9 +201,9 @@ Delete each private node:
 
 :::info
 `vcluster node delete` tries to evict any workload before deleting the
-node from the virtual cluster. If there's no other node for the workload to be re-scheduled to, the 
-workload stops. If you forgot to delete a node before change the CA cert, 
-you must append `--drain=false` to successfully delete the node.  
+node from the virtual cluster. If there's no other node for the workload to be re-scheduled to, the
+workload stops. If you forgot to delete a node before change the CA cert,
+you must append `--drain=false` to successfully delete the node.
 :::
 
 <InterpolatedCodeBlock
@@ -216,8 +216,8 @@ you must append `--drain=false` to successfully delete the node.
 
 ### Steps after changing the CA certificate
 
-After changing the CA certificate, by either rotating or restoring it, you need to re-create a token to join the virtual cluster 
-and join the private nodes back to the virtual cluster. 
+After changing the CA certificate, by either rotating or restoring it, you need to re-create a token to join the virtual cluster
+and join the private nodes back to the virtual cluster.
 
 <Flow>
 <Step>
@@ -239,7 +239,7 @@ vcluster token create
 </Step>
 <Step>
 
-Copy the command and append the `--force-join` flag. Run the updated command on every private node. 
+Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
 :::warning
 The `--force-join` flag leads to running containers being killed via the
@@ -256,3 +256,40 @@ curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --forc
 </Step>
 
 </Flow>
+
+## Steps required for Auto Nodes during CA changes {#auto-nodes-steps}
+
+In contrast to [Private Nodes](#private-nodes-steps) there are no additional
+steps necessary before cert rotation. Though, you still have to manually delete
+all `NodeClaims` from vcluster-platform that have previously been joined to the
+virtual cluster for which the CA certificate have been rotated.
+
+:::note
+The below steps assume you have a kubectl context to access the cluster hosting
+vcluster-platform.
+:::
+
+### List current NodeClaims in connected or local vcluster-platform cluster
+
+The following example shows existing NodeClaims using kubectl:
+
+```
+kubectl get nodeclaims.management.loft.sh -A
+NAMESPACE   NAME             STATUS      VCLUSTER     NODETYPE   CREATED AT
+p-default   vcluster-4zbg8   Available   vcluster     medium     2025-08-28T11:08:18Z
+p-default   vcluster-5xtx3   Available   vcluster-2   medium     2025-08-27T10:01:33Z
+```
+
+### Delete the NodeClaim and let it be recreated automatically
+
+Say you have rotated the CA certificate of the virtual cluster names "vcluster"
+you would have to delete the NodeClaim named "vcluster-4zbg8":
+
+```
+kubectl -n p-default delete nodeclaims.management.loft.sh vcluster-4zbg8
+nodeclaim.management.loft.sh "vcluster-4zbg8" deleted
+```
+
+This will remove the NodeClaim as well as the underlying Node. The responsible
+controller will recreate the NodeClaim and re-join it to the virtual cluster
+with the new CA certificate.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-925

