### PR TITLE
ci: add dependabot[bot] to auto-approve trusted authors

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -9,5 +9,6 @@ jobs:
     uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@683dc8cf19db7f624b51265c5d38d6a4f5aadb28
     with:
       auto-merge: false
+      trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
     secrets:
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
# Content Description
CI-only change: pass `trusted-authors` to the reusable auto-approve workflow so dependabot PRs are auto-approved like renovate/loft-bot/github-actions. No docs content changes.

## Preview Link
N/A — workflow-only change, no page content modified.

## Internal Reference
Closes DEVOPS-749

**Why**: The caller relied on the reusable workflow's default `trusted-authors` list (`renovate[bot],loft-bot,github-actions[bot]`), which excluded dependabot. Dependency-bump PRs from dependabot (e.g. #1912) sat waiting for manual approval even though their titles match the chore/fix(deps) patterns the shared workflow is designed to auto-approve.

**Change**: add one input line to the caller:
```yaml
trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
```

The reusable workflow in loft-sh/github-actions is unchanged — only the caller passes the extended list. Matches the pattern already used in `linear-pr-comments.yaml` which also references `dependabot[bot]`.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs