### PR TITLE
fix(docs): emit absolute urls in llms-full.txt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -179,6 +179,13 @@ const config = {
             '/tags/**',
           ],
         },
+        markdown: {
+          // Emit absolute URLs (https://www.vcluster.com/docs/...) instead of
+          // site-relative paths. Downstream consumers (R2R RAG, LLM agents)
+          // surface these links to users in CLI contexts where relative paths
+          // are not clickable or resolvable. See ENGAI-58.
+          relativePaths: false,
+        },
         siteTitle: 'vCluster Documentation',
         siteDescription: 'Documentation for vCluster (virtual Kubernetes clusters) and vCluster Platform (multi-cluster management)',
         enableDescriptions: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,8 +178,6 @@ const config = {
             '/search/**',
             '/tags/**',
           ],
-        },
-        markdown: {
           // Emit absolute URLs (https://www.vcluster.com/docs/...) instead of
           // site-relative paths. Downstream consumers (R2R RAG, LLM agents)
           // surface these links to users in CLI contexts where relative paths


### PR DESCRIPTION
# Content Description
Sets `markdown.relativePaths: false` on the `@signalwire/docusaurus-plugin-llms-txt` plugin so generated `llms-full.txt` contains absolute URLs (`https://www.vcluster.com/docs/...`) instead of site-relative paths (`/docs/...`).

**Why**: The R2R RAG pipeline (loft-prod `r2r-docs-sync` CronJob) ingests `llms-full.txt` and surfaces chunks to LLM agents and users in CLI contexts. Relative paths are unreachable when a chunk is displayed outside the docs site — the user/agent has no way to follow the link. Fixing this at the plugin layer (rather than post-processing in the sync pipeline) means every downstream consumer of `llms-full.txt` gets functional links.

## Preview Link
`llms-full.txt` is generated at build time, not a docs page — validate via the Netlify preview:
- https://deploy-preview-1914--vcluster-docs-site.netlify.app/llms-full.txt

Spot-check any `[text](...)` link — expect absolute `https://www.vcluster.com/docs/...` URLs rather than relative `/docs/...`.

## Internal Reference
Closes ENGAI-58