### PR TITLE
chore: indicate 0.24 EOL on the menu

### DIFF
--- a/src/theme/DocSidebar/Desktop/Content/index.js
+++ b/src/theme/DocSidebar/Desktop/Content/index.js
@@ -24,7 +24,7 @@ export default function ContentWrapper(props) {
       {shouldShowVClusterVersioning && <VersionSelector docsPluginId={"vcluster"} dropdownItemsAfter={[
         {
           to: "https://vcluster.com/docs/v0.24",
-          label: "v0.24 (EOS) ↗"
+          label: "v0.24 (EOL) ↗"
         },
         {
           to: "https://vcluster.com/docs/v0.23",


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
