### PR TITLE
refactor(layout): add some padding between enterprise label and chevron

### DIFF
--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -48,9 +48,10 @@
       border-radius: 3px;
     }
 
-    &:has(a.menu__link--sublist-caret[role="button"]) {
+    // When there's a collapsible button (chevron), move the label left
+    &:has(.menu__caret) {
       &::after {
-        right: 2.5rem;
+        right: 2.2rem;
       }
     }
   }


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
<img width="1551" height="1242" alt="image" src="https://github.com/user-attachments/assets/9934142e-37bb-4bf9-bd11-ca2c97fcc3b9" />


## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1108--vcluster-docs-site.netlify.app/docs/vcluster/deploy/worker-nodes/private-nodes/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-864


<!-- Do not change the line below -->
@netlify /docs
