### PR TITLE
Remove warning for ESO integration config deprecation

### DIFF
--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -1,5 +1,4 @@
 import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
-import Admonition from '@theme/Admonition';
 
 <ProAdmonition/>
 
@@ -15,17 +14,6 @@ Ensure your chosen version is supported by the External Secrets Operator on your
 :::
 
 # External secrets integration
-
-:::warning Configuration Changes
-The sync configuration for this integration has been updated.
-
-Configuration for each resource type is now defined under the relevant `toHost` or `fromHost` section.
-For more information, see the [configuration reference](#config-reference).
-
-Label selectors are now supported for all resources and follow the format used by the upstream Kubernetes API.
-
-Previous configuration keys are deprecated starting in version 0.27.0.
-:::
 
 To enable the external secret integration, set the following fields:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Remove deprecation warning for ESO integration config.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-8964


<!-- Do not change the line below -->
@netlify /docs
