### PR TITLE
chore: eos for v0.25 and v0.26

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -206,12 +206,12 @@ const config = {
             badge: true,
           },
           "0.26.0": {
-            label: "v0.26",
+            label: "v0.26 (EOS) ↗",
             banner: "none",
             badge: true,
           },
           "0.25.0": {
-            label: "v0.25",
+            label: "v0.25 (EOS) ↗",
             banner: "none",
             badge: true,
           },


### PR DESCRIPTION
Label releases that have reached EOS.

## Preview Link 
<!-- The preview link or links to the documents-->
[Preview Link](https://deploy-preview-1181--vcluster-docs-site.netlify.app/docs/vcluster/)

<!-- Do not change the line below -->
@netlify /docs
