### PR TITLE
Revert "feature(patches): Docs on adding new values to maps. (#945)"

### DIFF
--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -34,25 +34,20 @@ You can define a path for <code>{props.path}</code> field in `vcluster.yaml` usi
 
 <CodeBlock language="yaml">
 {`sync:
-    ${props.direction}:
-      ${props.resource}:
-        enabled: true
-        patches:
-        - path: ${props.path}
-          expression: '"my-prefix-"+value'
-          # optional reverseExpression to reverse the change from the host cluster
-          # reverseExpression: 'value.slice("my-prefix".length)'`}
+  ${props.direction}:
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: ${props.path}
+        expression: '"my-prefix-"+value'
+        # optional reverseExpression to reverse the change from the host cluster
+        # reverseExpression: 'value.slice("my-prefix".length)'`}
 </CodeBlock>
 
 In the example:
 
   - The path targets the <code>{props.path}</code> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
   - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{props.path}</code> field in the host cluster.
-
-:::warning Patch path validation
-If the `path` in a patch references a field where the parent object is `null` or doesn't exist, vCluster logs an error in the vCluster container but it does not block the synchronization to the host.
-For example, if you specify `path: spec.template.metadata.labels["my-label"]` but `spec.template` is `null`, the patch fails and you'll see an error in the vCluster logs.
-:::
 
 :::note Reverse sync
 You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
@@ -61,43 +56,15 @@ For example, add `reverseExpression: {"value.slice('my-prefix'.length)"}` to `vc
 
 To replace value with a hardcoded one, put the desired value in the quotation marks:
 <CodeBlock language="yaml">
-{`sync:
-    ${props.direction}:
-      ${props.resource}:
-        enabled: true
-        patches:
-        - path: ${props.path}
-          expression: '"my-value"'`}
+  {`sync:
+  ${props.direction}:
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: ${props.path}
+        expression: '"my-value"'
+`}
 </CodeBlock>
-
-Adding new keys in maps like annotations or labels to the resource is also possible with expressions.
-For example, to add a label to the resource in the host cluster, you can use:
-<CodeBlock language="yaml">
-{`sync:
-    toHost:
-      ${props.resource}:
-        enabled: true
-        patches:
-        - path: metadata.label["my-new-label"]
-          expression: 'valueExists ? value + "-changed" : "new-label-value"'`}
-</CodeBlock>
-
-The `value` variable in the case where the map entry does not exist is `null`.
-To distinguish between an entry that does not exist and an entry that exists with a `null` value, you can use the `valueExists` variable in your expression.
-The `valueExists` variable is `true` if the entry exists in the map, even if its value is `null`.
-
-The keys can also be conditionally added based on the value returned by the expression. If the expression evaluates to `null`, the key is not added to the map.
-Here is an example of conditionally adding a label based on the existence of another label:
-<CodeBlock language="yaml">
-{`sync:
-    toHost:
-      ${props.resource}:
-        enabled: true
-        patches:
-        - path: metadata.labels["conditional-label"]
-          expression: "context.virtualObject.metadata?.label?.['my-label'] ? 'my-value' : null"`}
-</CodeBlock>
-The above example checks if the `my-label` label exists in the virtual object. If it does, it adds the `conditional-label` with the value `my-value`. If it does not exist, it does not add the label.
 
 :::note JavaScript expressions
 The JavaScript expression patch supports a limited set of JavaScript features. For example, it does not support `import` statements or other Node.js-specific features. You can use standard JavaScript expressions, functions, and operators.
@@ -113,7 +80,7 @@ Another common use is the `optional chaining operator` like in: `value.myfield?.
 
 These functions are useful for encoding/decoding values when syncing between clusters:
 <CodeBlock language="yaml">
-{`sync:
+  {`sync:
     toHost:
       ${props.resource}:
         enabled: true
@@ -150,14 +117,14 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 
 <CodeBlock language="yaml">
 {`sync:
-    toHost:
-      ${props.resource}:
-        enabled: true
-        patches:
-        - path: metadata.annotations["my-secret-ref"]
-          reference:
-            apiVersion: v1
-            kind: Secret`}
+  toHost:
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: metadata.annotations["my-secret-ref"]
+        reference:
+          apiVersion: v1
+          kind: Secret`}
 </CodeBlock>
 
 In the example:


### PR DESCRIPTION
This reverts commit 47c30bd1e5036ff74d9667cc59efbe4146492814.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-8793


<!-- Do not change the line below -->
@netlify /docs
