### PR TITLE
Update backup.mdx - remove external DB limitation

### DIFF
--- a/vcluster/manage/backup-restore/backup.mdx
+++ b/vcluster/manage/backup-restore/backup.mdx
@@ -230,8 +230,5 @@ When taking snapshots and restoring virtual clusters, there are limitations:
 **Sleeping virtual clusters**
 - Snapshots require a running vCluster control plane and do not work with sleeping virtual clusters.
 
-**Virtual clusters using an external database**
-- Virtual clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
-
 **Distribution**
 - Snapshots work only with K8s


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
The virtual clusters using an external database are supported by the current implementation of the snapshot/restore mechanism, so the documented limitation is out of date.
Current implementation is connecting to the backing store with an etcd client from a running vcluster pod where kine is running to expose the external database with etcd api.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1574--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/backup#limitations

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
<!--Closes DOC- -->


<!-- Do not change the line below -->
@netlify /docs

<!-- CLAUDE_SUMMARY -->
> [!NOTE]
> Removes outdated limitation stating that virtual clusters with external databases cannot use vCluster's snapshot/restore mechanism. The current implementation supports external databases through kine's etcd API exposure.
>
> <sup>Generated by Claude for a21ee2c3375bccbdcecc940b9b8d2312660024a2</sup>
<!-- /CLAUDE_SUMMARY -->