### PR TITLE
fix(links): repair broken high availability link from standalone page

### DIFF
--- a/vcluster/deploy/control-plane/binary/README.mdx
+++ b/vcluster/deploy/control-plane/binary/README.mdx
@@ -73,7 +73,7 @@ Self-managed standalone clusters can later be connected to <b><Link to="/docs/pl
 
 ## vcluster.yaml configuration
 
-To create a vCluster Standalone with one node that is the control plane and worker node. Read more about [high availability](./high-availability).
+To create a vCluster Standalone with one node that is the control plane and worker node. Read more about [high availability](/docs/vcluster/deploy/control-plane/binary/high-availability).
 
 <Tabs
   groupId="standalone-management"


### PR DESCRIPTION
# Content Description

Fix a broken "high availability" link from the vCluster Standalone page (`vcluster/deploy/control-plane/binary/README.mdx`). The link resolved to `/docs/vcluster/deploy/control-plane/high-availability` (404) instead of `/docs/vcluster/deploy/control-plane/binary/high-availability`.

## Root Cause

README.mdx maps to a directory URL (`/binary`), not `/binary/README`. At runtime the served URL has no trailing slash, so browser url-relative resolution treats `binary` as a filename — `./high-availability` then resolves to `/control-plane/high-availability` (sibling of `binary`, not child) and 404s.

Sibling pages (`basics.mdx`, `high-availability.mdx`) are unaffected because their URLs include their own filenames.

## Fix

Single-line change to an absolute `/docs/...` path, which bypasses url-relative ambiguity at both build-time (Docusaurus) and runtime (browser).

## Preview Links

- https://deploy-preview-1915--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary
- https://deploy-preview-1915--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary/high-availability

## Internal Reference

Closes DOC-1302

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs