### PR TITLE
chore: mark 0.24 as EOL in its branch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -205,8 +205,8 @@ const config = {
             badge: true,
           },
           "0.24.0": {
-            label: "v0.24 (EOS)",
-            banner: "none",
+            label: "v0.24 (EOL)",
+            banner: "unmaintained",
             badge: true,
           },
           "0.23.0": {


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-349


<!-- Do not change the line below -->
@netlify /docs
