### PR TITLE
ci: pin auto-approve reusable workflow to @main

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-approve:
-    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@0927020e29dfd9d1398720a2d902fcd911780e3c
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main
     with:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'


### PR DESCRIPTION
# Content Description
Swap the pinned SHA back to \`@main\` on the auto-approve reusable workflow. Matches loft-prod's convention and removes the Renovate-bump maintenance burden.

The reusable workflow in loft-sh/github-actions now declares \`continue-on-error: true\` at the job level and guards every path so it can never hard-fail a caller's CI (loft-sh/github-actions#90). With that contract, pinning by SHA here costs maintenance without adding safety.

## Preview Link
N/A — CI-only change.

## Internal Reference
References DEVOPS-749

AI review: mention \`@claude\` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs