### PR TITLE
ci(auto-approve): switch to github app token for pr approval

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,5 +10,7 @@ jobs:
     with:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
+      app-id: ${{ secrets.AUTO_APPROVE_APP_ID }}
     secrets:
+      app-private-key: ${{ secrets.AUTO_APPROVE_APP_PRIVATE_KEY }}
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Pass `app-id` and `app-private-key` to the reusable auto-approve workflow using the `vcluster-pr-approver` GitHub App (org secrets)
- Keep `gh-access-token` (loft-bot PAT) as fallback during migration
- Resolves self-approval problem: loft-bot can't approve loft-bot-authored backport PRs

## How it works

The reusable workflow (loft-sh/github-actions#98, merged) mints a short-lived installation token from the App credentials. The App identity (`vcluster-pr-approver[bot]`) differs from the PR author (`loft-bot`), so GitHub allows the approval.

## Test plan

- [ ] CI green
- [ ] Trigger on a real loft-bot backport PR — approval should come from `vcluster-pr-approver[bot]`

References DEVOPS-751