### PR TITLE
fix: Added Least Privilege Mode Limitations section

### DIFF
--- a/platform/configure/agent-settings/least-privilege-mode.mdx
+++ b/platform/configure/agent-settings/least-privilege-mode.mdx
@@ -239,9 +239,9 @@ A typical rollout looks like this:
 
 ## Limitations
 
- - **Cost Control** incompatibility - Enabling the observability stack will expand the agent's RBAC permissions.
-   To limit the agent permissions to its runtime needs, the observability stack should be deployed via a dedicated process.
- - **Snapshots support** - Virtual cluster instances snapshot functionality requires additional permissions not supported by the default config. ex. pod/exec permissions.
+ - **Cost Control** incompatibility - Enabling the observability stack expands the agent's RBAC permissions.
+   To limit the agent permissions to its runtime needs, deploy the observability stack using a dedicated process.
+ - **Snapshots support** - The cluster instance snapshot feature requires `pods/exec` (`create` verb) in the managed namespaces, which is not included in the default **Least Privilege Mode** configuration. Organizations with strict policies that prohibit `pods/exec` cannot use this feature with **Least Privilege Mode** enabled.
 
 ## Troubleshooting
 

--- a/platform/configure/agent-settings/least-privilege-mode.mdx
+++ b/platform/configure/agent-settings/least-privilege-mode.mdx
@@ -237,6 +237,12 @@ A typical rollout looks like this:
 5. Test agent behavior in a non-production environment.
 6. Roll out the same configuration to production.
 
+## Limitations
+
+ - **Cost Control** incompatibility - Enabling the observability stack will expand the agent's RBAC permissions.
+   To limit the agent permissions to its runtime needs, the observability stack should be deployed via a dedicated process.
+ - **Snapshots support** - Virtual cluster instances snapshot functionality requires additional permissions not supported by the default config. ex. pod/exec permissions.
+
 ## Troubleshooting
 
 If the agent stops working after enabling **Least Privilege Mode**:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1922--vcluster-docs-site.netlify.app/docs/platform/next/configure/agent-settings/least-privilege-mode#limitations

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGPLAT-385


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

