### PR TITLE
fix(ci): stop using github app for auto-approving bot prs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -10,7 +10,5 @@ jobs:
     with:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
-      app-id: ${{ vars.AUTO_APPROVE_APP_ID }}
     secrets:
-      app-private-key: ${{ secrets.AUTO_APPROVE_APP_PRIVATE_KEY }}
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
# Content Description
Rolls back the GitHub App authentication path added in #1927 / DEVOPS-751. The auto-approve caller workflow now passes only \`gh-access-token\` (PAT) to the reusable workflow in \`loft-sh/github-actions\`, matching what \`vcluster\`, \`vcluster-pro\`, \`loft-enterprise\`, \`loft-prod\` and \`hosted-platform\` already use.

## Preview Link
N/A — CI-only change.

## Internal Reference
References DEVOPS-714

## Why
Reviews from GitHub Apps (installation-token reviews such as \`vcluster-pr-approver[bot]\`) do not satisfy \`required_approving_review_count\` in rulesets or in classic branch protection. Reviews only count when they come from a user whose \`authorAssociation\` is \`MEMBER\`/\`COLLABORATOR\` with write access — App reviews always land as \`authorAssociation: NONE\` regardless of what the App's installation permissions say. This is a hard GitHub behaviour confirmed by the public docs and reproduced on PRs #1930 and #1931:

\`\`\`
reviewDecision: REVIEW_REQUIRED
reviews:
  vcluster-pr-approver (Bot)   APPROVED   (authorAssoc: NONE)
  vcluster-pr-approver (Bot)   APPROVED   (authorAssoc: NONE)
\`\`\`

Two valid bot approvals against the current head sha, yet the ruleset still blocks merge. Adding the App as a ruleset bypass actor helps the App's own actions but does not change how reviews are counted.

Falling back to \`GH_ACCESS_TOKEN\` restores the approval identity to a real user with repo write access, whose review does count. The token owner is not \`loft-bot\`, so self-approval on backport PRs is not a concern — and this is already the shipped configuration in all the sister repos.

The composite action in \`loft-sh/github-actions\` still supports both auth modes, so this caller can opt back into the App path later without another upstream change.

The backport auto-approve rules themselves will be redesigned separately, off the GitHub-App path.

AI review: mention @claude in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs