### PR TITLE
ci(auto-approve): use dedicated bot-approver pat for approvals

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -11,4 +11,4 @@ jobs:
       auto-merge: false
       trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
     secrets:
-      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      gh-access-token: ${{ secrets.BOT_APPROVER_PAT }}


### PR DESCRIPTION
# Content Description
Swap the secret passed to the reusable `auto-approve-bot-prs` workflow from the general-purpose `GH_ACCESS_TOKEN` to a narrow-scoped `BOT_APPROVER_PAT` issued from the dedicated `vcluster-bot-approver` GitHub user. Approval still runs via `gh` CLI as a real user with repo write access, so the review counts toward branch protection's `required_approving_review_count`; nothing else in the caller changes.

## Preview Link
N/A — CI-only change.

## Internal Reference
References DEVOPS-714

## Why

`GH_ACCESS_TOKEN` has been org-wide for 4+ years with a broad, unclear scope bundled across unrelated CI uses. `BOT_APPROVER_PAT` is a fine-grained PAT:

- issued from a dedicated machine user (`vcluster-bot-approver`), so identity is distinct from `loft-bot` (the backport PR author) — avoids the self-approval block
- scoped at the GitHub PAT level to exactly the 6 repos that wire up the reusable workflow
- secret visibility at the org level restricted to those same 6 repos (minimum value exposure surface)
- clean rotation/audit path that doesn't disturb other CI consumers

This also replaces the earlier GitHub App token path (PR #1927 / DEVOPS-751), which didn't work: app reviews land with `authorAssociation: NONE` and are not counted by rulesets — confirmed in public GitHub docs and reproduced on PRs #1930 / #1931, where two valid bot approvals still left `reviewDecision: REVIEW_REQUIRED`.

## Rollout

This is the pilot; once verified on a real `loft-bot` backport PR (expect `reviewDecision: APPROVED`, `authorAssociation: MEMBER`), the same one-line swap goes to `vcluster`, `vcluster-pro`, `loft-enterprise`, `loft-prod`, `hosted-platform`.

AI review: mention \`@claude\` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs