### PR TITLE
Adds missing Istio information for sleep mode

### DIFF
--- a/platform/_partials/sleep/activity-detection.mdx
+++ b/platform/_partials/sleep/activity-detection.mdx
@@ -37,7 +37,8 @@ If your kube-context points to the platform's API server as a proxy before the a
 
 ### Ingress Requests
 
-For ingress-nginx based ingresses, activity detection also works automatically. Other ingress controllers are currently not supported. For nginx based ingresses, the platform will add a special annotation to each ingress that will track activity and reset the timer when a request is made to that ingress.
+For ingress-nginx based ingresses and Istio Gateways with Virtual Services, activity detection also works automatically. Other ingress and gateway controllers are currently not supported. For nginx based ingresses, the platform will add a special annotation to each ingress that will track activity and reset the timer when a request is made to that ingress.
+For Istio, the VirtualServices are modified to respond to activity when put to sleep and restored upon waking.
 
 <br></br>
 

--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -3,7 +3,7 @@ title: Sleep mode
 sidebar_label: sleepMode
 sidebar_position: 7
 sidebar_class_name: pro host-nodes
-description: Learn how to configure and manage sleep mode functionality in virtual clusters without using an agent.
+description: Learn how to configure and manage sleep mode feature in virtual clusters without using an agent.
 ---
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 import SleepMode from '../../_partials/config/sleepMode.mdx'
@@ -99,7 +99,7 @@ The [resource exemption](#resource-exemption) feature keeps specifically configu
 </details>
 
 :::note
-Add the annotations to the vCluster workload, such as the `StatefulSet` or `Deployment` running the virtual cluster. You can dynamically ignore any request by adding the `X-Sleep-Mode-Ignore` header.
+Add the annotations to the vCluster workload, such as the StatefulSet or Deployment running the virtual cluster. You can dynamically ignore any request by adding the `X-Sleep-Mode-Ignore` header.
 :::
 
 ## vCluster sleep mode compatibility with the platform
@@ -170,9 +170,9 @@ Ensure you install the necessary prerequisites.
 
 - `vCluster`: vCluster command-line tool to provision and manage virtual clusters.
   <InstallCli />
-- [`docker`](https://docs.docker.com/get-started/get-docker/): Platform for building and running containerized applications.
-- [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/): Tool for running local Kubernetes clusters in Docker.
-- [`curl`](https://curl.se/download.html): Command-line tool for transferring data over the network.
+- [`docker`](https://docs.docker.com/get-started/get-docker/): Platform for building and running containerized applications
+- [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/): Tool for running local Kubernetes clusters in Docker
+- [`curl`](https://curl.se/download.html): Command-line tool for transferring data over the network
 
 ### Deployment
 
@@ -200,9 +200,9 @@ To configure sleep mode for the ingress controller, make sure it stays responsiv
 Enable Istio integration for sleep mode to work with Istio resources.
 :::
 
-When Istio is installed on the host cluster and the [Istio integration](./integrations/istio) is enabled, the vCluster syncs [`Gateway`](https://istio.io/latest/docs/reference/config/networking/gateway/) and [`VirtualService`](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources to the host cluster.
+When Istio is installed on the host cluster and the [Istio integration](./integrations/istio) is enabled, the vCluster syncs [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) and [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources to the host cluster.
 
-With sleep mode enabled, any traffic routed to a `Service` in the vCluster is tracked as activity and keeps the vCluster awake. If the vCluster is asleep, incoming traffic wakes it up.
+With sleep mode enabled, any traffic routed to a Service in the vCluster is tracked as activity and keeps the vCluster awake. If the vCluster is asleep, incoming traffic wakes it up.
 
 <details>
   <summary>Configure an ingress gateway for cluster external access</summary>

--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -69,9 +69,12 @@ Sleep mode tracks certain actions to detect activity and wake the cluster when n
 
 - Accessing cluster resources through API calls (for example `kubectl get <resource>`).
 - Attempting to contact ingress endpoints (NGINX only).
+- Traffic routed to a Service in the vCluster through Istio Gateway (when Istio integration is enabled).
 
 :::note
 Ingress activity detection works only with [NGINX](https://github.com/kubernetes/ingress-nginx/tree/main) ingress controllers, using the [mirror-target](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#mirror) annotation. This overwrites any previously set mirror-target annotation.
+
+When Istio is installed on the host cluster and the [Istio integration](./integrations/istio) is enabled, traffic routed to a Service in the vCluster through Istio Gateway is tracked as activity and keeps the vCluster awake. If the vCluster is asleep, incoming traffic through Istio Gateway wakes it up.
 :::
 
 ### Ignore other types of activity in sleep mode
@@ -125,7 +128,7 @@ This requires compatible versions of vCluster and the platform. The [vCluster an
 | 0.23.x | 4.2.x | ✅ | Update the vCluster config manually, moving it from `experimental` to `external.platform`. Convert durations, such as "90m", into seconds, for example, "5400". Schema validation prevents both configurations from being applied at the same time. | Manually revert the configuration. |
 | 0.24.0 | &lt;4.3.0 | ❌ | These versions are not compatible, as the vCluster version is ahead of the platform, which causes the vCluster creation to be rejected. | Not applicable.|
 | 0.24.0 | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified vCluster config and takes over as if it had been configured for the platform all along. | Remove the annotation `vcluster.loft.sh/agent-installed` from the vCluster config secret in the host cluster to notify the vCluster that it needs to resume sleep mode. The secret’s name is `vc-config-[vcluster-name]`.|
-| &ge;0.24.0 (future release) | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified config and takes over as if it had been configured for the platform all along. | No action is required, and the vCluster resumes sleep mode for workloads only, not the control plane. |
+| &ge;0.24.0 | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified config and takes over as if it had been configured for the platform all along. | No action is required, and the vCluster resumes sleep mode for workloads only, not the control plane. |
 </details>
 
 :::note vCluster sleep mode considerations


### PR DESCRIPTION
<!--
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it.
In this case, follow the instructions from vale and fix the linting issues.
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1063




<!-- Do not change the line below -->
@netlify /docs

<!-- CLAUDE_SUMMARY -->
> [!NOTE]
> Documents Istio Gateway support for sleep mode activity detection in vCluster.
>
> - **platform/_partials/sleep/activity-detection.mdx**
>   - Added Istio Gateways with Virtual Services to supported ingress activity detection
>   - Added note about VirtualServices being modified during sleep/wake cycles
> - **vcluster/configure/vcluster-yaml/sleep-mode.mdx**
>   - Added bullet point for Istio Gateway traffic tracking as activity
>   - Added note explaining Istio integration requirements for sleep mode wake functionality
>   - Updated version compatibility table to remove "(future release)" from >=0.24.0
>   - Minor formatting fixes: removed backticks from Kubernetes resource names (StatefulSet, Deployment, Gateway, VirtualService, Service)
>   - Removed trailing periods from prerequisite list items
>
> <sup>Generated by Claude for commit 079d7c55a7ef74bf59a31d933d5337c72e351ce0. Updates automatically on new commits.</sup>
<!-- /CLAUDE_SUMMARY -->