### PR TITLE
Adds troubleshooting for standalone node join

### DIFF
--- a/vcluster/deploy/control-plane/binary/troubleshooting.mdx
+++ b/vcluster/deploy/control-plane/binary/troubleshooting.mdx
@@ -37,6 +37,12 @@ systemctl status vcluster.service
 
 Check that join tokens haven't expired and network connectivity exists between nodes.
 
+When running the join node script, if a 400 status code is received, check the URL directly to see if an error message exists. Alternatively you can pipe the entire response to the terminal and print it:
+
+```bash Print node join response
+curl -sSLk "https://<endpoint>/node/join?token=<token>" | { response=$(cat); echo "$response" | sh - 2>/dev/null || echo "Error: $response"; }
+```
+
 ### Resource constraints
 
 Ensure adequate CPU, memory, and disk space on nodes.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Part of ENG-9040

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
