### PR TITLE
docs(vcluster): remove private nodes support from workload service account

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -2,13 +2,17 @@
 title: Workload service account
 sidebar_label: workloadServiceAccount
 sidebar_position: 2
-sidebar_class_name: host-nodes private-nodes
+sidebar_class_name: host-nodes
 ---
 
 import WorkloadServiceAccount from '../../../../../_partials/config/controlPlane/advanced/workloadServiceAccount.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
-<TenancySupport hostNodes="true" privateNodes="true" />
+<TenancySupport hostNodes="true" />
+
+:::note Private Nodes
+For private nodes, workload pods run on dedicated nodes and do not sync to the Control Plane Cluster namespace. Configure image pull authentication at the node level using [`privateNodes.joinNode.containerd.registry`](/docs/vcluster/configure/vcluster-yaml/private-nodes/#privateNodes-joinNode-containerd-registry).
+:::
 
 The workloadServiceAccount allows you to enforce the use of a specific ServiceAccount for all vCluster workload pods running in the host cluster.
 For example, you can attach a shared imagePullSecret to the ServiceAccount so that all synced pods use the same secret when pulling container images.


### PR DESCRIPTION
## Summary

- Removes `privateNodes="true"` from the `TenancySupport` banner on the `workloadServiceAccount` page
- Removes `private-nodes` from `sidebar_class_name`
- Adds a note directing private node users to `privateNodes.joinNode.containerd.registry` for image pull configuration

`workloadServiceAccount.imagePullSecrets` does not apply to private nodes because workload pods run on dedicated private nodes and never sync to the Control Plane Cluster namespace. The equivalent for private nodes is containerd-level registry configuration.

Note: `controlPlane.advanced.serviceAccount` (the control plane's own ServiceAccount) correctly remains marked as supported for private nodes — that pod always runs in the Control Plane Cluster.

## Test plan

- [ ] Verify the `workloadServiceAccount` page no longer shows Private Nodes in the supported configurations banner
- [ ] Verify the Private Nodes note renders correctly with a working link to `privateNodes.joinNode.containerd.registry`

Closes DOC-1306

🤖 Generated with [Claude Code](https://claude.com/claude-code)