### PR TITLE
Move default vcluster yaml location for standalone

### DIFF
--- a/vcluster/_partials/manage/deploy-changes-standalone.mdx
+++ b/vcluster/_partials/manage/deploy-changes-standalone.mdx
@@ -6,7 +6,7 @@ Changing the `vcluster.yaml` configuration has to be done on all control plane n
   <Step>
     Modify the `vcluster.yaml`.
 
-    The `vcluster.yaml` is located at: `/var/lib/vcluster/config.yaml`. Edit and save your changes.
+    The `vcluster.yaml` is located at: `/etc/vcluster/vcluster.yaml`. Edit and save your changes.
   </Step>
   <Step>
     Restart vCluster systemD service to deploy your changes.

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -51,7 +51,7 @@ All steps are perfomed on the control plane node.
         Save a basic `vcluster.yaml` configuration file for vCluster Standalone on the control plane node.
 
         ```bash title="Create a vcluster.yaml for vCluster Standalone with only one control plane node"   
-        cat <<EOF > vcluster.yaml
+        cat <<EOF > /etc/vcluster/vcluster.yaml
         controlPlane:
           standalone:
             enabled: true
@@ -73,7 +73,7 @@ All steps are perfomed on the control plane node.
         export VCLUSTER_VERSION="v0.29.0"
         
         sudo su -
-        curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh | sh -s -- --vcluster-name standalone --config ${PWD}/vcluster.yaml
+        curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh | sh -s -- --vcluster-name standalone
         ```
 
     </Step>

--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -56,7 +56,7 @@ All steps are perfomed on the initial control plane node.
         Save a `vcluster.yaml` configuration file for vCluster Standalone on the control plane node.
 
         ```bash title="Create a vcluster.yaml to enable HA for vCluster Standalone"
-        cat <<EOF > vcluster.yaml
+        cat <<EOF > /etc/vcluster/vcluster.yaml
         controlPlane:
           standalone:
             enabled: true
@@ -83,7 +83,7 @@ All steps are perfomed on the initial control plane node.
         export VCLUSTER_VERSION="v0.29.0"
 
         sudo su -
-        curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh | sh -s -- --vcluster-name standalone --config ${PWD}/vcluster.yaml
+        curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh | sh -s -- --vcluster-name standalone
         ```
 
     </Step>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Part of ENG-9256

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
