### PR TITLE
fix(ci): sync main with next

### DIFF
--- a/.github/workflows/sync-next-branch.yml
+++ b/.github/workflows/sync-next-branch.yml
@@ -1,7 +1,8 @@
 name: Sync Next Branch
 
 # This workflow keeps the next branch in sync with main:
-# - Tries to rebase next onto main
+# - Tries to rebase next onto main  
+# - Verifies no commits are lost before pushing
 # - If rebase is clean → automatically pushes to next
 # - If there are conflicts → creates a PR for manual resolution
 
@@ -32,28 +33,110 @@ jobs:
 
       - name: Sync branches
         run: |
-          ./hack/sync-branches.sh > sync-output.txt 2>&1
+          # Run sync script and capture output
+          ./hack/sync-branches.sh > sync-output.txt 2>&1 || SYNC_EXIT_CODE=$?
+          
+          # Always show output for debugging
+          echo "=== Sync Script Output ==="
           cat sync-output.txt
-
-          if grep -q "Clean rebase successful" sync-output.txt; then
-            git push --force-with-lease origin HEAD:next
-            echo "Successfully rebased next onto main"
+          echo "========================="
+          
+          # Check exit code first - script exits 1 if commit loss detected
+          if [ "${SYNC_EXIT_CODE:-0}" -eq 1 ]; then
+            echo "::error::Sync failed - possible commit loss detected!"
+            exit 1
+          fi
+          
+          # Check for various outcomes
+          if grep -q "Clean rebase successful" sync-output.txt && grep -q "All commits preserved" sync-output.txt; then
+            echo "::notice::Rebase successful and all commits preserved"
+            
+            # Double-check we're not already up to date
+            if grep -q "No push needed" sync-output.txt; then
+              echo "::notice::Next branch is already up to date with main"
+              exit 0
+            fi
+            
+            # Get current branch SHA before pushing
+            CURRENT_SHA=$(git rev-parse HEAD)
+            echo "Current SHA to push: $CURRENT_SHA"
+            
+            # Push with force-with-lease for safety
+            echo "Pushing rebased branch to next..."
+            if git push --force-with-lease origin HEAD:next; then
+              echo "::notice::Successfully pushed rebased next branch"
+              
+              # Verify the push succeeded
+              git fetch origin next
+              REMOTE_SHA=$(git rev-parse origin/next)
+              if [ "$CURRENT_SHA" = "$REMOTE_SHA" ]; then
+                echo "::notice::Push verified - remote next branch updated correctly"
+              else
+                echo "::warning::Push may have been rejected - remote SHA doesn't match"
+              fi
+            else
+              echo "::error::Push failed - force-with-lease rejected the update"
+              echo "This likely means the remote branch was updated since we started"
+              exit 1
+            fi
 
           elif grep -q "Conflicts detected" sync-output.txt; then
+            echo "::notice::Rebase has conflicts - creating merge PR"
+            
+            # Extract branch name from output
             BRANCH_NAME=$(grep "created branch:" sync-output.txt | cut -d: -f2 | tr -d ' ')
+            
+            if [ -z "$BRANCH_NAME" ]; then
+              echo "::error::Could not extract branch name from sync output"
+              exit 1
+            fi
+            
+            echo "Pushing branch: $BRANCH_NAME"
             git push origin "$BRANCH_NAME"
-
+            
+            # Create PR with detailed information
             gh pr create \
               --title "Sync: Merge main into next (rebase conflicts)" \
-              --body "Automated sync from main to next branch.
+              --body "## Automated sync from main to next branch
 
