### PR TITLE
add section about upgrading vCluster Standalone

### DIFF
--- a/vcluster/deploy/control-plane/binary/manage.mdx
+++ b/vcluster/deploy/control-plane/binary/manage.mdx
@@ -19,6 +19,37 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <DeployChangesStandalone />
 
+## Upgrading vCluster Standalone version
+
+To upgrade a vCluster Standalone to the new version, download the binary from the releases page, and then restart the vCluster systemD service.
+
+<Flow>
+  <Step>
+    On the control-plane node, download the binary for the target version:
+    ```shell title="Download vCluster standalone binary"
+    export VCLUSTER_VERSION="vX.Y.Z" # modify to the target version
+    export TARGETARCH="amd64" # amd64 / arm64
+    curl -fsSLk -o /tmp/vcluster-new "https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/vcluster-linux-${TARGETARCH}-standalone"
+    ```
+    then, copy it to the `/var/lib/vcluster/bin/vcluster`:
+
+    ```shell title="Upgrade binary"
+    chmod +x /tmp/vcluster-new
+    # copy old version as a backup
+    cp /var/lib/vcluster/bin/vcluster /tmp/vcluster-old.bak
+    cp /tmp/vcluster-new /var/lib/vcluster/bin/vcluster
+    ```
+  </Step>
+  <Step>
+    Restart vCluster systemD service to deploy your changes.
+
+    ```bash title="Restart vCluster"
+    systemctl restart vcluster.service
+    ```
+
+  </Step>
+</Flow>
+
 ## Removing nodes
 
 If you have not enabled joining the control plane nodes as worker nodes, then removing vCluster


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
part of DOC-951


<!-- Do not change the line below -->
@netlify /docs
