### PR TITLE
fix: use the default bridge mode for the KubeVirt auto-nodes example

### DIFF
--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -116,16 +116,10 @@ spec:
                 - name: containerdisk
                   disk:
                     bus: virtio
-                interfaces:
-                - name: default
-                  masquerade: {}
               resources:
                 requests:
                   cpu: "1"
                   memory: "2Gi"
-            networks:
-            - name: default
-              pod: {}
             volumes:
             - name: containerdisk
               dataVolume:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Enhancement of KubeVirt VM example. For auto nodes users should use the bridge mode.
Otherwise all created guests will have the same IP address.


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
