### PR TITLE
Doc 1298/backport docs repositioning

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -81,7 +81,7 @@ import Link from '@docusaurus/Link';
 ## Where do you want to start?
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1.25rem', marginBottom: '3rem'}}>
-  <Link to="/vcluster/introduction/what-are-virtual-clusters/" className="audience-card">
+  <Link to="/vcluster/introduction/gpu-cloud-platform/" className="audience-card">
     <span className="audience-label">AI Cloud &amp; GPU Platforms</span>
     <h3>Build a managed Kubernetes platform</h3>
     <p>Deliver dedicated tenant clusters over GPU infrastructure. Full isolation, no cluster-per-tenant overhead.</p>

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -465,9 +465,9 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
-{/* vale off */}
+<!-- vale off -->
 ### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
-{/* vale on */}
+<!-- vale on -->
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform/understand/externally-vs-platform-deployed.mdx
+++ b/platform/understand/externally-vs-platform-deployed.mdx
@@ -41,7 +41,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
-## Choosing a deployment model
+## Choose a deployment model
 
 You can choose per-project or per-tenant-cluster, mixing both models in the same environment.
 

--- a/platform_versioned_docs/version-4.8.0/_partials/install/install-next-steps.mdx
+++ b/platform_versioned_docs/version-4.8.0/_partials/install/install-next-steps.mdx
@@ -10,7 +10,7 @@ clusters](../../use-platform/virtual-clusters/create/create-no-template.mdx) sec
 Otherwise, read more about some primary concepts:
 
 * [Projects](../../understand/what-are-projects.mdx) - How resources can be grouped together into different projects.
-* [Virtual clusters](../../understand/what-are-virtual-clusters.mdx) - How to create and manage virtual clusters.
+* [Tenant clusters](../../introduction/platform_intro.mdx) - How Platform deploys and manages tenant clusters.
 * [Templates](../../understand/what-are-templates.mdx) - How to use templates to control what type of resources that can be made.
-* [Host clusters](../../understand/what-are-clusters.mdx) - How to add more host clusters to the platform.
+* [Connected clusters](../../understand/what-are-clusters.mdx) - How to connect Control Plane Clusters to the platform.
 * [Auto sleep and wakeup](/vcluster/manage/sleep-wakeup) - How to temporarily scale down unused virtual clusters and bring them back up.

--- a/platform_versioned_docs/version-4.8.0/administer/_category_.json
+++ b/platform_versioned_docs/version-4.8.0/administer/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "For Administer",
+  "label": "For Administrators",
   "position": "2.22",
   "collapsible": true,
   "collapsed": true

--- a/platform_versioned_docs/version-4.8.0/administer/authentication/oidc-provider.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/authentication/oidc-provider.mdx
@@ -31,7 +31,7 @@ oidc:
 ```
 
 <!-- vale off -->
-## Add OIDC Clients to vCluster Platform OIDC Using Secrets
+## Add OIDC Clients to vCluster Platform OIDC Using Secrets {#adding-oidc-clients-to-vcluster-platform-oidc-using-secrets}
 <!-- vale on -->
 
 You can add OIDC clients to vCluster Platform using Kubernetes secrets. These secrets should contain the string fields `name`, `clientID`, `clientSecret`, and `redirectURIs`. Multiple redirect URIs should be delimitted by `\n`. vCluster Platform will only recognize an OIDC client secret if they posses the labels `clientID` and `component`. The value for `clientID` should match the `clientID` field's value and the value for `component` should be `oidcServer`. Here is an example of a yaml manifest that can be used to manage an OIDC client for vCluster Platform's OIDC provider:

--- a/platform_versioned_docs/version-4.8.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/clusters/connect-cluster.mdx
@@ -21,13 +21,13 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 
 
-The vCluster Platform supports managing multiple virtual clusters that run across different host clusters.
-A host cluster refers to the Kubernetes cluster where a virtual cluster is deployed. To enable management through the vCluster Platform,
-the vCluster Platform Agent must be installed on each host cluster you intend to manage.
+vCluster Platform manages tenant clusters that run across one or more connected clusters.
+A connected cluster is a Kubernetes cluster that serves as a Control Plane Cluster, where tenant cluster control planes run. To enable management through vCluster Platform,
+the vCluster Platform agent must be installed on each cluster you intend to manage.
 The installation can be performed through the vCluster Platform UI, CLI, or Helm.
 
-:::warning Host cluster access
-Direct access to a host cluster grants broad permissions to platform resources and virtual clusters running on that host. Grant host cluster access only to privileged platform administrators. Unprivileged users should access virtual clusters directly rather than through the host cluster or its pods.
+:::warning Control Plane Cluster access
+Direct access to a Control Plane Cluster grants broad permissions to platform resources and tenant clusters running on it. Grant this access only to privileged platform administrators. Unprivileged users should access tenant clusters directly rather than through the Control Plane Cluster or its pods.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
@@ -465,9 +465,9 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
-{/* vale off */}
+<!-- vale off -->
 ### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
-{/* vale on */}
+<!-- vale on -->
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
@@ -465,7 +465,9 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
-### `kubevirt.vcluster.com/network-attachment-definition`
+{/* vale off */}
+### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
+{/* vale on */}
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.8.0/administer/users-permissions/overview.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/users-permissions/overview.mdx
@@ -7,17 +7,17 @@ description: Learn about RBAC.
 
 # Overview
 
-The platform uses [Kubernetes role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to manage access for platform resources and objects, including platform Custom Resource Definitions (CRDs) and virtual clusters.
+The platform uses [Kubernetes role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to manage access for platform resources and objects, including platform Custom Resource Definitions (CRDs) and tenant clusters.
 
-RBAC manages user and team permissions by assigning them roles that specify what actions they can perform. These permissions are applied using *ClusterRoleBindings*, which connect a specific role to a user or team, which defines their access across platform resources and virtual clusters.
+RBAC manages user and team permissions by assigning them roles that specify what actions they can perform. These permissions are applied using *ClusterRoleBindings*, which connect a specific role to a user or team, which defines their access across platform resources and tenant clusters.
 
 Depending on the scope of access, these bindings are created in one of three types of clusters:
 
 | Cluster Type | Description |
 | --- | --- |
 | **Local cluster** | The cluster where the platform is installed. |
-| **Connected host cluster** | A host cluster that hosts virtual clusters. |
-| **vCluster** | A certified Kubernetes distribution managed virtually.|
+| **Connected cluster** | A Control Plane Cluster that hosts tenant cluster control planes. |
+| **Tenant cluster** | A certified Kubernetes distribution managed by Platform.|
 
 To learn more about the platform’s resource types, see the [API resources](https://www.vcluster.com/docs/platform/api/use-api).
 
@@ -36,7 +36,7 @@ You can also review the glossary of terms that relate to RBAC.
 | Project Role | Special role with loft.sh/project-role: "true" label | Available in UI for assignment within projects |
 | Permission Level | Degree of access granted | Ranges from view-only to full administrative control |
 | Security Layer | Components of defense-in-depth approach | Includes identity management, RBAC policies, namespace isolation, and network policies |
-| Virtual Cluster | Isolated Kubernetes environment | Provides full API compatibility while sharing infrastructure |
+| Tenant Cluster | Isolated Kubernetes environment | Provides full API compatibility with dedicated control plane |
 | Namespace | Enhanced namespace with management capabilities | Offers more granular control than standard Kubernetes namespaces |
 
 </details>

--- a/platform_versioned_docs/version-4.8.0/configure/agent-settings/overview.mdx
+++ b/platform_versioned_docs/version-4.8.0/configure/agent-settings/overview.mdx
@@ -113,7 +113,7 @@ NAME                   READY   STATUS    RESTARTS   AGE
 loft-d6c6d5576-7kqwx   1/1     Running   0          9d
 ```
 
-## Retrieve agent values
+## Retrieve agent values {#loftsh-annotations}
 
 For a platform instance on host `nimbus.vcluster.cloud` with a connected cluster named `staging`, the following table shows how to retrieve agent values for each tier. Use these endpoints to determine current agent configuration or to layer values instead of overriding them.
 

--- a/platform_versioned_docs/version-4.8.0/configure/agent-settings/security-context.mdx
+++ b/platform_versioned_docs/version-4.8.0/configure/agent-settings/security-context.mdx
@@ -102,4 +102,4 @@ podSecurityContext:
   - 5000
 ```
 
-Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](overview#override-values) and add your security context configuration in the Extra Agent Values text area.
+Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](overview#connect-to-platform) and add your security context configuration in the Extra Agent Values text area.

--- a/platform_versioned_docs/version-4.8.0/configure/introduction.mdx
+++ b/platform_versioned_docs/version-4.8.0/configure/introduction.mdx
@@ -7,15 +7,15 @@ description: Learn how to configure the vCluster Platform, modify its behavior, 
 
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
-When a **vCluster Platform** is deployed on a host cluster (or, primary host cluster), it can act as a centralized control plane. Other host clusters can connect to the vCluster Platform running on the primary host cluster and be managed by it. In this architecture:
-- The primary host cluster runs the vCluster Platform.
-- Other host clusters connect to the primary host cluster and run the vCluster Platform Agent.
-- The Platform coordinates and manages all connected host clusters through their agents.
-- There are both vCluster Platform and vCluster Platform agent running on the primary host cluster. The vCluster Platform manages the primary host cluster through its vCluster Platform Agent as well.
+**vCluster Platform** is deployed on a Kubernetes cluster that acts as the primary Control Plane Cluster. Additional clusters can connect to this Platform instance and be managed by it. In this architecture:
+- The primary cluster runs vCluster Platform.
+- Additional Control Plane Clusters connect to the primary cluster and run the vCluster Platform agent.
+- Platform coordinates and manages all connected clusters through their agents.
+- The primary cluster also runs the vCluster Platform agent, so Platform manages it the same way as any other connected cluster.
 
 The `values.yaml` of `vcluster-platform` Helm chart in `loft-sh` repository contains the configuration values when installing or upgrading vCluster Platform or vCluster Platform Agent.
 Both vCluster Platform and vCluster Platform Agent are using the `vcluster-platform` Helm chart. By setting values in `values.yaml`, you can choose to install or upgrade vCluster Platform or vCluster Platform Agent. You can also control the post-deployment platform behavior and the
-behavior of agents in other managed host clusters.
+behavior of agents on other connected clusters.
 
 ## Values sections
 The platform's `values.yaml` file contains multiple configuration sections:
@@ -31,7 +31,7 @@ The platform's `values.yaml` file contains multiple configuration sections:
    - Examples: `config.auth`, `config.audit`, `config.loftHost`.
 <!-- vale on -->
 
-3. **Agent settings** - Control how the platform agent operates in connected clusters
+3. **Agent settings** - Control how the platform agent operates on connected clusters
    - Set through the top-level `agentValues:` section of the `vcluster-platform` chart. You can override these per-cluster with annotations.
    - Located in the `vcluster-platform` Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart)).
    - Examples: `replicaCount`, `resources`, `ingress`, `persistence`, etc.

--- a/platform_versioned_docs/version-4.8.0/install/quick-start-guide.mdx
+++ b/platform_versioned_docs/version-4.8.0/install/quick-start-guide.mdx
@@ -43,7 +43,7 @@ For more detailed information about networking requirements, see [Networking](/d
 
 ## Deployment
 
-Before installing the platform, ensure the correct host cluster kube-context is in use. The host cluster kube-context configures which Kubernetes cluster and namespace `kubectl` commands interact with. To confirm the current context, run:
+Before installing the platform, ensure the correct kube-context is active. The kube-context configures which Kubernetes cluster and namespace `kubectl` commands interact with. To confirm the current context, run:
 
 ```bash title="Get the current Kubernetes context"
 kubectl config current-context
