### PR TITLE
feat(generator): add ExtraContent fields to preserve hand-authored prose (DOC-1315)

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -572,7 +572,7 @@ spec:
 			"\n" +
 			"| Verb | Description |\n" +
 			"|------|-------------|\n" +
-			"| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and virtual clusters on the cluster. |\n" +
+			"| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and tenant clusters on the cluster. |\n" +
 			"| `connectlocal` | Required when setting `spec.local: true` on a cluster. Allows connecting the local cluster (where the platform is installed) to the platform for management. |\n" +
 			"\n" +
 			"### Example access rule with bind verb\n" +
@@ -671,7 +671,7 @@ spec:
 			"| Verb | Description |\n" +
 			"|------|-------------|\n" +
 			"| `bind` | Required when adding a user to ClusterAccess rules or other access rules. Allows granting the user permissions on platform resources. |\n" +
-			"| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, virtual clusters, spaces, or other platform resources. |\n" +
+			"| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, tenant clusters, spaces, or other platform resources. |\n" +
 			"\n" +
 			"### Example access rule with makeowner verb\n" +
 			"\n" +
@@ -979,6 +979,7 @@ spec:
 			"| `nodetypes` | Node type definitions |\n" +
 			"| `ownedaccesskeys` | User-owned access keys |\n" +
 			"| `projects` | Projects |\n" +
+			"| `projectsecrets` | Project-scoped secrets |\n" +
 			"| `selves` | Current user information |\n" +
 			"| `sharedsecrets` | Shared secrets |\n" +
 			"| `spaceinstances` | Space instances |\n" +
@@ -986,8 +987,8 @@ spec:
 			"| `tasks` | Platform tasks |\n" +
 			"| `teams` | Teams |\n" +
 			"| `users` | Users |\n" +
-			"| `virtualclusterinstances` | Virtual cluster instances |\n" +
-			"| `virtualclustertemplates` | Virtual cluster templates |\n" +
+			"| `virtualclusterinstances` | Tenant cluster instances |\n" +
+			"| `virtualclustertemplates` | Tenant cluster templates |\n" +
 			"\n" +
 			"Common subresources include `projects/members`, `projects/templates`, `clusters/members`, `virtualclusterinstances/kubeconfig`, and `virtualclusterinstances/log`.\n" +
 			"\n" +
@@ -1020,12 +1021,12 @@ spec:
 						Rules: []rbacv1.PolicyRule{
 							{
 								Verbs:     []string{"get", "list", "update"},
-								APIGroups: []string{managementv1.SchemeGroupVersion.String()},
+								APIGroups: []string{managementv1.SchemeGroupVersion.Group},
 								Resources: []string{"spaceinstances", "virtualclusterinstances"},
 							},
 							{
 								Verbs:     []string{"get", "list"},
-								APIGroups: []string{managementv1.SchemeGroupVersion.String()},
+								APIGroups: []string{managementv1.SchemeGroupVersion.Group},
 								Resources: []string{"projectsecrets"},
 							},
 						},
