### PR TITLE
feat(docs): inject hidden llms.txt directive on every doc page

### DIFF
--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import DocItemLayout from '@theme-original/DocItem/Layout';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+/**
+ * Wraps every doc page with a visually-hidden directive pointing to llms.txt.
+ *
+ * Agents that arrive at a doc URL via training-data recall have no other way
+ * to discover the documentation index. This element is invisible to human
+ * readers but present in the DOM for LLM agents and other crawlers.
+ *
+ * Satisfies the `llms-txt-directive` check from the agent-docs spec:
+ * https://agentdocsspec.com/spec/#llms-txt-directive
+ */
+export default function DocItemLayoutWrapper(props) {
+  const llmsTxtUrl = useBaseUrl('/llms.txt');
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        For the complete documentation index, see{' '}
+        <a href={llmsTxtUrl}>llms.txt</a>
+      </div>
+      <DocItemLayout {...props} />
+    </>
+  );
+}


### PR DESCRIPTION

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Swizzles DocItem/Layout to render a visually-hidden element before each doc page's content, pointing agents to /docs/llms.txt. Satisfies the llms-txt-directive check from the agent-docs spec so agents that arrive at a doc URL via training data can discover the documentation index. Invisible to human readers via CSS; aria-hidden removes it from the accessibility tree. 

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1317


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