@@ -55,7 +55,7 @@ Once you've confirmed the correct context, install the platform by running:
 vcluster platform start
 ```
 
-This command installs the platform onto the host-cluster in the `vcluster-platform` namespace.
+This command installs the platform into the current cluster in the `vcluster-platform` namespace.
 The `vcluster-platform` namespace is created automatically and serves as a
 dedicated space for the platform components.
 
@@ -163,6 +163,6 @@ This command opens the browser for signing in using the login data displayed in 
 
 ## Next steps
 
-### Create virtual clusters
+### Create tenant clusters
 
 <InstallNextSteps />

--- a/platform_versioned_docs/version-4.8.0/integrations/certified-stacks/index.mdx
+++ b/platform_versioned_docs/version-4.8.0/integrations/certified-stacks/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 Certified Stacks are tested, versioned, one-command deployments of a vCluster plus a complete
 application stack. Each stack handles provisioning, dependency orchestration, and configuration
-automatically, so platform teams can go from zero to a fully configured multi-tenant environment
+automatically, so platform teams can go from zero to a fully configured tenant cluster environment
 without manual integration work.
 
 Stacks are maintained in the [certified-stacks](https://github.com/loft-sh/certified-stacks)
@@ -20,22 +20,22 @@ components — operators, controllers, CRDs, Helm charts — and getting the seq
 configuration right across all of them. Certified Stacks eliminate that gap by providing
 pre-built, tested configurations that work out of the box.
 
-- **Multi-tenancy out of the box.** Stacks ship with pre-built configurations for both hard and
-  soft isolation models, so platform teams can match their tenancy architecture to their security
+- **Tenant isolation out of the box.** Stacks ship with pre-built configurations for both private and
+  shared node models, so platform teams can match their worker node architecture to their security
   and performance requirements without custom integration work.
 - **Built on validated reference architectures.** Each stack extends partner-published reference
   architectures with additional deployment flexibility and tenancy options.
 - **Forkable and extensible.** Every stack is a starting point, not a black box. Fork the repo,
   modify Helm values, swap components, or adapt the orchestration to your environment.
 
-## Tenancy models
+## Worker node models
 
-Each stack supports two isolation models:
+Each stack supports two worker node models:
 
 | Model | Description | Use case |
 |-------|-------------|----------|
-| **Hard multitenancy** | Each tenant gets a dedicated vCluster with private auto-provisioned nodes. Full isolation of control plane, GPU operators, drivers, and networking. | Untrusted tenants, strict compliance requirements |
-| **Soft multitenancy** | Tenants share host cluster nodes via label-based assignment. Each tenant still gets its own vCluster with a separate Kubernetes API and workload scheduling. | Trusted tenants, cost-efficient shared infrastructure |
+| **Private nodes** | Each tenant gets a dedicated tenant cluster with private auto-provisioned nodes. Full isolation of control plane, GPU operators, drivers, and networking. | Untrusted tenants, strict compliance requirements |
+| **Shared nodes** | Tenants share Control Plane Cluster nodes via label-based assignment. Each tenant gets its own tenant cluster with a separate Kubernetes API and workload scheduling. | Trusted tenants, cost-efficient shared infrastructure |
 
 ## Available stacks
 

--- a/platform_versioned_docs/version-4.8.0/integrations/certified-stacks/runai.mdx
+++ b/platform_versioned_docs/version-4.8.0/integrations/certified-stacks/runai.mdx
@@ -23,9 +23,9 @@ vCluster supports all three deployment models with NVIDIA Run:ai:
 
 | Model | Description | Use case |
 |-------|-------------|----------|
-| **Shared nodes** | Tenants share host cluster nodes with label-based scheduling. Each tenant gets a separate vCluster with its own Kubernetes API. | Trusted tenants, cost-efficient GPU sharing |
-| **Private nodes** | Each tenant gets a dedicated vCluster with auto-provisioned private nodes. | Untrusted tenants, strict compliance requirements |
-| **Standalone** | A single-tenant deployment where NVIDIA Run:ai manages the full node pool within one vCluster. No multi-tenancy overhead. | Single team, dedicated GPU pool |
+| **Shared nodes** | Tenants share Control Plane Cluster nodes with label-based scheduling. Each tenant gets a separate tenant cluster with its own Kubernetes API. | Trusted tenants, cost-efficient GPU sharing |
+| **Private nodes** | Each tenant gets a dedicated tenant cluster with auto-provisioned private nodes. | Untrusted tenants, strict compliance requirements |
+| **Standalone** | A single-tenant deployment where NVIDIA Run:ai manages the full node pool within one tenant cluster. | Single team, dedicated GPU pool |
 
 ## Installation
 

--- a/platform_versioned_docs/version-4.8.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.8.0/introduction/platform_intro.mdx
@@ -7,110 +7,121 @@ hide_table_of_contents: false
 slug: /
 ---
 
-vCluster Platform lets you manage your virtual clusters and users across your Kubernetes clusters.
+import GlossaryTerm from '@site/src/components/GlossaryTerm';
 
-## Platform features
+vCluster Platform is the management plane for your tenant cluster fleet. It provides a web UI, CLI, and API for deploying, configuring, and operating <GlossaryTerm term="tenant-cluster">tenant clusters</GlossaryTerm> across one or more <GlossaryTerm term="control-plane-cluster">Control Plane Clusters</GlossaryTerm>. Access control, lifecycle automation, resource governance, and node management are all built in.
 
-The vCluster Platform provides a single pane of glass that lets you connect your clusters, deploy virtual clusters, configure user access, and reduce operational costs.
+Without Platform, operating tenant clusters at scale requires custom tooling for provisioning workflows, RBAC, quota enforcement, and cluster lifecycle. Platform replaces that custom work with a production-ready management layer.
 
-### Projects
+{/* TODO: screenshot — Platform dashboard showing tenant cluster fleet across multiple projects, with cluster status indicators and resource usage */}
 
-Projects are the highest organizational unit that vCluster Platform uses. They
-help logically group resources by team or division, and as a container to apply
-role based access controls (RBAC). Projects are central part of your vCluster
-Platform experience, so make sure to read more about them in the [Projects
-section](../understand/what-are-projects.mdx).
+## How Platform fits into the picture
 
-### Clusters
+vCluster creates and runs tenant clusters. Platform manages the fleet. The relationship is straightforward:
 
-vCluster Platform is installed into, and can connect to, as many physical Kubernetes clusters as you need to manage. vCluster Platform can then be used to manage workloads in each of the physical clusters, deploying spaces, virtual clusters, and apps as needed. vCluster Platform provides granular role based access control (RBAC) allowing for vCluster Platform administrators to limit which users and teams have access to which clusters, as well as much more granular control at the project, space, and virtual cluster levels. Read more about vCluster Platform integration with physical clusters in the [Clusters section](../understand/what-are-clusters.mdx).
+{/* vale off */}
+- **vCluster** handles the tenant cluster, including the API server, control plane, <GlossaryTerm term="syncer">syncer</GlossaryTerm>, and node connectivity
+{/* vale on */}
+- **Platform** handles everything around the tenant cluster. It controls who can access it, how it's configured, when it sleeps, and when nodes are provisioned or deprovisioned
 
-### Virtual clusters
+Platform installs into a Kubernetes cluster and connects to other clusters in your environment. Those connected clusters become the Control Plane Clusters where tenant cluster control planes run. Platform doesn't replace those clusters. It manages what runs inside them.
 
-Virtual clusters are _virtual_ Kubernetes clusters. These virtual clusters run inside a namespace within the "parent" or "host" physical cluster, thereby allowing administrators to effectively create many Kubernetes instance in a single instance -- ideal for development, testing, and even production workloads. See the [Virtual Clusters section](../understand/what-are-virtual-clusters.mdx) for details.
+## Projects
 
-### Apps
+Projects are the primary organizational unit in Platform. Each project is a policy boundary that groups tenant clusters and the users or teams who access them.
 
-Apps allow users to define applications that users can then be empowered to deploy in clusters, spaces, and virtual clusters they have appropriate access to. The idea here is nothing new, however, vCluster Platform's Apps interface allows for easily packaging applications, and critically, exposing parameters that users can then select or input at deployment time. Apps can be specified via Kubernetes Manifests,
-bash scripts, Helm charts, etc. See the [Apps section](../understand/what-are-apps.mdx), and be sure to learn about [versioning](../administer/templates/versioning.mdx) and [parameters](../administer/templates/parameters.mdx).
+Inside a project you can:
+- Set resource quotas that cap compute and storage across all tenant clusters in the project
+- Assign default and allowed templates so teams can only create clusters that meet your requirements
+- Grant users and teams access to just this project, with no visibility into other projects
 
-### Cost reduction tools
+For AI cloud operators serving paying customers, projects map naturally to customer accounts or organizational boundaries. For internal platforms, projects map to teams, cost centers, or environments.
 
-vCluster Platform provides features to reduce Kubernetes costs.
+{/* TODO: screenshot — Projects list view showing multiple projects with tenant cluster count and quota usage per project */}
 
-- Auto Sleep
+[Learn about projects →](../understand/what-are-projects.mdx)
 
-  Put Kubernetes namespaces to sleep. vCluster Platform sets `replicas: 0` for all replica-controlled resources such as `Deployments` and `StatefulSets`. This means that Kubernetes will delete all pods but the entire configuration of resources within the namespace is still there. Auto sleep can be:
+## Tenant cluster management
 
-  - Invoked manually
-  - Triggered by an inactivity timeout (no one has run a `kubectl` command in this namespace for X
-minutes)
-  - Scheduled using a CRON syntax
+Platform provides a complete lifecycle interface for tenant clusters. Create, configure, upgrade, connect, and delete tenant clusters from the UI or through the Platform API.
 
+### Templates
 
-- Auto delete inactive virtual clusters
+Templates define a baseline `vcluster.yaml` configuration applied to every tenant cluster created from them. Administrators define the templates available in each project. Users choose from those templates at creation time and can optionally customize within allowed bounds.
 
-  Configure an auto-delete for virtual clusters that have not been used for a
-  certain period of time (inactivity). See [Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for details.
+Templates solve the consistency problem at scale. Instead of relying on users to configure settings correctly, you encode requirements into a template and enforce them across the fleet.
 
+{/* TODO: screenshot — Template configuration screen showing vcluster.yaml editor with version selector and allowed customization fields */}
 
-- Inactivity Detection
+[Create templates →](../administer/templates/create-templates.mdx)
 
-  All requests that are made through vCluster Platform count as activity in the namespace.
+### Deploy and connect
 
-<div style={{display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '2em 0'}}>
-  <div style={{display: 'flex', alignItems: 'center', gap: '2em'}}>
-    <div style={{
-      background: '#f0f0f0',
-      padding: '1em',
-      borderRadius: '8px',
-      border: '2px solid #ddd',
-      fontFamily: 'monospace',
-      fontSize: '14px'
-    }}>
-      $ kubectl get pod my-pod
-    </div>
+{/* vale off */}
+Tenant clusters can be created from the Platform UI, CLI (`vcluster create`), or Platform API. This makes Platform a good fit for GitOps workflows and automated provisioning pipelines. Once created, Platform generates a `kubeconfig` scoped to the tenant cluster. Users access their cluster directly. They never need credentials for the underlying Control Plane Cluster.
+{/* vale on */}
 
-    <div style={{fontSize: '24px'}}>→</div>
+{/* TODO: screenshot — Create tenant cluster drawer showing project selector, template dropdown, version picker, and name field */}
 
-    <div style={{
-      background: '#f0f0f0',
-      padding: '1em',
-      borderRadius: '8px',
-      border: '2px solid #ddd'
-    }}>
-      vCluster Platform
-    </div>
+[Create a tenant cluster →](../use-platform/virtual-clusters/create/create-no-template.mdx)
 
-    <div style={{fontSize: '24px'}}>→</div>
+### Upgrade
 
-    <div style={{
-      background: '#f0f0f0',
-      padding: '1em',
-      borderRadius: '8px',
-      border: '2px solid #ddd'
-    }}>
-      <div style={{marginBottom: '0.5em'}}>Connected Cluster</div>
-      <div style={{fontSize: '12px'}}>Kubernetes API Server</div>
-    </div>
+Platform coordinates vCluster version upgrades with rolling updates. Upgrades can be initiated from the UI or automated through Platform's GitOps integration. Configuration changes to `vcluster.yaml` can be applied at the same time as version upgrades.
 
-    <div style={{fontSize: '24px'}}>→</div>
+## Sleep and wake
 
-    <div style={{
-      background: '#f0f0f0',
-      padding: '1em',
-      borderRadius: '8px',
-      border: '2px solid #ddd',
-      fontFamily: 'monospace',
-      fontSize: '12px'
-    }}>
-      <div>apiVersion: v1</div>
-      <div>kind: Pod</div>
-      <div>metadata:</div>
-      <div style={{paddingLeft: '1em'}}>name: my-pod</div>
-      <div>...</div>
-    </div>
-  </div>
-</div>
+Platform can automatically sleep idle tenant clusters, suspending the control plane and stopping synced workloads to free resources. When activity resumes, Platform wakes the cluster and restores it to its previous state. The tenant experience is seamless. Their next `kubectl` command triggers the wake automatically.
 
-  If your kube-context points to vCluster Platform's API server as a proxy before the actual connected cluster's API server, every `kubectl` request will be an activity and reset the inactivity timeout.
+Sleep can be configured three ways:
+- **Manual** — sleep or wake a cluster on demand from the UI or CLI
+- **Inactivity timeout** — sleep after a configurable period with no API activity
+- **Schedule** — sleep and wake on a CRON schedule, useful for environments with predictable working hours
+
+Auto-delete works the same way. Tenant clusters idle beyond a configured threshold are deleted automatically. This is useful for ephemeral developer and CI environments where clusters are created frequently and often abandoned.
+
+{/* TODO: screenshot or GIF — Tenant cluster card showing sleep/wake toggle, or the sleep configuration panel with inactivity timeout and schedule fields */}
+
+[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+
+## Access control
+
+Platform uses a layered RBAC model. Administrators control access at the platform, project, and individual tenant cluster level.
+
+- **Platform roles** — control access to global settings, connected clusters, and user management
+- **Project roles** — control access to tenant clusters, spaces, and resources within a project
+- **Tenant cluster roles** — control what a user can do inside a specific tenant cluster
+
+Platform integrates with any OIDC provider for SSO, including Okta, Azure AD, Dex, and others. Teams and group memberships from your identity provider map directly to Platform roles.
+
+{/* TODO: screenshot — Project members panel showing users and teams with role assignments */}
+
+[Configure SSO →](../configure/platform-configs/single-sign-on.mdx)
+
+## Node management
+
+For tenant clusters running on [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/), Platform manages node lifecycle. Nodes are provisioned and joined automatically based on workload demand, and deprovisioned when no longer needed.
+
+Node providers integrate with cloud APIs (AWS, GCP, Azure, and others) to provision VMs that join as private nodes. For bare metal infrastructure, [vMetal](/docs/platform/administer/bare-metal/overview) handles physical server provisioning using the same model.
+
+This is the operational foundation for AI cloud providers. Tenant clusters with GPU nodes scale up when a customer submits a job and scale down when it finishes, without manual intervention.
+
+{/* TODO: screenshot — Node provider configuration screen or node list view showing nodes joined to a tenant cluster with status and resource metrics */}
+
+[Configure node providers →](../administer/node-providers/overview.mdx)
+
+## Connected clusters
+
+Platform connects to as many Kubernetes clusters as your infrastructure requires. These become the Control Plane Clusters for your tenant cluster fleet. You can distribute tenant clusters across regions, cloud providers, or on-premises environments and manage all of them from one Platform instance.
+
+{/* TODO: screenshot — Connected clusters list showing multiple clusters across regions with agent status and tenant cluster count */}
+
+[Connect a cluster →](../understand/what-are-clusters.mdx)
+
+## Next steps
+
+- [Install vCluster Platform](../install/quick-start-guide.mdx)
+- [Create your first tenant cluster](../use-platform/virtual-clusters/create/create-no-template.mdx)
+- [Set up a project](../administer/projects/create.mdx)
+- [Configure templates](../administer/templates/create-templates.mdx)
+- [Set up SSO](../configure/platform-configs/single-sign-on.mdx)

--- a/platform_versioned_docs/version-4.8.0/introduction/vcluster_intro.mdx
+++ b/platform_versioned_docs/version-4.8.0/introduction/vcluster_intro.mdx
@@ -2,37 +2,12 @@
 title: What is vCluster?
 sidebar_position: 1
 sidebar_label: What is vCluster?
-description: Introduction to vCluster virtual clusters
+description: Introduction to vCluster tenant clusters
 hide_table_of_contents: false
 ---
 
-vCluster is an open source solution that enables teams to run virtual Kubernetes clusters inside existing infrastructure. It helps platform engineers create secure, isolated environments for development, testing, CI/CD, and even production workloads, without the cost or overhead of managing separate physical clusters.
+vCluster provisions fully isolated Kubernetes environments, called tenant clusters, on your infrastructure. Each tenant gets a dedicated API server, its own CRDs and RBAC, and a cluster experience indistinguishable from a dedicated Kubernetes cluster.
 
-## What is a virtual cluster?
+vCluster Platform is the management layer on top: it handles deployment, access control, lifecycle, and governance across your tenant cluster fleet.
 
-A virtual cluster is a fully functional Kubernetes cluster that runs on top of another Kubernetes cluster. Virtual clusters run inside a namespace of a host cluster, but operate as independent environments with their own API server, control plane, and resource set.
-
-Virtual clusters are certified Kubernetes distributions. They adhere to upstream Kubernetes standards while maintaining isolation from the host cluster. This means you can use standard Kubernetes tooling and workflows with virtual clusters.
-
-## Why use virtual clusters?
-
-Virtual clusters provide several advantages over traditional Kubernetes multi-tenancy approaches:
-
-- **Strong isolation**: Each virtual cluster has its own control plane, CRDs, and RBAC configuration
-- **Fast provisioning**: Create a new virtual cluster in seconds instead of minutes
-- **Cost efficiency**: Run multiple virtual clusters on shared infrastructure
-- **Flexibility**: Choose from multiple tenancy models to match your isolation and performance requirements
-- **Compatibility**: Use any Kubernetes tooling and deploy any workload type
-
-## How vCluster Platform helps manage virtual clusters
-
-vCluster Platform extends open source vCluster with enterprise features for managing virtual clusters at scale:
-
-- **Centralized management**: Manage virtual clusters across multiple host clusters from a single interface
-- **Access control**: Configure fine-grained RBAC for users and teams
-- **Templates**: Define reusable virtual cluster configurations
-- **Cost optimization**: Automatically sleep idle virtual clusters and set resource quotas
-
-## Learn more
-
-For detailed information about vCluster architecture, configuration, and deployment options, see the [vCluster documentation](/docs/vcluster).
+For the full vCluster architecture and deployment path guide, see the [vCluster documentation](/docs/vcluster/introduction/what-are-virtual-clusters).

--- a/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
@@ -1,100 +1,71 @@
 ---
-title: Externally Deployed Virtual Clusters
-sidebar_label: Externally Deployed Virtual Clusters
-description: Understanding the lifecycle and management of platform deployed and externally deployed virtual clusters.
+title: Platform-Managed vs. Externally Deployed Tenant Clusters
+sidebar_label: Platform-Managed vs. Externally Deployed
+description: Understanding the lifecycle and management of platform-managed and externally deployed tenant clusters.
 ---
 
-# Externally deployed virtual cluster
-
-Virtual clusters can be classified into two main types based on their deployment
-method and management: **platform deployed** and **externally deployed**.
-Understanding the differences between these types is crucial for effective
-virtual cluster management and utilization of platform capabilities.
+Tenant clusters in vCluster Platform are either **platform-managed** or **externally deployed**, depending on how they are created and who manages their lifecycle.
 
 ![externally deployed](/img/external-clusters.png)
 
-## Platform deployed virtual clusters
+## Platform-managed tenant clusters
 
-Platform deployed virtual clusters are deployed and fully managed through the platform. They benefit from the platform's complete set of features and automated lifecycle management.
+Platform deploys and fully manages platform-managed tenant clusters. It handles provisioning, upgrades, configuration changes, and deletion. All platform features are available.
 
-:::info Characteristics of platform deployed virtual clusters
-- Deployment methods:
-  - Platform UI
-  - `vCluster platform create vCluster <name>` command
-- Full platform lifecycle management and reconciliation
-- Complete access to platform-specific features
-:::
+Deployment methods:
+- Platform UI
+- `vcluster platform create vcluster <name>` CLI command
 
-Platform deployed clusters provide an integrated experience with centralized management and full platform feature utilization.
+## Externally deployed tenant clusters
 
-## Externally deployed virtual clusters
+Externally deployed tenant clusters are created outside Platform using tools like Helm, Argo CD, Terraform, or ClusterAPI. You can connect them to Platform to gain visibility and access to certain features without changing how their lifecycle is managed.
 
-Externally deployed virtual clusters are initially deployed outside of the platform, using tools like Helm, Argo, Terraform, or custom scripts. They can be added to the platform for enhanced management and feature access without changing their original deployment method.
+Perform lifecycle changes (upgrades, configuration updates, deletion) through the original deployment tool, not the Platform UI. Platform does not reconcile externally deployed clusters.
 
-:::info Characteristics of externally deployed virtual clusters
-- Deployed using external tools (e.g., Helm, Argo CD, ClusterAPI, Terraform)
-- Added to the platform using `vCluster platform add vCluster [name]` command
-- Platform does not manage lifecycle (no reconciliation)
-- Allows use of certain platform features when connected with an agent
-:::
+### Available Platform features when connected
 
-For externally deployed virtual clusters, lifecycle changes should be performed using the original deployment tool (e.g., Argo CD, ClusterAPI) rather than the platform UI.
-
-### Platform features for externally deployed virtual clusters
-
-When an externally deployed virtual cluster is added to the platform and connected with an agent, certain platform features become available:
+When you add an externally deployed tenant cluster to Platform and connect it with the vCluster Platform agent, the following features become available:
 
 <!-- vale off -->
-- Auto sleep (requires agent and vCluster.yaml configuration)
+- Auto sleep (requires agent and `vcluster.yaml` configuration)
 <!-- vale on -->
 - Pro features of vCluster (license key distribution)
-- Administrative overview of virtual cluster fleet
-- UI-based inspection of cluster versions, enabled features, and resources
-- Issue detection (e.g., vCluster errors, outdated Kubernetes versions)
-- Enhanced debugging information and health status monitoring
-- User access management through the platform (useful with SSO)
-- Platform integrations (e.g., Argo CD, Vault secrets)
+- Administrative overview of the tenant cluster fleet
+- UI inspection of cluster versions, enabled features, and resources
+- Issue detection (outdated Kubernetes versions, vCluster errors)
+- Health status monitoring and enhanced debugging
+- User access management through Platform (useful with SSO)
+- Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of the vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
-## Understand the differences
+## Choosing a deployment model
 
-Virtual clusters are classified based on two key factors:
-1. Creation method: Via the platform or external tools
-2. Management approach: Fully platform-managed or externally managed with optional platform features
+You can choose per-project or per-tenant-cluster, mixing both models in the same environment.
 
-:::note Key differences
-- Lifecycle management: Platform-driven vs. externally controlled
-- Feature availability: Full platform features vs. selective feature access (with agent)
-:::
+**Use platform-managed when:**
+- You want the simplest operational model with full feature access
+- Tenant clusters are created on demand with no need for external provisioning tooling
 
-## Choose the deployment model
+**Use externally deployed when:**
+- You already manage tenant cluster lifecycle with Argo CD, ClusterAPI, or Terraform and want to keep that workflow
+- You need GitOps-driven provisioning with Platform visibility and access control
 
-The choice between platform deployed and externally deployed virtual clusters can be made on a per-project or per-vCluster basis, allowing for a mix-and-match approach.
+## Connect an externally deployed tenant cluster
 
-Consider the following factors:
+To add an existing tenant cluster to Platform without transferring lifecycle management:
 
-1. Existing Infrastructure: If you already use tools like Argo CD for virtual cluster management, you might prefer externally deployed clusters for those specific projects.
-2. Integration Needs: For projects requiring tight integration with all platform features, platform deployed clusters might be more suitable.
-3. Management Preferences: Some teams might prefer the centralized management of platform deployed clusters, while others might opt for the flexibility of externally deployed clusters with selective platform feature usage.
-
-Remember, you can use both types within the same environment, choosing the most appropriate option for each virtual cluster based on its specific requirements and your team's preferences.
-
-## Add externally deployed clusters to the platform
-
-To add an existing virtual cluster to the platform without changing its lifecycle management:
-
-1. Ensure the virtual cluster is running vCluster v0.20 or greater.
-2. Run the following command:
-   ```
+1. Ensure the tenant cluster is running vCluster v0.20 or later.
+2. Run:
+   ```bash
    vcluster platform add vcluster [name]
    ```
 