@@ -1039,13 +1040,13 @@ spec:
 
 	// NodeProvider
 	util.GenerateObjectOverview(&util.ObjectInformation{
-		Title:       "Node Provider",
-		Name:        "NodeProvider",
-		Resource:    "nodeproviders",
-		ExtraImports:              "import FeatureTable from '@site/src/components/FeatureTable';",
-		ExtraContentBeforeExample: "<FeatureTable names=\"auto-nodes-clusterapi\" />",
-		Description: "NodeProvider holds the node provider information",
-		File:        path.Join(util.BaseResourcesPath, "nodeprovider.mdx"),
+		Title:                         "Node Provider",
+		Name:                          "NodeProvider",
+		Resource:                      "nodeproviders",
+		ExtraImports:                  "import FeatureTable from '@site/src/components/FeatureTable';",
+		ExtraContentBeforeDescription: "<FeatureTable names=\"auto-nodes-clusterapi\" />",
+		Description:                   "NodeProvider holds the node provider information",
+		File:                          path.Join(util.BaseResourcesPath, "nodeprovider.mdx"),
 		Object: &managementv1.NodeProvider{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "NodeProvider",

--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -566,6 +566,33 @@ spec:
 		Resource:    "clusters",
 		Description: "Connected Kubernetes clusters that can be managed through the platform. You can allow users and teams to access those clusters and they can create new spaces and virtual clusters inside them.",
 		File:        path.Join(util.BaseResourcesPath, "clusters/clusters.mdx"),
+		ExtraContentBeforeExample: "## Platform-specific verbs\n" +
+			"\n" +
+			"In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the Cluster resource supports these platform-specific verbs for access control:\n" +
+			"\n" +
+			"| Verb | Description |\n" +
+			"|------|-------------|\n" +
+			"| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and virtual clusters on the cluster. |\n" +
+			"| `connectlocal` | Required when setting `spec.local: true` on a cluster. Allows connecting the local cluster (where the platform is installed) to the platform for management. |\n" +
+			"\n" +
+			"### Example access rule with bind verb\n" +
+			"\n" +
+			"```yaml\n" +
+			"apiVersion: management.loft.sh/v1\n" +
+			"kind: Team\n" +
+			"metadata:\n" +
+			"  name: my-team\n" +
+			"spec:\n" +
+			"  access:\n" +
+			"    - name: cluster-access\n" +
+			"      verbs:\n" +
+			"        - get\n" +
+			"        - bind\n" +
+			"      subresources:\n" +
+			"        - clusters\n" +
+			"      teams:\n" +
+			"        - my-team\n" +
+			"```",
 		Object: &storagev1.Cluster{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Cluster",
@@ -637,6 +664,32 @@ spec:
 		Resource:    "users",
 		Description: "Users that can access the platform.",
 		File:        path.Join(util.BaseResourcesPath, "user.mdx"),
+		ExtraContentBeforeExample: "## Platform-specific verbs\n" +
+			"\n" +
+			"In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the User resource supports these platform-specific verbs for access control:\n" +
+			"\n" +
+			"| Verb | Description |\n" +
+			"|------|-------------|\n" +
+			"| `bind` | Required when adding a user to ClusterAccess rules or other access rules. Allows granting the user permissions on platform resources. |\n" +
+			"| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, virtual clusters, spaces, or other platform resources. |\n" +
+			"\n" +
+			"### Example access rule with makeowner verb\n" +
+			"\n" +
+			"```yaml\n" +
+			"apiVersion: management.loft.sh/v1\n" +
+			"kind: User\n" +
+			"metadata:\n" +
+			"  name: admin-user\n" +
+			"spec:\n" +
+			"  access:\n" +
+			"    - name: user-management\n" +
+			"      verbs:\n" +
+			"        - get\n" +
+			"        - update\n" +
+			"        - makeowner\n" +
+			"      users:\n" +
+			"        - admin-user\n" +
+			"```",
 		Object: &storagev1.User{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "User",
@@ -669,6 +722,32 @@ spec:
 		Resource:    "teams",
 		Description: "Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access the platform through their own access keys and own spaces or other objects.",
 		File:        path.Join(util.BaseResourcesPath, "team.mdx"),
+		ExtraContentBeforeExample: "## Platform-specific verbs\n" +
+			"\n" +
+			"In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the Team resource supports these platform-specific verbs for access control:\n" +
+			"\n" +
+			"| Verb | Description |\n" +
+			"|------|-------------|\n" +
+			"| `bind` | Allows binding permissions to a team, enabling assignment of access rules and roles to that team. Required when adding a team to ClusterAccess rules. |\n" +
+			"| `makeowner` | Allows transferring ownership of platform resources to a team. Used when changing the owner of projects, clusters, or other resources to a team. |\n" +
+			"\n" +
+			"### Example access rule with bind verb\n" +
+			"\n" +
+			"```yaml\n" +
+			"apiVersion: management.loft.sh/v1\n" +
+			"kind: Team\n" +
+			"metadata:\n" +
+			"  name: platform-admins\n" +
+			"spec:\n" +
+			"  access:\n" +
+			"    - name: team-management\n" +
+			"      verbs:\n" +
+			"        - get\n" +
+			"        - update\n" +
+			"        - bind\n" +
+			"      users:\n" +
+			"        - admin\n" +
+			"```",
 		Object: &storagev1.Team{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Team",
@@ -843,6 +922,82 @@ spec:
 		Resource:    "clusterroletemplates",
 		Description: "ClusterRoleTemplate holds the clusterRoleTemplate information",
 		File:        path.Join(util.BaseResourcesPath, "clusterroletemplate.mdx"),
+		ExtraContentAfterExample: "## Policy rules\n" +
+			"\n" +
+			"The `rules` field under `clusterRoleTemplate` defines RBAC permissions using standard Kubernetes PolicyRule objects. Each rule specifies which actions (verbs) are allowed on which resources.\n" +
+			"\n" +
+			"### Verbs\n" +
+			"\n" +
+			"Verbs define the actions allowed on resources. Standard Kubernetes RBAC verbs include:\n" +
+			"\n" +
+			"| Verb | Description |\n" +
+			"|------|-------------|\n" +
+			"| `get` | Retrieve a single resource |\n" +
+			"| `list` | Retrieve a collection of resources |\n" +
+			"| `watch` | Watch for changes to resources |\n" +
+			"| `create` | Create a new resource |\n" +
+			"| `update` | Update an existing resource (replaces the entire object) |\n" +
+			"| `patch` | Partially modify an existing resource |\n" +
+			"| `delete` | Delete a single resource |\n" +
+			"| `deletecollection` | Delete a collection of resources |\n" +
+			"| `*` | Wildcard representing all verbs |\n" +
+			"\n" +
+			"### API groups\n" +
+			"\n" +
+			"API groups define which API the resources belong to. Common API groups include:\n" +
+			"\n" +
+			"| API Group | Description |\n" +
+			"|-----------|-------------|\n" +
+			"| `\"\"` | Core API group (pods, services, configmaps, secrets, namespaces) |\n" +
+			"| `apps` | Deployments, DaemonSets, ReplicaSets, StatefulSets |\n" +
+			"| `batch` | Jobs, CronJobs |\n" +
+			"| `networking.k8s.io` | NetworkPolicies, Ingresses |\n" +
+			"| `rbac.authorization.k8s.io` | Roles, RoleBindings, ClusterRoles, ClusterRoleBindings |\n" +
+			"| `management.loft.sh` | vCluster Platform resources |\n" +
+			"| `storage.loft.sh` | vCluster Platform storage resources |\n" +
+			"| `*` | Wildcard matching all API groups |\n" +
+			"\n" +
+			"### Platform resources\n" +
+			"\n" +
+			"vCluster Platform resources in the `management.loft.sh` API group:\n" +
+			"\n" +
+			"| Resource | Description |\n" +
+			"|----------|-------------|\n" +
+			"| `announcements` | Platform announcements |\n" +
+			"| `apps` | Application configurations |\n" +
+			"| `backups` | Platform backups |\n" +
+			"| `clusteraccesses` | Cluster access permissions |\n" +
+			"| `clusterroletemplates` | Cluster role templates |\n" +
+			"| `clusters` | Connected clusters |\n" +
+			"| `configs` | Platform configuration |\n" +
+			"| `events` | Platform events |\n" +
+			"| `features` | Platform features |\n" +
+			"| `licenses` | Platform licenses |\n" +
+			"| `nodeclaims` | Node claims for auto-provisioning |\n" +
+			"| `nodeenvironments` | Node environment configurations |\n" +
+			"| `nodeproviders` | Node provider configurations |\n" +
+			"| `nodetypes` | Node type definitions |\n" +
+			"| `ownedaccesskeys` | User-owned access keys |\n" +
+			"| `projects` | Projects |\n" +
+			"| `selves` | Current user information |\n" +
+			"| `sharedsecrets` | Shared secrets |\n" +
+			"| `spaceinstances` | Space instances |\n" +
+			"| `spacetemplates` | Space templates |\n" +
+			"| `tasks` | Platform tasks |\n" +
+			"| `teams` | Teams |\n" +
+			"| `users` | Users |\n" +
+			"| `virtualclusterinstances` | Virtual cluster instances |\n" +
+			"| `virtualclustertemplates` | Virtual cluster templates |\n" +
+			"\n" +
+			"Common subresources include `projects/members`, `projects/templates`, `clusters/members`, `virtualclusterinstances/kubeconfig`, and `virtualclusterinstances/log`.\n" +
+			"\n" +
+			"### Resource names\n" +
+			"\n" +
+			"The `resourceNames` field optionally restricts a rule to specific named resources. When empty, the rule applies to all resources of the specified type.\n" +
+			"\n" +
+			"### Non-resource URLs\n" +
+			"\n" +
+			"The `nonResourceURLs` field specifies access to non-resource endpoints like `/healthz`, `/api`, `/apis`, and `/version`. Use `*` as a suffix to match paths (for example, `/healthz/*`).",
 		Object: &managementv1.ClusterRoleTemplate{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterRoleTemplate",
@@ -887,6 +1042,8 @@ spec:
 		Title:       "Node Provider",
 		Name:        "NodeProvider",
 		Resource:    "nodeproviders",
+		ExtraImports:              "import FeatureTable from '@site/src/components/FeatureTable';",
+		ExtraContentBeforeExample: "<FeatureTable names=\"auto-nodes-clusterapi\" />",
 		Description: "NodeProvider holds the node provider information",
 		File:        path.Join(util.BaseResourcesPath, "nodeprovider.mdx"),
 		Object: &managementv1.NodeProvider{

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -45,6 +45,8 @@ type ObjectInformation struct {
 
 	// ExtraImports is rendered with the import block at the top of the overview file.
 	ExtraImports string
+	// ExtraContentBeforeDescription is rendered between the imports and the description.
+	ExtraContentBeforeDescription string
 	// ExtraContentBeforeExample is rendered between the description and the example section.
 	ExtraContentBeforeExample string
 	// ExtraContentAfterExample is rendered between the YAML example and the reference section.
@@ -309,9 +311,10 @@ func GenerateObjectOverview(information *ObjectInformation) {
 		Plural:       information.Plural,
 		YAMLObject:   string(out),
 
-		ExtraImports:              information.ExtraImports,
-		ExtraContentBeforeExample: information.ExtraContentBeforeExample,
-		ExtraContentAfterExample:  information.ExtraContentAfterExample,
+		ExtraImports:                  information.ExtraImports,
+		ExtraContentBeforeDescription: information.ExtraContentBeforeDescription,
+		ExtraContentBeforeExample:     information.ExtraContentBeforeExample,
+		ExtraContentAfterExample:      information.ExtraContentAfterExample,
 
 		Project: information.Project,
 

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -43,6 +43,13 @@ type ObjectInformation struct {
 
 	Object client.Object
 
+	// ExtraImports is rendered with the import block at the top of the overview file.
+	ExtraImports string
+	// ExtraContentBeforeExample is rendered between the description and the example section.
+	ExtraContentBeforeExample string
+	// ExtraContentAfterExample is rendered between the YAML example and the reference section.
+	ExtraContentAfterExample string
+
 	Project bool
 
 	Retrieve bool
@@ -301,6 +308,10 @@ func GenerateObjectOverview(information *ObjectInformation) {
 		Name:         information.Name,
 		Plural:       information.Plural,
 		YAMLObject:   string(out),
+
+		ExtraImports:              information.ExtraImports,
+		ExtraContentBeforeExample: information.ExtraContentBeforeExample,
+		ExtraContentAfterExample:  information.ExtraContentAfterExample,
 
 		Project: information.Project,
 

--- a/hack/platform/util/template_overview.go
+++ b/hack/platform/util/template_overview.go
@@ -14,6 +14,8 @@ type ObjectOverviewValues struct {
 
 	// ExtraImports is rendered with the import block at the top of the file.
 	ExtraImports string
+	// ExtraContentBeforeDescription is rendered between the imports and the description.
+	ExtraContentBeforeDescription string
 	// ExtraContentBeforeExample is rendered between the description and the example section.
 	ExtraContentBeforeExample string
 	// ExtraContentAfterExample is rendered between the YAML example and the reference section.
@@ -59,6 +61,10 @@ import Delete from "{{ .RelativePath }}/_partials/resources/{{ .Resource }}/dele
 {{- end }}
 {{- if .ExtraImports }}
 {{ .ExtraImports }}
+{{- end }}
+{{- if .ExtraContentBeforeDescription }}
+
+{{ .ExtraContentBeforeDescription }}
 {{- end }}
 
 {{ .Description }}

--- a/hack/platform/util/template_overview.go
+++ b/hack/platform/util/template_overview.go
@@ -12,6 +12,13 @@ type ObjectOverviewValues struct {
 	Description string
 	YAMLObject  string
 
+	// ExtraImports is rendered with the import block at the top of the file.
+	ExtraImports string
+	// ExtraContentBeforeExample is rendered between the description and the example section.
+	ExtraContentBeforeExample string
+	// ExtraContentAfterExample is rendered between the YAML example and the reference section.
+	ExtraContentAfterExample string
+
 	Project bool
 
 	Create   bool
@@ -50,8 +57,15 @@ import Update from "{{ .RelativePath }}/_partials/resources/{{ .Resource }}/upda
 import Delete from "{{ .RelativePath }}/_partials/resources/{{ .Resource }}/delete.mdx"
 {{- end }}
 {{- end }}
+{{- if .ExtraImports }}
+{{ .ExtraImports }}
+{{- end }}
 
 {{ .Description }}
+{{- if .ExtraContentBeforeExample }}
+
+{{ .ExtraContentBeforeExample }}
+{{- end }}
 
 ## {{ .Name }} example
 
@@ -59,6 +73,10 @@ An example {{ .Name }}:
 ` + "```yaml" + `
 {{ .YAMLObject }}
 ` + "```" + `
+{{- if .ExtraContentAfterExample }}
+
+{{ .ExtraContentAfterExample }}
+{{- end }}
 
 ## {{ .Name }} reference
 

--- a/platform/api/_partials/resources/clusterroletemplates/create.mdx
+++ b/platform/api/_partials/resources/clusterroletemplates/create.mdx
@@ -28,7 +28,7 @@ spec:
     metadata: {}
     rules:
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - spaceinstances
       - virtualclusterinstances
@@ -37,7 +37,7 @@ spec:
       - list
       - update
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - projectsecrets
       verbs:
@@ -77,7 +77,7 @@ spec:
     metadata: {}
     rules:
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - spaceinstances
       - virtualclusterinstances
@@ -86,7 +86,7 @@ spec:
       - list
       - update
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - projectsecrets
       verbs:

--- a/platform/api/resources/clusterroletemplate.mdx
+++ b/platform/api/resources/clusterroletemplate.mdx
@@ -48,6 +48,83 @@ status: {}
 
 ```
 
+## Policy rules
+
+The `rules` field under `clusterRoleTemplate` defines RBAC permissions using standard Kubernetes PolicyRule objects. Each rule specifies which actions (verbs) are allowed on which resources.
+
+### Verbs
+
+Verbs define the actions allowed on resources. Standard Kubernetes RBAC verbs include:
+
+| Verb | Description |
+|------|-------------|
+| `get` | Retrieve a single resource |
+| `list` | Retrieve a collection of resources |
+| `watch` | Watch for changes to resources |
+| `create` | Create a new resource |
+| `update` | Update an existing resource (replaces the entire object) |
+| `patch` | Partially modify an existing resource |
+| `delete` | Delete a single resource |
+| `deletecollection` | Delete a collection of resources |
+| `*` | Wildcard representing all verbs |
+
+### API groups
+
+API groups define which API the resources belong to. Common API groups include:
+
+| API Group | Description |
+|-----------|-------------|
+| `""` | Core API group (pods, services, configmaps, secrets, namespaces) |
+| `apps` | Deployments, DaemonSets, ReplicaSets, StatefulSets |
+| `batch` | Jobs, CronJobs |
+| `networking.k8s.io` | NetworkPolicies, Ingresses |
+| `rbac.authorization.k8s.io` | Roles, RoleBindings, ClusterRoles, ClusterRoleBindings |
+| `management.loft.sh` | vCluster Platform resources |
+| `storage.loft.sh` | vCluster Platform storage resources |
+| `*` | Wildcard matching all API groups |
+
+### Platform resources
+
+vCluster Platform resources in the `management.loft.sh` API group:
+
+| Resource | Description |
+|----------|-------------|
+| `announcements` | Platform announcements |
+| `apps` | Application configurations |
+| `backups` | Platform backups |
+| `clusteraccesses` | Cluster access permissions |
+| `clusterroletemplates` | Cluster role templates |
+| `clusters` | Connected clusters |
+| `configs` | Platform configuration |
+| `events` | Platform events |
+| `features` | Platform features |
+| `licenses` | Platform licenses |
+| `nodeclaims` | Node claims for auto-provisioning |
+| `nodeenvironments` | Node environment configurations |
+| `nodeproviders` | Node provider configurations |
+| `nodetypes` | Node type definitions |
+| `ownedaccesskeys` | User-owned access keys |
+| `projects` | Projects |
+| `selves` | Current user information |
+| `sharedsecrets` | Shared secrets |
+| `spaceinstances` | Space instances |
+| `spacetemplates` | Space templates |
+| `tasks` | Platform tasks |
+| `teams` | Teams |
+| `users` | Users |
+| `virtualclusterinstances` | Virtual cluster instances |
+| `virtualclustertemplates` | Virtual cluster templates |
+
+Common subresources include `projects/members`, `projects/templates`, `clusters/members`, `virtualclusterinstances/kubeconfig`, and `virtualclusterinstances/log`.
+
+### Resource names
+
+The `resourceNames` field optionally restricts a rule to specific named resources. When empty, the rule applies to all resources of the specified type.
+
+### Non-resource URLs
+
+The `nonResourceURLs` field specifies access to non-resource endpoints like `/healthz`, `/api`, `/apis`, and `/version`. Use `*` as a suffix to match paths (for example, `/healthz/*`).
+
 ## ClusterRoleTemplate reference
 
 <Reference />

--- a/platform/api/resources/clusterroletemplate.mdx
+++ b/platform/api/resources/clusterroletemplate.mdx
@@ -24,7 +24,7 @@ spec:
     metadata: {}
     rules:
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - spaceinstances
       - virtualclusterinstances
@@ -33,7 +33,7 @@ spec:
       - list
       - update
     - apiGroups:
-      - management.loft.sh/v1
+      - management.loft.sh
       resources:
       - projectsecrets
       verbs:
@@ -105,6 +105,7 @@ vCluster Platform resources in the `management.loft.sh` API group:
 | `nodetypes` | Node type definitions |
 | `ownedaccesskeys` | User-owned access keys |
 | `projects` | Projects |
+| `projectsecrets` | Project-scoped secrets |
 | `selves` | Current user information |
 | `sharedsecrets` | Shared secrets |
 | `spaceinstances` | Space instances |
@@ -112,8 +113,8 @@ vCluster Platform resources in the `management.loft.sh` API group:
 | `tasks` | Platform tasks |
 | `teams` | Teams |
 | `users` | Users |
-| `virtualclusterinstances` | Virtual cluster instances |
-| `virtualclustertemplates` | Virtual cluster templates |
+| `virtualclusterinstances` | Tenant cluster instances |
+| `virtualclustertemplates` | Tenant cluster templates |
 
 Common subresources include `projects/members`, `projects/templates`, `clusters/members`, `virtualclusterinstances/kubeconfig`, and `virtualclusterinstances/log`.
 

--- a/platform/api/resources/clusters/clusters.mdx
+++ b/platform/api/resources/clusters/clusters.mdx
@@ -10,6 +10,34 @@ import Delete from "../../_partials/resources/clusters/delete.mdx"
 
 Connected Kubernetes clusters that can be managed through the platform. You can allow users and teams to access those clusters and they can create new spaces and virtual clusters inside them.
 
+## Platform-specific verbs
+
+In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the Cluster resource supports these platform-specific verbs for access control:
+
+| Verb | Description |
+|------|-------------|
+| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and virtual clusters on the cluster. |
+| `connectlocal` | Required when setting `spec.local: true` on a cluster. Allows connecting the local cluster (where the platform is installed) to the platform for management. |
+
+### Example access rule with bind verb
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: Team
+metadata:
+  name: my-team
+spec:
+  access:
+    - name: cluster-access
+      verbs:
+        - get
+        - bind
+      subresources:
+        - clusters
+      teams:
+        - my-team
+```
+
 ## Cluster example
 
 An example Cluster:

--- a/platform/api/resources/clusters/clusters.mdx
+++ b/platform/api/resources/clusters/clusters.mdx
@@ -16,7 +16,7 @@ In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`
 
 | Verb | Description |
 |------|-------------|
-| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and virtual clusters on the cluster. |
+| `bind` | Required when adding a cluster to ClusterAccess rules. Allows granting users or teams permission to create spaces and tenant clusters on the cluster. |
 | `connectlocal` | Required when setting `spec.local: true` on a cluster. Allows connecting the local cluster (where the platform is installed) to the platform for management. |
 
 ### Example access rule with bind verb

--- a/platform/api/resources/nodeprovider.mdx
+++ b/platform/api/resources/nodeprovider.mdx
@@ -6,9 +6,9 @@ import Reference from "../_partials/resources/nodeproviders/reference.mdx"
 import Create from "../_partials/resources/nodeproviders/create.mdx"
 import FeatureTable from '@site/src/components/FeatureTable';
 
-NodeProvider holds the node provider information
-
 <FeatureTable names="auto-nodes-clusterapi" />
+
+NodeProvider holds the node provider information
 
 ## NodeProvider example
 

--- a/platform/api/resources/nodeprovider.mdx
+++ b/platform/api/resources/nodeprovider.mdx
@@ -6,10 +6,9 @@ import Reference from "../_partials/resources/nodeproviders/reference.mdx"
 import Create from "../_partials/resources/nodeproviders/create.mdx"
 import FeatureTable from '@site/src/components/FeatureTable';
 
-<FeatureTable names="auto-nodes-clusterapi" />
-
-
 NodeProvider holds the node provider information
+
+<FeatureTable names="auto-nodes-clusterapi" />
 
 ## NodeProvider example
 

--- a/platform/api/resources/team.mdx
+++ b/platform/api/resources/team.mdx
@@ -10,6 +10,33 @@ import Delete from "../_partials/resources/teams/delete.mdx"
 
 Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access the platform through their own access keys and own spaces or other objects.
 
+## Platform-specific verbs
+
+In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the Team resource supports these platform-specific verbs for access control:
+
+| Verb | Description |
+|------|-------------|
+| `bind` | Allows binding permissions to a team, enabling assignment of access rules and roles to that team. Required when adding a team to ClusterAccess rules. |
+| `makeowner` | Allows transferring ownership of platform resources to a team. Used when changing the owner of projects, clusters, or other resources to a team. |
+
+### Example access rule with bind verb
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: Team
+metadata:
+  name: platform-admins
+spec:
+  access:
+    - name: team-management
+      verbs:
+        - get
+        - update
+        - bind
+      users:
+        - admin
+```
+
 ## Team example
 
 An example Team:

--- a/platform/api/resources/user.mdx
+++ b/platform/api/resources/user.mdx
@@ -10,6 +10,33 @@ import Delete from "../_partials/resources/users/delete.mdx"
 
 Users that can access the platform.
 
+## Platform-specific verbs
+
+In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`, `patch`, `delete`), the User resource supports these platform-specific verbs for access control:
+
+| Verb | Description |
+|------|-------------|
+| `bind` | Required when adding a user to ClusterAccess rules or other access rules. Allows granting the user permissions on platform resources. |
+| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, virtual clusters, spaces, or other platform resources. |
+
+### Example access rule with makeowner verb
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: User
+metadata:
+  name: admin-user
+spec:
+  access:
+    - name: user-management
+      verbs:
+        - get
+        - update
+        - makeowner
+      users:
+        - admin-user
+```
+
 ## User example
 
 An example User:

--- a/platform/api/resources/user.mdx
+++ b/platform/api/resources/user.mdx
@@ -17,7 +17,7 @@ In addition to standard Kubernetes RBAC verbs (`get`, `list`, `create`, `update`
 | Verb | Description |
 |------|-------------|
 | `bind` | Required when adding a user to ClusterAccess rules or other access rules. Allows granting the user permissions on platform resources. |
-| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, virtual clusters, spaces, or other platform resources. |
+| `makeowner` | Required when changing the owner of a resource to a user. Allows transferring ownership of projects, tenant clusters, spaces, or other platform resources. |
 
 ### Example access rule with makeowner verb
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

The generator's `os.RemoveAll` + regenerate pattern overwrites overview pages, silently deleting manually-added prose sections. This PR moves that content into the generator definition so it survives future runs.

Adds `ExtraImports`, `ExtraContentBeforeExample`, and `ExtraContentAfterExample` fields to `ObjectInformation` / `ObjectOverviewValues`, then wires them up to restore the prose deleted by DOC-1313 / PR #1945 :

- **Cluster**: Platform-specific verbs (`bind`, `connectlocal`)
- **User**: Platform-specific verbs (`bind`, `makeowner`)
- **Team**: Platform-specific verbs (`bind`, `makeowner`)
- **ClusterRoleTemplate**: Policy rules section (verbs, API groups, platform resources tables)
- **NodeProvider**: `FeatureTable` import + component

## Preview Link
<!-- The preview link or links to the documents-->
- [clusters](https://deploy-preview-1957--vcluster-docs-site.netlify.app/docs/platform/api/resources/clusters/)
- [cluter role templates](https://deploy-preview-1957--vcluster-docs-site.netlify.app/docs/platform/api/resources/clusterroletemplate#verbs)
- [user](https://deploy-preview-1957--vcluster-docs-site.netlify.app/docs/platform/api/resources/user)
- [team](https://deploy-preview-1957--vcluster-docs-site.netlify.app/docs/platform/api/resources/team)
- [node provider](https://deploy-preview-1957--vcluster-docs-site.netlify.app/docs/platform/api/resources/nodeprovider)

## Internal Reference

Closes DOC-1315


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs