### PR TITLE
docs(standalone): fix install script version, flags, and terminology

### DIFF
--- a/.claude/skills/vcluster-docs-releaser/references/release-checklist.md
+++ b/.claude/skills/vcluster-docs-releaser/references/release-checklist.md
@@ -72,6 +72,12 @@ The version is deployed hidden, then exposed via a config flip PR on release day
 - [ ] Remove: All `(lines X-Y)` references from section headers
 - [ ] Note: Tests run AFTER PR deployed
 
+### Item 2b: Update InterpolatedCodeBlock Fallback Versions
+
+- [ ] File: `src/components/InterpolatedCodeBlock/index.js`
+- [ ] Change: `LATEST_VERSIONS.vcluster` to new version (without `v` prefix, e.g. `'0.XX.0'`)
+- [ ] Change: `LATEST_VERSIONS.platform` if platform version is also changing
+
 ### Additional AI Tasks:
 
 - [ ] Update main docs label (line ~81): `label: "v0.XX"`

--- a/.claude/skills/vcluster-docs-releaser/references/version-changes-pattern.md
+++ b/.claude/skills/vcluster-docs-releaser/references/version-changes-pattern.md
@@ -186,6 +186,28 @@ announcementBar: {
 },
 ```
 
+## InterpolatedCodeBlock Fallback Versions
+
+**File:** `src/components/InterpolatedCodeBlock/index.js`
+
+**Before:**
+```js
+const LATEST_VERSIONS = {
+  platform: '4.4.0',
+  vcluster: '0.29.0',
+};
+```
+
+**After:**
+```js
+const LATEST_VERSIONS = {
+  platform: '4.4.0',  // update if platform version also changed
+  vcluster: '0.30.0',
+};
+```
+
+**Note:** Version is without `v` prefix. This fallback is used when the Docusaurus version context is unavailable (e.g. non-versioned pages, SSR edge cases).
+
 ## netlify.toml Changes
 
 ### Redirect Configuration (~line 521)

--- a/src/components/InterpolatedCodeBlock/index.js
+++ b/src/components/InterpolatedCodeBlock/index.js
@@ -6,8 +6,8 @@ import { usePageVariables } from '../PageVariables/PageVariablesContext';
 
 // Latest versions - fallback if not in versioned docs context
 const LATEST_VERSIONS = {
-  platform: '4.8.0',
-  vcluster: '0.33.0',
+  platform: '4.8.1',
+  vcluster: '0.33.1',
 };
 
 /**

--- a/src/components/InterpolatedCodeBlock/index.js
+++ b/src/components/InterpolatedCodeBlock/index.js
@@ -6,8 +6,8 @@ import { usePageVariables } from '../PageVariables/PageVariablesContext';
 
 // Latest versions - fallback if not in versioned docs context
 const LATEST_VERSIONS = {
-  platform: '4.6.0',
-  vcluster: '0.31.0',
+  platform: '4.8.0',
+  vcluster: '0.33.0',
 };
 
 /**

--- a/vcluster/_fragments/deploy/standalone-flags.mdx
+++ b/vcluster/_fragments/deploy/standalone-flags.mdx
@@ -7,9 +7,15 @@ There are several flags available that can be added to the script.
 | `--vcluster-name` | Name of the vCluster instance |
 | `--vcluster-version` | Specific vCluster version to install |
 | `--config` | Path to the vcluster.yaml configuration file |
+| `--binary` | Path to an existing vCluster binary (use with `--skip-download`) |
 | `--skip-download` | Skip downloading vCluster binary (use existing) |
 | `--skip-wait` | Exit without waiting for vCluster to be ready |
 | `--extra-env` | Additional environment variables for vCluster |
+| `--join-token` | Token for joining additional nodes to the cluster |
+| `--join-endpoint` | Endpoint address for joining additional nodes |
+| `--vcluster-kubernetes-bundle` | Path to an air-gapped Kubernetes bundle |
+| `--reset-only` | Uninstall and reset the vCluster installation without reinstalling |
+| `--fips` | Enable FIPS-compliant mode |
 | `--platform-access-key` | Access key for vCluster Platform integration |
 | `--platform-host` | vCluster Platform host URL |
 | `--platform-insecure` | Skip TLS verification for Platform connection |

--- a/vcluster/_fragments/standalone.mdx
+++ b/vcluster/_fragments/standalone.mdx
@@ -1,10 +1,7 @@
 
-vCluster Standalone is a different architecture model for vCluster for the control plane and node as there is no requirement
-of a host cluster. vCluster is deployed directly onto nodes like other Kubernetes distribution. vCluster Standalone can
- run on any type of node, whether that is a bare-metal node or VM. It provides the strictest isolation for workloads as there is no shared host cluster for the control plane or worker nodes.
- 
-When enabling vCluster Standalone, the control plane is now no longer on a shared host cluster, but on its own independent node. Worker
-nodes must be private nodes.
+vCluster Standalone is a different architecture model for vCluster where the control plane runs directly on your infrastructure with no dependency on an existing Control Plane Cluster. vCluster is deployed directly onto nodes like other Kubernetes distributions. vCluster Standalone can run on any type of node, whether that is a bare-metal node or VM. It provides the strictest tenant isolation as there is no shared Control Plane Cluster for the control plane or worker nodes.
+
+When using vCluster Standalone, the control plane runs on its own independent node rather than as a pod on a shared cluster. Worker nodes must be private nodes.
 
 <br />
 

--- a/vcluster/deploy/control-plane/binary/README.mdx
+++ b/vcluster/deploy/control-plane/binary/README.mdx
@@ -6,7 +6,6 @@ sidebar_class_name: standalone private-nodes
 ---
 
 import Standalone from '../../../_fragments/standalone.mdx'
-import PrivateNodeLimitations from '../../../_fragments/private-nodes-limitations.mdx'
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 import Link from '@docusaurus/Link'
@@ -66,5 +65,3 @@ Self-managed Standalone clusters can later be connected to <b><Link to="/docs/pl
 </Tabs>
 
 [Install the control plane →](./basics)
-
-<PrivateNodeLimitations />

--- a/vcluster/deploy/control-plane/binary/README.mdx
+++ b/vcluster/deploy/control-plane/binary/README.mdx
@@ -17,7 +17,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <Standalone />
 
-## Compute resource requirements
+## Resource requirements
 
 vCluster Standalone can be deployed on bare metal, virtual machines, or containers. The minimal recommended resource requirements for vCluster Standalone are as follows:
 
@@ -26,120 +26,45 @@ vCluster Standalone can be deployed on bare metal, virtual machines, or containe
 - 1 GiB of ephemeral storage
 
 :::info
-These are minimal requirements suitable for testing and development. Production deployments should be sized based on your specific workload, cluster size, and the number of virtual clusters you plan to run.
+These are minimal requirements suitable for testing and development. Production deployments should be sized based on your specific workload, cluster size, and the number of tenant clusters you plan to run.
 :::
 
 ## Installation overview
 
-vCluster Standalone needs its own set of nodes for the control plane, and you can add extra nodes later if you want them to act as workers.
-
-:::info
-Choose your management model: <b><Link to="/docs/platform">vCluster Platform</Link></b>-managed provides automated provisioning and rolling upgrades, while self-managed provides full control without the platform dependency.
-:::
-
-The steps to bring up a vCluster Standalone cluster are: 
+vCluster Standalone requires its own node for the control plane. You can add additional nodes later as workers.
 
 <Tabs
   groupId="standalone-management"
-  defaultValue="platform"
+  defaultValue="self-managed"
   values={[
-    { label: 'Managed by vCluster Platform', value: 'platform' },
     { label: 'Self-managed', value: 'self-managed' },
+    { label: 'Platform-managed', value: 'platform' },
   ]}
 >
+  <TabItem value="self-managed">
+
+| Step | Summary |
+| --- | --- |
+| 1. [Install control plane node](./basics) | Install the initial control plane node on your infrastructure. |
+| 2. [Join control plane nodes](./high-availability) (optional) | Join additional control plane nodes for HA. |
+| 3. [Join worker nodes](../../worker-nodes/private-nodes) (optional) | Join worker nodes as private nodes. |
+
+:::info
+Self-managed Standalone clusters can later be connected to <b><Link to="/docs/platform">vCluster Platform</Link></b>. Once connected, configuration updates and version upgrades can be coordinated from the platform with rolling upgrades, while node management remains self-managed.
+:::
+
+  </TabItem>
   <TabItem value="platform">
 
 | Step | Summary |
 | --- | --- |
-| 1. Create control plane node | Use vCluster Platform to provision the initial control plane node using auto nodes. |
+| 1. [Install control plane node](./basics) | Use vCluster Platform to provision the initial control plane node. |
 | 2. Add control plane nodes (optional) | Scale control plane nodes from the Platform UI. |
 | 3. Add worker nodes (optional) | Add private worker nodes from the Platform UI. |
 
   </TabItem>
-  <TabItem value="self-managed">
-
-| Step | Summary |
-| --- | --- |
-| 1. Install control plane node | Install the initial control plane node on your infrastructure. |
-| 2. Join control plane nodes (optional) | Join additional control plane nodes for HA. |
-| 3. Join worker nodes (optional) | Join worker nodes as private nodes. |
-
-  </TabItem>
 </Tabs>
 
-:::info
-Self-managed standalone clusters can later be connected to <b><Link to="/docs/platform">vCluster Platform</Link></b>. Once connected, configuration updates and version upgrades can be coordinated from the platform with rolling upgrades, while node management remains self-managed.
-:::
-
-## vcluster.yaml configuration
-
-To create a vCluster Standalone with one node that is the control plane and worker node. Read more about [high availability](/docs/vcluster/deploy/control-plane/binary/high-availability).
-
-<Tabs
-  groupId="standalone-management"
-  defaultValue="platform"
-  values={[
-    { label: 'Managed by vCluster Platform', value: 'platform' },
-    { label: 'Self-managed', value: 'self-managed' },
-  ]}
->
-  <TabItem value="platform">
-
-```yaml title="Standalone cluster managed by vCluster Platform"
-controlPlane:
-  standalone:
-    enabled: true
-    autoNodes: 
-      provider: aws # Node provider you want to use
-      quantity: 1 # Number of nodes (HA requires embedded etcd or external DB)
-  distro:
-    k8s:
-      image:
-        tag: v1.35.0 # Kubernetes version you want to use
-
-# Networking configuration
-networking:
-  # Specify the pod CIDR
-  podCIDR: 10.64.0.0/16
-  # Specify the service CIDR
-  serviceCIDR: 10.128.0.0/16
-```
-
-Control plane and worker nodes are provisioned and managed through <b><Link to="/docs/platform">vCluster Platform</Link></b>.
-
-  </TabItem>
-  <TabItem value="self-managed">
-
-```yaml title="Self-managed standalone cluster"
-controlPlane:
-  distro:
-    k8s:
-      image:
-        tag: v1.35.0 # Kubernetes version you want to use
-
-# Networking configuration
-networking:
-  # Specify the pod CIDR
-  podCIDR: 10.64.0.0/16
-  # Specify the service CIDR
-  serviceCIDR: 10.128.0.0/16
-```
-
-Control plane and worker nodes are provisioned and managed outside <b><Link to="/docs/platform">vCluster Platform</Link></b>.
-
-  </TabItem>
-</Tabs>
-
-:::tip Additional configuration options
-This minimal configuration is all you need to get started. Once you're ready to customize your deployment:
-
-- **Dedicated control plane** - Set `controlPlane.standalone.joinNode.enabled: false` to prevent the control plane node from running workloads
-- **Private registries** - Configure `controlPlane.standalone.joinNode.containerd` for registry mirrors, authentication, and TLS settings
-- **Node customization** - Use `controlPlane.standalone.joinNode.nodeRegistration` for kubelet arguments, taints, and CRI socket configuration
-
-See the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone) for all available options.
-:::
-
-
+[Install the control plane →](./basics)
 
 <PrivateNodeLimitations />

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -88,11 +88,14 @@ to `false` and use dedicated worker nodes.
 ### Self-managed
 
 :::tip Control Plane Node
-Perform all steps on the control plane node.
+Perform all steps on the control plane node as root.
 :::
 <Flow>
     <Step>
-    Replace `CONFIG_DIRECTORY` with the directory to store the vCluster configuration values file, the `vcluster.yaml`.
+    Switch to root and set `CONFIG_DIRECTORY` to the directory where you want to store the `vcluster.yaml` configuration file.
+    ```bash
+    sudo su -
+    ```
     <PageVariables CONFIG_DIRECTORY="/etc/vcluster" />
     </Step>
     <Step>
@@ -119,11 +122,7 @@ Adding additional control plane nodes is not supported unless you follow the [hi
 :::
     </Step>
     <Step>
-       Authenticate with sudo privileges to access the Kubernetes context:
-        ```bash
-        sudo su -
-        ```
-        Then run the installation script on the control plane node:
+        Run the installation script on the control plane node:
         <InterpolatedCodeBlock
           code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone`}
           title="Install vCluster Standalone on control plane node"