-This action is non-invasive and easily reversible, allowing you to benefit from platform features while maintaining your existing deployment workflows.
+This is non-invasive and reversible. Your existing deployment workflow remains unchanged.
 
 ## Next steps
 
-1. [Create a virtual cluster](/docs/platform/use-platform/virtual-clusters/create/create-no-template) in the platform.
-2. [Add externally deployed virtual cluster](/docs/platform/use-platform/virtual-clusters/add-virtual-clusters) virtual clusters to the platform.
+- [Create a tenant cluster](/docs/platform/use-platform/virtual-clusters/create/create-no-template) in the platform
+- [Add an externally deployed tenant cluster](/docs/platform/use-platform/virtual-clusters/add-virtual-clusters) to the platform

--- a/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
@@ -41,7 +41,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
-## Choosing a deployment model
+## Choose a deployment model
 
 You can choose per-project or per-tenant-cluster, mixing both models in the same environment.
 

--- a/platform_versioned_docs/version-4.8.0/understand/what-are-clusters.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/what-are-clusters.mdx
@@ -1,13 +1,35 @@
 ---
-title: What are Host Clusters
-sidebar_label: What Are Host Clusters
+title: What are Connected Clusters
+sidebar_label: What Are Connected Clusters
 sidebar_position: 3
 ---
 
-## What are Host clusters?
+A connected cluster is a Kubernetes cluster linked to vCluster Platform. It serves as the Control Plane Cluster where tenant cluster control planes run. Platform deploys, manages, and monitors everything that runs inside it.
 
-A connected or host cluster is a Kubernetes cluster that can be connected to, where virtual clusters can be created in and can be managed from the vCluster Platform UI. This can be a local Kubernetes cluster where vCluster Platform is installed in or an external cluster which is deployed on a cloud provider for instance.
+## How connection works
 
-When connecting a cluster to vCluster Platform, vCluster Platform tries to install the vCluster Platform agent on the cluster which is used to orchestrate all further interactions with the cluster.
+Connecting a cluster installs the vCluster Platform agent on it. The agent provides the communication layer between Platform and that cluster: tenant cluster provisioning, access control enforcement, lifecycle operations, and health monitoring. It uses an outbound connection to Platform, so no inbound firewall rules are required on the cluster.
 
-Once connected, you can create virtual clusters and spaces in the selected cluster.
+Once connected, the cluster appears in the Platform UI and can be assigned to projects. Members of those projects can then create tenant clusters and spaces within the cluster, scoped to their access level.
+
+{/* TODO: screenshot — Connected clusters list showing cluster name, region, agent status, and tenant cluster count */}
+
+## Multi-cluster deployments
+
+Platform can connect to as many clusters as your infrastructure requires. This lets you:
+
+- Distribute tenant clusters across regions or cloud providers for latency or data residency requirements
+- Isolate different environments (production, staging, development) onto separate clusters
+- Scale capacity by adding clusters without changing how tenants access their environments
+
+All connected clusters are managed from one Platform instance. Tenants interact only with their tenant clusters and never have direct access to the connected cluster.
+
+## The cluster where Platform is installed
+
+Platform itself runs on a Kubernetes cluster. That cluster is automatically connected and available as a Control Plane Cluster. For smaller deployments, all tenant clusters can run on the same cluster as Platform. For larger fleets or stricter isolation requirements, dedicated clusters are connected separately.
+
+## Connectivity and resilience
+
+The agent maintains a persistent outbound connection to the Platform API server. If connectivity is lost, existing tenant clusters continue running without interruption. Platform resumes full management once the connection is restored.
+
+[Connect a cluster →](../administer/clusters/connect-cluster.mdx)

--- a/platform_versioned_docs/version-4.8.0/understand/what-are-namespaces.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/what-are-namespaces.mdx
@@ -7,12 +7,10 @@ sidebar_position: 7
 Namespaces are regular Kubernetes namespaces managed by vCluster Platform that are owned by a user or team.
 In Kubernetes, namespaces provide a mechanism for isolating groups of resources within a single cluster.
 
-In vCluster Platform, each namespace belongs to a host cluster and project. A Namespace can be [created from a template](../use-platform/namespaces/create/create-with-template.mdx) to ensure the Kubernetes namespace and objects within it conform to isolation best practices
-or [created manually in vCluster Platform UI](../use-platform/namespaces/create/create-no-template.mdx) for project admins.
-Admins can also easily [manage access to a Namespace](../administer/users-permissions/permissions/namespace.mdx) and users can [connect to the Namespace via CLI](../use-platform/namespaces/retrieve-kube-config.mdx). 
+In vCluster Platform, each namespace belongs to a Control Plane Cluster and project. Namespaces can be [created from a template](../use-platform/namespaces/create/create-with-template.mdx) to enforce isolation best practices or [created manually](../use-platform/namespaces/create/create-no-template.mdx) by project admins. Admins can [manage access](../administer/users-permissions/permissions/namespace.mdx) and users can [connect via CLI](../use-platform/namespaces/retrieve-kube-config.mdx).
 
 :::info
-For applications that require multiple namespaces or need to create cluster scoped resources, [virtual clusters](what-are-virtual-clusters.mdx) are recommended instead.
+For applications that require multiple namespaces or need to create cluster scoped resources, [tenant clusters](/docs/vcluster/introduction/what-are-virtual-clusters) are recommended instead.
 :::
 
 There are multiple key features you can use with namespaces:

--- a/platform_versioned_docs/version-4.8.0/understand/what-are-projects.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/what-are-projects.mdx
@@ -4,38 +4,42 @@ sidebar_label: What Are Projects
 sidebar_position: 1
 ---
 
-## What are Projects?
+Projects are the primary organizational unit in vCluster Platform. Each project is a policy boundary that groups tenant clusters, spaces, and the users or teams who access them.
 
-Projects are the highest level organizational unit in vCluster Platform. In the simplest form, projects can be thought of as
-folders for resources (e.g. virtual clusters), however, they also play an important role in
-enforcing role based access and quotas within the platform.
+For AI cloud operators, projects map naturally to customer accounts: each customer gets a project, sees only their resources, and operates within the resource limits you define. For internal platforms, projects map to teams, cost centers, or environments.
 
-### Members
+{/* TODO: screenshot — Projects overview showing multiple projects with member count, tenant cluster count, and quota usage */}
 
-Perhaps the most important aspect of projects is that they contain members, that is, users and teams that are a part
-of the given project. Only users and teams that are part of the project (and global admins) will have access to the
-project. Moreover, each user or team can be given specific roles that define their access within the
-project. See the [Manage Project Members](../api/resources/project/members.mdx) section for more information.
+## Members
 
-### Templates
+Every project has members: the users and teams authorized to access it. Only members (and global admins) can see or interact with resources inside a project. Each member is assigned a role that defines what they can do within the project.
 
-Projects contain a list of allowed templates that can be used by members to create virtual
-cluster instances. Admins can configure default templates, or simply allow all templates for the project.
-See the [Manage Allowed Templates](../administer/projects/allowed/templates.mdx) section for more information.
+[Manage project members →](../api/resources/project/members.mdx)
 
-### Allowed Clusters
+## Allowed clusters
 
-Each project may define specific clusters that members of the project have access to. The member users and teams
-will have their roles propagated to each allowed cluster. See the [Manage Allowed Clusters](../administer/projects/allowed/clusters.mdx) section for more information.
+Each project specifies which connected clusters its members can deploy tenant clusters into. This lets you direct different customers or teams to specific infrastructure — for example, routing GPU workloads to a cluster with GPU nodes, or keeping a customer's resources in a specific region.
 
-### Quotas
+[Configure allowed clusters →](../administer/projects/allowed/clusters.mdx)
 
-Each project may define a quota to limit resource consumption. By limiting how much resources can be consumed helps prevent from any instance or user to abuse the cluster resources.
+## Templates
 
-### Project Secrets
+Projects define which templates members can use when creating tenant clusters. Admins can set a default template, restrict members to an approved set, or allow all templates. This ensures tenant clusters created within the project meet your configuration and security requirements.
 
-Each project can define secrets to be used within the project. See the [Project Secrets](../administer/secrets/project/create.mdx) section for more information.
+[Configure allowed templates →](../administer/projects/allowed/templates.mdx)
 
-### Integrations
+## Quotas
 
-To help in managing virtual clusters, our projects interate with various external tools like ArgoCD and Rancher. See the [Integrations](../integrations/argocd.mdx) section for more information on what integrations exist.
+Projects can define resource quotas that cap total compute and storage consumption across all tenant clusters and spaces in the project. Quotas prevent any single project from consuming disproportionate infrastructure resources.
+
+## Secrets
+
+Projects can store secrets that are shared across resources within the project. These are useful for distributing credentials, tokens, or configuration that multiple tenant clusters need access to.
+
+[Manage project secrets →](../administer/secrets/project/create.mdx)
+
+## Integrations
+
+Projects support integrations with external tools including ArgoCD and Rancher, allowing you to connect tenant cluster lifecycle management with your existing GitOps or platform tooling.
+
+[View integrations →](../integrations/argocd.mdx)

--- a/platform_versioned_docs/version-4.8.0/understand/what-are-templates.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/what-are-templates.mdx
@@ -4,23 +4,24 @@ sidebar_label: What Are Templates
 sidebar_position: 5
 ---
 
+Templates define a baseline configuration applied to every tenant cluster or space created from them. They are how Platform administrators enforce consistency across a fleet without requiring each user to configure resources manually.
 
-Templates can be created for various resources (i.e. virtual clusters or spaces), that can be used when creating the resource. All the options available in resource creation is available in the template.
+Templates solve a governance problem at scale. Instead of trusting users to apply the right security settings, resource limits, and networking policies, you encode those requirements into a template and make it the only option available in a project.
 
-Templates are a great way for admins to control what configuration options they want to out to end users. Some examples of usage of templates:
-* Creating standard developer environment for a
-given team or organization
-* Creating pre-built environments to be used in continuous
-integration and testing
+## What templates can include
 
-Templates can include settings such as:
+- A base `vcluster.yaml` configuration defining the tenant cluster's control plane, worker node type, backing store, and sync settings
+- Resource quotas, limit ranges, and network policies for namespace-level isolation
+- Kubernetes objects deployed into the tenant cluster at creation time, such as tooling, pre-populated test data, or CRDs
+- [Apps](what-are-apps.mdx) — packaged applications deployed into the tenant cluster when it is created
+- Parameters that let users customize within defined bounds at creation time
 
-- Isolation relevant objects, such as resource quotas, limit ranges and [network policies](/vcluster/configure/vcluster-yaml/policies/network-policy).
-- Kubernetes objects (including CRDs for virtual clusters). This could include development tooling, pre-populated databases with test data, or any other useful resources.
-- Custom defined [Apps](what-are-apps.mdx)
+## How templates work with projects
 
-## Allow templates in projects
+Templates are created at the global level by Platform administrators. To make a template available to project members, it must be explicitly allowed within that project. Admins can set a default template for a project, restrict members to a specific set, or allow all templates.
 
-Templates are created at a global level, but to use a template, they need to be given permission to be allowed in a given project.
+This two-level model (global definition, per-project access) means you can maintain a library of approved configurations and expose only the relevant ones to each team or customer.
 
