### PR TITLE
Update add-virtual-clusters.mdx

### DIFF
--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -97,7 +97,7 @@ With visibility and access mode:
 - ✅ Basic monitoring and metrics
 - ✅ Continue managing with original deployment tool
 - ❌ No Platform lifecycle management
-- ❌ No templates, sleep mode, or auto-delete
+- ❌ No templates, platform sleep mode, or auto-delete
 
 ## Enable full platform management
 
@@ -145,8 +145,6 @@ metadata:
 spec:
   clusterRef:
     cluster: {{ .Values.cluster | default "loft-cluster" }}
-    namespace: {{ .Values.namespace }}
-    virtualCluster: {{ .Values.vclusterName }}
   external: false  # Platform manages lifecycle
   owner:
     user: {{ .Values.owner }}
@@ -175,8 +173,6 @@ metadata:
 spec:
   clusterRef:
     cluster: loft-cluster
-    namespace: gitops-vcluster-ns
-    virtualCluster: gitops-cluster
   external: false  # Platform manages from creation
   owner:
     user: admin
@@ -288,7 +284,7 @@ Once `external: false` is set, the following Platform features become available:
 - **[Full lifecycle management](/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
 - **[Auto-delete](./key-features/sleep-mode.mdx#work-with-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Sleep mode](/platform/use-platform/virtual-clusters/key-features/sleep-mode)**: Automatic sleep/wake based on activity to save resources
+- **[Sleep mode](/platform/use-platform/virtual-clusters/key-features/sleep-mode)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/platform/administer/projects/create)**: Organize virtual clusters into projects with quotas
 - **[SSO integration](/platform/configure/single-sign-on/overview)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](/platform/configure/advanced/audit)**: Centralized audit trails for compliance


### PR DESCRIPTION
# Content Description
I feel like the `namespace` and `virtualcluster` fields should be removed from the `clusterRefs` as it is best practice to let the Platform manage that. Not sure if it needs to be documented. Also, wanted to highlight that externally managed vCluster instances still support sleep mode, just not platform sleep mode that includes scaling down the vCluster control plane.


## Preview Link 
<!-- The preview link or links to the documents-->


<!-- Do not change the line below -->
@netlify /docs
