### PR TITLE
Fixing HA vCluster.yaml for standalone

### DIFF
--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -67,8 +67,8 @@ All steps are perfomed on the initial control plane node.
             etcd:
               embedded:
                 enabled: true  # Required for HA
-          privateNodes:
-            enabled: true
+        privateNodes:
+          enabled: true
         EOF
         ```
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Fixing HA vCluster.yaml for standalone

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
