### PR TITLE
feat(ci): rebase main onto next istead of merging to avoid conflicts

### DIFF
--- a/.github/workflows/sync-next-branch.yml
+++ b/.github/workflows/sync-next-branch.yml
@@ -1,5 +1,10 @@
 name: Sync Next Branch
 
+# This workflow keeps the next branch in sync with main:
+# - Tries to rebase next onto main
+# - If rebase is clean → automatically pushes to next
+# - If there are conflicts → creates a PR for manual resolution
+
 on:
   push:
     branches:
@@ -30,22 +35,22 @@ jobs:
           ./hack/sync-branches.sh > sync-output.txt 2>&1
           cat sync-output.txt
 
-          if grep -q "Clean merge successful" sync-output.txt; then
-            # Push the merge
-            git push origin next
-            echo "✅ Auto-merged main into next"
+          if grep -q "Clean rebase successful" sync-output.txt; then
+            git push --force-with-lease origin HEAD:next
+            echo "Successfully rebased next onto main"
 
           elif grep -q "Conflicts detected" sync-output.txt; then
-            # Extract branch name and push it
             BRANCH_NAME=$(grep "created branch:" sync-output.txt | cut -d: -f2 | tr -d ' ')
             git push origin "$BRANCH_NAME"
 
-            # Create PR
             gh pr create \
-              --title "Sync: Merge main into next" \
+              --title "Sync: Merge main into next (rebase conflicts)" \
               --body "Automated sync from main to next branch.
 
-              This PR has conflicts that need manual resolution." \
+              Rebase conflicts detected - falling back to merge strategy for manual resolution.
+              
+              This PR contains a merge commit because rebasing had conflicts that need manual resolution.
+              After resolving, consider rebasing the next branch to maintain clean history." \
               --base next \
               --head "$BRANCH_NAME" \
               --label "sync"

--- a/hack/sync-branches.sh
+++ b/hack/sync-branches.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Simple sync script: merge main into next, or create PR if conflicts
-
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 NEXT_BRANCH="${NEXT_BRANCH:-next}"
 REMOTE="${REMOTE:-origin}"
@@ -10,28 +8,22 @@ REMOTE="${REMOTE:-origin}"
 git fetch "$REMOTE" "$MAIN_BRANCH"
 git fetch "$REMOTE" "$NEXT_BRANCH"
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
 
-git checkout "$NEXT_BRANCH"
+TEMP_BRANCH="temp-sync-$(date +%s)"
+git checkout -b "$TEMP_BRANCH" "$REMOTE/$NEXT_BRANCH"
 
-if git merge "$REMOTE/$MAIN_BRANCH" --no-edit; then
-    # Clean merge - just push it
-    echo "Clean merge successful"
-    echo "Run: git push $REMOTE $NEXT_BRANCH"
+if git rebase "$REMOTE/$MAIN_BRANCH"; then
+    echo "Clean rebase successful"
 else
-    # Has conflicts - create PR branch
+    git rebase --abort
+    
     BRANCH_NAME="sync/$MAIN_BRANCH-to-$NEXT_BRANCH-$(date +%Y%m%d-%H%M%S)"
-
-    # Reset and create new branch from current next
-    git merge --abort
     git checkout -b "$BRANCH_NAME" "$REMOTE/$NEXT_BRANCH"
-
-    # Merge with conflicts
+    
     git merge "$REMOTE/$MAIN_BRANCH" --no-edit || true
-
+    
     echo "Conflicts detected - created branch: $BRANCH_NAME"
-    echo "Run: git push $REMOTE $BRANCH_NAME"
-    echo "Then create PR from $BRANCH_NAME to $NEXT_BRANCH"
 fi
 
-git checkout "$CURRENT_BRANCH"
+git checkout "$CURRENT_BRANCH" 2>/dev/null || git checkout "$MAIN_BRANCH"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

