### PR TITLE
fix: links and references before docs versioning

### DIFF
--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -7,7 +7,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 import CertManagerPartial from "../../_partials/config/integrations/certManager.mdx";
-import BasePrerequisites from "../../../platform/_partials/install/base-prerequisites.mdx";
+import BasePrerequisites from "@site/docs/_partials/base-prerequisites.mdx";
 import CodeBlock from "@theme/CodeBlock";
 import Deploy from "../../_partials/deploy/deploy.mdx";
 import ProAdmonition from "../../_partials/admonitions/pro-admonition.mdx";

--- a/vcluster/_fragments/integrations/istio.mdx
+++ b/vcluster/_fragments/integrations/istio.mdx
@@ -7,7 +7,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 import IstioPartial from "../../_partials/config/integrations/istio.mdx";
-import BasePrerequisites from "../../../platform/_partials/install/base-prerequisites.mdx";
+import BasePrerequisites from "@site/docs/_partials/base-prerequisites.mdx";
 import CodeBlock from "@theme/CodeBlock";
 import Deploy from "../../_partials/deploy/deploy.mdx";
 import ProAdmonition from "../../_partials/admonitions/pro-admonition.mdx";

--- a/vcluster/configure/vcluster-yaml/external/platform/README.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/README.mdx
@@ -6,7 +6,7 @@ sidebar_class_name: pro host-nodes private-nodes standalone
 
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
-import Platform from '../../../../../platform/api/_partials/resources/config/external/platform.mdx'
+import Platform from '@site/platform/api/_partials/resources/config/external/platform.mdx'
 
 <ProAdmonition/>
 

--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -7,9 +7,9 @@ description: Learn how to configure and manage sleep mode functionality in virtu
 ---
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 import SleepMode from '../../_partials/config/sleepMode.mdx'
-import SleepModeDeploymentExample from '../../../vcluster/_fragments/sleepmode-deployment-example.mdx'
-import SleepModeIngressExample from '../../../vcluster/_fragments/sleepmode-ingress-example.mdx'
-import SleepModeIstioExample from '../../../vcluster/_fragments/sleepmode-istio-example.mdx'
+import SleepModeDeploymentExample from '../../_fragments/sleepmode-deployment-example.mdx'
+import SleepModeIngressExample from '../../_fragments/sleepmode-ingress-example.mdx'
+import SleepModeIstioExample from '../../_fragments/sleepmode-istio-example.mdx'
 import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 import TenancySupport from '../../_fragments/tenancy-support.mdx';

--- a/vcluster/contribute/contribute.mdx
+++ b/vcluster/contribute/contribute.mdx
@@ -4,7 +4,7 @@ sidebar_label: Contribute
 sidebar_position: 1
 sidebar_class_name: host-nodes private-nodes standalone
 ---
-import Contribute from '../../CONTRIBUTING.md'
+import Contribute from '@site/CONTRIBUTING.md'
 
 <Contribute />
 

--- a/vcluster/deploy/control-plane/container/environment/gke.mdx
+++ b/vcluster/deploy/control-plane/container/environment/gke.mdx
@@ -7,7 +7,7 @@ description: Learn how to deploy vCluster on Google Kubernetes Engine (GKE), inc
 sidebar_class_name: host-nodes private-nodes 
 ---
 
-import BasePrerequisites from '../../../../../platform/_partials/install/base-prerequisites.mdx';
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import Mark from "@site/src/components/Mark";
 import InstallCli from '../../../../_partials/deploy/install-cli.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -6,7 +6,7 @@ description: Learn how to migrate virtual clusters from the K3s distribution to 
 sidebar_class_name: host-nodes
 ---
 
-import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 
 import TenancySupport from '../../_fragments/tenancy-support.mdx';
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
This fixes docs references such that new `vCluster` versions wouldn't result in broken links.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-948


<!-- Do not change the line below -->
@netlify /docs
