### PR TITLE
fix(ci): use vars context for app-id in auto-approve caller

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,7 +10,7 @@ jobs:
     with:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
-      app-id: ${{ secrets.AUTO_APPROVE_APP_ID }}
+      app-id: ${{ vars.AUTO_APPROVE_APP_ID }}
     secrets:
       app-private-key: ${{ secrets.AUTO_APPROVE_APP_PRIVATE_KEY }}
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
# Content Description
Fixes a workflow validation failure in `.github/workflows/auto-approve-bot-prs.yaml` introduced by #1927 (commit `e93cd54a`). The caller passed `app-id: ${{ secrets.AUTO_APPROVE_APP_ID }}` inside the reusable workflow's `with:` block, but GitHub Actions parses `with:` in a restricted context that **excludes secrets**. Every push since the merge has produced a startup failure, and no `pull_request` runs were ever created — so backport PRs (e.g. #1930, #1931) sat without auto-approval.

The fix moves the App ID reference from `secrets.X` to `vars.X`. App IDs are public identifiers and belong in Actions Variables; only `app-private-key` needs to remain a secret.

## Preview Link
N/A — workflow-only change, no docs preview affected.

## Internal Reference
References DEVOPS-714

## Required follow-up before this fix takes full effect
A new **org-level Actions Variable** must be created:

- Name: `AUTO_APPROVE_APP_ID`
- Value: same App ID currently stored in the org secret of the same name
- Visibility: scoped to `loft-sh/vcluster-docs` (and any other repo that calls this workflow with the App auth path)

Until the variable exists, `${{ vars.AUTO_APPROVE_APP_ID }}` resolves to an empty string and the reusable workflow falls back to the `GH_ACCESS_TOKEN` PAT (the `if: inputs.app-id != ''` guard in the reusable workflow handles this gracefully). After the variable is created, App-token auth resumes automatically. The org secret of the same name can be deleted once the variable is in place.

## Evidence of the bug
- 39 push runs of `auto-approve-bot-prs.yaml` failed with "This run likely failed because of a workflow file issue" between 2026-04-14 15:23 UTC (merge of `e93cd54a`) and now.
- Zero `pull_request` runs were created in the same window (verified via `gh api .../workflows/258982043/runs?event=pull_request`).
- PR #1926 (head sha `81cfe93`, branched **before** `e93cd54a`) was the last PR where auto-approve ran successfully.
- Confirmed by GitHub docs: secrets context is excluded from the restricted parsing context applied to job-level `with:` for reusable workflow calls.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs