### PR TITLE
fix(platform): invalid semantic snapshot type in examples

### DIFF
--- a/platform/use-platform/virtual-clusters/key-features/snapshots.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/snapshots.mdx
@@ -216,9 +216,9 @@ It's recommended to store your credentials to your OCI registry in a secret and 
         storage:
           type: oci
           oci:
-            # Location of S3 bucket
+            # Location of OCI registry
             # Must be prefixed with `oci://`
-            repository: s3://my-registry/snapshots
+            repository: oci://my-registry/snapshots
             credential:
               secretName: oci-cred
               secretNamespace: p-default
@@ -241,9 +241,9 @@ external:
         storage:
           type: oci
           oci:
-            # Location of S3 bucket
+            # Location of OCI registry
             # Must be prefixed with `oci://`
-            repository: s3://my-registry/snapshots
+            repository: oci://my-registry/snapshots
             credential:
               username: "my-username"
               password: "my-pasword"

--- a/platform/use-platform/virtual-clusters/key-features/snapshots.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/snapshots.mdx
@@ -13,11 +13,11 @@ vCluster Platform allows you to configure taking snapshots of the vCluster at sp
 This allows administrators to capture and store the vCluster state in scheduled intervals to help protect 
 against infrastructure failures, data corruption, and configuration errors. By maintaining consistent 
 recovery points, administrators can quickly restore the vCluster to a known good state without relying on manual backup processes. 
