### PR TITLE
fix: use stable vcluster cli in deployment docs

### DIFF
--- a/vcluster/_partials/deploy/deploy.mdx
+++ b/vcluster/_partials/deploy/deploy.mdx
@@ -6,7 +6,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
 import TerraformDeploy from '!!raw-loader!./terraform-deploy.tf'
-import InstallCLIFragment from './install-cli-beta.mdx'
+import InstallCLIFragment from './install-cli.mdx'
 
 All of the deployment options below have the following assumptions:
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/deploy/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/deploy/deploy.mdx
@@ -6,7 +6,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
 import TerraformDeploy from '!!raw-loader!./terraform-deploy.tf'
-import InstallCLIFragment from './install-cli-beta.mdx'
+import InstallCLIFragment from './install-cli.mdx'
 
 
 <Tabs

--- a/vcluster_versioned_docs/version-0.27.0/_partials/deploy/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.27.0/_partials/deploy/deploy.mdx
@@ -6,7 +6,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
 import TerraformDeploy from '!!raw-loader!./terraform-deploy.tf'
-import InstallCLIFragment from './install-cli-beta.mdx'
+import InstallCLIFragment from './install-cli.mdx'
 
 All of the deployment options below have the following assumptions:
 

--- a/vcluster_versioned_docs/version-0.28.0/_partials/deploy/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.28.0/_partials/deploy/deploy.mdx
@@ -6,7 +6,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
 import TerraformDeploy from '!!raw-loader!./terraform-deploy.tf'
-import InstallCLIFragment from './install-cli-beta.mdx'
+import InstallCLIFragment from './install-cli.mdx'
 
 All of the deployment options below have the following assumptions:
 


### PR DESCRIPTION
Changes the recommended CLI version to stable in Deployment basics docs.

[Preview link](https://deploy-preview-1170--vcluster-docs-site.netlify.app/docs/vcluster/deploy/control-plane/container/basics/#deploy-vcluster)

## Internal Reference
Closes DOC-965

<!-- Do not change the line below -->
@netlify /docs