@@ -203,7 +202,7 @@ privateNodes:
   autoNodes: # (optional) Add worker nodes with Auto Nodes
     provider: [[GLOBAL:NODE_PROVIDER]]
     dynamic:
-    - name: aws-pool-1
+      - name: aws-pool-1
 
 # Networking configuration
 networking:

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -146,8 +146,8 @@ All steps are performed on the control plane node.
 :::
 <Flow>
     <Step>
-    Replace the `VCLUSTER_VERSION` with the vCluster version you want to install and the `CONFIG_DIRECTORY` with the directory to store the vCluster configuration values file, the `vcluster.yaml`.
-    <PageVariables VCLUSTER_VERSION="v0.31.0" CONFIG_DIRECTORY="/etc/vcluster" />
+    Replace `CONFIG_DIRECTORY` with the directory to store the vCluster configuration values file, the `vcluster.yaml`.
+    <PageVariables CONFIG_DIRECTORY="/etc/vcluster" />
     </Step>
     <Step>
         Create directory for storing vCluster Standalone configuration.
@@ -179,7 +179,7 @@ Adding additional control plane nodes will not be supported unless you follow th
         ```
         Then run the installation script on the control plane node:
         <InterpolatedCodeBlock
-          code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/[[GLOBAL:VCLUSTER_VERSION]]/install-standalone.sh | sh -s -- --vcluster-name standalone`}
+          code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone`}
           title="Install vCluster Standalone on control plane node"
           language="bash"
         />
@@ -222,7 +222,7 @@ Adding additional control plane nodes will not be supported unless you follow th
 #### Access your cluster
 
 After installation, the kubeconfig is automatically configured on the control plane node. The kubectl context is set to interact with your new vCluster Standalone instance.
-If you decide to use vCluster Standalone as a host cluster for virtual clusters, then you can set your current kube context to the vCluster Standalone and create and interact with virtual clusters using vCluster CLI.
+If you decide to use vCluster Standalone as a Control Plane Cluster for tenant clusters, then you can set your current kube context to the vCluster Standalone and create and interact with tenant clusters using vCluster CLI.
 
 To access the cluster from other machines, copy the kubeconfig from `/var/lib/vcluster/kubeconfig.yaml` on the control plane node, then replace the server field with relevant IP or DNS to access the cluster.
 You can also configure vCluster to make [external access easier](../../../manage/accessing-vcluster#access-vcluster-externally).

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -20,15 +20,15 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <Tabs
   groupId="standalone-basics-management"
-  defaultValue="platform"
+  defaultValue="self-managed"
   values={[
-    { label: 'Managed by vCluster Platform', value: 'platform' },
     { label: 'Self-managed', value: 'self-managed' },
+    { label: 'Platform-managed', value: 'platform' },
   ]}
 >
   <TabItem value="platform">
 
-When deploying a vCluster Standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, the control plane node is provisioned and managed through the platform using <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link>.
+When deploying a Platform-managed vCluster Standalone cluster, <Link to="/docs/platform">vCluster Platform</Link> handles automated provisioning and lifecycle management of the control plane node, including rolling upgrades.
 
   </TabItem>
   <TabItem value="self-managed">
@@ -36,12 +36,12 @@ When deploying a vCluster Standalone cluster managed by <Link to="/docs/platform
 When deploying a self-managed vCluster Standalone cluster, the assets required to install the control plane are located in the [GitHub releases](https://github.com/loft-sh/vcluster/releases) of vCluster.
 
 :::info Why is the configuration so minimal?
-vCluster Standalone eliminates the need for an external host cluster by running directly on your infrastructure. This architectural difference means:
+vCluster Standalone eliminates the dependency on an external Control Plane Cluster by running directly on your infrastructure. This architectural difference means:
 
 - **`controlPlane.standalone.enabled`** is automatically set when vCluster detects it's running as a binary rather than as a pod
-- **`controlPlane.privateNodes.enabled`** is automatically set because standalone mode has no host cluster, so all worker nodes are private nodes that join directly
+- **`controlPlane.privateNodes.enabled`** is automatically set because standalone mode has no Control Plane Cluster, so all worker nodes are private nodes that join directly
 
-If you're familiar with traditional vCluster deployments, you'll notice this configuration is simpler because there's no host cluster relationship to configure.
+If you're familiar with traditional vCluster deployments, you'll notice this configuration has fewer required settings because there's no Control Plane Cluster relationship to configure.
 
 For optional settings like dedicating the control plane node (not running workloads on it), configuring containerd, or customizing node registration, see the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone).
 :::
@@ -52,9 +52,7 @@ For optional settings like dedicating the control plane node (not running worklo
 
 ## Predeployment configuration options
 
-Before deploying, it's recommended to review the set of configuration options
- that cannot be updated post deployment. These options require deploying a new
- vCluster instead of upgrading your vCluster with new options.
+Before deploying, review the configuration options that can't be updated after deployment. These options require you to deploy a new vCluster instance rather than upgrading your existing one.
 
 ### Control-plane options  {#control-plane-options}
 
@@ -63,7 +61,7 @@ Before deploying, it's recommended to review the set of configuration options
 * Backing Store - Decide how the data of your cluster is stored, must be one of either [embedded SQLite](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/sqlite) (the default) or [embedded etcd](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded).
 
 
-### Node Roles
+### Node roles
 
 Decide if the control plane node will also be a worker node or not. Once a node joins the cluster, the roles of the node cannot change.
 
@@ -76,10 +74,10 @@ the vCluster control-plane process and its credentials. For production deploymen
 to `false` and use dedicated worker nodes.
 :::
 
-### Worker Nodes
+### Worker nodes
 
- With vCluster Standalone, worker node pools can only be [private nodes](../../worker-nodes/private-nodes). Since there is no host cluster,
- there is no concept of host nodes.
+ With vCluster Standalone, worker node pools can only be [private nodes](../../worker-nodes/private-nodes). Since there is no Control Plane Cluster,
+ there is no concept of Shared Nodes.
 
 ## Prerequisites
 
@@ -87,11 +85,97 @@ to `false` and use dedicated worker nodes.
 
 ## Install control plane node
 
+### Self-managed
+
+:::tip Control Plane Node
+Perform all steps on the control plane node.
+:::
+<Flow>
+    <Step>
+    Replace `CONFIG_DIRECTORY` with the directory to store the vCluster configuration values file, the `vcluster.yaml`.
+    <PageVariables CONFIG_DIRECTORY="/etc/vcluster" />
+    </Step>
+    <Step>
+        Create directory for storing vCluster Standalone configuration.
+        <InterpolatedCodeBlock
+          code={`mkdir -p [[GLOBAL:CONFIG_DIRECTORY]]`}
+          title="Create config directory"
+          language="bash"
+        />
+        Save a basic `vcluster.yaml` configuration file for vCluster Standalone on the control plane node.
+        <InterpolatedCodeBlock
+          code={`cat <<EOF > [[GLOBAL:CONFIG_DIRECTORY]]/vcluster.yaml
+  controlPlane:
+    distro:
+      k8s:
+        version: v1.34.0
+  EOF`}
+          title="Create vCluster config file"
+          language="yaml"
+        />
+
+:::warning
+Adding additional control plane nodes is not supported unless you follow the [high availability](./high-availability) steps for configuration.
+:::
+    </Step>
+    <Step>
+       Authenticate with sudo privileges to access the Kubernetes context:
+        ```bash
+        sudo su -
+        ```
+        Then run the installation script on the control plane node:
+        <InterpolatedCodeBlock
+          code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone`}
+          title="Install vCluster Standalone on control plane node"
+          language="bash"
+        />
+
+    </Step>
+    <Step>
+        Check that the control plane node is ready by running these commands:
+
+        ```bash title="Check node status"
+        kubectl get nodes
+        ```
+
+        Expected output:
+        ```bash
+        NAME               STATUS   ROLES                  AGE   VERSION
+        ip-192-168-3-131   Ready    control-plane,master   11m   v1.32.1
+        ```
+
+        ```bash title="Verify cluster components are running"
+        kubectl get pods -A
+        ```
+
+        Pods should include:
+        - **Flannel**: CNI for container networking
+        - **CoreDNS**: DNS service for the cluster
+        - **KubeProxy**: Network traffic routing and load balancing
+        - **Konnectivity**: Secure control plane to worker node communication
+        - **Local Path Provisioner**: Dynamic storage provisioning
+    </Step>
+
+</Flow>
+
+<StandaloneFlags />
+
+#### Access your cluster
+
+After installation, vCluster automatically configures the kubeconfig on the control plane node and sets the kubectl context to your new vCluster Standalone instance.
+
+To use vCluster Standalone as a Control Plane Cluster for tenant clusters, set your kubectl context to the vCluster Standalone instance. You can then create and manage tenant clusters using the vCluster CLI.
+
+To access the cluster from other machines, copy the kubeconfig from `/var/lib/vcluster/kubeconfig.yaml` on the control plane node, then replace the server field with relevant IP or DNS to access the cluster.
+You can also configure vCluster to make [external access easier](../../../manage/accessing-vcluster#access-vcluster-externally).
+
+The vCluster CLI is installed at `/var/lib/vcluster/bin/vcluster-cli`.
+
 <!-- vale Google.Headings = NO -->
-### Managed by vCluster Platform
+### Platform-managed
 <!-- vale Google.Headings = YES -->
 
-When managing a standalone cluster through <Link to="/docs/platform">vCluster Platform</Link>, the initial control plane node is provisioned through the platform using <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link>.
+When managing a standalone cluster through <Link to="/docs/platform">vCluster Platform</Link>, the initial control plane node is provisioned through the platform using <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link>. Platform connects to your node provider (such as AWS, GCP, or a bare metal provisioner), provisions a VM or physical server, installs the vCluster binary, and joins the node as the control plane. Once the cluster is running, Platform manages its full lifecycle. Platform coordinates configuration updates and version upgrades as rolling operations, eliminating the need for manual SSH access.
 
 Use <Link to="/docs/platform">vCluster Platform</Link> to:
 
@@ -135,96 +219,6 @@ After provisioning completes, <Link to="/docs/platform">vCluster Platform</Link>
 
 #### Access your cluster
 
-To access a standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the platform UI and click `Connect`.
+To access a Standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the platform UI and click `Connect`.
 
 As an alternative, use the [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) command.
-
-### Self-managed
-
-:::tip Control Plane Node
-All steps are performed on the control plane node.
-:::
-<Flow>
-    <Step>
-    Replace `CONFIG_DIRECTORY` with the directory to store the vCluster configuration values file, the `vcluster.yaml`.
-    <PageVariables CONFIG_DIRECTORY="/etc/vcluster" />
-    </Step>
-    <Step>
-        Create directory for storing vCluster Standalone configuration.
-        <InterpolatedCodeBlock
-          code={`mkdir -p [[GLOBAL:CONFIG_DIRECTORY]]`}
-          title="Create config directory"
-          language="bash"
-        />
-        Save a basic `vcluster.yaml` configuration file for vCluster Standalone on the control plane node.
-        <InterpolatedCodeBlock
-          code={`cat <<EOF > [[GLOBAL:CONFIG_DIRECTORY]]/vcluster.yaml
-  controlPlane:
-    distro:
-      k8s:
-        version: v1.34.0
-  EOF`}
-          title="Create vCluster config file"
-          language="yaml"
-        />
-
-:::warning
-Adding additional control plane nodes will not be supported unless you follow the [high availability](./high-availability) steps for configuration.
-:::
-    </Step>
-    <Step>
-       Authenticate with sudo privileges to access the Kubernetes context:
-        ```bash
-        sudo su -
-        ```
-        Then run the installation script on the control plane node:
-        <InterpolatedCodeBlock
-          code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone`}
-          title="Install vCluster Standalone on control plane node"
-          language="bash"
-        />
-
-    </Step>
-    <Step>
-        Check that the control plane node is ready.
-
-        After installation, the kubeconfig is automatically configured on the control plane node.
-        The kubectl context is set to interact with your new vCluster Standalone instance.
-
-        Run these commands on the control plane node:
-
-        ```bash title="Check node status"
-        kubectl get nodes
-        ```
-
-        Expected output:
-        ```bash
-        NAME               STATUS   ROLES                  AGE   VERSION
-        ip-192-168-3-131   Ready    control-plane,master   11m   v1.32.1
-        ```
-
-        ```bash title="Verify cluster components are running"
-        kubectl get pods -A
-        ```
-
-        Pods should include:
-        - **Flannel**: CNI for container networking
-        - **CoreDNS**: DNS service for the cluster
-        - **KubeProxy**: Network traffic routing and load balancing
-        - **Konnectivity**: Secure control plane to worker node communication
-        - **Local Path Provisioner**: Dynamic storage provisioning
-    </Step>
-
-</Flow>
-
-<StandaloneFlags />
-
-#### Access your cluster
-
-After installation, the kubeconfig is automatically configured on the control plane node. The kubectl context is set to interact with your new vCluster Standalone instance.
-If you decide to use vCluster Standalone as a Control Plane Cluster for tenant clusters, then you can set your current kube context to the vCluster Standalone and create and interact with tenant clusters using vCluster CLI.
-
-To access the cluster from other machines, copy the kubeconfig from `/var/lib/vcluster/kubeconfig.yaml` on the control plane node, then replace the server field with relevant IP or DNS to access the cluster.
-You can also configure vCluster to make [external access easier](../../../manage/accessing-vcluster#access-vcluster-externally).
-
-The vCluster CLI is installed at `/var/lib/vcluster/bin/vcluster-cli`.

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -200,16 +200,9 @@ Use <Link to="/docs/platform">vCluster Platform</Link> to:
 privateNodes:
   enabled: true
   autoNodes: # (optional) Add worker nodes with Auto Nodes
-    provider: [[GLOBAL:NODE_PROVIDER]]
-    dynamic:
-      - name: aws-pool-1
-
-# Networking configuration
-networking:
-  # Specify the pod CIDR
-  podCIDR: 10.64.0.0/16
-  # Specify the service CIDR
-  serviceCIDR: 10.128.0.0/16`}
+    - provider: [[GLOBAL:NODE_PROVIDER]]
+      dynamic:
+        - name: aws-pool-1`}
   title="vcluster.yaml for a standalone control plane managed by vCluster Platform"
   language="yaml"
 />

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -43,7 +43,7 @@ vCluster Standalone eliminates the dependency on an external Control Plane Clust
 
 If you're familiar with traditional vCluster deployments, you'll notice this configuration has fewer required settings because there's no Control Plane Cluster relationship to configure.
 
-For optional settings like dedicating the control plane node (not running workloads on it), configuring containerd, or customizing node registration, see the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone).
+For optional settings like dedicating the control plane node (not running workloads on it), configuring containerd, or customizing node registration, see the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone). For vcluster.yaml options that are not supported in Standalone mode, see [Unsupported configuration options](./troubleshooting#unsupported-configuration-options).
 :::
 
   </TabItem>

--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -83,7 +83,7 @@ privateNodes:
   autoNodes: # (optional) Add worker nodes with Auto Nodes
     provider: [[GLOBAL:NODE_PROVIDER]]
     dynamic:
-    - name: aws-pool-1
+      - name: aws-pool-1
 
 # Networking configuration
 networking:

--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -7,22 +7,19 @@ sidebar_class_name: pro standalone private-nodes
 
 import Flow, { Step } from "@site/src/components/Flow"
 import Link from '@docusaurus/Link'
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
 
 import StandaloneFlags from '../../../_fragments/deploy/standalone-flags.mdx'
-
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
-
-
+import PageVariables from '@site/src/components/PageVariables';
+import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport standalone="true" />
 
 ## Overview
 
-By default, vCluster Standalone is installed on one initial control plane node. This deployment method is recommended for any uses cases that are very ephemeral (e.g. dev environments, CI/CD, etc.), but for production
-use cases, it's recommended to run vCluster with more redundancy. We recommend deploying vCluster Standalone with multiple nodes for the control plane (i.e. in high availability (HA)) in order
-have the virtual cluster be more resilient to failures.
-
-Each control plane node needs to be added one by one to the cluster starting with an initial control plane node.
+By default, vCluster Standalone installs on a single control plane node. For production deployments, run multiple control plane nodes to improve resilience. Each additional control plane node joins the cluster one at a time, starting after the initial node is running.
 
 ## Predeployment configuration options
 
@@ -30,34 +27,107 @@ Each control plane node needs to be added one by one to the cluster starting wit
 ### Backing store must be embedded etcd or external database
 <!-- vale Loft.imperative-headings = YES -->
 
-When running vCluster Standalone in HA, the only option for the backing store is
-embedded etcd or external database, which needs to be specifically enabled from the initial node.
+HA requires either embedded etcd or an external database as the backing store. This must be configured on the initial node before adding additional control plane nodes.
 
-### Control Plane Node Roles
+### Control plane node roles
 
-Decide if the control plane node will also be a worker node or not.
+Decide if each control plane node will also act as a worker node. Once a node joins the cluster, its roles cannot change.
 
-### Worker Nodes
+### Worker nodes
 
- With vCluster Standalone, worker nodes can only be [private nodes](../../worker-nodes/private-nodes/join). Since there is no host cluster,
- there is no concept of host nodes.
+With vCluster Standalone, worker nodes can only be [private nodes](../../worker-nodes/private-nodes/join). Since there is no Control Plane Cluster, there is no concept of Shared Nodes.
 
 ## Prerequisites
 
-- Access to nodes that satisfies the [node requirements](./node-requirements)
+- Access to nodes that satisfy the [node requirements](./node-requirements)
 
-## Install Initial Control Plane Node
+## Install initial control plane node
+
+<Tabs
+  groupId="standalone-ha-management"
+  defaultValue="self-managed"
+  values={[
+    { label: 'Self-managed', value: 'self-managed' },
+    { label: 'Platform-managed', value: 'platform' },
+  ]}
+>
+  <TabItem value="self-managed">
+
+:::tip Control Plane Node
+Perform all steps on the initial control plane node as root.
+:::
+
+<Flow>
+    <Step>
+        Switch to root, then create a `vcluster.yaml` with HA enabled.
+
+        ```bash title="Switch to root"
+        sudo su -
+        ```
+
+        <InterpolatedCodeBlock
+          code={`mkdir -p /etc/vcluster\ncat <<EOF > /etc/vcluster/vcluster.yaml\ncontrolPlane:\n  distro:\n    k8s:\n      version: v1.35.0\n  backingStore:\n    etcd:\n      embedded:\n        enabled: true  # Required for HA (or use external DB)\nEOF`}
+          title="Create vCluster config file with HA enabled"
+          language="bash"
+        />
+    </Step>
+    <Step>
+        Run the installation script on the control plane node:
+
+        <InterpolatedCodeBlock
+          code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone`}
+          title="Install vCluster Standalone on control plane node"
+          language="bash"
+        />
+    </Step>
+    <Step>
+        Check that the control plane node is ready by running these commands:
+
+        ```bash title="Check node status"
+        kubectl get nodes
+        ```
+
+        Expected output:
+        ```bash
+        NAME               STATUS   ROLES                  AGE   VERSION
+        ip-192-168-3-131   Ready    control-plane,master   11m   v1.32.1
+        ```
+
+        ```bash title="Verify cluster components are running"
+        kubectl get pods -A
+        ```
+
+        Pods should include:
+        - **Flannel**: CNI for container networking
+        - **CoreDNS**: DNS service for the cluster
+        - **KubeProxy**: Network traffic routing and load balancing
+        - **Konnectivity**: Secure control plane to worker node communication
+        - **Local Path Provisioner**: Dynamic storage provisioning
+    </Step>
+</Flow>
+
+<StandaloneFlags />
+
+#### Access your cluster
+
+After installation, vCluster automatically configures the kubeconfig on the control plane node and sets the kubectl context to your new vCluster Standalone instance.
+
+To access the cluster from other machines, copy the kubeconfig from `/var/lib/vcluster/kubeconfig.yaml` on the control plane node or use the vCluster CLI to [generate access credentials](../../../manage/accessing-vcluster).
+
+  </TabItem>
+  <TabItem value="platform">
 
 <!-- vale Google.Headings = NO -->
-### Managed by vCluster Platform
+#### Platform-managed
 <!-- vale Google.Headings = YES -->
 
-When managing a standalone HA cluster through <Link to="/docs/platform">vCluster Platform</Link>, the initial control plane node is provisioned through the Platform using <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link>.
+When managing a Standalone HA cluster through <Link to="/docs/platform">vCluster Platform</Link>, the initial control plane node is provisioned through the Platform using <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link>. Platform coordinates configuration updates and version upgrades as rolling operations, eliminating the need for manual SSH access.
 
-Use vCluster Platform to:
+Use <Link to="/docs/platform">vCluster Platform</Link> to:
 
 1. Add a [Node Provider](/docs/platform/administer/node-providers/overview).
 2. Add the vCluster configuration (example below).
+3. Provision the cluster from the platform UI.
 
 <PageVariables K8S_VERSION="v1.35.0" NODE_PROVIDER="aws" CONTROL_PLANE_NODES="3" />
 
@@ -95,150 +165,72 @@ networking:
   language="yaml"
 />
 
-3. Provision the cluster from the platform UI.
-
 After provisioning completes, <Link to="/docs/platform">vCluster Platform</Link> manages the control plane node lifecycle. Worker node lifecycle also remains managed through the platform UI when <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link> are used.
 
 #### Access your cluster
 
-To access a standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the Platform UI and click `Connect`.
+To access a Standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the Platform UI and click `Connect`.
 
 As an alternative, use the [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) command.
 
-### Self-managed
+  </TabItem>
+</Tabs>
 
-<!-- vale off -->
-When deploying vCluster Standalone outside vCluster Platform, the assets required to install the control plane are located in
-the [GitHub releases](https://github.com/loft-sh/vcluster/releases) of vCluster.
-<!-- vale on -->
+## Add additional control plane nodes
 
-:::tip Control Plane Node
-All steps are performed on the initial control plane node.
-:::
+After the initial control plane node is running, additional nodes join the cluster using a bootstrap token and the install script.
 
-<Flow>
-    <Step>
-        Switch to root, then save a `vcluster.yaml` configuration file for vCluster Standalone on the control plane node's `/etc` directory.
+### Create a join token
 
-        ```bash title="Switch to root"
-        sudo su -
-        ```
-
-        ```bash title="Create a vcluster.yaml to enable HA for vCluster Standalone"
-        mkdir -p /etc/vcluster
-        cat <<EOF > /etc/vcluster/vcluster.yaml
-        controlPlane:
-          distro:
-            k8s:
-              version: v1.35.0
-          backingStore:
-            etcd:
-              embedded:
-                enabled: true  # Required for HA (or use external DB)
-        EOF
-        ```
-
-:::warning
-Adding additional control plane nodes will not be supported unless you follow the [high availability](./high-availability) steps for configuration.
-:::
-    </Step>
-    <Step>
-        Run the installation script on the control plane node:
-
-        ```bash title="Install vCluster Standalone on control plane node"
-        export VCLUSTER_VERSION="v0.33.0"
-        curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh | sh -s -- --vcluster-name standalone
-        ```
-
-    </Step>
-    <Step>
-        Check that the control plane node is ready.
-
-        After installation, the kubeconfig is automatically configured on the control plane node.
-        The kubectl context is set to interact with your new vCluster Standalone instance.
-
-        Run these commands on the control plane node:
-
-        ```bash title="Check node status"
-        kubectl get nodes
-        ```
-
-        Expected output:
-        ```bash
-        NAME               STATUS   ROLES                  AGE   VERSION
-        ip-192-168-3-131   Ready    control-plane,master   11m   v1.32.1
-        ```
-
-        ```bash title="Verify cluster components are running"
-        kubectl get pods -A
-        ```
-
-        Pods should include:
-        - **Flannel**: CNI for container networking
-        - **CoreDNS**: DNS service for the cluster
-        - **KubeProxy**: Network traffic routing and load balancing
-        - **Konnectivity**: Secure control plane to worker node communication
-        - **Local Path Provisioner**: Dynamic storage provisioning
-    </Step>
-
-</Flow>
-
-<StandaloneFlags />
-
-#### Add Additional control plane nodes
-
-After installing the initial control plane node, vCluster Standalone is already running and
-new nodes only need to join the cluster.
-
-#### Create token for control plane nodes
-
-To join control plane nodes, a token from the vCluster must be created to provide access and permissions. A single token can be used for any node(s) to join, or if you wanted to, you could create a token for each node.
-
-By default, the token expires within 1 hour. The token is stored as a secret prefixed with bootstrap-token- in the kube-system namespace. The expiry timestamp is stored under the expiration key in the secret.
+Generate a token on the initial control plane node. A single token can be used for multiple nodes, or you can create one per node.
 
 ```bash title="Create a token for control plane nodes"
-# Create a token
 /var/lib/vcluster/bin/vcluster-cli token create --control-plane --expires=1h
 ```
 
-The output provides a command to run on your control plane node:
+The command returns the join endpoint and token:
 
-```bash title="Example output from creating a token"
-curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh -
+```bash title="Example output"
+Join endpoint: https://<vcluster-endpoint>
+Join token:    <token>
 ```
 
-#### Join each control plane node
+By default the token expires after 1 hour. The token is stored as a Secret prefixed with `bootstrap-token-` in the `kube-system` namespace.
 
-For each control plane node that you want to join vCluster, run the command on the node.
+### Join each control plane node
 
-The new node will automatically download the necessary binaries and configuration, and join the cluster as an additional control plane node.
+On each additional control plane node, run the install script with the `--join-token` and `--join-endpoint` flags:
+
+<InterpolatedCodeBlock
+  code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- \\
+  --vcluster-name standalone \\
+  --join-token [[VAR:JOIN_TOKEN:your-token]] \\
+  --join-endpoint [[VAR:JOIN_ENDPOINT:https://your-vcluster-endpoint]]`}
+  title="Join an additional control plane node"
+  language="bash"
+/>
+
+The node automatically downloads the necessary binaries and configuration, and joins as an additional control plane node.
 
 ```mermaid
 sequenceDiagram
 participant User as User/Admin
 participant NodeA as Control Plane Node A
 participant ServerB as Server B
-    User->>NodeA: 1. Run command vcluster token create --control-plane
-    NodeA-->>User: Returns: `curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh -`
+    User->>NodeA: 1. Run vcluster token create --control-plane
+    NodeA-->>User: Returns join endpoint and token
 
-    User->>ServerB: 2. Copy & run `curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh -`
-    ServerB->>NodeA: 3. Script curls endpoint on Node A
+    User->>ServerB: 2. Run install script with --join-token and --join-endpoint
+    ServerB->>NodeA: 3. Script contacts Node A endpoint
     NodeA-->>ServerB: Returns: vcluster.yaml, vcluster binary and k8s binaries
 
-    ServerB->>ServerB: 4. unpack, configure and start vcluster systemD unit
+    ServerB->>ServerB: 4. Unpack, configure and start vCluster systemd unit
     ServerB->>NodeA: 5. Join cluster as another control plane node
-    NodeA-->>ServerB: ✓ control plane node joined successfully
+    NodeA-->>ServerB: ✓ Control plane node joined successfully
 ```
 
-#### Kubeconfig
+## Add worker nodes
 
-After installation, the kubeconfig is automatically configured on the control plane node. The kubectl context is set to interact with your new vCluster Standalone instance.
+After the vCluster control plane is up and running, add [dedicated worker nodes](../../worker-nodes/private-nodes/join).
 
-To access the cluster from other machines, copy the kubeconfig from `/var/lib/vcluster/kubeconfig.yaml` on the control plane node or use the vCluster CLI to [generate access credentials](../../../manage/accessing-vcluster).
-
-#### Add worker nodes
-
-After the vCluster control plane is up and running, you can add [dedicated worker nodes](../../worker-nodes/private-nodes/join).
-
-The API Server endpoint must be reachable from the worker nodes. You can additional
-configure the `controlPlane.endpoint` and `controlPlane.proxy.extraSANs` in your vCluster configuration to expose the API Server.
+The API server endpoint must be reachable from the worker nodes. Configure `controlPlane.endpoint` and `controlPlane.proxy.extraSANs` in your vCluster configuration to expose the API server.

--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -19,7 +19,7 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 ## Overview
 
-By default, vCluster Standalone installs on a single control plane node. For production deployments, run multiple control plane nodes to improve resilience. Each additional control plane node joins the cluster one at a time, starting after the initial node is running.
+By default, vCluster Standalone installs on a single control plane node. For production deployments, run multiple control plane nodes in high availability (HA) to improve resilience. Each additional control plane node joins the cluster one at a time, starting after the initial node is running.
 
 ## Predeployment configuration options
 
@@ -211,23 +211,6 @@ On each additional control plane node, run the install script with the `--join-t
 />
 
 The node automatically downloads the necessary binaries and configuration, and joins as an additional control plane node.
-
-```mermaid
-sequenceDiagram
-participant User as User/Admin
-participant NodeA as Control Plane Node A
-participant ServerB as Server B
-    User->>NodeA: 1. Run vcluster token create --control-plane
-    NodeA-->>User: Returns join endpoint and token
-
-    User->>ServerB: 2. Run install script with --join-token and --join-endpoint
-    ServerB->>NodeA: 3. Script contacts Node A endpoint
-    NodeA-->>ServerB: Returns: vcluster.yaml, vcluster binary and k8s binaries
-
-    ServerB->>ServerB: 4. Unpack, configure and start vCluster systemd unit
-    ServerB->>NodeA: 5. Join cluster as another control plane node
-    NodeA-->>ServerB: ✓ Control plane node joined successfully
-```
 
 ## Add worker nodes
 

--- a/vcluster/deploy/control-plane/binary/high-availability.mdx
+++ b/vcluster/deploy/control-plane/binary/high-availability.mdx
@@ -151,16 +151,9 @@ Use <Link to="/docs/platform">vCluster Platform</Link> to:
 privateNodes:
   enabled: true
   autoNodes: # (optional) Add worker nodes with Auto Nodes
-    provider: [[GLOBAL:NODE_PROVIDER]]
-    dynamic:
-      - name: aws-pool-1
-
-# Networking configuration
-networking:
-  # Specify the pod CIDR
-  podCIDR: 10.64.0.0/16
-  # Specify the service CIDR
-  serviceCIDR: 10.128.0.0/16`}
+    - provider: [[GLOBAL:NODE_PROVIDER]]
+      dynamic:
+        - name: aws-pool-1`}
   title="vcluster.yaml for an HA standalone control plane managed by vCluster Platform"
   language="yaml"
 />

--- a/vcluster/deploy/control-plane/binary/manage.mdx
+++ b/vcluster/deploy/control-plane/binary/manage.mdx
@@ -230,7 +230,7 @@ If you want to reuse a node that was already running vCluster standalone, you ca
         ```
       </Step>
       <Step>
-        From the primary node for virtual cluster, create a node join token.
+        From the primary node for the tenant cluster, create a node join token.
 
         ```bash title="Create node join token"
         vcluster token create

--- a/vcluster/deploy/control-plane/binary/security/fips.mdx
+++ b/vcluster/deploy/control-plane/binary/security/fips.mdx
@@ -6,6 +6,8 @@ sidebar_class_name: pro
 ---
 
 import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import PageVariables from '@site/src/components/PageVariables';
+import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <ProAdmonition />
 
@@ -17,7 +19,7 @@ FIPS 140-2 is a U.S. Federal Government security standard used to approve
 cryptographic modules. This document explains how vCluster Standalone and all its components
 are built with FIPS-validated cryptographic libraries.
 
-## Use of FIPS compatible Go toolchain
+## Use of FIPS-compatible Go toolchain
 
 vCluster is written in [Go](https://go.dev/), and the FIPS-compliant builds
 are compiled using the `GOFIPS140=v1.0.0` environment variable.
@@ -78,10 +80,8 @@ privateNodes:
 
 To create the FIPS-compliant vCluster Standalone, save this config to `/etc/vcluster/vcluster.yaml` on the node and then run:
 
-<PageVariables VCLUSTER_VERSION="v0.31.0"/>
-
 <InterpolatedCodeBlock
-  code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/[[GLOBAL:VCLUSTER_VERSION]]/install-standalone.sh | sh -s -- --vcluster-name standalone --fips`}
+  code={`curl -sfL https://github.com/loft-sh/vcluster/releases/download/v__VCLUSTER_VERSION__/install-standalone.sh | sh -s -- --vcluster-name standalone --fips`}
   title="Install FIPS-compliant vCluster Standalone on control plane node"
   language="bash"
 />