-Read more about how to [allow templates in a project](../administer/templates/create-templates#management-access).
+[Create a template →](../administer/templates/create-templates.mdx)
+
+[Allow templates in a project →](../administer/templates/create-templates.mdx#management-access)

--- a/vcluster/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster/deploy/control-plane/docker-container/basics.mdx
@@ -239,7 +239,7 @@ This command removes all Docker containers and networks created for the vCluster
 
 - [Configure Docker-specific settings](../../../configure/vcluster-yaml/experimental/docker.mdx)
 - [Worker node options](../../../introduction/architecture.mdx#worker-nodes)
-- [Explore vCluster features](../../../quick-start-guide.mdx#explore-features)
+- [Explore vCluster features](../../../quick-start-guide.mdx#use-your-tenant-cluster)
 
 ## Config reference
 

--- a/vcluster/introduction/architecture.mdx
+++ b/vcluster/introduction/architecture.mdx
@@ -61,9 +61,9 @@ For AI cloud providers standing up infrastructure from scratch, Standalone solve
   <figcaption>vCluster Standalone control planes as binaries on dedicated VMs</figcaption>
 </figure>
 
-{/* vale off */}
+<!-- vale off -->
 ### vind (vCluster in Docker)
-{/* vale on */}
+<!-- vale on -->
 
 vind runs a complete tenant cluster entirely in Docker containers, with no Kubernetes dependency. The control plane and worker nodes run as containers on a single Docker host. vind always uses private nodes — worker nodes are Docker containers provisioned automatically.
 

--- a/vcluster_versioned_docs/version-0.33.0/_fragments/tenancy-support.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_fragments/tenancy-support.mdx
@@ -8,14 +8,14 @@ Running the control plane as a container with:
 {props.hostNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#host-nodes">Host Nodes</Link>
+      <Link to="/docs/vcluster/introduction/architecture#shared-nodes">Shared Nodes</Link>
     </b>
   </li>
 )}
 {props.privateNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#private-nodes">Private Nodes</Link>
+      <Link to="/docs/vcluster/introduction/architecture#private-nodes">Private Nodes</Link>
     </b>
   </li>
 )}
@@ -23,6 +23,6 @@ Running the control plane as a container with:
 </div>
 )}
 {props.standalone && (
-<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/configure/tenancy-model#private-nodes">private nodes</Link></b>.</div>
+<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/introduction/architecture#private-nodes">private nodes</Link></b>.</div>
 )}
 :::

--- a/vcluster_versioned_docs/version-0.33.0/_partials/deploy/install-cli.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/deploy/install-cli.mdx
@@ -76,9 +76,14 @@ Line 4 of this install script adds the install directory `%APPDATA%\vcluster` to
 </TabItem>
 </Tabs>
 
-Confirm that you've installed the correct version of the vCluster CLI.
+Verify the CLI installed successfully.
 
 ```bash
 vcluster --version
+```
+
+Output is similar to:
+```
+vCluster version 0.x.x
 ```
 

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/deploy-resources.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/deploy-resources.mdx
@@ -1,13 +1,21 @@
 
-To illustrate what happens in the host cluster, create a namespace and deploy NGINX in the virtual cluster.
+Deploy a namespace and workload to your tenant cluster. The next section shows how these resources relate to the Control Plane Cluster.
 
 ```bash
 kubectl create namespace demo-nginx
 kubectl create deployment nginx-deployment -n demo-nginx --image=nginx -r 2
 ```
 
-Check that this deployment creates two pods inside the virtual cluster.
+Check that this deployment creates two pods inside the tenant cluster.
 
 ```bash
 kubectl get pods -n demo-nginx
+```
+
+Output is similar to:
+
+```bash
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-6d6565499c-cbv4w   1/1     Running   0          2m
+nginx-deployment-6d6565499c-s7g8z   1/1     Running   0          2m
 ```

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/deploy-vcluster-with-cli.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/deploy-vcluster-with-cli.mdx
@@ -5,12 +5,13 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 <Flow id="deploy-vcluster">
   <Step>
-   **(Optional)** Create a `vcluster.yaml` to configure your vCluster. Various options can be configured before deploying your vCluster, but even without a `vcluster.yaml`, a vCluster can be deployed with the default options.
+   **(Optional)** If you want to customize how vCluster deploiys, create a `vcluster.yaml`. Various options can be configured before deploying your vCluster. Refer to the `vcluster.yaml` [reference docs](/vcluster/configure/vcluster-yaml/) to explore all configuration options.
+   
+   Otherwise, continue without a `vcluster.yaml` file to deploy a vCluster with default options.
 
-   Refer to the `vcluster.yaml` [reference docs](/vcluster/configure/vcluster-yaml/) to explore all configuration options.
 
 :::tip vcluster.yaml configuration
-If you aren't sure what options you want to configure, you can always upgrade your vCluster after deployment with an updated `vcluster.yaml` to change your configuration. There are some configuration options (e.g. backing store) that can only be defined during deployment and not changed during upgrade.
+If you aren't sure what options you want to configure, you can always upgrade your vCluster after deployment with an updated `vcluster.yaml` to change your configuration. While most options can be configured later, some options can only be defined during the initial deployment. See [pre-deployment configuration options](../../deploy/control-plane/kubernetes-pod/basics.mdx#predeployment-configuration-options) for the full list.
 :::
 
   </Step>
@@ -45,10 +46,10 @@ If you aren't sure what options you want to configure, you can always upgrade yo
 
   </Step>
   <Step>
-    Check out the namespaces in your virtual cluster. When the virtual cluster deployment finishes, your kube context is automatically updated to the virtual cluster. When you run `kubectl` commands, it will now be pointed at your virtual cluster instead of the original Kubernetes cluster.
+    When the tenant cluster deployment finishes, your kube context automatically updates to point to the tenant cluster. Check the namespaces to confirm.
 
     ```
-    kubectl get namespaces # See the namespaces of your virtual cluster
+    kubectl get namespaces # See the namespaces of your tenant cluster
     ```
 
   </Step>

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/explore-features.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/explore-features.mdx
@@ -1,14 +1,15 @@
 import Flow, { Step } from "@site/src/components/Flow";
+import GlossaryTerm from '@site/src/components/GlossaryTerm';
 
 import DeployChangesQuickStartOnly from './deploy-changes-quick-start-vcluster.mdx'
 
 
-Configure features in a `vcluster.yaml` file. These examples show you how to configure some popular features. See the `vcluser.yaml` [configuration reference](/vcluster/configure/vcluster-yaml/) for how to configure additional features.
+Each example below shows a common configuration pattern. Apply any of them by modifying `vcluster.yaml` and redeploying. See the [vcluster.yaml reference](/vcluster/configure/vcluster-yaml/) for the full list of options.
 
 <details>
     <summary>Expose the vCluster control plane</summary>
 
-    There are multiple ways of granting access to the vCluster control plane for external applications like kubectl. The following example uses an Ingress, but you can also do it via ServiceAccount, LoadBalancer, and NodePort.
+    There are multiple ways of granting access to the vCluster control plane for external applications like kubectl. The following example uses an Ingress, but you can also do it with ServiceAccount, LoadBalancer, and NodePort.
 
     <Flow>
         <Step>
@@ -40,14 +41,14 @@ Configure features in a `vcluster.yaml` file. These examples show you how to con
 <details>
     <summary>Show real nodes</summary>
 
-        By default, vCluster syncs pseudo nodes from the host cluster to the virtual cluster. However, deploying a vCluster instance via the CLI on a local Kubernetes cluster automatically enables real node syncing, so you would not see a difference in this context.
+        By default, vCluster syncs <GlossaryTerm term="pseudo-nodes">pseudo nodes</GlossaryTerm> from the Control Plane Cluster to the tenant cluster. However, deploying a vCluster instance with the CLI on a local Kubernetes cluster automatically enables real node syncing, so you would not see a difference in this context.
 
-        Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. Therefore, for use cases requiring real node information, you can opt to sync the real nodes into the virtual cluster.
+        Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. Therefore, for use cases requiring real node information, you can opt to sync the real nodes into the tenant cluster.
 
         <Flow>
                 <Step>
 
-                    Modify `vcluster.yaml` to sync the nodes from the host cluster to the virtual cluster.
+                    Modify `vcluster.yaml` to sync the Nodes from the Control Plane Cluster to the tenant cluster.
 
                     ```yaml title="vcluster.yaml node sync configuration"
                     sync:
@@ -68,14 +69,14 @@ Configure features in a `vcluster.yaml` file. These examples show you how to con
 </details>
 
 <details>
-    <summary>Sync ingress classes from host cluster to virtual cluster</summary>
+    <summary>Sync Ingress classes from the Control Plane Cluster to the tenant cluster</summary>
 
-        If you want to use an ingress controller from the host cluster inside your virtual cluster by syncing `Ingress` resources from the virtual cluster to host cluster, and allow the host cluster IngressClasses to be viewable, enable `IngressClass` syncing from the host cluster to virtual cluster.
+        If you want to use an Ingress controller from the Control Plane Cluster inside your tenant cluster by syncing Ingress resources from the tenant cluster to the Control Plane Cluster, and allow the Control Plane Cluster IngressClasses to be viewable, enable `IngressClass` syncing from the Control Plane Cluster to the tenant cluster.
 
         <Flow>
             <Step>
 
-                Modify `vcluster.yaml` to sync the IngressClasses from the host cluster to the virtual cluster.
+                Modify `vcluster.yaml` to sync the IngressClasses from the Control Plane Cluster to the tenant cluster.
 
                 ```yaml title="vcluster.yaml ingress class sync configuration"
                 sync:
@@ -96,14 +97,14 @@ Configure features in a `vcluster.yaml` file. These examples show you how to con
 </details>
 
 <details>
-    <summary>Sync ingress from virtual cluster to host cluster</summary>
+    <summary>Sync Ingress from the tenant cluster to the Control Plane Cluster</summary>
 
-        Create an ingress in a virtual cluster to make a service in that virtual cluster available via a hostname/domain. Instead of having to run a separate ingress controller in each virtual cluster, sync the ingress resource to the host cluster so that the virtual cluster can use a shared ingress controller running in the host cluster.
+        Create an Ingress in a tenant cluster to make a service in that tenant cluster available from a hostname/domain. Instead of having to run a separate Ingress controller in each tenant cluster, sync the Ingress resource to the Control Plane Cluster so that the tenant cluster can use a shared Ingress controller running in the Control Plane Cluster.
 
         <Flow>
             <Step>
 
-                Modify `vcluster.yaml` to sync the ingresses from the virtual cluster to the host cluster.
+                Modify `vcluster.yaml` to sync the Ingresses from the tenant cluster to the Control Plane Cluster.
 
                 ```yaml
                 sync:
@@ -124,14 +125,14 @@ Configure features in a `vcluster.yaml` file. These examples show you how to con
 </details>
 
 <details>
-    <summary>Sync services from host cluster to virtual cluster</summary>
+    <summary>Sync Services from the Control Plane Cluster to the tenant cluster</summary>
 
-        In this example, you map a service `my-host-service` in the namespace `my-host-namespace` to the virtual cluster service `my-virtual-service` inside the virtual cluster namespace `team-x`.
+        In this example, you map a Service `my-host-service` in the namespace `my-host-namespace` to the tenant cluster Service `my-virtual-service` inside the tenant cluster namespace `team-x`.
 
         <Flow>
             <Step>
 
-                Modify `vcluster.yaml` to sync the ingresses from the virtual cluster to the host cluster.
+                Modify `vcluster.yaml` to sync the Services from the Control Plane Cluster to the tenant cluster.
 
                 ```yaml
                 replicateServices:

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/key-concepts.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/key-concepts.mdx
@@ -1,8 +1,5 @@
-Before deploying a vCluster, it's important to understand the components of a virtual cluster and how that creates 
-a certain level of tenancy for your virtual cluster. 
+Before deploying a vCluster, it's important to understand the components of a tenant cluster and how they determine your isolation model.
 
-- [**Architecture of Tenancy Models**](../../introduction/architecture.mdx): Different tenancy models can be achieved based on how the vCluster is built, but the main two
-components that will dictate your tenancy models are the vCluster control plane and worker nodes.
-- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane): Contains a Kubernetes API server, a controller manager and a data store mount. 
-- [**Worker Nodes**](../../configure/tenancy-model.mdx): Worker nodes can be either from the host cluster that the vCluster control plane is deployed on.
+- [**Control plane**](../../introduction/architecture.mdx#control-plane): Contains a Kubernetes API server, a controller manager, and a data store. Runs on the Control Plane Cluster but is completely invisible to tenants.
+- [**Worker nodes**](../../introduction/architecture.mdx#worker-nodes): Worker nodes can be drawn from the Control Plane Cluster's node pool (shared nodes) or provisioned as dedicated private nodes.
 

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/pre-requisites.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/pre-requisites.mdx
@@ -1,7 +1,29 @@
-In order to deploy vCluster, you need the following:
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+Prerequisites depend on your deployment model. Pick your path before continuing.
+
+<Tabs
+  groupId="deployment-method"
+  defaultValue="kubernetes"
+  values={[
+    { label: "Kubernetes Cluster", value: "kubernetes" },
+    { label: "Docker (vind)", value: "docker" },
+  ]
+}>
+<TabItem value="kubernetes">
 
 * [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 * [Helm v3.10.0+](https://helm.sh/docs/intro/install/)
-* Access to a Kubernetes v1.28+ cluster with permissions to deploy applications into a namespace. This is considered the host cluster for the vCluster deployment. 
+* Access to a Kubernetes v1.28+ cluster with permissions to deploy applications into a namespace. No cluster-admin or cluster-wide permissions are required. This cluster acts as the Control Plane Cluster for the tenant cluster deployment.
 
-<p></p>
+</TabItem>
+<TabItem value="docker">
+
+* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+* [Docker](https://docs.docker.com/get-docker/) installed and running
+
+No Kubernetes cluster required.
+
+</TabItem>
+</Tabs>

--- a/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/view-host-resources.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/_partials/quick-start-guide/view-host-resources.mdx
@@ -1,20 +1,19 @@
 import Flow, { Step } from "@site/src/components/Flow";
 
-Most resources inside your virtual cluster only exist in your virtual cluster and not in the host cluster.
-
+This step shows the core isolation guarantee: most resources in your tenant cluster remain invisible on the Control Plane Cluster. Only the pods required for scheduling are synced across.
 
 To verify this, perform these steps:
 
 <Flow>
    <Step>
-      Switch your kube context from the virtual cluster to the host cluster by disconnecting.
+      Switch your kube context from the tenant cluster back to the Control Plane Cluster by disconnecting.
 
       ```bash
       vcluster disconnect
       ```
    </Step>
    <Step>
-      Check the namespaces in the host cluster to confirm you are in the correct kube context.
+      Check the namespaces on the Control Plane Cluster to confirm you are in the correct kube context.
 
       ```bash
       kubectl get namespaces
@@ -30,17 +29,17 @@ To verify this, perform these steps:
       ```
    </Step>
    <Step>
-      Look at all the deployments in the `team-x` namespace to see if the `nginx-deployment` deployment was deployed on the host cluster.
+      Look at the deployments in the `team-x` namespace to verify `nginx-deployment` was not synced to the Control Plane Cluster.
 
       ```bash
       kubectl get deployments -n team-x
       ```
 
-      Notice that this `deployment` resource does **not** exist in the host cluster. By default, it does not get synced from the virtual cluster to the host cluster because it isn't required to run this workload in the host cluster.
+      This `deployment` resource does **not** exist on the Control Plane Cluster. By default, Deployments are not synced from the tenant cluster to the Control Plane Cluster. Only the pods that need to be scheduled sync.
 
    </Step>
    <Step>
-      Now, look for the NGINX pods on the host cluster.
+      Now look for the NGINX pods on the Control Plane Cluster.
 
       ```bash
       kubectl get pods -n team-x
@@ -55,29 +54,20 @@ To verify this, perform these steps:
       nginx-deployment-6d6565499c-s7g8z-x-demo-nginx-x-my-vcluster   1/1     Running   0          20m
       ```
 
-      You can see from the output that the the two NGINX pods exist in the host cluster. To prevent collisions, the pod names and their namespaces are rewritten by vCluster during the sync process from the virtual cluster to the host cluster.
+      The two NGINX pods exist on the Control Plane Cluster. vCluster rewrites pod names and namespaces during the sync process to prevent collisions.
 
+<details>
+<summary>How vCluster stores state (StatefulSet vs Deployment)</summary>
 
-:::info vCluster Control Plane
-The vCluster `my-cluster-0` pod is also known as the vCluster control plane.
+The `my-vcluster-0` pod is the vCluster control plane.
 
-When a local persistent storage is needed, a virtual cluster is deployed as a
-[StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/),
-which provides stable, unique pod identities including a persistent volume.
-StatefulSets ensure that each vCluster pod maintains a consistent network identity and, when configured, persistent storage.
-This is essential for vCluster’s internal data, as it utilizes
-[Kine](https://github.com/k3s-io/kine), a shim between Kubernetes and relational
-databases, along with an embedded SQLite database (`state.db`) to store state information.
+vCluster deploys as a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) when it needs local persistent storage. The StatefulSet provides stable pod identities and a persistent volume for [Kine](https://github.com/k3s-io/kine), vCluster's internal data store, which uses an embedded SQLite database (`state.db`).
 
-However when no local persistent storage is needed, as is in the case of
-external database, a  virtual cluster is deployed as a
-[Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/).
+When you configure an external database, vCluster deploys as a [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) instead.
 
-By default, vCluster does not persist data outside of its pods.
-Consequently, deleting a vCluster pod without persistent storage results in data
-loss. You can configure external [backingStore](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/) to persist data outside of the
-pod.
-:::
+By default, vCluster does not persist data outside of its pods. Deleting a vCluster pod without persistent storage causes data loss. Configure an external [backing store](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/) to persist data outside the pod.
+
+</details>
 
    </Step>
 </Flow>

--- a/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/README.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/README.mdx
@@ -38,10 +38,9 @@ To explore configuration options, review the [vCluster chart values file](https:
 
 ## Deploy a virtual cluster
 
-Before you deploy, you should review the [different tenancy models](../tenancy-model) to determine how the infrastructure of the virtual
-cluster will be configured.
+Before you deploy, review the [worker node deployment options](../../introduction/architecture#worker-nodes) to determine how the infrastructure of the tenant cluster will be configured.
 
-Once you've determined your tenancy model, read the different ways to deploy:
+Once you've chosen your deployment path, read the different ways to deploy:
 
 * [Basics](../../deploy/control-plane/kubernetes-pod/basics)
 * [High Availability](../../deploy/control-plane/kubernetes-pod/high-availability)

--- a/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -241,6 +241,8 @@ Check the logs to verify the pod rejoins successfully:
 If more than one pod is down with `podManagementPolicy: OrderedReady`, migrate to `Parallel` first before attempting recovery.
 :::
 
+### Migrate to Parallel {#migrate-to-parallel}
+
 <Flow>
 <Step title="Verify PVC retention policy">
 Check that the StatefulSet retains PVCs on deletion:
@@ -265,7 +267,6 @@ Delete the StatefulSet without deleting the pods:
 </Step>
 
 <Step title="Update configuration to Parallel">
-<a id="migrate-to-parallel"></a>
 
 Update your virtual cluster configuration to use `Parallel` pod management policy.
 

--- a/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/sleep.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/configure/vcluster-yaml/sleep.mdx
@@ -98,7 +98,7 @@ With auto sleep enabled, any traffic routed to a Service in the virtual cluster 
   <SleepIstioExample />
 </details>
 
-### Enable auto sleep with label selectors and schedules
+### Enable auto sleep with label selectors and schedules {#enable-sleep-with-label-selectors-and-schedules}
 
 Use label selectors and schedules to configure auto sleep based on inactivity or specific timing:
 

--- a/vcluster_versioned_docs/version-0.33.0/configure/what-is-vcluster-yaml.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/configure/what-is-vcluster-yaml.mdx
@@ -14,14 +14,13 @@ import TenancySupport from '../_fragments/tenancy-support.mdx';
 
 <!-- vale off -->
 
-Every virtual cluster requires configuration settings that define how the vCluster operates. 
-The `vcluster.yaml` file is the central configuration source for these settings. It controls everything from the control plane architecture and
- worker node pool and based on those choices, other features may be limtied. 
+The `vcluster.yaml` file is the central configuration source for a tenant cluster. It controls the control plane architecture, worker node pool, resource sync rules, networking, and access settings. Some choices — such as the worker node type and backing store — must be made at deployment time and cannot be changed later.
 
-When you deploy a virtual cluster, the vCluster CLI uses this configuration file and applies your specified settings. 
-The file is optional - if you don't provide one, vCluster applies defaults that work for most use cases using the shared nodes tenancy model, which assumes
-using the all the host cluster's worker nodes and all resources syncing to the same namespace on the host cluster. However, most production deployments 
-benefit from custom configuration to match specific requirements.
+The file is optional. If you don't provide one, vCluster uses shared nodes (the underlying cluster's node pool) with all resources syncing to a single namespace. Most production deployments benefit from explicit configuration.
+
+:::tip New to vCluster?
+If you haven't chosen a deployment path yet, start with [What is vCluster?](../introduction/what-are-virtual-clusters.mdx) or the [architecture overview](../introduction/architecture.mdx) before configuring `vcluster.yaml`.
+:::
 
 ## Configuration structure for vcluster.yaml 
 
@@ -43,9 +42,8 @@ Key configuration areas include:
 
 You can configure which type of worker nodes to use for the virtual cluster. 
 
-- **Host Cluster's Worker Nodes**: Choose either all or specific set of nodes of the host cluster's worker nodes. 
-- **Private Nodes**: Choose to use individual nodes that are not connected to any other Kubernetes cluster. You can either join manually provisioned nodes to a vCluster or can configure vCluster
-to automatically provision and join nodes based on resource requirements.
+- **Shared nodes**: Use all or a labeled subset of the underlying cluster's worker nodes.
+- **Private nodes**: Dedicated nodes that join exclusively through a token-based process. Nodes can be manually provisioned or automatically managed by vCluster Platform.
 
 ### Access configuration
 
@@ -58,10 +56,10 @@ You can configure access settings to control how users and applications connect 
 
 <TenancySupport hostNodes="true" />
 
-When running the deployment as a container and using the host cluster's worker nodes, virtual clusters need to share certain resources with their host cluster to function properly. The sync configuration controls this sharing in both directions:
+When using shared nodes, the tenant cluster shares certain resources with the underlying cluster to function properly. The sync configuration controls this in both directions:
 
-- **From host to virtual**: Configure which host cluster resources appear inside the virtual cluster through [host-to-virtual synchronization](/vcluster/configure/vcluster-yaml/sync/from-host/). Common examples include nodes, storage classes, and priority classes.
-- **From virtual to host**: Define which virtual cluster resources sync to the host cluster through [virtual-to-host synchronization](/vcluster/configure/vcluster-yaml/sync/to-host/). This typically includes pods, services, and persistent volume claims that need to run on the host.
+- **From underlying cluster to tenant**: Configure which resources from the underlying cluster appear inside the tenant cluster through [host-to-virtual synchronization](/vcluster/configure/vcluster-yaml/sync/from-host/). Common examples include nodes, storage classes, and priority classes.
+- **From tenant to underlying cluster**: Define which tenant cluster resources sync to the underlying cluster through [virtual-to-host synchronization](/vcluster/configure/vcluster-yaml/sync/to-host/). This typically includes pods, services, and persistent volume claims.
 
 ## Example vcluster.yaml configuration
 
@@ -75,7 +73,7 @@ Each configuration section has a specific purpose in the virtual cluster setup:
 - **Real node synchronization**: Instead of using vCluster's default "pseudo" nodes, this configuration syncs real [node](/vcluster/configure/vcluster-yaml/sync/from-host/nodes) information from the host cluster. The `clearImageStatus` option removes image information from synced nodes to reduce data transfer and storage requirements.
 - **Kubeconfig access**: The configuration defines how vCluster exports the [kubeconfig](/vcluster/configure/vcluster-yaml/export-kube-config) for accessing the virtual cluster. The exported kubeconfig gets stored in a Kubernetes secret, making it available for CI/CD pipelines, ArgoCD apps, or Terraform configurations.
 
-### Control plane as a container and host nodes
+### Control plane as a container and shared nodes
 
 <TenancySupport hostNodes="true" />
 
@@ -178,10 +176,9 @@ exportKubeConfig:
 
 ## Deploy a virtual cluster 
 
-Before you deploy, you should review the [different tenancy models](./tenancy-model) to determine how the infrastructure of the virtual 
-cluster will be configured. 
+Before you deploy, review the [worker node deployment options](../introduction/architecture#worker-nodes) to determine how the infrastructure of the tenant cluster will be configured.
 
-Once you've determined your tenancy model, read the different ways to deploy:
+Once you've chosen your deployment path, read the different ways to deploy:
 
 ### Control plane as a container
 

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/docker-container/basics.mdx
@@ -238,7 +238,7 @@ This command removes all Docker containers and networks created for the vCluster
 ## Next steps
 
 - [Configure Docker-specific settings](../../../configure/vcluster-yaml/experimental/docker.mdx)
-- [Learn about different tenancy models](../../../configure/tenancy-model.mdx)
+- [Worker node options](../../../introduction/architecture.mdx#worker-nodes)
 - [Explore vCluster features](../../../quick-start-guide.mdx#explore-features)
 
 ## Config reference

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/docker-container/basics.mdx
@@ -239,7 +239,7 @@ This command removes all Docker containers and networks created for the vCluster
 
 - [Configure Docker-specific settings](../../../configure/vcluster-yaml/experimental/docker.mdx)
 - [Worker node options](../../../introduction/architecture.mdx#worker-nodes)
-- [Explore vCluster features](../../../quick-start-guide.mdx#explore-features)
+- [Explore vCluster features](../../../quick-start-guide.mdx#use-your-tenant-cluster)
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/kubernetes-pod/basics.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/kubernetes-pod/basics.mdx
@@ -26,7 +26,7 @@ Before deploying, it's recommended to review the set of configuration options th
 
 <PreRequisites />
 
-Detailed instructions are provided for starting different types of host clusters, e.g. [EKS](./environment/eks), [AKS](./environment/aks), [GKE](./environment/gke) or [OpenShift](./environment/openshift).
+Detailed instructions are provided for specific Control Plane Cluster environments: [EKS](./environment/eks), [AKS](./environment/aks), [GKE](./environment/gke), and [OpenShift](./environment/openshift).
 
 ## Deploy vCluster
 
@@ -37,11 +37,10 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 <Deploy />
 
-## Deploy vCluster with the vCluster Platform
+## Deploy with vCluster Platform
 
-Virtual clusters can be deployed as standalone virtual clusters on host clusters as described above, but there is also a vCluster Platform that is a UI to manage your virtual clusters, host clusters and other resources.
+Tenant clusters can be deployed directly as described above, or managed centrally through vCluster Platform — a management UI for tenant clusters, access control, and lifecycle operations.
 
-There are many [features](/platform/) that are included as part of the vCluster Platform besides having a central management platform for virtual clusters.
+There are many [features](/platform/) included as part of vCluster Platform beyond central management.
 
-If you already have vCluster Platform, [learn how to deploy virtual
-clusters in the platform](/platform/use-platform/virtual-clusters/create/create-no-template).
+If you already have vCluster Platform, [learn how to deploy tenant clusters in the platform](/platform/use-platform/virtual-clusters/create/create-no-template).

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx
@@ -14,12 +14,12 @@ import Flow, { Step } from '@site/src/components/Flow';
 
 This guide provides comprehensive CIS Kubernetes Benchmark implementation and assessment for vCluster deployments according to the [Center for Internet Security (CIS) Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes). The CIS Kubernetes Benchmark is an industry-standard security framework that defines best practices for securing Kubernetes environments. This guide is designed for platform engineers managing virtual Kubernetes clusters, DevOps teams deploying vCluster in production environments, security teams responsible for compliance and cluster hardening, and anyone running vCluster in multi-tenant or production environments.
 
-vCluster creates a lightweight, virtual Kubernetes control plane that runs inside pods within your existing (host) Kubernetes cluster. The architecture creates a unique security situation where virtualized components such as the vCluster API server, scheduler, and controller manager run as containers, while host dependencies mean some security controls still depend on the underlying host cluster, and namespace isolation ensures each vCluster operates within its own namespace on the host cluster. Because of the hybrid approach, traditional CIS benchmark controls need adaptation specifically for vCluster environments. Some controls apply directly, others require modifications, and some may not apply at all.
+vCluster creates a lightweight, virtualized Kubernetes control plane that runs inside pods on your Control Plane Cluster. The architecture creates a unique security situation where virtualized components such as the vCluster API server, scheduler, and controller manager run as containers, while some security controls still depend on the underlying Control Plane Cluster, and namespace isolation ensures each vCluster operates within its own namespace. Because of the hybrid approach, traditional CIS benchmark controls need adaptation specifically for vCluster environments. Some controls apply directly, others require modifications, and some may not apply at all.
 
-By following this guide, you apply relevant CIS controls specifically adapted for vCluster's architecture and improve security posture of your virtual clusters without breaking functionality. You'll also understand responsibility boundaries between your host cluster and vCluster security, implement auditable hardening that can be validated for compliance purposes, and maintain operational efficiency while meeting security requirements.
+By following this guide, you apply relevant CIS controls specifically adapted for vCluster's architecture and improve the security posture of your tenant clusters without breaking functionality. You'll also understand responsibility boundaries between your Control Plane Cluster and vCluster security, implement auditable hardening that can be validated for compliance purposes, and maintain operational efficiency while meeting security requirements.
 
 :::note
-This guide assumes that the host Kubernetes cluster is already hardened in accordance with the CIS benchmark. The focus here is on securing the vCluster environment itself, including its API server, control plane components, and access controls.
+This guide assumes that the Control Plane Cluster is already hardened in accordance with the CIS benchmark. The focus here is on securing the vCluster environment itself, including its API server, control plane components, and access controls.
 :::
 
 This guide is intended to be used with the following versions of CIS Kubernetes Benchmark, Kubernetes, and vCluster:
@@ -194,11 +194,11 @@ controlPlane:
 
 ### API Server setting EventRateLimit
 
-In multi-tenant environments or production clusters, a misbehaving application could overwhelm your API server by generating excessive events. Event flooding could make the entire cluster unresponsive, prevent legitimate workloads from functioning, and create cascading failures across your infrastructure. EventRateLimit admission control ensures no single source can flood the API server with too many requests. The following example configuration sets a server-wide limit of 50 events per second with a burst allowance of 100 events.
+In environments with multiple tenant clusters or in production, a misbehaving application could overwhelm your API server by generating excessive events. Event flooding could make the entire cluster unresponsive, prevent legitimate workloads from functioning, and create cascading failures across your infrastructure. EventRateLimit admission control ensures no single source can flood the API server with too many requests. The following example configuration sets a server-wide limit of 50 events per second with a burst allowance of 100 events.
 
 You can ensure that the admission control plugin EventRateLimit is set.
 
-Using EventRateLimit admission control enforces a limit on the number of events that the API Server accepts in a given time slice. A misbehaving workload could overwhelm and DoS the API Server and make it unavailable. This particularly applies to a multi-tenant cluster, where there might be a small percentage of misbehaving tenants which could have a significant impact on the performance of the cluster overall. It is recommended to limit the rate of events that the API server accepts.
+Using EventRateLimit admission control enforces a limit on the number of events that the API Server accepts in a given time slice. A misbehaving workload could overwhelm and DoS the API Server and make it unavailable. This particularly applies when multiple tenants share infrastructure, where a small percentage of misbehaving tenants could have a significant impact on the performance of the cluster overall. It is recommended to limit the rate of events that the API server accepts.
 
 The following configuration prevents denial-of-service attacks by limiting how many events the API server processes. 
 
@@ -255,11 +255,10 @@ controlPlane:
 
 ## Reference hardened vCluster configuration
 
-Since the worker nodes of a vCluster can be either from a shared host cluster or individual private nodes, there
-are different hardened vCluster configuration files and assessment guides. 
+Since the worker nodes of a vCluster can be either shared nodes from the Control Plane Cluster or dedicated private nodes, there are different hardened vCluster configuration files and assessment guides. 
 
 <details>
-    <summary>vCluster with shared host cluster nodes</summary>
+    <summary>vCluster with shared nodes</summary>
 
     The configuration combines all the individual security settings into a single vCluster values file. You need to create the supporting ConfigMaps and Secrets (shown in the sections above) before applying the configuration. Key security features include disabled anonymous authentication, strong TLS ciphers only, multiple admission controllers for enhanced security, disabled profiling on control plane components, tuned garbage collection, and enabled virtual scheduler for improved workload isolation.
 
@@ -332,7 +331,7 @@ are different hardened vCluster configuration files and assessment guides.
           enabled: true
     ```   
 
-  The hardening guide helps you configure your virtual cluster to meet the CIS Kubernetes Benchmark. Review the [assessment guide for using shared host cluster nodes](./host-nodes/self-assessment.mdx) to validate the configuration by testing it against specific CIS controls. Not all controls apply directly because of the namespaced and virtualized nature of vCluster.
+  The hardening guide helps you configure your tenant cluster to meet the CIS Kubernetes Benchmark. Review the [assessment guide for shared nodes](./host-nodes/self-assessment.mdx) to validate the configuration by testing it against specific CIS controls. Not all controls apply directly because of the namespaced and virtualized nature of vCluster.
 
 </details>
 
@@ -426,6 +425,6 @@ are different hardened vCluster configuration files and assessment guides.
       serviceCIDR: 10.128.0.0/16
     ```   
 
-  The hardening guide helps you configure your virtual cluster to meet the CIS Kubernetes Benchmark. Review the [assessment guide for private nodes](./private-nodes/self-assessment.mdx) to validate the configuration by testing it against specific CIS controls. Not all controls apply directly because of the namespaced and virtualized nature of vCluster.
+  The hardening guide helps you configure your tenant cluster to meet the CIS Kubernetes Benchmark. Review the [assessment guide for private nodes](./private-nodes/self-assessment.mdx) to validate the configuration by testing it against specific CIS controls. Not all controls apply directly because of the namespaced and virtualized nature of vCluster.
 
 </details>

--- a/vcluster_versioned_docs/version-0.33.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/architecture.mdx
@@ -61,9 +61,9 @@ For AI cloud providers standing up infrastructure from scratch, Standalone solve
   <figcaption>vCluster Standalone control planes as binaries on dedicated VMs</figcaption>
 </figure>
 
-{/* vale off */}
+<!-- vale off -->
 ### vind (vCluster in Docker)
-{/* vale on */}
+<!-- vale on -->
 
 vind runs a complete tenant cluster entirely in Docker containers, with no Kubernetes dependency. The control plane and worker nodes run as containers on a single Docker host. vind always uses private nodes — worker nodes are Docker containers provisioned automatically.
 

--- a/vcluster_versioned_docs/version-0.33.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/architecture.mdx
@@ -7,105 +7,146 @@ sidebar_class_name: host-nodes private-nodes standalone
 
 import HowDoesSyncingWork from '../_fragments/how-does-syncing-work.mdx'
 import TenancySupport from '../_fragments/tenancy-support.mdx';
+import GlossaryTerm from '@site/src/components/GlossaryTerm';
+import ControlPlanesAsPods from '@site/static/media/diagrams/control-planes-as-pods.svg';
+import ControlPlanesOnVMs from '@site/static/media/diagrams/control-planes-on-vms.svg';
 
+vCluster provisions <GlossaryTerm term="tenant-cluster">tenant clusters</GlossaryTerm> on your infrastructure or directly on bare metal. Two choices shape your deployment architecture: where the control plane runs, and how worker nodes are deployed. Together, these determine the isolation level each tenant receives.
 
+## Control plane
 
-Virtual clusters are fully functional Kubernetes clusters, but how you deploy the control plane and worker nodes
-defines the tenancy model for the virtual cluster.
+Every tenant cluster runs a dedicated <GlossaryTerm term="control-plane">control plane</GlossaryTerm>. The control plane manages all operations within the tenant cluster and is completely invisible to tenants. It contains:
 
-## Shared Nodes
+- A **Kubernetes API server**, the management interface for all API requests within the tenant cluster.
+- A **controller manager**, which maintains the state of Kubernetes resources like pods, ensuring they match the desired configuration.
+- A **data store**, which stores all API resources. By default, an embedded SQLite database is used, but you can [choose other data stores](../configure/vcluster-yaml/control-plane/components/backing-store/) like <GlossaryTerm term="etcd">etcd</GlossaryTerm>, MySQL, and PostgreSQL.
+- A **syncer**, which synchronizes resources between the tenant cluster and the underlying infrastructure.
+- A **scheduler**, an optional component for scheduling workloads. By default, vCluster reuses the Control Plane Cluster's scheduler to reduce resource usage. You can [enable the virtual scheduler](../configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler) when you need node labels, taints, drain operations, or custom scheduling behavior.
 
-The shared nodes tenancy model allows multiple virtual clusters to run workloads on the same physical 
-Kubernetes nodes. This configuration is ideal for scenarios where maximizing resource utilization is a 
-top priority—especially for internal developer environments, CI/CD pipelines, and cost-sensitive use cases.
+All of these components run together in a single container within a StatefulSet pod. The API server, controller manager, data store, and syncer are one unified process. CoreDNS deploys as a separate pod in the same namespace. If you opt into external etcd, it runs as its own StatefulSet. On the underlying cluster, `kubectl get pods -n <vcluster-namespace>` shows something like:
 
-Each virtual cluster has its own isolated control plane, API server, and CRDs, but workloads are scheduled
- without node-level isolation. This setup helps platform teams deliver the benefits of vCluster 
- (like per-tenant customization and faster provisioning) while minimizing infrastructure costs by 
- sharing underlying compute across all tenants.
+```
+NAME                                 READY   STATUS    AGE
+vcluster-0                           1/1     Running   5m
+vcluster-coredns-6b9f8d6f6b-xk2p9    1/1     Running   5m
+```
 
-<figure>
-<img
-  src={require('@site/static/media/diagrams/shared-nodes.png').default}
-  alt="Architecture for Shared Nodes"
- />
-  <figcaption>Architecture for Shared Nodes</figcaption>
-</figure>
+Where that control plane runs is your first architectural choice.
 
-## Dedicated Nodes
+### On an existing Kubernetes cluster
 
-Dedicated Nodes allow platform teams to give each virtual cluster exclusive access to a set of physical nodes—without having to provision entirely separate clusters. By combining vCluster’s multi-tenant architecture with Kubernetes node selectors, workloads from each virtual cluster can be scoped to a specific group of labeled nodes, ensuring compute separation across tenants.
+<TenancySupport hostNodes="true" />
 
-This approach enables strong operational boundaries and predictable performance, while maintaining all the benefits of shared infrastructure. It’s especially effective for teams who want dedicated compute for certain tenants, environments, or workloads—without duplicating every part of the platform stack.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/dedicated-nodes.png').default}
-  alt="Architecture for Dedicated Nodes"
- />
-  <figcaption>Architecture for Dedicated Nodes</figcaption>
-</figure>
-
-## Virtual Nodes
-
-Virtualizes node boundaries for enhanced security and separation inside a shared cluster.
-Virtual Nodes provide an effective way to isolate tenant workloads without allocating dedicated physical nodes per tenant. This model leverages virtualization at the node level—through vNode—to create strong scheduling boundaries while continuing to share the underlying infrastructure.
-Each virtual cluster receives its own control plane and interacts with a virtualized view of the node environment. Workloads are scheduled into tenant-scoped virtual nodes, which are translated into actual pods on the shared cluster. This allows teams to achieve node-level isolation semantics, including taints and tolerations, without managing separate node pools.
+The default deployment mode. The tenant cluster control plane runs as a pod on a <GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm> you operate. vCluster deploys the control plane as a StatefulSet (default) or Deployment inside a dedicated namespace on that cluster.
 
 <figure>
-<img
-  src={require('@site/static/media/diagrams/virtual-nodes.png').default}
-  alt="Architecture for Virtual Nodes"
- />
-  <figcaption>Architecture for Virtual Nodes</figcaption>
+  <ControlPlanesAsPods style={{width: '100%', maxWidth: '600px', height: 'auto', display: 'block', margin: '0 auto'}} role="img" aria-label="Multiple tenant cluster control planes running as pods on a Control Plane Cluster, each connected to external worker nodes" />
+  <figcaption>Tenant cluster control planes as pods on a Control Plane Cluster</figcaption>
 </figure>
 
-## Private Nodes
+Each tenant cluster runs inside its own namespace on the Control Plane Cluster. A namespace contains exactly one tenant cluster. Nesting tenant clusters inside one another is also supported.
 
-Private Nodes provide the strongest isolation among vCluster tenancy models. In this setup, each virtual cluster runs inside its own dedicated Kubernetes host cluster—backed by physically separate nodes, a separate control plane, and separate infrastructure components like CNI and CSI drivers. From the tenant’s perspective, the environment behaves like a single-tenant Kubernetes cluster, with all platform services fully isolated.
+All resources synchronized to the Control Plane Cluster namespace carry owner references back to the tenant cluster. Deleting the tenant cluster — or its namespace — removes all associated resources automatically. No orphaned resources remain.
 
-This approach ensures that no tenant shares compute, networking, or storage with others. It’s best suited for highly sensitive workloads that require strict compliance, regulatory boundaries, or strong guarantees around performance, network isolation, and tenant autonomy.
+<!-- vale off -->
+### vCluster Standalone
+<!-- vale on -->
+
+vCluster Standalone is a complete, zero-dependency Kubernetes distribution. It runs as a self-contained binary on bare metal or VMs, with no dependency on any other Kubernetes distribution. Once deployed, it behaves like any other Kubernetes cluster. You can install vCluster Platform on top of it, deploy tenant clusters, and join additional nodes, exactly as you would with any other cluster.
+
+For AI cloud providers standing up infrastructure from scratch, Standalone solves the "cluster one" problem. You can bootstrap your entire platform using only vCluster tooling, with no external dependencies.
+
+<figure>
+  <ControlPlanesOnVMs style={{width: '100%', maxWidth: '600px', height: 'auto', display: 'block', margin: '0 auto'}} role="img" aria-label="Two vCluster Standalone control planes running as binaries on dedicated VMs, each connected to external worker nodes" />
+  <figcaption>vCluster Standalone control planes as binaries on dedicated VMs</figcaption>
+</figure>
+
+{/* vale off */}
+### vind (vCluster in Docker)
+{/* vale on */}
+
+vind runs a complete tenant cluster entirely in Docker containers, with no Kubernetes dependency. The control plane and worker nodes run as containers on a single Docker host. vind always uses private nodes — worker nodes are Docker containers provisioned automatically.
+
+vind is suited for local development and CI/CD pipelines. It also supports hybrid deployments: external cloud nodes can join a vind cluster through a VPN, combining a local control plane with remote compute.
+
+Key capabilities that distinguish vind from KinD:
+
+- **Sleep and wake** — pause a cluster to free resources and resume it instantly, without deleting and recreating it.
+- **Load balancers out of the box** — Services of type `LoadBalancer` work automatically with no extra setup.
+- **Pull-through image cache** — vind uses the host Docker daemon's image cache directly, so there is no need to run `kind load docker-image` before tests.
+- **External nodes** — cloud instances can join a vind cluster through a VPN for hybrid development scenarios.
+
+| Feature | vind | KinD |
+|---|---|---|
+| Sleep and wake | Yes | No — must delete and recreate |
+| Load balancers | Automatic | Manual setup required |
+| Image caching | Pull-through Docker daemon | Direct registry pulls |
+| External nodes | Yes, via VPN | Local only |
+| CNI/CSI choice | Yes | Limited |
+
+## Worker nodes
+
+Your second architectural choice is how worker nodes are deployed. This determines compute isolation between tenants.
+
+### Private nodes
+
+Each tenant cluster runs on dedicated nodes that join exclusively through a token-based process. Each tenant gets its own CNI, CSI, and compute. No cross-tenant visibility exists at the infrastructure level.
+
+From the tenant's perspective, the environment is indistinguishable from a single-tenant Kubernetes cluster.
 
 <figure>
 <img
   src={require('@site/static/media/diagrams/private-nodes.png').default}
   alt="Architecture for Private Nodes"
+  style={{maxWidth: '600px', display: 'block', margin: '0 auto'}}
  />
   <figcaption>Architecture for Private Nodes</figcaption>
 </figure>
 
-<!-- vale off -->
-## vCluster Standalone
-<!-- vale on -->
+Nodes can come from any Linux infrastructure: bare metal servers, cloud VMs, or any manually joined Linux machine. With [Auto Nodes](../deploy/worker-nodes/private-nodes/auto-nodes/README.mdx), vCluster Platform can provision and deprovision nodes automatically.
 
-vCluster Standalone eliminates the need for a pre-existing Kubernetes host cluster. Instead, the virtual cluster runs as a fully self-contained process—typically inside a single container or VM—capable of bootstrapping its own control plane and simulating the Kubernetes environment.
-This model is ideal for use cases where speed, portability, or independence are paramount. Whether you’re running workloads in CI pipelines, demos, local development setups, or air-gapped environments, vCluster Standalone offers a fast, lightweight way to provision isolated Kubernetes environments without relying on cluster-level infrastructure or orchestration.
+This model suits GPU tenants, regulated workloads, and any environment where full infrastructure separation is required.
+
+### Shared nodes
+
+Tenant workloads run on the same cluster that hosts the control planes, sharing the existing node pool. Multiple tenant clusters run side by side on the same physical nodes. A <GlossaryTerm term="syncer">syncer</GlossaryTerm> component translates workload resources from each tenant cluster into a dedicated namespace on the underlying cluster. Each tenant sees only their own namespaces, pods, and services. The translated copies are invisible to them.
 
 <figure>
 <img
-  src={require('@site/static/media/diagrams/vcluster-standalone-shared-nodes.png').default}
-  alt="Architecture for vCluster Standalone"
+  src={require('@site/static/media/diagrams/shared-nodes.png').default}
+  alt="Architecture for Shared Nodes"
+  style={{maxWidth: '600px', display: 'block', margin: '0 auto'}}
  />
-  <figcaption>Architecture for vCluster Standalone</figcaption>
+  <figcaption>Architecture for Shared Nodes</figcaption>
 </figure>
 
-## vCluster components for host nodes 
- 
-<TenancySupport hostNodes="true" />
+This model suits developer environments, CI/CD pipelines, and high-density internal platforms where compute separation is not required.
 
-### Virtual control plane as a container
+For tenants that need predictable per-tenant compute without full Private Nodes, you can scope workloads to a labeled node pool using [Dedicated Nodes](../deploy/worker-nodes/host-nodes/isolated-workloads.mdx). Node selectors enforce placement on a reserved subset of the underlying cluster's nodes without provisioning separate infrastructure.
 
-vCluster creates isolated Kubernetes environments by deploying a virtual cluster that contains its own dedicated virtual control plane as a container. This control plane orchestrates operations within the virtual cluster and facilitates interaction with the underlying host cluster.
+### Worker node comparison
 
-The virtual control plane is deployed as a single pod managed as a StatefulSet (default) or Deployment that contains the following components:
+| Feature | Private Nodes | Shared Nodes | vind (Docker) |
+|---|---|---|---|
+| Isolated control plane | Yes | Yes | Yes |
+| Custom CNI | Yes | No | Yes |
+| Custom CSI drivers | Yes | No | Limited |
+| Isolated network | Yes | No | Yes |
+| Reuse Control Plane Cluster controllers | No | Yes | No |
+| Tenant workloads visible on Control Plane Cluster | No | Yes | No |
+| Automatic node provisioning | Yes | No | Yes |
+| Requires Control Plane Cluster | Yes | Yes | No |
+| Suitable for local development | No | Limited | Yes |
+| Suitable for CI/CD | Limited | Yes | Yes |
+| Infrastructure overhead | High | Low | Low |
 
-- A **Kubernetes API server**, which is the management interface for all API requests within the virtual cluster.
-- A **controller manager**, which maintains the state of Kubernetes resources like pods, ensuring they match the desired configurations.
-- A **data store**, which is a connection to or mount of the data store where the API stores all resources. By default, an embedded SQLite is used as the datastore, but you can [choose other data stores](../configure/vcluster-yaml/control-plane/components/backing-store/) like etcd, MySQL, and PostgreSQL.
-- A **syncer**, which is a component that synchronizes resources between the virtual cluster and host cluster and facilitates workload management on the host's infrastructure.
-- A **scheduler**, which is an optional component that schedules workloads. By default, vCluster reuses the host cluster scheduler to save on computing resources. If you need to add node labels or taints to control scheduling, drain nodes, or utilize custom schedulers, you can [enable the virtual scheduler](../configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler).
+## Virtual Nodes
 
-### Syncer
+Virtual Nodes add a strong isolation boundary between tenant workloads at the node level. Using [vNode](https://www.vnode.com/docs/) to virtualize node boundaries, each tenant cluster gets its own view of the node environment. vNode enforces taints, tolerations, and scheduling boundaries per tenant.
+
+Virtual Nodes are not a separate deployment choice. They are an isolation layer that applies to any deployment model — shared nodes, private nodes, or Standalone. This makes them particularly valuable for GPU workloads where strict per-tenant separation is required regardless of how the underlying nodes are deployed.
+
+## Syncer
 
 <figure>
 <img
@@ -115,48 +156,42 @@ The virtual control plane is deployed as a single pod managed as a StatefulSet (
   <figcaption>vCluster Architecture for the syncer</figcaption>
 </figure>
 
-When a virtual cluster doesn't have actual worker nodes or a network, it uses a syncer component to synchronize the virtual cluster pods to the underlying host cluster. The host cluster schedules the pod, and the syncer keeps the virtual cluster pod and host cluster pod in sync.
+The syncer links the tenant cluster to the Control Plane Cluster. It keeps the two environments consistent so tenants see a complete, functional Kubernetes cluster without direct access to the Control Plane Cluster. Its role depends on how worker nodes are deployed.
 
-Higher-level Kubernetes resources, such as Deployment, StatefulSet, and CRDs only exist inside the virtual cluster and never reach the API server or data store of the host cluster.
+**With private nodes**, only control plane state is synchronized. The syncer coordinates the tenant cluster's API server with the underlying infrastructure. From an operator's perspective this is nearly transparent. Workloads run directly on dedicated nodes with no sync overhead.
 
-By default, the syncer component synchronizes certain low-level virtual cluster Pod resources, such as ConfigMap and Secret, to the host namespace so that the host cluster scheduler can schedule these pods with access to these resources.
-
-While primarily focused on syncing from the virtual cluster to the host cluster, the syncer also propagates certain changes made in the host cluster back into the virtual cluster. This bi-directional syncing ensures that the virtual cluster remains up-to-date with the underlying infrastructure it depends on.
-
-You can [read more about how the syncer works in more detail](../configure/vcluster-yaml/sync/) and learn how to sync resources to and from the host cluster depending on your use case.
-
-### Host cluster and namespace
-
-Each virtual cluster runs as a regular StatefulSet (default) or Deployment inside a host cluster namespace. Everything that you create inside the virtual cluster lives either inside the virtual cluster itself and/or inside the host namespace.
-
-A host namespace can only contain a single virtual cluster. However, it is possible to run a virtual cluster within another virtual cluster, a concept known as vCluster nesting.
+**With shared nodes**, the syncer also translates workload resources between the tenant cluster and the underlying cluster. This includes Pods, ConfigMaps, Secrets, Services, Ingress, and Gateway API objects. Each resource type has specific sync behavior. Networking resources in particular require careful configuration. If you are deploying with shared nodes, read the [full sync documentation](../configure/vcluster-yaml/sync/) to understand what is synced and how to configure it for your workloads.
 
 <!-- vale off -->
 
-### Networking in virtual clusters
+## Networking
 
-Networking within virtual clusters is crucial for facilitating communication within the virtual environment itself, across different virtual clusters, and between the virtual and host clusters.
+Networking within tenant clusters covers communication inside the tenant cluster, between tenant clusters, and between tenant clusters and the underlying cluster.
+
+:::note
+The networking features below apply to **shared nodes** deployments, where the syncer bridges tenant cluster resources to the underlying cluster. With private nodes, tenant workloads run on dedicated infrastructure and networking is fully isolated per tenant.
+:::
 
 #### Ingress traffic
 
-Instead of having to run a separate ingress controller in each virtual cluster to provide external access to services within the virtual cluster, vCluster can [synchronize Ingress resources](../configure/vcluster-yaml/sync/to-host/networking/ingresses) to utilize the host cluster's ingress controller, facilitating resource sharing across virtual clusters and easing management like configuring DNS for each virtual cluster.
+Instead of running a separate Ingress controller in each tenant cluster, vCluster can [synchronize Ingress resources](../configure/vcluster-yaml/sync/to-host/networking/ingresses) to use the underlying cluster's Ingress controller. This reduces per-tenant overhead and simplifies DNS management across tenant clusters.
 
-#### DNS in virtual clusters
+#### DNS
 
-By default, each virtual cluster deploys its own individual DNS service, which is [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns). The DNS service lets pods within the virtual cluster resolve the IP addresses of other services running in the same virtual environment. This capability is anchored by the syncer component, which maps service DNS names within the virtual cluster to their corresponding IP addresses in the host cluster, adhering to Kubernetes' DNS naming conventions.
+By default, each tenant cluster deploys its own [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns) instance. CoreDNS lets pods within the tenant cluster resolve other services in the same environment. The syncer maps service DNS names in the tenant cluster to their corresponding IP addresses on the underlying cluster, following Kubernetes DNS naming conventions.
 
-With vCluster Pro, [CoreDNS can be embedded](../configure/vcluster-yaml/control-plane/components/coredns) directly into the virtual control plane pod, minimizing the overall footprint of each virtual cluster.
+With vCluster Pro, [CoreDNS can be embedded](../configure/vcluster-yaml/control-plane/components/coredns) directly into the control plane pod, reducing the per-tenant footprint.
 
-#### Communication within a virtual cluster
+#### Communication within a tenant cluster
 
-* **Pod to pod** - Pods within a virtual cluster communicate using the host cluster's network infrastructure, with no additional configuration required. The syncer component ensures these pods maintain Kubernetes-standard networking.
+* **Pod to pod** — Pods within a tenant cluster communicate using the underlying cluster's network infrastructure. No additional configuration is required. The syncer ensures Kubernetes-standard networking is maintained.
 
-* **Pod to service** - Services within a virtual cluster are synchronized to allow pod communication, leveraging the virtual cluster's [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns) for intuitive domain name mappings, as in regular Kubernetes environments.
+* **Pod to service** — Services within a tenant cluster are synchronized to allow pod communication, using [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns) for domain name resolution.
 
-* **Pod to host cluster service** - Services from the host cluster can be [replicated](../configure/vcluster-yaml/networking/replicate-services) into the virtual cluster, allowing pods within the virtual cluster to access host services using names that are meaningful within the virtual context.
+* **Pod to underlying cluster service** — Services from the underlying cluster can be [replicated](../configure/vcluster-yaml/networking/replicate-services) into a tenant cluster, allowing tenant pods to access platform services by name.
 
-* **Pod to another virtual cluster service** - Services can also be mapped between [different virtual clusters](../configure/vcluster-yaml/networking/resolve-dns.mdx). This is achieved through DNS configurations that direct service requests from one virtual cluster to another.
+* **Pod to another tenant cluster's service** — Services can be mapped [between tenant clusters](../configure/vcluster-yaml/networking/resolve-dns.mdx) using DNS configuration that routes requests from one tenant cluster to another.
 
-#### Communication from the host cluster
+#### Communication from the underlying cluster
 
-* **Host pod to virtual cluster service** - Host cluster pods can access services within a virtual cluster by [replicating](../configure/vcluster-yaml/networking/replicate-services#virtual-cluster-to-host-cluster) virtual cluster services to any host cluster namespace. This enables applications running inside the virtual cluster to be accessible to other workloads on the host cluster.
+* **Underlying cluster pod to tenant cluster service** — Pods on the underlying cluster can access services within a tenant cluster by [replicating](../configure/vcluster-yaml/networking/replicate-services#virtual-cluster-to-host-cluster) tenant cluster services to any namespace on the underlying cluster.

--- a/vcluster_versioned_docs/version-0.33.0/introduction/gpu-cloud-platform.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/gpu-cloud-platform.mdx
@@ -1,0 +1,75 @@
+---
+title: Building a GPU cloud platform
+sidebar_label: GPU cloud platform
+sidebar_position: 3
+sidebar_class_name: host-nodes private-nodes standalone
+---
+
+import GlossaryTerm from '@site/src/components/GlossaryTerm';
+
+AI cloud providers face a specific problem: enterprise AI teams expect dedicated Kubernetes clusters with full isolation, GPU Operator support, and the same operational behavior they get from hyperscaler Kubernetes services. Building and operating a real cluster per customer is expensive and operationally unsustainable. Sharing a single cluster across tenants introduces noisy neighbors and hard-to-enforce boundaries.
+
+vCluster solves this by virtualizing the Kubernetes control plane. Every tenant gets a dedicated API server, their own CRDs, RBAC, and a complete cluster experience. From the tenant's perspective it's indistinguishable from a real cluster. For the provider, it provisions in seconds and vCluster Platform manages it centrally — without the overhead of a physical cluster per customer.
+
+## How it fits into your platform
+
+A vCluster deployment has two layers:
+
+1. A **<GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm>** that hosts the virtualized control planes for your tenant clusters. This can be an existing Kubernetes cluster, a purpose-built cluster, or a [vCluster Standalone](#bootstrap-with-vcluster-standalone) instance on your own infrastructure.
+2. **<GlossaryTerm term="tenant-cluster">Tenant clusters</GlossaryTerm>** that run on top of that infrastructure. Each tenant cluster has its own API server, controller manager, data store, and lifecycle.
+
+[vCluster Platform](/platform/) sits above both layers. It handles provisioning, access control, lifecycle management, and node automation across all your tenant clusters and Control Plane Clusters.
+
+## Worker nodes for GPU workloads
+
+The worker node model determines how isolated each tenant's compute is. For AI cloud workloads, the choice typically comes down to whether tenants need fully dedicated infrastructure or whether shared infrastructure with per-tenant node pools is sufficient.
+
+### Private nodes
+
+Each tenant cluster runs on its own dedicated physical nodes, with a separate CNI, CSI, and control plane. No compute, network, or storage is shared. Tenants get full NCCL bandwidth and hardware-level separation.
+
+Private nodes are the right choice for:
+- Multi-node distributed training and large model inference
+- Customers requiring compliance or regulatory isolation
+- Workloads where performance predictability is non-negotiable
+
+[Deploy with private nodes →](../deploy/worker-nodes/private-nodes/README.mdx)
+
+### Shared infrastructure with dedicated node pools
+
+Each tenant cluster gets exclusive access to a labeled node pool on the Control Plane Cluster. Compute is scoped per tenant without provisioning separate infrastructure. CNI, CSI, and platform services are shared.
+
+This is the right choice for:
+- Per-tenant GPU node pools with elastic scaling
+- Customers who need compute separation but not full infrastructure isolation
+- Environments where shared platform services are acceptable
+
+[Dedicated Nodes in the architecture overview →](./architecture.mdx#shared-nodes)
+
+### Add Virtual Nodes for stronger isolation
+
+Virtual Nodes add a strong isolation boundary at the node level using [vNode](https://www.vnode.com/docs/). vNode enforces scheduling boundaries per tenant, giving each tenant its own view of the node environment.
+
+Virtual Nodes are not a deployment model. They are an optional isolation layer that applies to either worker node choice above — private or shared. This makes them valuable when strict per-tenant workload separation is required regardless of how the underlying nodes are deployed.
+
+[Learn about Virtual Nodes →](./architecture.mdx#virtual-nodes)
+
+<!-- vale off -->
+## Bootstrap with vCluster Standalone
+<!-- vale on -->
+
+Every vCluster deployment needs a Control Plane Cluster. For AI cloud providers standing up infrastructure from scratch, [vCluster Standalone](../deploy/control-plane/binary/README.mdx) is a natural choice.
+
+vCluster Standalone is a complete, zero-dependency Kubernetes distribution. It runs on bare metal or VMs with no dependency on any other Kubernetes distribution. Once deployed, it behaves like any Kubernetes cluster. You install vCluster Platform on top of it, deploy tenant clusters, and join bare metal worker nodes — all using vCluster tooling, with no external dependencies.
+
+This solves the "cluster one" problem: you can bootstrap your entire platform stack from bare metal without adopting another Kubernetes distribution.
+
+[Deploy vCluster Standalone →](../deploy/control-plane/binary/README.mdx)
+
+## Next steps
+
+- [Architecture](./architecture.mdx) — understand control plane deployment options, worker node models, and the syncer
+- [Private Nodes](../deploy/worker-nodes/private-nodes/README.mdx) — deploy dedicated GPU infrastructure per tenant
+- [vCluster Standalone](../deploy/control-plane/binary/README.mdx) — bootstrap your Control Plane Cluster on bare metal
+- [vCluster Platform](/platform/) — centralized management, access control, and node automation
+- [vNode](https://www.vnode.com/docs/) — workload isolation layer for GPU tenants

--- a/vcluster_versioned_docs/version-0.33.0/introduction/oss-vs-free.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/oss-vs-free.mdx
@@ -1,7 +1,7 @@
 ---
 title: Open Source vs Free tier
 sidebar_label: OSS vs Free
-sidebar_position: 4
+sidebar_position: 5
 description: Compare vCluster Open Source and Free tier features, understand licensing, and learn how to activate the Free tier
 ---
 

--- a/vcluster_versioned_docs/version-0.33.0/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/what-are-virtual-clusters.mdx
@@ -5,22 +5,56 @@ sidebar_position: 1
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 
-import PartialWhatAreVirtualClusters from '../_partials/what-are-virtual-clusters.mdx'
 import GlossaryTerm from '@site/src/components/GlossaryTerm'
 import FeatureTable from '@site/src/components/FeatureTable';
 
-<FeatureTable names="vclusters" />
+vCluster provisions fully isolated Kubernetes environments, called <GlossaryTerm term="tenant-cluster">tenant clusters</GlossaryTerm>, on your infrastructure or directly on bare metal. Each tenant gets a dedicated API server, its own CRDs and RBAC, and a cluster experience indistinguishable from a dedicated Kubernetes cluster.
 
+The control plane is completely invisible to tenants. There are no shared control plane nodes, no in-cluster agent pods, and no lateral path between environments. vCluster suits any environment where isolation is a hard requirement, from developer platforms and CI/CD pipelines to GPU cloud infrastructure serving paying tenants.
 
-vCluster is an open source solution that enables teams to run virtual Kubernetes clusters inside existing infrastructure. It helps platform engineers create secure, isolated environments for development, testing, CI/CD, and even production workloads, without the cost or overhead of managing separate physical clusters.
+## How to start
 
-vCluster supports a wide range of tenancy models, from lightweight namespace-based setups to more advanced configurations with private nodes, GPUs, and bare metal. Environments are defined declaratively, allowing teams to provision repeatable clusters that match their isolation and performance needs.
+Two questions determine your deployment path.
 
-By consolidating workloads onto fewer host clusters, vCluster reduces infrastructure sprawl, lowers Kubernetes costs, and simplifies multi-tenant platform operations.
+### 1. Do you already have a Kubernetes cluster?
 
-## All vCluster features
+**Yes** — your existing cluster becomes the <GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm> that hosts tenant cluster control planes. You need no additional infrastructure to get started.
 
-vCluster provides a comprehensive set of features across multiple product tiers, from open source capabilities to enterprise-grade features. The table below shows all available features, their product tier availability (OSS, Free, Dev, Prod, Scale, Enterprise), and compatibility with different tenancy models (Shared Nodes, Private Nodes, Standalone).
+**No** — choose one of:
+- **vCluster Standalone** — a zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Suited for AI cloud providers and neoclouds building from bare metal, as well as edge and air-gapped production deployments.
+- **vind (vCluster in Docker)** — runs a complete cluster in Docker containers with no Kubernetes dependency. Suited for local development and CI/CD pipelines.
+
+### 2. How will worker nodes run?
+
+**Shared nodes** — Tenant workloads run on the same cluster that hosts the control planes, sharing the existing node pool. Multiple tenant clusters run side by side on the same physical nodes. Lower overhead, fastest to set up. Suited for developer environments, CI/CD, and high-density internal platforms.
+
+**Private nodes** — Each tenant cluster gets dedicated nodes that join through a token-based process. The network, storage, and compute are fully isolated per tenant. No cross-tenant visibility exists at the infrastructure level. This is the isolation model GPU workloads, regulated industries, and multi-tenant AI cloud platforms require. Nodes can come from any Linux infrastructure. Join nodes to your vCluster from bare metal servers using [vMetal](/docs/platform/administer/bare-metal/overview), cloud VMs through a Terraform node provider, or any manually joined Linux machine, including nodes from other cloud environments.
+
+## Deployment paths
+
+| | Shared nodes | Private nodes |
+|---|---|---|
+| **Existing K8s cluster** | [Deploy the control plane](../deploy/control-plane/kubernetes-pod/basics.mdx) | [Join private nodes](../deploy/worker-nodes/private-nodes/README.mdx) |
+| **vCluster Standalone** | [Install Standalone for density](../deploy/control-plane/binary/basics.mdx) | [Install Standalone for isolation](../deploy/control-plane/binary/basics.mdx) |
+| **vind (Docker)** | — | [Deploy in Docker](../deploy/control-plane/docker-container/basics.mdx) |
+
+:::note
+vind always uses private nodes. It automatically provisions worker nodes as Docker containers.
+:::
+
+## How it works
+
+Each tenant cluster runs a dedicated virtualized control plane as a containerized process on the Control Plane Cluster. The control plane manages all operations within the tenant cluster and cannot be accessed by other tenants.
+
+With **shared nodes**, a <GlossaryTerm term="syncer">syncer</GlossaryTerm> component translates workload resources (Pods, Secrets, ConfigMaps, Services) from each tenant cluster into a dedicated namespace on the underlying cluster. Tenants see their own resources. The translated copies are invisible to them.
+
+With **private nodes**, vCluster synchronizes only control plane state. Workloads run directly on dedicated infrastructure with no sync overhead. Tenants see an environment identical to a dedicated single-tenant cluster.
+
+Tenant clusters are certified Kubernetes distributions. Any conformant tool works against them without modification: `kubectl`, Helm, Argo, Crossplane, and others.
+
+## Features and plans
+
+vCluster is available as open source and as an enterprise-grade platform with additional features across paid tiers:
 
 <!--
   Shows OSS (7), Free (1), and Paid (42) features.
@@ -31,114 +65,12 @@ vCluster provides a comprehensive set of features across multiple product tiers,
   - src/data/products.yaml (product tier assignments)
 -->
 
-## What is a virtual cluster?
+<FeatureTable names="all" />
 
-A <GlossaryTerm term="virtual-cluster">virtual cluster</GlossaryTerm> is a fully functional Kubernetes cluster that runs on top of another Kubernetes cluster.
+## Next steps
 
-Typically, a virtual cluster runs inside a namespace of a <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>, but it operates as an independent environment, with its own API server, control plane, and resource set.
-
-Depending on the tenancy model, virtual clusters may share or isolate compute and networking resources. Regardless of the underlying setup, they remain abstracted from the host cluster’s global state, enabling strong workload separation and tenant autonomy.
-
-vCluster extends this concept to support a full spectrum of tenancy models, from simple namespace syncing to advanced configurations using shared nodes, dedicated nodes, virtual nodes, private nodes or as a standalone Kubernetes cluster.
-
-Virtual clusters are certified Kubernetes distributions, adhering to upstream Kubernetes standards while maintaining isolation from the host cluster.
-
-This flexibility allows you to select the ideal tenancy model for your team’s security, cost, and performance requirements, while also benefiting from faster provisioning and centralized management.
-
-
-## Tenancy models overview
-
-vCluster supports a range of tenancy models, allowing you to choose the right balance of isolation, cost-efficiency, and operational complexity for your platform.
-Each virtual cluster runs on top of a host Kubernetes cluster, but how it isolates workloads, consumes resources, and interacts with the underlying infrastructure depends on the tenancy model you select.
-
-Below are the tenancy models supported by vCluster:
-
-### Shared Nodes
-* The control plane of the vCluster is deployed as a container on a host cluster. 
-* Worker nodes of the vCluster are from the same host cluster. 
-
-#### How it works
-
-All virtual clusters run in a single Kubernetes host cluster and schedule pods onto the same shared node pool. The vCluster control plane enforces separation at the API, RBAC, and CRD levels, but does not restrict pod scheduling unless additional mechanisms (e.g., taints, affinities) are applied.
-Tenants interact with their own virtual clusters as if they are separate environments, but their workloads run side-by-side with those from other virtual clusters at the node level. Shared infrastructure components like the container runtime, CNI, and CSI drivers are used across all tenants.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/shared-nodes.png').default}
-  alt="Architecture for Shared Nodes"
- />
-  <figcaption>Architecture for Shared Nodes</figcaption>
-</figure>
-
-### Dedicated Nodes
-* The control plane of the vCluster is deployed as a container on a host cluster. 
-* Worker nodes of the vCluster are from a specific set of nodes of the same host cluster. 
-
-#### How it works
-
-Each vCluster is configured with a Kubernetes nodeSelector (or affinity rules) that ensures all tenant workloads are scheduled only to nodes with specific labels. For example, a virtual cluster assigned to nodegroup=team-a will only run pods on nodes matching that label.
-
-While compute is scoped to these dedicated nodes, all other components—like the CNI, CSI, and underlying Kubernetes host cluster—remain shared. The vCluster itself maintains full API isolation, separate CRDs, tenant-specific RBAC, and control plane security.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/dedicated-nodes.png').default}
-  alt="Architecture for Dedicated Nodes"
- />
-  <figcaption>Architecture for Dedicated Nodes</figcaption>
-</figure>
-
-### Virtual Nodes
-* The control plane of the vCluster is deployed as a container on a host cluster. 
-* Worker nodes of the virtual cluster are running [vNode](https://www.vnode.com/docs/) on the set of nodes of the same host cluster. 
-
-#### How it works
-Virtual Nodes are implemented within vCluster by inserting a translation layer between the virtual control plane and the physical cluster. From the perspective of a tenant, the vCluster presents one or more virtual nodes, each representing a safe, scoped execution environment.
-
-Internally, workloads from these virtual nodes are scheduled as regular pods on shared physical nodes, but the tenant does not see or interact with the real underlying node environment. This abstraction enables stronger isolation, enforces placement boundaries, and prevents tenants from seeing or interacting with each other’s workloads—even though compute is technically shared.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/virtual-nodes.png').default}
-  alt="Architecture for Virtual Nodes"
- />
-  <figcaption>Architecture for Virtual Nodes</figcaption>
-</figure>
-
-### Private Nodes
-* The control plane of the vCluster is deployed as a container on a host cluster. 
-* Worker nodes of the vCluster are individual nodes that are not connected to any other Kubernetes cluster. You can either join manually provisioned nodes to a vCluster or can configure vCluster
-to automatically provision and join nodes based on resource requirements.
-
-#### How it works
-
-Each vCluster is deployed into its own Kubernetes host cluster, provisioned with a dedicated set of physical nodes. The CNI, CSI, kube-proxy, and all other Kubernetes components are fully isolated per tenant.
-
-Because vCluster runs on top of this separate host cluster, it inherits the benefits of virtual cluster abstraction (faster startup, CRD freedom, sleep mode, etc.), but adds an additional hard isolation boundary beneath it. Tenants cannot interfere with one another’s environments at any layer—from API server to node kernel.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/private-nodes.png').default}
-  alt="Architecture for Private Nodes"
- />
-  <figcaption>Architecture for Private Nodes</figcaption>
-</figure>
-
-<!-- vale off -->
-### vCluster Standalone
-<!-- vale on -->
-* The control plane of the vCluster is deployed as a binary on individual nodes.  
-* Worker nodes of the vCluster are individual nodes that are not part of any other Kubernetes cluster. 
-
-#### How it works
-
-vCluster Standalone launches its own lightweight control plane components (like an API server and scheduler) and backs workloads with a local Kubernetes-compatible runtime. Since no Kubernetes host cluster is required, virtual clusters can run independently in a container, virtual machine, or even on a developer laptop.
-Despite being self-contained, vCluster Standalone behaves just like a regular Kubernetes control plane: it supports custom resources, RBAC, workload scheduling, and even integrations with CI/CD tools. Workloads are managed entirely within the vCluster and does not require a host cluster to function.
-
-<figure>
-<img
-  src={require('@site/static/media/diagrams/vcluster-standalone-shared-nodes.png').default}
-  alt="Architecture for vCluster Standalone as the host cluster"
- />
-  <figcaption>Architecture for vCluster Standalone</figcaption>
-</figure>
+- [Architecture](./architecture.mdx) — control plane internals, syncer behavior, and networking
+- [Private Nodes](../deploy/worker-nodes/private-nodes/README.mdx) — dedicated infrastructure for GPU tenants and regulated workloads
+- [vCluster Standalone](../deploy/control-plane/binary/basics.mdx) — zero-dependency Kubernetes for bare metal and edge
+- [Building a GPU cloud platform](./gpu-cloud-platform.mdx) — deployment models for AI cloud providers
+- [vcluster.yaml reference](../configure/what-is-vcluster-yaml.mdx) — full configuration reference

--- a/vcluster_versioned_docs/version-0.33.0/key-features/sleep.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/key-features/sleep.mdx
@@ -134,7 +134,7 @@ Auto sleep involves two main actions: **sleeping** and **waking**. These actions
 With auto sleep, you can prevent specific resources from entering sleep by configuring them with the following options:
 
 - Add the annotation `sleepmode.loft.sh/exclude: true` to the resource.
-- Configure `sleep` with [specific labels](../configure/vcluster-yaml/sleep.mdx#enable-auto-sleep-with-label-selectors-and-schedules) to define which resources should remain active. This allows targeting specific resources based on their labels.
+- Configure `sleep` with [specific labels](../configure/vcluster-yaml/sleep.mdx#enable-sleep-with-label-selectors-and-schedules) to define which resources should remain active. This allows targeting specific resources based on their labels.
 - Add labels to workloads that you want to remain active. By using labels, it is possible to control which resources are exempt from sleep at a more granular level.
 
 For example, the following Deployment would not sleep when the virtual cluster is sleeping:

--- a/vcluster_versioned_docs/version-0.33.0/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
@@ -36,7 +36,7 @@ You can skip the CSI driver installation steps in the setup guide as the EBS CSI
 
 ## Deploy vCluster
 
-Choose the deployment option based on your tenancy model. You can read more about private nodes and shared nodes tenancy model [here](../../../configure/tenancy-model).
+Choose the deployment option based on your worker node type. See [worker nodes](../../../introduction/architecture#worker-nodes) for an overview of shared and private node options.
 <Tabs
   groupId="tenancy-model"
   defaultValue="host-nodes"

--- a/vcluster_versioned_docs/version-0.33.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/manage/certificates.mdx
@@ -86,7 +86,7 @@ The restart does not affect running application workloads because the underlying
   language="bash"
 />
 
-Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-the-ca-certificate).
+Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificate).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
 ## Changing the CA certificate

--- a/vcluster_versioned_docs/version-0.33.0/quick-start-guide.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/quick-start-guide.mdx
@@ -2,7 +2,7 @@
 title: Quick Start Guide
 sidebar_position: 1
 slug: /
-description: Learn how to configure, deploy, use, and delete a vCluster instance.
+description: Learn how to configure, deploy, use, and delete a tenant cluster.
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 
@@ -17,9 +17,18 @@ import ViewHostResources from './_partials/quick-start-guide/view-host-resources
 import ExploreFeatures from './_partials/quick-start-guide/explore-features.mdx'
 import InstallCLIFragment from './_partials/deploy/install-cli.mdx'
 
-## Key concepts
+This guide walks through deploying a tenant cluster, running a workload against it, and understanding the core isolation model.
+
+:::note For AI Cloud and GPU workloads
+This guide deploys a tenant cluster using the Shared Nodes default, which is suitable for testing and development. For production GPU workloads, see [Building a GPU cloud platform](./introduction/gpu-cloud-platform.mdx) to choose the right deployment model for your use case.
+:::
+
+<details>
+<summary>How tenant clusters work</summary>
 
 <KeyConcepts />
+
+</details>
 
 ## Prerequisites
 
@@ -27,11 +36,13 @@ import InstallCLIFragment from './_partials/deploy/install-cli.mdx'
 
 ## Deploy vCluster
 
-Install the vCluster CLI.
+### Install the vCluster CLI
 
 <InstallCLIFragment/>
 
-Choose between deploying to a Kubernetes cluster or using Docker containers:
+### Deploy a tenant cluster
+
+Deploying to an existing Kubernetes cluster? Use the **Kubernetes** tab. Testing locally without a cluster? Use **Docker (vind)** — no Kubernetes required.
 <br />
 
 <Tabs
@@ -44,14 +55,14 @@ Choose between deploying to a Kubernetes cluster or using Docker containers:
 }>
 <TabItem value="kubernetes">
 
-Deploy a vCluster instance called `my-vcluster` to namespace `team-x` on an existing Kubernetes cluster. This guide uses the vCluster CLI to deploy vCluster, but there are multiple ways to deploy vCluster using other tools like Helm, Terraform, ArgoCD, ClusterAPI, etc. Read about the additional options in the [deployment section of the docs](./deploy/control-plane/kubernetes-pod/basics.mdx).
+For this quickstart, you'll deploy a tenant cluster called `my-vcluster` to the namespace `team-x` on a Control Plane Cluster. This guide uses the vCluster CLI, but there are multiple ways to deploy vCluster using other tools like Helm, Terraform, ArgoCD, ClusterAPI, or similar. Read about the additional options in the [deployment section of the docs](./deploy/control-plane/kubernetes-pod/basics.mdx).
 
 <DeployVclusterWithCLI />
 
 </TabItem>
 <TabItem value="docker">
 
-Deploy a vCluster instance called `my-vcluster` using Docker containers. This creates a complete Kubernetes cluster without requiring a host Kubernetes cluster.
+For this quickstart, you'll deploy a tenant cluster called `my-vcluster` using Docker containers. This creates a complete Kubernetes cluster without any external infrastructure.
 
 <Flow id="deploy-vcluster-docker">
   <Step>
@@ -62,36 +73,47 @@ Deploy a vCluster instance called `my-vcluster` using Docker containers. This cr
    ```
   </Step>
   <Step>
-   **(Optional)** Create a `vcluster.yaml` to configure your Docker-specific settings such as ports, volumes, or additional nodes.
+   **(Optional)** Create a `vcluster.yaml` to customize your tenant cluster. Refer to the [Docker configuration docs](./configure/vcluster-yaml/experimental/docker.mdx) for Docker-specific options, or the [vcluster.yaml reference](./configure/what-is-vcluster-yaml.mdx) for all configuration options.
 
-   ```yaml
-   experimental:
-     docker:
-       nodes:
-       # Add an additional node called 'my-worker'
-       - name: my-worker
-   ```
+:::tip vcluster.yaml configuration
+If you aren't sure what options you want to configure, you can always upgrade your vCluster after deployment with an updated `vcluster.yaml`. While most options can be configured later, the [backing store](./configure/vcluster-yaml/control-plane/components/backing-store/) can only be set during the initial deployment.
+:::
 
-   Refer to the [Docker configuration docs](./configure/vcluster-yaml/experimental/docker.mdx) to explore all Docker-specific options.
   </Step>
   <Step>
    Deploy vCluster using Docker containers.
+
+   <Tabs
+   groupId="docker-deploy"
+   defaultValue="default"
+   values={[
+      { label: "Default (No vcluster.yaml)", value: "default" },
+      { label: 'With vcluster.yaml', value: 'with-vcluster-yaml', },
+   ]
+   }>
+   <TabItem value="default">
 
    ```bash
    vcluster create my-vcluster
    ```
 
-   Or with custom configuration:
+   </TabItem>
+   <TabItem value="with-vcluster-yaml">
+   Include your `vcluster.yaml` configuration file.
 
    ```bash
    vcluster create my-vcluster --values vcluster.yaml
    ```
+
+   </TabItem>
+   </Tabs>
+
   </Step>
   <Step>
-    Check out the namespaces in your virtual cluster. When the virtual cluster deployment finishes, your kube context is automatically updated to the virtual cluster.
+    When the tenant cluster deployment finishes, your kube context automatically updates to the tenant cluster. Check the namespaces to confirm.
 
     ```bash
-    kubectl get namespaces # See the namespaces of your virtual cluster
+    kubectl get namespaces # See the namespaces of your tenant cluster
     ```
   </Step>
 </Flow>
@@ -99,15 +121,15 @@ Deploy a vCluster instance called `my-vcluster` using Docker containers. This cr
 </TabItem>
 </Tabs>
 
-## Use your virtual cluster
+## Use your tenant cluster
 
-After immediately creating your virtual cluster, your kube context is updated to point to the virtual cluster and all these commands are directed at the virtual cluster. 
+Deploy a test workload and explore your running tenant cluster.
 
-### Deploy resources inside the virtual cluster
+### Deploy a test workload
 
 <DeployResources />
 
-### View resources in the underlying infrastructure
+### Understand resource isolation
 
 <Tabs
   groupId="deployment-method"
@@ -124,60 +146,60 @@ After immediately creating your virtual cluster, your kube context is updated to
 </TabItem>
 <TabItem value="docker">
 
-For Docker deployments, you can inspect the underlying Docker containers and networks that vCluster created:
-
-#### View Docker containers
-
-Check the Docker containers created for your vCluster:
-
-```
-docker ps --filter name=my-vcluster
-```
-
-Output is similar to:
-```
-CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS     NAMES
-a1b2c3d4e5f6   ghcr.io/loft-sh/vm...   "/usr/bin/supervisor…"   10 minutes ago   Up 10 minutes   ...       vcluster.cp.my-vcluster
-b2c3d4e5f6a1   ghcr.io/loft-sh/vm...   "/usr/bin/supervisor…"   10 minutes ago   Up 10 minutes   ...       vcluster.node.my-vcluster.worker-1
-```
-
-#### View Docker networks
-
-Check the Docker network created for your vCluster:
-
-```
-docker network inspect vcluster.my-vcluster
-```
-
-#### View container logs
-
-You can view logs from the vCluster containers:
-
-```
-# View control plane logs
-docker exec -it vcluster.cp.my-vcluster journalctl -u vcluster --no-pager
-
-# View kubelet logs
-docker exec -it vcluster.node.my-vcluster.my-node journalctl -u kubelet --no-pager
-
-# View containerd logs
-docker exec -it vcluster.node.my-vcluster.my-node journalctl -u containerd --no-pager
-```
-
 :::info vCluster in Docker
-Unlike Kubernetes deployments, Docker-based vClusters don't sync resources to a host cluster. Instead, all resources exist within the Docker containers that make up your virtual cluster. The containers simulate a complete Kubernetes environment without requiring an underlying Kubernetes cluster.
+Docker-based tenant clusters are fully self-contained. All resources exist within the Docker containers — no Control Plane Cluster required.
 :::
+
+<Flow>
+  <Step>
+    Check the Docker containers running for your tenant cluster.
+
+    ```bash
+    docker ps --filter name=my-vcluster
+    ```
+
+    Output is similar to:
+    ```
+    CONTAINER ID   IMAGE                    COMMAND                  CREATED          STATUS          PORTS     NAMES
+    a1b2c3d4e5f6   ghcr.io/loft-sh/vm...   "/usr/bin/supervisor…"   10 minutes ago   Up 10 minutes   ...       vcluster.cp.my-vcluster
+    b2c3d4e5f6a1   ghcr.io/loft-sh/vm...   "/usr/bin/supervisor…"   10 minutes ago   Up 10 minutes   ...       vcluster.node.my-vcluster.worker-1
+    ```
+  </Step>
+  <Step>
+    Inspect the Docker network created for your tenant cluster.
+
+    ```bash
+    docker network inspect vcluster.my-vcluster
+    ```
+  </Step>
+  <Step>
+    View logs from the containers if you need to troubleshoot.
+
+    ```bash
+    # View control plane logs
+    docker exec -it vcluster.cp.my-vcluster journalctl -u vcluster --no-pager
+
+    # View kubelet logs
+    docker exec -it vcluster.node.my-vcluster.my-node journalctl -u kubelet --no-pager
+
+    # View containerd logs
+    docker exec -it vcluster.node.my-vcluster.my-node journalctl -u containerd --no-pager
+    ```
+  </Step>
+</Flow>
 
 </TabItem>
 </Tabs>
 
-## Explore features
+## Common configuration patterns
 
 <ExploreFeatures />
 
-## Delete vCluster
+## Delete a tenant cluster
 
-Deleting a vCluster also deletes all resources within the virtual cluster and all states related to the vCluster.
+:::warning
+Deleting a tenant cluster deletes all resources within the cluster and all associated state. This cannot be undone.
+:::
 
 <Tabs
   groupId="deployment-method"
@@ -189,7 +211,7 @@ Deleting a vCluster also deletes all resources within the virtual cluster and al
 }>
 <TabItem value="kubernetes">
 
-If the namespace on the host cluster was created by the vCluster CLI, then that namespace is also deleted.
+If the namespace on the Control Plane Cluster was created by the vCluster CLI, then that namespace is also deleted.
 
 ```bash
 vcluster delete my-vcluster --namespace team-x
@@ -198,11 +220,38 @@ vcluster delete my-vcluster --namespace team-x
 </TabItem>
 <TabItem value="docker">
 
-For Docker deployments, this removes all Docker containers and networks created for the vCluster.
+For Docker deployments, this removes all Docker containers and networks created for the tenant cluster.
 
 ```bash
 vcluster delete my-vcluster
 ```
+
+</TabItem>
+</Tabs>
+
+## Next steps
+
+<Tabs
+  groupId="deployment-method"
+  defaultValue="kubernetes"
+  values={[
+    { label: "Kubernetes Cluster", value: "kubernetes" },
+    { label: "Docker (vind)", value: "docker" },
+  ]
+}>
+<TabItem value="kubernetes">
+
+- [Architecture](./introduction/architecture.mdx) — understand control plane and worker node deployment models
+- [Private nodes](./deploy/worker-nodes/private-nodes/README.mdx) — dedicated infrastructure for GPU tenants and regulated workloads
+- [Production deployment](./deploy/control-plane/kubernetes-pod/basics.mdx) — deploy with Helm, Terraform, or ArgoCD
+- [vcluster.yaml reference](./configure/what-is-vcluster-yaml.mdx) — full configuration reference
+
+</TabItem>
+<TabItem value="docker">
+
+- [Docker configuration](./configure/vcluster-yaml/experimental/docker.mdx) — ports, volumes, multi-node setups
+- [vcluster.yaml reference](./configure/what-is-vcluster-yaml.mdx) — full configuration reference
+- [Deploy to Kubernetes](./deploy/control-plane/kubernetes-pod/basics.mdx) — when you're ready to move beyond local development
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Backports docs repositioning changes from #1889 for vCluster 0.33 and Platform 4.8.0.
Had to ask Claude to do this manually because that PR changed pages in both doc sets.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1298


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

