### PR TITLE
Adds workaround to cert-rotation standalone, only in 0.29 docs

### DIFF
--- a/vcluster_versioned_docs/version-0.29.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/manage/certificates.mdx
@@ -171,7 +171,7 @@ Log out and perform a regular leaf [certificate rotation](#rotate-client-and-ser
 
 ## Rotate certificates using vCluster Standalone
 
-The general advices and warnings mentioned in sections [Rotate client and
+The general advice and warnings mentioned in sections [Rotate client and
 server leaf certificates](#rotate-client-and-server-leaf-certificates) and
 [Rotate the CA Certificate](#rotate-ca-certificate) still apply.
 
@@ -196,6 +196,7 @@ rotation differ slightly.
       code={`VCLUSTER_NAME=[[VAR:VCLUSTER_NAME:standalone]] /var/lib/vcluster/bin/vcluster certs [[VAR:ROTATE_SUBCOMMAND:rotate]] --path=/var/lib/vcluster/pki --standalone`}
       language="bash"
     />
+    In version 0.29.0 you may need to set the env var `NAMESPACE=default` when running the command to avoid a `getting remote client` error. This namespace is not used, and can be removed when using version 0.29.1 or later.
   </Step>
   <Step>
     Restart vCluster:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Part of ENG-8077

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


<!-- Do not change the line below -->
@netlify /docs