-              Rebase conflicts detected - falling back to merge strategy for manual resolution.
+### Why this PR exists
+Rebase conflicts were detected when trying to rebase \`next\` onto \`main\`.
+This PR uses a merge strategy instead to preserve all commits from both branches.
+
+### What to do
+1. Review and resolve any merge conflicts in this PR
+2. Ensure all tests pass
+3. Merge this PR to update the next branch
+
+### Alternative
+If you prefer a clean history, you can manually rebase \`next\` onto \`main\` locally and force-push.
+**Warning**: Be very careful to preserve all commits unique to the next branch!
+
+### Verification steps
+Before merging, verify that:
+- [ ] All commits from \`next\` are preserved
+- [ ] All commits from \`main\` are included
+- [ ] No documentation or features are lost
               
-              This PR contains a merge commit because rebasing had conflicts that need manual resolution.
-              After resolving, consider rebasing the next branch to maintain clean history." \
+This PR was created because rebasing had conflicts that need manual resolution." \
               --base next \
               --head "$BRANCH_NAME" \
-              --label "sync"
+              --label "sync" \
+              --label "automated"
+              
+            echo "::notice::Created PR for manual conflict resolution"
+            
+          elif grep -q "ERROR: Commit loss detected" sync-output.txt; then
+            echo "::error::Commit loss detected during rebase - aborting!"
+            echo "The sync script detected that commits would be lost during the rebase."
+            echo "This is a safety mechanism to prevent data loss."
+            echo "Please investigate manually."
+            exit 1
+            
+          else
+            echo "::warning::Unexpected output from sync script"
+            echo "Please check the sync-output.txt content above"
+            exit 1
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/hack/sync-branches.sh
+++ b/hack/sync-branches.sh
@@ -1,29 +1,112 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
 NEXT_BRANCH="${NEXT_BRANCH:-next}"
 REMOTE="${REMOTE:-origin}"
 
+echo "Starting sync of $NEXT_BRANCH with $MAIN_BRANCH"
+
+# Fetch latest changes
+echo "Fetching latest changes..."
 git fetch "$REMOTE" "$MAIN_BRANCH"
 git fetch "$REMOTE" "$NEXT_BRANCH"
 
+# Save current branch to return to it later
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
 
+# Get commits that are only on next (not on main)
+echo "Analyzing commits unique to $NEXT_BRANCH..."
+NEXT_ONLY_COMMITS=$(git log --oneline "$REMOTE/$MAIN_BRANCH..$REMOTE/$NEXT_BRANCH" 2>/dev/null | wc -l)
+echo "Found $NEXT_ONLY_COMMITS commits on $NEXT_BRANCH that are not on $MAIN_BRANCH"
+
+if [ "$NEXT_ONLY_COMMITS" -gt 0 ]; then
+    echo "Commits unique to $NEXT_BRANCH:"
+    git log --oneline "$REMOTE/$MAIN_BRANCH..$REMOTE/$NEXT_BRANCH" | head -20
+fi
+
+# Store the original next SHA for verification
+ORIGINAL_NEXT_SHA=$(git rev-parse "$REMOTE/$NEXT_BRANCH")
+echo "Original $NEXT_BRANCH SHA: $ORIGINAL_NEXT_SHA"
+
+# Create a temp branch for the rebase attempt
 TEMP_BRANCH="temp-sync-$(date +%s)"
+echo "Creating temporary branch: $TEMP_BRANCH"
 git checkout -b "$TEMP_BRANCH" "$REMOTE/$NEXT_BRANCH"
 
+# Try to rebase onto main
+echo "Attempting to rebase $NEXT_BRANCH onto $MAIN_BRANCH..."
 if git rebase "$REMOTE/$MAIN_BRANCH"; then
+    echo -e "${GREEN}Clean rebase successful${NC}"
+    
+    # CRITICAL: Verify no commits were lost
+    echo "Verifying all commits are preserved..."
+    
+    # Get the new commit count after rebase
+    NEW_COMMITS_AFTER_REBASE=$(git log --oneline "$REMOTE/$MAIN_BRANCH..HEAD" 2>/dev/null | wc -l)
+    
+    # Check if we have at least the same number of unique commits
+    if [ "$NEW_COMMITS_AFTER_REBASE" -lt "$NEXT_ONLY_COMMITS" ]; then
+        echo -e "${RED}ERROR: Commit loss detected!${NC}"
+        echo "Original unique commits: $NEXT_ONLY_COMMITS"
+        echo "Commits after rebase: $NEW_COMMITS_AFTER_REBASE"
+        echo "Aborting to prevent data loss!"
+        
+        # Clean up and exit
+        git checkout "$CURRENT_BRANCH" 2>/dev/null || git checkout "$MAIN_BRANCH"
+        git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+        exit 1
+    fi
+    
+    # Additional safety check: verify specific important commits if needed
+    # This could check for specific commit messages or authors
+    echo "Rebase statistics:"
+    echo "  - Commits unique to next before: $NEXT_ONLY_COMMITS"
+    echo "  - Commits unique to next after: $NEW_COMMITS_AFTER_REBASE"
+    
+    # Check if any commits were actually added from main
+    MAIN_COMMITS_ADDED=$(git log --oneline "$ORIGINAL_NEXT_SHA..$REMOTE/$MAIN_BRANCH" 2>/dev/null | wc -l)
+    echo "  - New commits from main: $MAIN_COMMITS_ADDED"
+    
+    if [ "$MAIN_COMMITS_ADDED" -eq 0 ]; then
+        echo -e "${YELLOW}Warning: No new commits from main. Next is already up to date.${NC}"
+        echo "No push needed."
+        git checkout "$CURRENT_BRANCH" 2>/dev/null || git checkout "$MAIN_BRANCH"
+        git branch -D "$TEMP_BRANCH" 2>/dev/null || true
+        exit 0
+    fi
+    
+    # Success - rebase worked and no commits lost
+    echo -e "${GREEN}All commits preserved. Safe to push.${NC}"
     echo "Clean rebase successful"
+    
 else
+    echo -e "${YELLOW}Rebase has conflicts${NC}"
     git rebase --abort
     
+    # Fall back to merge strategy for manual resolution
+    echo "Creating merge PR for manual conflict resolution..."
     BRANCH_NAME="sync/$MAIN_BRANCH-to-$NEXT_BRANCH-$(date +%Y%m%d-%H%M%S)"
     git checkout -b "$BRANCH_NAME" "$REMOTE/$NEXT_BRANCH"
     
-    git merge "$REMOTE/$MAIN_BRANCH" --no-edit || true
+    # Try to merge main into next
+    echo "Attempting merge of $MAIN_BRANCH into $NEXT_BRANCH..."
+    if git merge "$REMOTE/$MAIN_BRANCH" --no-edit; then
+        echo -e "${GREEN}Merge completed successfully${NC}"
+    else
+        echo -e "${YELLOW}Merge has conflicts that need manual resolution${NC}"
+    fi
     
     echo "Conflicts detected - created branch: $BRANCH_NAME"
 fi
 
+# Return to original branch
 git checkout "$CURRENT_BRANCH" 2>/dev/null || git checkout "$MAIN_BRANCH"
+
+echo "Sync process completed"


### PR DESCRIPTION
Correctly preserve all commits from both branches

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

