### PR TITLE
feat: add UI permalink for versioning templates

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -387,6 +387,15 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   from = "/docs/platform-ui-link/platform/template-parameters/:version"
   to = "/docs/platform/:version/administer/templates/parameters"
 
+# Versioning Templates
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/versioning-templates"
+  to = "/docs/platform/administer/templates/versioning"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/versioning-templates/:version"
+  to = "/docs/platform/:version/administer/templates/versioning"
+
 # Sleep Mode (moved to vcluster docs)
 [[redirects]]
   from = "/docs/platform-ui-link/platform/sleep-mode"


### PR DESCRIPTION
## Summary
- Adds Netlify redirect for `versioning-templates` permalink used by Platform UI
- Unversioned: `/docs/platform-ui-link/platform/versioning-templates` → `/docs/platform/administer/templates/versioning`
- Versioned: `/docs/platform-ui-link/platform/versioning-templates/:version` → `/docs/platform/:version/administer/templates/versioning`