### PR TITLE
docs(platform): fix metal3 config property names and descriptions

### DIFF
--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -14,7 +14,7 @@ import Flow, {Step} from "@site/src/components/Flow";
 The Metal3 provider allows you to provision bare metal servers as Machines using [Metal3](https://metal3.io/) and [Ironic](https://ironicbaremetal.org/).
 When a Machine is requested, the platform claims an available `BareMetalHost` resource, configures it with the requested OS image and user data, and Ironic handles the PXE boot and OS installation on the physical server.
 
-This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a host cluster. Machines can be used as private nodes for virtual clusters or provisioned independently.
+This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a Control Plane Cluster. Machines can be used as private nodes for tenant clusters or provisioned independently.
 
 ```mermaid
 flowchart LR
@@ -25,7 +25,7 @@ flowchart LR
         Configure("Configure image & userData")
     end
 
-    subgraph host_cluster["Host Cluster"]
+    subgraph host_cluster["Control Plane Cluster"]
         direction TB
         BMH["BareMetalHost"]
         Ironic["Ironic"]
@@ -42,8 +42,8 @@ flowchart LR
 
 ## Overview
 
-The Metal3 provider works by selecting available BareMetalHost resources on a host cluster and provisioning them with an OS image and user data configuration.
-Node types allow organizing bare metal servers based on type, location, or other criteria. When a Machine is created, the platform:
+The Metal3 provider works by selecting available BareMetalHost resources on a Control Plane Cluster and provisioning them with an OS image and user data configuration.
+Node types let you organize bare metal servers based on type, location, or other criteria. When a Machine is created, the platform:
 
 1. Selects an available BareMetalHost matching the node type's label selector and resource requirements
 2. Configures the BareMetalHost with the OS image, user data, and optional network configuration
@@ -56,16 +56,16 @@ When the Machine is deleted, the platform restores the BareMetalHost to its orig
 
 When a Machine is created, the platform provisions the bare metal server through the following steps:
 
-1. The platform generates a user data configuration and stores it in a Kubernetes Secret on the host cluster.
+1. The platform generates a user data configuration and stores it in a Kubernetes Secret on the Control Plane Cluster.
 2. The provider sets the BareMetalHost's `userData` reference to this Secret and the image information from the configured [OSImage](../../use-platform/machines/os-images.mdx) or direct image properties.
 3. Ironic provisions the server through a series of steps: power management, PXE boot, and an in-memory installer that writes the OS to disk.
 4. The server boots into the provisioned OS and is initialized with the user data configuration.
 
-When a Machine is used as a private node for a vCluster, the user data includes registration scripts that automatically join the server to the virtual cluster.
+When a Machine is used as a private node for a tenant cluster, the user data includes registration scripts that automatically join the server to the tenant cluster.
 
 ## Infrastructure deployment
 
-The Metal3 provider can deploy the required infrastructure components on the host cluster. Each component can be individually enabled and customized with Helm values. Metal3 and Ironic may also be managed yourself — disable the respective component and the provider uses whatever is already deployed.
+The Metal3 provider can deploy the required infrastructure components on the Control Plane Cluster. Each component can be individually enabled and customized with Helm values. Metal3 and Ironic may also be managed yourself — disable the respective component and the provider uses whatever is already deployed.
 
 <Tabs>
 <TabItem value="metal3" label="Metal3 & Ironic">
@@ -103,7 +103,7 @@ Handles PXE boot by acting as a proxy between bare metal servers and Ironic, whi
 | Value | Description | Default |
 |---|---|---|
 | `networkAttachmentDefinition.vip` | Virtual IP with prefix for the DHCP server. Injected into the NetworkAttachmentDefinition under `ipam.static`. | — |
-| `networkAttachmentDefinition.config` | CNI configuration JSON for the NetworkAttachmentDefinition. Use `bridge` if host nodes have a bridge attached to the provisioning network. Use `macvlan` if the bare metal servers are on the same network as the host cluster nodes. | — |
+| `networkAttachmentDefinition.config` | CNI configuration JSON for the NetworkAttachmentDefinition. Use `bridge` if Control Plane Cluster nodes have a bridge attached to the provisioning network. Use `macvlan` if the bare metal servers are on the same network as the Control Plane Cluster nodes. | — |
 | `proxy.ironicHttpUrl` | Ironic HTTP endpoint for image serving | Auto-configured when Metal3 is enabled |
 | `proxy.ironicApiUrl` | Ironic API endpoint | Auto-configured when Metal3 is enabled |
 | `proxy.image.registry` | Container image registry | `ghcr.io` |
@@ -128,7 +128,7 @@ deploy:
           }
 ```
 
-Example with macvlan (bare metal servers on the same network as the host cluster nodes):
+Example with macvlan (bare metal servers on the same network as the Control Plane Cluster nodes):
 
 ```yaml
 deploy:
@@ -179,15 +179,15 @@ A Metal3 `NodeProvider` configuration consists of a cluster reference, optional 
 
 ### Cluster reference
 
-The `clusterRef` specifies the host cluster where the platform installs Metal3 components and where the BareMetalHost resources live. This cluster must be connected to vCluster Platform.
+The `clusterRef` specifies the Control Plane Cluster where the platform installs Metal3 components and where the BareMetalHost resources live. This cluster must be connected to vCluster Platform.
 
 | Field | Description | Required |
 |---|---|---|
-| `clusterRef.cluster` | Name of the connected host cluster | Yes |
-| `clusterRef.namespace` | Namespace on the host cluster for Metal3 components and BareMetalHost resources | Yes |
+| `clusterRef.cluster` | Name of the connected Control Plane Cluster | Yes |
+| `clusterRef.namespace` | Namespace on the Control Plane Cluster for Metal3 components and BareMetalHost resources | Yes |
 
 :::info Ironic network access
-Ironic must have network access to the BMC addresses of the bare metal servers. Ensure the host cluster where Ironic is deployed can reach the BMC network (Redfish/IPMI endpoints).
+Ironic must have network access to the BMC addresses of the bare metal servers. Ensure the Control Plane Cluster where Ironic is deployed can reach the BMC network (Redfish/IPMI endpoints).
 :::
 
 ### Example
@@ -233,13 +233,13 @@ spec:
 
 ## Get started
 
-This walkthrough covers the essential steps to go from a connected host cluster to a provisioned bare metal server.
+This walkthrough covers the essential steps to go from a connected Control Plane Cluster to a provisioned bare metal server.
 
 <Flow>
 <Step>
 Apply the NodeProvider.
 
-Create a NodeProvider that references your host cluster and defines at least one node type. The node type's label selector determines which BareMetalHosts it can claim.
+Create a NodeProvider that references your Control Plane Cluster and defines at least one node type. The node type's label selector determines which BareMetalHosts it can claim.
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -275,7 +275,7 @@ spec:
 kubectl apply -f metal3-provider.yaml
 ```
 
-Wait for Metal3 and Ironic to be running on the host cluster before creating BareMetalHost resources. The Metal3 webhook must be ready to validate them.
+Wait for Metal3 and Ironic to be running on the Control Plane Cluster before creating BareMetalHost resources. The Metal3 webhook must be ready to validate them.
 </Step>
 
 <Step>
@@ -361,11 +361,11 @@ privateNodes:
               value: compute-node
 ```
 
-After provisioning completes, the server boots into the configured OS and joins the virtual cluster as a worker node.
+After provisioning completes, the server boots into the configured OS and joins the tenant cluster as a worker node.
 </Step>
 </Flow>
 
-## Define NodeTypes
+## Define node types
 
 Each node type specifies which BareMetalHosts it can claim and what properties to apply during provisioning.
 
@@ -434,11 +434,11 @@ Checksum algorithm. Supported values: `md5`, `sha256`, `sha512`. If omitted, the
 
 #### `metal3.vcluster.com/network-cidr`
 
-**Type:** `string` (format: `CIDR/gateway`)
+**Type:** `string` (standard CIDR notation)
 
-Specifies a CIDR range with gateway for IP allocation. The platform allocates IPs from this range using its built-in IPAM.
+Specifies the gateway IP and subnet for IP allocation. Use standard CIDR notation where the host portion is the gateway address. The platform allocates IPs from the resulting subnet using its built-in IPAM.
 
-Example: `10.0.0.0/24/10.0.0.1`
+Example: `10.0.0.1/24`
 
 #### `metal3.vcluster.com/network-ip-range`
 
@@ -476,11 +476,11 @@ Pins a Machine to a specific BareMetalHost by name. This is useful when creating
 
 References [SSHKey](../../use-platform/machines/ssh-keys.mdx) resources by name. The public keys are included in the user data during provisioning.
 
-#### `vcluster.com/extra-user-data`
+#### `vcluster.com/user-data`
 
 **Type:** `string`
 
-Additional cloud-init configuration appended to the generated user data.
+Custom cloud-init configuration merged with the generated user data. Accepts any valid cloud-config directives (`packages`, `write_files`, `runcmd`, etc.). The platform's provisioning commands are appended after any user-supplied `runcmd` entries.
 
 ## Try it yourself
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Corrects inaccurate configuration property names and descriptions on the Metal3 node provider page, and applies repositioning terminology throughout.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-1948--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/metal3#vclustercomuser-data

## Internal Reference

Closes DOC-1316

## Summary

- Fix `vcluster.com/extra-user-data` → `vcluster.com/user-data` (wrong annotation name; verified against source constant `UserDataProperty`)
- Fix `metal3.vcluster.com/network-cidr` format: documented as invented `10.0.0.0/24/10.0.0.1` format; correct format is standard CIDR notation `10.0.0.1/24` (code calls `net.ParseCIDR()` directly)
- Apply repositioning terminology: "host cluster" → "Control Plane Cluster", "virtual cluster" → "tenant cluster"

## Test plan

- [x] Build passes (`npm run build`) with no new errors or warnings
- [x] Vale linting passes clean
- [x] Property names verified against `pkg/autoscaling/provider_metal3.go` and `pkg/autoscaling/user_data.go` in loft-enterprise
- [x] `network-cidr` format verified against `parseGatewayCIDR` in `pkg/autoscaling/provider_kubevirt.go`

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs