### PR TITLE
ci: bump auto-approve-bot-prs reusable workflow to post-fix sha

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-approve:
-    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@683dc8cf19db7f624b51265c5d38d6a4f5aadb28
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@0927020e29dfd9d1398720a2d902fcd911780e3c
     with:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'


### PR DESCRIPTION
# Content Description
Bumps the pinned SHA of the \`loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml\` reusable workflow from \`683dc8cf\` to \`0927020e\`, picking up two fixes from loft-sh/github-actions#89:
- workflow_ref resolution (fixes \`upload-pack: not our ref\` checkout failure on callers like this repo).
- graceful skip when the GH_ACCESS_TOKEN identity == PR author (fixes the red check on https://github.com/loft-sh/vcluster-docs/pull/1917, where \`loft-bot\` can't approve its own backport PR).

No behavioural change for the already-working path — renovate/dependabot/github-actions-bot PRs continue to auto-approve.

## Preview Link
N/A — CI-only change, no docs content modified.

## Internal Reference
Closes DEVOPS-749

AI review: mention \`@claude\` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs