### PR TITLE
Add security warning for joinNode.enabled sharing credentials with tenants

### DIFF
--- a/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
+++ b/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
@@ -20,7 +20,16 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 
 </summary>
 
+:::warning Security consideration
+When `joinNode.enabled` is `true`, the control-plane node also runs kubelet as a worker.
+Tenant workloads scheduled onto this node share the machine with the vCluster control-plane
+process and its platform credentials. A tenant with sufficient privileges (such as `hostPID`,
+hostPath volumes, or `nodes/proxy` access) can read the platform access key from the process
+environment.
 
+For production deployments, keep the control-plane node dedicated by setting
+`joinNode.enabled: false` and use separate worker nodes for tenant workloads.
+:::
 
 </details>
 

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -69,6 +69,13 @@ Decide if the control plane node will also be a worker node or not. Once a node 
 
 By default, the control plane node also acts as a worker node. To deploy a dedicated control plane that does not run workloads, set [`controlPlane.standalone.joinNode.enabled`](../../../configure/vcluster-yaml/control-plane/components/standalone#standalone-joinNode-enabled) to `false`.
 
+:::warning
+When the control plane node also acts as a worker, tenant workloads share the machine with
+the vCluster control-plane process and its credentials. For production deployments, set
+[`controlPlane.standalone.joinNode.enabled`](../../../configure/vcluster-yaml/control-plane/components/standalone#standalone-joinNode-enabled)
+to `false` and use dedicated worker nodes.
+:::
+
 ### Worker Nodes
 
  With vCluster Standalone, worker node pools can only be [private nodes](../../worker-nodes/private-nodes). Since there is no host cluster,


### PR DESCRIPTION
## Summary

- Add security warnings to the `joinNode.enabled` config reference and the standalone basics page
- When `joinNode.enabled: true`, the CP node runs kubelet, exposing platform credentials to tenant workloads
- Warning recommends keeping CP nodes dedicated in production

Related: ENGCP-288

## Test plan

- [x] `npm run start` — verify warnings render correctly on both pages
- [x] Verify links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)