### PR TITLE
Reverts standalone cert-rotation

### DIFF
--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -169,44 +169,6 @@ Log out and perform a regular leaf [certificate rotation](#rotate-client-and-ser
 </Step>
 </Flow>
 
-## Rotate certificates using vCluster Standalone
-
-The general advices and warnings mentioned in sections [Rotate client and
-server leaf certificates](#rotate-client-and-server-leaf-certificates) and
-[Rotate the CA Certificate](#rotate-ca-certificate) still apply.
-
-Though, when running vCluster Standalone the actual steps to perform the
-rotation differ slightly.
-
-<Flow>
-  <Step>
-    Login to the machine where vCluster is currently running.
-  </Step>
-  <Step>
-    Stop currently running vCluster:
-
-    ```
-    systemctl stop vcluster
-    ```
-  </Step>
-  <Step>
-    Rotate the certificates:
-
-    <InterpolatedCodeBlock
-      code={`VCLUSTER_NAME=[[VAR:VCLUSTER_NAME:standalone]] /var/lib/vcluster/bin/vcluster certs [[VAR:ROTATE_SUBCOMMAND:rotate]] --path=/var/lib/vcluster/pki --standalone`}
-      language="bash"
-    />
-  </Step>
-  <Step>
-    Restart vCluster:
-
-    ```
-    systemctl start vcluster
-    ```
-  </Step>
-</Flow>
-
-
 ## Additional steps required for private nodes
 
 There are additional steps required for private nodes. Depending on how your private worker nodes were added will indicate what needs to be done.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Part of ENG-8077

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
