### PR TITLE
fix(vale): blockignore should be on separate lines

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,12 +10,11 @@ mdx = md
 BasedOnStyles = Loft, Google, Vale
 Vale.Spelling = NO
 
-# Ignore JSX tags in .mdx files, import statements, InterpolatedCodeBlock components, and code blocks
-BlockIgnores = (?s)(<(?!(?i:Flow|Step)\b)([a-zA-Z]+)(?:\s+[^>]*)?>)([\s\S]*?)(<\/\2>), \
-               (?s)import .*, \
-               (?s)(<InterpolatedCodeBlock[\s\S]*?/>), \
-               (?s)(```[\s\S]*?```), \
-               (?s)(`[^`]+`)
+# Ignore JSX tags in .mdx files
+BlockIgnores = '(<(?!(?i:Flow|Step)\b)([a-zA-Z]+)(?:\s+[^>]*)?>)([\s\S]*?)(<\/\2>)'
+BlockIgnores = 'import .*'
+BlockIgnores = '(<InterpolatedCodeBlock[\s\S]*?/>)'
+BlockIgnores = '(<InterpolatedCodeBlock[^>]*>[\s\S]*?</InterpolatedCodeBlock>)'
 TokenIgnores = (\(#.*\)),(\]\(),(http.*),({{<\s*\/?expand),(\!\[),(\d.*px),(\d\.\d\.\d)
 TokenIgnores = (?<=\[[\s\S]+?\])\([^)]+\)
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Vale `BlockIgnore` must be on separate lines.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
