### PR TITLE
fix(docs): add .mdx to architecture page relative links to fix 404s on click

### DIFF
--- a/vcluster/introduction/architecture.mdx
+++ b/vcluster/introduction/architecture.mdx
@@ -19,9 +19,9 @@ Every tenant cluster runs a dedicated <GlossaryTerm term="control-plane">control
 
 - A **Kubernetes API server**, the management interface for all API requests within the tenant cluster.
 - A **controller manager**, which maintains the state of Kubernetes resources like pods, ensuring they match the desired configuration.
-- A **data store**, which stores all API resources. By default, an embedded SQLite database is used, but you can [choose other data stores](../configure/vcluster-yaml/control-plane/components/backing-store/) like <GlossaryTerm term="etcd">etcd</GlossaryTerm>, MySQL, and PostgreSQL.
+- A **data store**, which stores all API resources. By default, an embedded SQLite database is used, but you can [choose other data stores](../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx) like <GlossaryTerm term="etcd">etcd</GlossaryTerm>, MySQL, and PostgreSQL.
 - A **syncer**, which synchronizes resources between the tenant cluster and the underlying infrastructure.
-- A **scheduler**, an optional component for scheduling workloads. By default, vCluster reuses the Control Plane Cluster's scheduler to reduce resource usage. You can [enable the virtual scheduler](../configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler) when you need node labels, taints, drain operations, or custom scheduling behavior.
+- A **scheduler**, an optional component for scheduling workloads. By default, vCluster reuses the Control Plane Cluster's scheduler to reduce resource usage. You can [enable the virtual scheduler](../configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx) when you need node labels, taints, drain operations, or custom scheduling behavior.
 
 All of these components run together in a single container within a StatefulSet pod. The API server, controller manager, data store, and syncer are one unified process. CoreDNS deploys as a separate pod in the same namespace. If you opt into external etcd, it runs as its own StatefulSet. On the underlying cluster, `kubectl get pods -n <vcluster-namespace>` shows something like:
 
@@ -160,7 +160,7 @@ The syncer links the tenant cluster to the Control Plane Cluster. It keeps the t
 
 **With private nodes**, only control plane state is synchronized. The syncer coordinates the tenant cluster's API server with the underlying infrastructure. From an operator's perspective this is nearly transparent. Workloads run directly on dedicated nodes with no sync overhead.
 
-**With shared nodes**, the syncer also translates workload resources between the tenant cluster and the underlying cluster. This includes Pods, ConfigMaps, Secrets, Services, Ingress, and Gateway API objects. Each resource type has specific sync behavior. Networking resources in particular require careful configuration. If you are deploying with shared nodes, read the [full sync documentation](../configure/vcluster-yaml/sync/) to understand what is synced and how to configure it for your workloads.
+**With shared nodes**, the syncer also translates workload resources between the tenant cluster and the underlying cluster. This includes Pods, ConfigMaps, Secrets, Services, Ingress, and Gateway API objects. Each resource type has specific sync behavior. Networking resources in particular require careful configuration. If you are deploying with shared nodes, read the [full sync documentation](../configure/vcluster-yaml/sync/README.mdx) to understand what is synced and how to configure it for your workloads.
 
 <!-- vale off -->
 
@@ -174,24 +174,24 @@ The networking features below apply to **shared nodes** deployments, where the s
 
 #### Ingress traffic
 
-Instead of running a separate Ingress controller in each tenant cluster, vCluster can [synchronize Ingress resources](../configure/vcluster-yaml/sync/to-host/networking/ingresses) to use the underlying cluster's Ingress controller. This reduces per-tenant overhead and simplifies DNS management across tenant clusters.
+Instead of running a separate Ingress controller in each tenant cluster, vCluster can [synchronize Ingress resources](../configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx) to use the underlying cluster's Ingress controller. This reduces per-tenant overhead and simplifies DNS management across tenant clusters.
 
 #### DNS
 
-By default, each tenant cluster deploys its own [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns) instance. CoreDNS lets pods within the tenant cluster resolve other services in the same environment. The syncer maps service DNS names in the tenant cluster to their corresponding IP addresses on the underlying cluster, following Kubernetes DNS naming conventions.
+By default, each tenant cluster deploys its own [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns.mdx) instance. CoreDNS lets pods within the tenant cluster resolve other services in the same environment. The syncer maps service DNS names in the tenant cluster to their corresponding IP addresses on the underlying cluster, following Kubernetes DNS naming conventions.
 
