### PR TITLE
fix(infra): netlify redirects should not be generated for remove

### DIFF
--- a/hack/redirect-resolver/main.go
+++ b/hack/redirect-resolver/main.go
@@ -409,7 +409,14 @@ func detectPathChanges(baseDir string) (*PathChanges, error) {
 	}
 
 	for filename, oldPath := range previousFiles {
-		if newPath, exists := currentFiles[filename]; exists && oldPath != newPath {
+		newPath, exists := currentFiles[filename]
+		// Only create redirects for files that exist in current docs but have moved
+		// Skip files that have been deleted (not in currentFiles)
+		if !exists {
+			// File was deleted, no redirect needed
+			continue
+		}
+		if oldPath != newPath {
 			// Never create redirects for underscore directories - Docusaurus doesn't generate pages from these
 			if strings.Contains(oldPath, "/_") || strings.Contains(newPath, "/_") {
 				continue


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
