### PR TITLE
fix(annotations): remove caution admonition from generated stubs

### DIFF
--- a/hack/annotations/mdx.go
+++ b/hack/annotations/mdx.go
@@ -131,10 +131,6 @@ func insertStubs(content, stubs string) string {
 
 	// No "Needs documentation" section — create one
 	section := "\n## Needs documentation {#needs-documentation}\n\n" +
-		":::caution\n" +
-		"The following annotations were detected in the codebase but lack full documentation.\n" +
-		"Entries are auto-generated stubs.\n" +
-		":::\n\n" +
 		stubs
 
 	// Try to insert before <!-- vale on -->


### PR DESCRIPTION
## Summary

- Remove the `:::caution` admonition from the "Needs documentation" section generated by the annotation drift tool
- The admonition exposed internal tooling language ("auto-generated stubs") in end-user facing documentation

Closes DOC-1215

## Test plan

- [ ] Build annotation tool and verify output has no admonition
- [ ] Re-run workflow to confirm stubs render cleanly