-For more details on how snapshots work, please refer to the documentation in the [Snapshot and Restore](https://www.vcluster.com/docs/vcluster/manage/backup-restore/) section.
+For more details on how snapshots work, refer to the documentation in the [Snapshot and Restore](https://www.vcluster.com/docs/vcluster/manage/backup-restore/) section.
 
 In the `vcluster.yaml`, it is configured under `external.platform.autoSnapshot`. Using the UI, you 
 can configure the management of snapshots in the config options of a virtual cluster under **Snapshots**. Though 
-snapshot configuration is configured on the virtual cluster itself, the functionality and logic of scheduling snapshots 
+snapshot configuration is configured on the virtual cluster itself, the capability and logic of scheduling snapshots
 is in vCluster Platform. 
 
 
@@ -47,7 +47,7 @@ external:
       
 ```
 
-### Scheduling and Retention Options
+### Available scheduling and retention options
 
 | Option | Required | Description | Default | 
 | ---|---|---|---|
@@ -64,17 +64,17 @@ The snapshot file can be saved in specific locations:
 - AWS S3 buckets
 - OCI registries
 
-### Storage Type Options
+### Storage type options
 
 | Option  | Description  |
 |---|---|
 | `storage.type`  |  Defines the type of storage used to store the snapshot, the platform supports the following types: AWS S3 and OCI. |
 
-### AWS S3 buckets
+### Store snapshots in AWS S3 buckets
 
-Snapshots can be stored in an AWS S3 bucket. 
+Snapshots can be stored in an AWS S3 bucket.
 
-#### S3 Configuration Options
+#### S3 configuration options
 
 | Option  | Description  |
 |---|---|
@@ -162,7 +162,7 @@ Alternatively, you can create a Kubernetes secret with your AWS credentials.
 
 Snapshots can be stored in an OCI image registry. 
 
-#### OCI Configuration Options
+#### OCI configuration options
 
 | Option  | Description  |
 |---|---|
@@ -249,11 +249,11 @@ external:
               password: "my-pasword"
 ```
 
-## View Snapshots
+## View snapshots
 
 After enabling automatic snapshots, you can view the list of snapshots for each virtual cluster in the details of the virtual cluster. 
 
-### Snapshot Name
+### Snapshot name
 
 Snapshots are identified by a generated name formatted as `<Virtual_Cluster_Name>-<Snapshot_Timestamp>.tar.gz`.
 

--- a/platform_versioned_docs/version-4.4.0/use-platform/virtual-clusters/key-features/snapshots.mdx
+++ b/platform_versioned_docs/version-4.4.0/use-platform/virtual-clusters/key-features/snapshots.mdx
@@ -216,9 +216,9 @@ It's recommended to store your credentials to your OCI registry in a secret and 
         storage:
           type: oci
           oci:
-            # Location of S3 bucket
+            # Location of OCI registry
             # Must be prefixed with `oci://`
-            repository: s3://my-registry/snapshots
+            repository: oci://my-registry/snapshots
             credential:
               secretName: oci-cred
               secretNamespace: p-default
@@ -241,9 +241,9 @@ external:
         storage:
           type: oci
           oci:
-            # Location of S3 bucket
+            # Location of OCI registry
             # Must be prefixed with `oci://`
-            repository: s3://my-registry/snapshots
+            repository: oci://my-registry/snapshots
             credential:
               username: "my-username"
               password: "my-pasword"

--- a/platform_versioned_docs/version-4.4.0/use-platform/virtual-clusters/key-features/snapshots.mdx
+++ b/platform_versioned_docs/version-4.4.0/use-platform/virtual-clusters/key-features/snapshots.mdx
@@ -13,11 +13,11 @@ vCluster Platform allows you to configure taking snapshots of the vCluster at sp
 This allows administrators to capture and store the vCluster state in scheduled intervals to help protect 
 against infrastructure failures, data corruption, and configuration errors. By maintaining consistent 
 recovery points, administrators can quickly restore the vCluster to a known good state without relying on manual backup processes. 
-For more details on how snapshots work, please refer to the documentation in the [Snapshot and Restore](https://www.vcluster.com/docs/vcluster/manage/backup-restore/) section.
+For more details on how snapshots work, refer to the documentation in the [Snapshot and Restore](https://www.vcluster.com/docs/vcluster/manage/backup-restore/) section.
 
 In the `vcluster.yaml`, it is configured under `external.platform.autoSnapshot`. Using the UI, you 
 can configure the management of snapshots in the config options of a virtual cluster under **Snapshots**. Though 
-snapshot configuration is configured on the virtual cluster itself, the functionality and logic of scheduling snapshots 
+snapshot configuration is configured on the virtual cluster itself, the capability and logic of scheduling snapshots
 is in vCluster Platform. 
 
 
@@ -47,7 +47,7 @@ external:
       
 ```
 
-### Scheduling and Retention Options
+### Available scheduling and retention options
 
 | Option | Required | Description | Default | 
 | ---|---|---|---|
@@ -64,17 +64,17 @@ The snapshot file can be saved in specific locations:
 - AWS S3 buckets
 - OCI registries
 
-### Storage Type Options
+### Storage type options
 
 | Option  | Description  |
 |---|---|
 | `storage.type`  |  Defines the type of storage used to store the snapshot, the platform supports the following types: AWS S3 and OCI. |
 
-### AWS S3 buckets
+### Store snapshots in AWS S3 buckets
 
-Snapshots can be stored in an AWS S3 bucket. 
+Snapshots can be stored in an AWS S3 bucket.
 
-#### S3 Configuration Options
+#### S3 configuration options
 
 | Option  | Description  |
 |---|---|
@@ -162,7 +162,7 @@ Alternatively, you can create a Kubernetes secret with your AWS credentials.
 
 Snapshots can be stored in an OCI image registry. 
 
-#### OCI Configuration Options
+#### OCI configuration options
 
 | Option  | Description  |
 |---|---|
@@ -249,11 +249,11 @@ external:
               password: "my-pasword"
 ```
 
-## View Snapshots
+## View snapshots
 
-After enabling automatic snapshots, you can view the list of snapshots for each virtual cluster in the details of the virtual cluster. 
+After enabling automatic snapshots, you can view the list of snapshots for each virtual cluster in the details of the virtual cluster.
 
-### Snapshot Name
+### Snapshot name
 
 Snapshots are identified by a generated name formatted as `<Virtual_Cluster_Name>-<Snapshot_Timestamp>.tar.gz`.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1200--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/virtual-clusters/key-features/snapshots

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-985


<!-- Do not change the line below -->
@netlify /docs