@@ -90,7 +90,7 @@ As a result, vCluster Standalone will automatically use FIPS-compliant images an
 
 :::info
 
-To use a different Kubernetes version in your virtual cluster than the host cluster, set the `controlPlane.distro.k8s.version` field in your configuration:
+To use a different Kubernetes version in your tenant cluster, set the `controlPlane.distro.k8s.version` field in your configuration:
 
 ```yaml
 controlPlane:

--- a/vcluster/deploy/control-plane/binary/troubleshooting.mdx
+++ b/vcluster/deploy/control-plane/binary/troubleshooting.mdx
@@ -6,6 +6,7 @@ sidebar_class_name: standalone private-nodes
 ---
 
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+import PrivateNodeLimitations from '../../../_fragments/private-nodes-limitations.mdx';
 
 <TenancySupport standalone="true" />
 
@@ -46,3 +47,7 @@ curl -sSLk "https://<endpoint>/node/join?token=<token>" | { response=$(cat); ech
 ### Resource constraints
 
 Ensure adequate CPU, memory, and disk space on nodes.
+
+## Unsupported configuration options {#unsupported-configuration-options}
+
+<PrivateNodeLimitations />


### PR DESCRIPTION

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Fixes for the Standalone docs page.
- There was some version drift. Updated the page the use the correct version variable instead of manual entry. Also updated some of the .js files that had fallen behind releases. Updated the Claude releaser skill to catch those files, as well.
- Adds missing flags for the standalone install script
- Updates virtual cluster terminology
- Addresses over-reliance on auto node feature

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1921--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary/basics

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1303
Closes DOC-1304


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

