### PR TITLE
fix(ci): pr cannot be created with pending merge conflicts

### DIFF
--- a/hack/sync-branches.sh
+++ b/hack/sync-branches.sh
@@ -35,4 +35,6 @@ else
     echo "Manual resolution required"
 fi
 
+# Abort any merge in progress before switching branches
+git merge --abort 2>/dev/null || true
 git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
