### PR TITLE
ci: add auto-approve workflow for bot prs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -1,0 +1,11 @@
+name: Auto-approve bot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-approve:
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@683dc8cf19db7f624b51265c5d38d6a4f5aadb28
+    secrets:
+      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Backport Docusaurus Changes
         uses: loft-sh/docs-backport-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/forwardport-docs.yml
+++ b/.github/workflows/forwardport-docs.yml
@@ -19,4 +19,4 @@ jobs:
 
       - uses: loft-sh/docs-forwardport-action@main
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
# Content Description

Add thin caller workflow for the reusable auto-approve workflow from `loft-sh/github-actions`. Chore, dependency, backport, and renovate PRs from trusted bots (renovate[bot], loft-bot, github-actions[bot]) get auto-approved and auto-merged when CI passes and there are no merge conflicts.

Also switches backport and forwardport workflows from `GITHUB_TOKEN` to `GH_ACCESS_TOKEN`. `GITHUB_TOKEN`-created PRs don't trigger `pull_request` events, so the auto-approve caller would never fire for backport/forwardport PRs. This matches the vcluster repo's backport pattern.

Same caller setup already deployed to hosted-platform and loft-prod.

## Preview Link

N/A (CI workflows only, no docs changes)

## Internal Reference

References DEVOPS-714

<!-- CLAUDE_SUMMARY -->
@netlify /docs