### PR TITLE
chore(codeowners): exempt versioned_docs paths from code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
 # All PRs in this repo will be assigned to the docs team
 * @loft-sh/Eng-Docs-Admin
+
+# Backport targets — the loft-bot backport action copies files from
+# the current docs into frozen, versioned snapshots under these paths.
+# The content has already been reviewed on its original location, and
+# the auto-approve bot handles these PRs. Clearing the code owner here
+# keeps backport PRs unblocked without opening the rest of the repo.
+/vcluster_versioned_docs/
+/platform_versioned_docs/


### PR DESCRIPTION
# Content Description
Exempts `vcluster_versioned_docs/` and `platform_versioned_docs/` from the repo-wide `* @loft-sh/Eng-Docs-Admin` rule so that backport PRs (which only touch those folders) are no longer blocked by a Code Owner review requirement. The auto-approve bot (`vcluster-pr-approver`) still leaves its approval, and the org ruleset still requires one approval — that combination is enough for backports to merge without manual Eng-Docs-Admin intervention.

Regular PRs that touch `docs/`, `vcluster/`, `platform/`, or anything else in the repo continue to require an Eng-Docs-Admin Code Owner review exactly as today.

## Preview Link
N/A — governance-only change, no docs preview.

## Internal Reference
References DEVOPS-714

## Why
With CODEOWNERS set to `* @loft-sh/Eng-Docs-Admin`, every backport PR still showed "Waiting on code owner review from loft-sh/eng-docs-admin" even after the auto-approve bot approved it. GitHub Apps cannot be added as Code Owners (Apps can't be team members), so the bot's approval satisfied the generic "1 approval" requirement but not the CODEOWNERS gate. Verified by inspection: every recent backport PR (#1917, #1926, #1930, #1931, #1935) touches only `vcluster_versioned_docs/version-*/` paths — no file sits outside the exempt prefixes.

## Verification before merge
Reviewing this PR is itself a data point: it touches `.github/CODEOWNERS` (covered by the unchanged `* @loft-sh/Eng-Docs-Admin` line), so it still requires an Eng-Docs-Admin review. Normal repo PRs behave unchanged.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs