### PR TITLE
fix(llms-txt): strip react jsx comment markers from generated .md

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,7 @@ const __webpack_public_path__ = "/docs/";
 
 import resolveGlob from "resolve-glob";
 import remarkVersionTokens from "./plugins/remark-version-tokens.js";
+import rehypeStripComments from "./plugins/rehype-strip-comments.js";
 
 const newDocTemplate = `---
 title: Your Document Title
@@ -183,6 +184,11 @@ const config = {
           // surface these links to users in CLI contexts where relative paths
           // are not clickable or resolvable. See ENGAI-58.
           relativePaths: false,
+          // Strip React-emitted `<!-- -->` JSX expression markers before the
+          // HTML→Markdown conversion. Runs at the hast stage, ahead of
+          // rehype-remark, so comment nodes are gone before mdast is built.
+          // See DOC-1322.
+          beforeDefaultRehypePlugins: [rehypeStripComments],
         },
         siteTitle: 'vCluster Documentation',
         siteDescription: 'Documentation for vCluster (virtual Kubernetes clusters) and vCluster Platform (multi-cluster management)',

--- a/plugins/rehype-strip-comments.js
+++ b/plugins/rehype-strip-comments.js
@@ -1,0 +1,26 @@
+/**
+ * Rehype plugin: drop HTML comment nodes from the hast tree.
+ *
+ * React emits empty `<!-- -->` markers around JSX expression boundaries
+ * (e.g. `<GlossaryTerm>...</GlossaryTerm>` in the middle of a sentence).
+ * These markers survive the HTML → Markdown pipeline in
+ * `@signalwire/docusaurus-plugin-llms-txt`, producing literal `<!-- -->`
+ * strings inside `.md` output that downstream consumers (RAG, LLM agents)
+ * then ingest as noise.
+ *
+ * This plugin is meant to run as a `beforeDefaultRehypePlugins` entry on
+ * the llms-txt plugin pipeline, before `rehype-remark` converts the tree
+ * to mdast.
+ */
+
+module.exports = function rehypeStripComments() {
+  return (tree) => {
+    walk(tree);
+  };
+};
+
+function walk(node) {
+  if (!node || !Array.isArray(node.children)) return;
+  node.children = node.children.filter((child) => child && child.type !== 'comment');
+  for (const child of node.children) walk(child);
+}

--- a/tests/specs/markdown-parity.spec.js
+++ b/tests/specs/markdown-parity.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Markdown content parity regression tests.
+ *
+ * Guards the fix from DOC-1322: React emits empty `<!-- -->` markers
+ * around JSX expression boundaries (e.g. around `<GlossaryTerm>`
+ * mid-sentence), and those markers used to survive the HTML → Markdown
+ * pipeline in @signalwire/docusaurus-plugin-llms-txt. Any `.md` emitted
+ * with `<!--` / `-->` substrings means the rehype plugin at
+ * plugins/rehype-strip-comments.js has regressed or been unhooked.
+ *
+ * The sample pages are ones that were heavily affected before the fix
+ * (glossary terms appear mid-sentence, so the JSX comment markers
+ * clustered on them).
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.TEST_BASE_URL || 'https://www.vcluster.com';
+
+const SAMPLE_PAGES = [
+  '/docs/vcluster/key-features/sleep.md',
+  '/docs/vcluster/manage/backup-restore/backup.md',
+  '/docs/vcluster/manage/sleep-wakeup.md',
+];
+
+test.describe('llms-txt markdown parity', () => {
+  for (const path of SAMPLE_PAGES) {
+    test(`${path} contains no JSX comment markers`, async ({ page }) => {
+      const response = await page.goto(`${BASE_URL}${path}`, { waitUntil: 'load', timeout: 30000 });
+      expect(response?.status()).toBe(200);
+
+      const body = await page.evaluate(() => document.body.innerText);
+
+      expect(body, `${path} has <!-- markers leaking through from JSX boundaries`).not.toContain('<!--');
+      expect(body, `${path} has --> markers leaking through from JSX boundaries`).not.toContain('-->');
+    });
+  }
+});


### PR DESCRIPTION
# Content Description

React emits empty `<!-- -->` comment nodes around JSX expression boundaries (for example, around `<GlossaryTerm>` in the middle of a sentence). Those markers survive the HTML → Markdown pipeline in `@signalwire/docusaurus-plugin-llms-txt`, so the generated `.md` files end up with noise like:

```
put <!-- -->virtual cluster<!-- -->s to sleep
```

On this branch's local build, **131** `.md` files contained such artifacts. After this change, **0** do.

The fix is a tiny rehype plugin (`plugins/rehype-strip-comments.js`) that drops hast `comment` nodes. It is wired in via the `beforeDefaultRehypePlugins` slot on the llms-txt plugin, so it runs ahead of `rehype-remark` and only affects the `.md` output — the rendered site HTML is untouched.

## Why this matters beyond aesthetics

`afdocs`' `markdown-content-parity` check compares HTML text against the served `.md`. Its `normalize()` step converts `<!-- -->` into literal `!-- --` on the markdown side, while the HTML side strips comments entirely. That mismatch made any sentence containing a glossary term look like "missing content" to the parity checker, inflating the failure count.

Stripping the comment nodes at the rehype stage closes that class of false positives.

## Scope

- Only the three failure categories called out in DOC-1322; this PR addresses **category 1** (glossary `<!-- -->` noise).
- Categories 2 (custom React components without a markdown fallback) and 3 (admonition serialization drift) remain, and are further confounded by an afdocs / `node-html-parser` issue: Docusaurus v3.8.0 emits minified HTML without explicit `<head>`/`<body>` tags, which causes `node-html-parser` to fall back to `root.text` and not apply its block-tag separation or chrome-stripping logic. Those are better handled in follow-up work.
- No existing CI workflow runs parity checks — wiring one is out of scope here.

## Preview Link

- https://deploy-preview-1961--vcluster-docs-site.netlify.app/docs/vcluster/next/key-features/sleep (content unchanged; plugin config only)

## Internal Reference

Closes DOC-1322

<!-- Do not change the line below -->
@netlify /docs

## Regression test

Added a Playwright spec (`tests/specs/markdown-parity.spec.js`) that fetches three pages with dense glossary usage and asserts the served body contains neither `<!--` nor `-->`. Auto-picked up via `testDir: './specs'`. Run via the `run-e2e` label.