### PR TITLE
current helm provider has kubernetes =

### DIFF
--- a/vcluster/_partials/deploy/terraform-deploy.tf
+++ b/vcluster/_partials/deploy/terraform-deploy.tf
@@ -1,5 +1,5 @@
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
It looks like the provider for Helm has kubernetes = now instead of just kubernetes with a block.

https://registry.terraform.io/providers/hashicorp/helm/latest/docs#example-usage

Updated the Terraform section to have "kubernetes =" and then tested it, and it works.

Previous error:

➜ terraform plan
╷
│ Error: Unsupported block type
│
│   on main.tf line 2, in provider "helm":
│    2:   kubernetes {
│
│ Blocks of type "kubernetes" are not expected here. Did you mean to define argument "kubernetes"? If so, use the
│ equals sign to assign it a value.
╵

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
