### PR TITLE
docs(private-nodes): add vNode secure platform access key via secret

### DIFF
--- a/vcluster/deploy/worker-nodes/private-nodes/README.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/README.mdx
@@ -7,6 +7,7 @@ sidebar_class_name: free private-nodes standalone
 
 import PrivateNodes from '../../../_fragments/private-nodes.mdx'
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport privateNodes="true" standalone="true"/>
 
@@ -49,6 +50,38 @@ networking:
 :::info Connecting to the platform
 Follow [this guide](/docs/vcluster/next/configure/vcluster-yaml/platform) to create an access key and set up the vCluster for deployment using Helm or other tools.
 :::
+
+### Configure vNode with a secure platform access key {#configure-vnode-access-key}
+
+When deploying [vNode](https://www.vnode.com/docs/) alongside private nodes, the vNode DaemonSet authenticates with vCluster Platform using a platform access key. Instead of providing the key as plaintext in the Helm values, reference a Kubernetes secret for improved security and GitOps compatibility.
+
+Create a Kubernetes secret containing the access key:
+
+<InterpolatedCodeBlock
+  code={'kubectl create secret generic [[VAR:SECRET_NAME:platform-secret]] \\\n' +
+  '  --namespace [[VAR:NAMESPACE:vnode]] \\\n' +
+  '  --from-literal=[[VAR:SECRET_KEY:accesskey]]=<your-access-key>'}
+  language="bash"
+/>
+
+Reference the secret in your vNode Helm values using `daemonSet.envValueFrom`:
+
+<InterpolatedCodeBlock
+  code={'config:\n' +
+  '  platform:\n' +
+  '    host: [[VAR:PLATFORM_HOST:my-platform.example.com]]\n' +
+  '\n' +
+  'daemonSet:\n' +
+  '  envValueFrom:\n' +
+  '    VNODE_PLATFORM_ACCESS_KEY:\n' +
+  '      secretKeyRef:\n' +
+  '        name: [[VAR:SECRET_NAME:platform-secret]]\n' +
+  '        key: [[VAR:SECRET_KEY:accesskey]]'}
+  language="yaml"
+  title="vnode-values.yaml"
+/>
+
+When the `VNODE_PLATFORM_ACCESS_KEY` environment variable is set, vNode uses it instead of `config.platform.accessKey`. This keeps the access key out of your Helm values and version control.
 
 ### Join worker nodes
 


### PR DESCRIPTION
# Content Description
Add documentation for providing the vNode platform access key securely via a Kubernetes secret instead of plaintext Helm values. This uses the `daemonSet.envValueFrom` configuration with `secretKeyRef`, which is the preferred approach for GitOps workflows.

## Preview Link
<!-- CLAUDE_SUMMARY -->
- https://deploy-preview-1833--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes#configure-vnode-access-key

## Internal Reference
Closes DOC-1269

**AI review:** mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs