### PR TITLE
ci: use pull_request_target so dependabot PRs get secrets

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -1,8 +1,8 @@
 name: Auto-approve bot PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   auto-approve:


### PR DESCRIPTION
# Content Description

Switch the auto-approve caller from \`pull_request\` to \`pull_request_target\` so dependabot PRs have access to \`secrets.GH_ACCESS_TOKEN\`.

## Why

Dependabot PRs run with no secrets on the \`pull_request\` event (GitHub security isolation). \`gh-access-token\` arrived empty at the reusable workflow, so the mergeable check returned null and auto-approve skipped for the wrong reason. Visible in the run log of PR #1912: \`GH_TOKEN:\` (blank) + \`Notice: PR mergeability is 'null', skipping\`.

\`pull_request_target\` runs in the base-branch context with secrets available. Safe here because the reusable workflow only calls the GitHub API — no untrusted code from the PR branch is executed. It's the exact pattern [hmarr/auto-approve-action documents](https://github.com/hmarr/auto-approve-action#approving-dependabot-pull-requests) for this case.

## Preview Link
N/A — CI-only change.

## Internal Reference
Closes DEVOPS-749

AI review: mention \`@claude\` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs