### PR TITLE
ci: disable auto-merge in auto-approve caller

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -7,5 +7,7 @@ on:
 jobs:
   auto-approve:
     uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@683dc8cf19db7f624b51265c5d38d6a4f5aadb28
+    with:
+      auto-merge: false
     secrets:
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
# Content Description

Disables auto-merge in the auto-approve bot PRs workflow. Bot PRs (chore, backport, renovate) get auto-approved but Daryl merges manually.

Sets `auto-merge: false` on the reusable workflow call — the "Enable auto-merge" step is gated on `inputs.auto-merge` (line 104 of the reusable workflow) and will be skipped.

## Preview Link

N/A (CI workflow only)

## Internal Reference

References DEVOPS-714

<!-- CLAUDE_SUMMARY -->
@netlify /docs