-With vCluster Pro, [CoreDNS can be embedded](../configure/vcluster-yaml/control-plane/components/coredns) directly into the control plane pod, reducing the per-tenant footprint.
+With vCluster Pro, [CoreDNS can be embedded](../configure/vcluster-yaml/control-plane/components/coredns.mdx) directly into the control plane pod, reducing the per-tenant footprint.
 
 #### Communication within a tenant cluster
 
 * **Pod to pod** — Pods within a tenant cluster communicate using the underlying cluster's network infrastructure. No additional configuration is required. The syncer ensures Kubernetes-standard networking is maintained.
 
-* **Pod to service** — Services within a tenant cluster are synchronized to allow pod communication, using [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns) for domain name resolution.
+* **Pod to service** — Services within a tenant cluster are synchronized to allow pod communication, using [CoreDNS](../configure/vcluster-yaml/control-plane/components/coredns.mdx) for domain name resolution.
 
-* **Pod to underlying cluster service** — Services from the underlying cluster can be [replicated](../configure/vcluster-yaml/networking/replicate-services) into a tenant cluster, allowing tenant pods to access platform services by name.
+* **Pod to underlying cluster service** — Services from the underlying cluster can be [replicated](../configure/vcluster-yaml/networking/replicate-services.mdx) into a tenant cluster, allowing tenant pods to access platform services by name.
 
 * **Pod to another tenant cluster's service** — Services can be mapped [between tenant clusters](../configure/vcluster-yaml/networking/resolve-dns.mdx) using DNS configuration that routes requests from one tenant cluster to another.
 
 #### Communication from the underlying cluster
 
-* **Underlying cluster pod to tenant cluster service** — Pods on the underlying cluster can access services within a tenant cluster by [replicating](../configure/vcluster-yaml/networking/replicate-services#virtual-cluster-to-host-cluster) tenant cluster services to any namespace on the underlying cluster.
+* **Underlying cluster pod to tenant cluster service** — Pods on the underlying cluster can access services within a tenant cluster by [replicating](../configure/vcluster-yaml/networking/replicate-services.mdx#virtual-cluster-to-host-cluster) tenant cluster services to any namespace on the underlying cluster.


### PR DESCRIPTION
# Content Description

Nine links on the architecture page navigate to 404 when clicked because they were written as bare relative paths without the `.mdx` extension. The static HTML rendered by SSR is correct, but Docusaurus' client-side Link component re-resolves the raw relative string against `window.location` at click time, injecting `/introduction/` into the path. Reported by Andrew Brooks and Joyce Zhang in Slack.

Empirically reproduced in Chrome via `history.pushState` interception, and verified the fix works on the local dev server. Root cause: Docusaurus' MDX plugin only rewrites file-reference links to internal absolute routes when they carry the `.mdx` (or `.md`) suffix.

All nine broken links were introduced in #1889 (same commit correctly used `.mdx` on three other links — inconsistency, not a wholesale pattern). Backport #1907 propagated them to v0.33.0.

## Preview Link

- Fixed: https://deploy-preview-NNNN--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/architecture (replace NNNN with the PR number once assigned by Netlify)

Click through each of the previously broken links below and verify no 404s:

- "choose other data stores" → backing-store/
- "enable the virtual scheduler" → virtual-scheduler
- "full sync documentation" → sync/
- "synchronize Ingress resources" → ingresses
- "CoreDNS" (three occurrences) → coredns
- "replicated" / "replicating" → replicate-services (including anchor `#virtual-cluster-to-host-cluster`)

## Internal Reference

Closes DOC-1311

---

### Follow-up (separate tickets recommended)

- Repo-wide scan for the same pattern on other pages touched by #1889
- CI linter to reject relative MDX links without `.mdx`/`.md`/`#`/`README.mdx` suffix
- Update `CLAUDE.md` and `.claude/skills/vcluster-docs-writer/` to document this failure mode (link-formatting.md currently says "links are resolved at build time" which is only true for `.mdx` paths)

@netlify /docs