### PR TITLE
feat(vale): add rule warning about not wrapping kubernetes resources in backticks

### DIFF
--- a/.github/styles/Loft/kubernetes-api-kinds.yml
+++ b/.github/styles/Loft/kubernetes-api-kinds.yml
@@ -1,0 +1,23 @@
+extends: existence
+message: "Kubernetes/Platform API kinds like '%s' should not use backticks. Write them as plain text (e.g., StatefulSet not `StatefulSet`)."
+level: warning
+scope: raw
+ignorecase: false
+vocab: false
+raw:
+  # Use raw to have full control over the regex pattern
+  - '`(?:StatefulSet|Deployment|DaemonSet|ReplicaSet|Job|CronJob|Pod|'
+  - 'Service|Ingress|NetworkPolicy|Endpoints|EndpointSlice|'
+  - 'ConfigMap|Secret|PersistentVolume|PersistentVolumeClaim|StorageClass|'
+  - 'ServiceAccount|Role|ClusterRole|RoleBinding|ClusterRoleBinding|'
+  - 'Namespace|Node|ResourceQuota|LimitRange|PodDisruptionBudget|'
+  - 'HorizontalPodAutoscaler|VerticalPodAutoscaler|PodSecurityPolicy|'
+  - 'CustomResourceDefinition|MutatingWebhookConfiguration|ValidatingWebhookConfiguration|'
+  - 'VolumeSnapshot|VolumeSnapshotClass|VolumeSnapshotContent|'
+  - 'CSIDriver|CSINode|VolumeAttachment|'
+  - 'PriorityClass|RuntimeClass|PodTemplate|'
+  - 'VirtualCluster|VirtualClusterInstance|VirtualClusterTemplate|'
+  - 'SpaceInstance|SpaceTemplate|ProjectSecret|SharedSecret|'
+  - 'DevPodWorkspace|DevPodWorkspaceInstance|DevPodWorkspaceTemplate|'
+  - 'AppInstance|AppTemplate|ClusterRoleTemplate|AccessKey|'
+  - 'VirtualClusterInstanceKubeConfig|VirtualService)`'


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Testing strategy:
-  API kinds with backticks - Should trigger warnings (e.g., StatefulSet)
-  API kinds without backticks - Should NOT trigger warnings (e.g., StatefulSet)
- possessive forms - Should work correctly (StatefulSet's = OK, StatefulSet's = warning)
-  triple backtick code blocks - Should be ignored completely
-  inline code - Commands like kubectl get pods should be ignored
-  both K8s and Platform CRDs - Verified both standard and vCluster-specific types


## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1158--vcluster-docs-site.netlify.app/docs

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-956


<!-- Do not change the line below -->
@netlify /docs
