### PR TITLE
test(ci): wire ai-pr-review workflow for openai provider smoke test

### DIFF
--- a/.github/ai-review-test-matrix.md
+++ b/.github/ai-review-test-matrix.md
@@ -1,39 +1,57 @@
 # ai-pr-review smoke-test matrix (PR #1962)
 
 PR #1962 is a permanent test bed for `loft-sh/github-actions` ai-pr-review.
-Never merge. Each row = one configuration commit on this branch.
+Never merge. Each row = one configuration cell exercised on a sibling PR
+(or on this PR itself for the `openai / low` baseline).
 
-Input axes (see `loft-sh/github-actions/.github/actions/ai-pr-review/action.yml`
-and `src/resolve-config.sh`):
+Input axes (see
+[`loft-sh/github-actions/.github/actions/ai-pr-review/action.yml`](https://github.com/loft-sh/github-actions/blob/main/.github/actions/ai-pr-review/action.yml)
+and its `src/resolve-config.sh`):
 
 - `provider`: `anthropic` | `openai`
 - `effort`: `low` | `medium` | `high` → resolves to a provider-specific model
   - openai: low=`gpt-5.4-mini`, medium=`gpt-5.3-codex`, high=`gpt-5.4`
   - anthropic: low=`claude-haiku-4-5`, medium=`claude-sonnet-4-6`, high=`claude-opus-4-7`
-- `outcome`: `pr-comment` (both providers) | `inline-review` (anthropic only)
+
+The `outcome` axis is gone as of
+[`loft-sh/github-actions#129`](https://github.com/loft-sh/github-actions/pull/129)
+— the model now picks comment shape per finding (inline for localized
+risks, summary for cross-cutting, or both). OpenAI stays summary-only
+because `codex-action` has no inline surface.
 
 Verdict legend:
 
 - `check`: conclusion of the `review / ai-review` job on the commit
-- `comment`: did `github-actions[bot]` post a new comment after the job?
-- `shape`: `ok` (expected shape), `silent` (no comment where one was expected),
-  `skipped` (resolver declined, expected for openai+inline-review), or `fail`
+- `comment`: did a bot comment carrying the `ai-pr-review` provenance
+  marker land after the check-run started? (`posted` | `none`)
+- `shape`: `ok` (expected shape), `silent` (no comment where one was
+  expected), or `fail`
+- verdicts populated by `scripts/verify-ai-review.sh <sha>`
 
-## Matrix
+## Active matrix
 
-Cell 1 lives on this PR (#1962). Cells 2–11 are disposable sibling PRs;
-each branches off `main` with only the workflow file edit.
+Three cells stay live as ongoing smoke tests. The other provider/effort
+combinations were exercised during the sweep and closed; verdicts from
+the sweep are captured below for history.
 
-| # | PR | provider | effort | outcome | model | check | comment | shape | notes |
-|---|----|----------|--------|---------|-------|-------|---------|-------|-------|
-| 1 | #1962 | openai | low | pr-comment | gpt-5.4-mini | success | yes | ok | "No findings." baseline |
-| 2 | #1965 | openai | medium | pr-comment | gpt-5.3-codex | | | | |
-| 3 | #1966 | openai | high | pr-comment | gpt-5.4 | | | | |
-| 4 | #1967 | openai | low | inline-review | (n/a) | | | | expect `skipped` (openai+inline unsupported) |
-| 5 | #1968 | anthropic | low | pr-comment | claude-haiku-4-5 | | | | |
-| 6 | #1969 | anthropic | medium | pr-comment | claude-sonnet-4-6 | | | | |
-| 7 | #1970 | anthropic | high | pr-comment | claude-opus-4-7 | | | | |
-| 8 | #1971 | anthropic | low | inline-review | claude-haiku-4-5 | | | | |
-| 9 | #1972 | anthropic | medium | inline-review | claude-sonnet-4-6 | | | | |
-| 10 | #1973 | anthropic | high | inline-review | claude-opus-4-7 | | | | |
-| 11 | #1974 | openai | low | pr-comment | gpt-5.4-mini | | | | finding-forcing prompt (negative test) |
+| # | PR | provider | effort | model | check | comment | shape | notes |
+|---|----|----------|--------|-------|-------|---------|-------|-------|
+| 1 | #1962 | openai | low | gpt-5.4-mini | success | posted | ok | baseline on this PR |
+| 2 | #1966 | openai | high | gpt-5.4 | success | posted | ok | openai ceiling |
+| 3 | #1973 | anthropic | high | claude-opus-4-7 | success | posted | ok | anthropic ceiling + inline path |
+
+## Closed-cell history (pre-#129 sweep)
+
+Sweep validated every provider × effort combo end-to-end before the
+outcome drop. Branches deleted, verdict below:
+
+| provider | effort | outcome | result |
+|----------|--------|---------|--------|
+| openai | medium | pr-comment | success (#1965, closed) |
+| openai | low | inline-review | correctly skipped (#1967, closed) |
+| anthropic | low | pr-comment | success (#1968, closed) |
+| anthropic | medium | pr-comment | success (#1969, closed) |
+| anthropic | high | pr-comment | success after #126 opus-4-7 fix (#1970, closed) |
+| anthropic | low | inline-review | success (#1971, closed) |
+| anthropic | medium | inline-review | success (#1972, closed) |
+| openai | low | pr-comment + force-finding prompt | success (#1974, closed) |

--- a/.github/ai-review-test-matrix.md
+++ b/.github/ai-review-test-matrix.md
@@ -1,0 +1,36 @@
+# ai-pr-review smoke-test matrix (PR #1962)
+
+PR #1962 is a permanent test bed for `loft-sh/github-actions` ai-pr-review.
+Never merge. Each row = one configuration commit on this branch.
+
+Input axes (see `loft-sh/github-actions/.github/actions/ai-pr-review/action.yml`
+and `src/resolve-config.sh`):
+
+- `provider`: `anthropic` | `openai`
+- `effort`: `low` | `medium` | `high` → resolves to a provider-specific model
+  - openai: low=`gpt-5.4-mini`, medium=`gpt-5.3-codex`, high=`gpt-5.4`
+  - anthropic: low=`claude-haiku-4-5`, medium=`claude-sonnet-4-6`, high=`claude-opus-4-7`
+- `outcome`: `pr-comment` (both providers) | `inline-review` (anthropic only)
+
+Verdict legend:
+
+- `check`: conclusion of the `review / ai-review` job on the commit
+- `comment`: did `github-actions[bot]` post a new comment after the job?
+- `shape`: `ok` (expected shape), `silent` (no comment where one was expected),
+  `skipped` (resolver declined, expected for openai+inline-review), or `fail`
+
+## Matrix
+
+| # | sha | provider | effort | outcome | model | check | comment | shape | notes |
+|---|-----|----------|--------|---------|-------|-------|---------|-------|-------|
+| 1 | 7a52fb961 | openai | low | pr-comment | gpt-5.4-mini | success | yes | ok | "No findings." — baseline after allowed-bots drop |
+| 2 | _pending_ | openai | medium | pr-comment | gpt-5.3-codex | | | | |
+| 3 | _pending_ | openai | high | pr-comment | gpt-5.4 | | | | |
+| 4 | _pending_ | openai | low | inline-review | (n/a) | | | | expect `skipped` (openai+inline unsupported) |
+| 5 | _pending_ | anthropic | low | pr-comment | claude-haiku-4-5 | | | | needs `ANTHROPIC_API_KEY` secret wired |
+| 6 | _pending_ | anthropic | medium | pr-comment | claude-sonnet-4-6 | | | | |
+| 7 | _pending_ | anthropic | high | pr-comment | claude-opus-4-7 | | | | |
+| 8 | _pending_ | anthropic | low | inline-review | claude-haiku-4-5 | | | | |
+| 9 | _pending_ | anthropic | medium | inline-review | claude-sonnet-4-6 | | | | |
+| 10 | _pending_ | anthropic | high | inline-review | claude-opus-4-7 | | | | |
+| 11 | _pending_ | openai | low | pr-comment | gpt-5.4-mini | | | | finding-forcing prompt (negative test) |

--- a/.github/ai-review-test-matrix.md
+++ b/.github/ai-review-test-matrix.md
@@ -21,16 +21,19 @@ Verdict legend:
 
 ## Matrix
 
-| # | sha | provider | effort | outcome | model | check | comment | shape | notes |
-|---|-----|----------|--------|---------|-------|-------|---------|-------|-------|
-| 1 | 7a52fb961 | openai | low | pr-comment | gpt-5.4-mini | success | yes | ok | "No findings." — baseline after allowed-bots drop |
-| 2 | _pending_ | openai | medium | pr-comment | gpt-5.3-codex | | | | |
-| 3 | _pending_ | openai | high | pr-comment | gpt-5.4 | | | | |
-| 4 | _pending_ | openai | low | inline-review | (n/a) | | | | expect `skipped` (openai+inline unsupported) |
-| 5 | _pending_ | anthropic | low | pr-comment | claude-haiku-4-5 | | | | needs `ANTHROPIC_API_KEY` secret wired |
-| 6 | _pending_ | anthropic | medium | pr-comment | claude-sonnet-4-6 | | | | |
-| 7 | _pending_ | anthropic | high | pr-comment | claude-opus-4-7 | | | | |
-| 8 | _pending_ | anthropic | low | inline-review | claude-haiku-4-5 | | | | |
-| 9 | _pending_ | anthropic | medium | inline-review | claude-sonnet-4-6 | | | | |
-| 10 | _pending_ | anthropic | high | inline-review | claude-opus-4-7 | | | | |
-| 11 | _pending_ | openai | low | pr-comment | gpt-5.4-mini | | | | finding-forcing prompt (negative test) |
+Cell 1 lives on this PR (#1962). Cells 2–11 are disposable sibling PRs;
+each branches off `main` with only the workflow file edit.
+
+| # | PR | provider | effort | outcome | model | check | comment | shape | notes |
+|---|----|----------|--------|---------|-------|-------|---------|-------|-------|
+| 1 | #1962 | openai | low | pr-comment | gpt-5.4-mini | success | yes | ok | "No findings." baseline |
+| 2 | #1965 | openai | medium | pr-comment | gpt-5.3-codex | | | | |
+| 3 | #1966 | openai | high | pr-comment | gpt-5.4 | | | | |
+| 4 | #1967 | openai | low | inline-review | (n/a) | | | | expect `skipped` (openai+inline unsupported) |
+| 5 | #1968 | anthropic | low | pr-comment | claude-haiku-4-5 | | | | |
+| 6 | #1969 | anthropic | medium | pr-comment | claude-sonnet-4-6 | | | | |
+| 7 | #1970 | anthropic | high | pr-comment | claude-opus-4-7 | | | | |
+| 8 | #1971 | anthropic | low | inline-review | claude-haiku-4-5 | | | | |
+| 9 | #1972 | anthropic | medium | inline-review | claude-sonnet-4-6 | | | | |
+| 10 | #1973 | anthropic | high | inline-review | claude-opus-4-7 | | | | |
+| 11 | #1974 | openai | low | pr-comment | gpt-5.4-mini | | | | finding-forcing prompt (negative test) |

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -10,7 +10,6 @@ jobs:
     with:
       provider: openai
       effort: low
-      outcome: pr-comment
       prompt: |
         Review this PR for risk CI cannot catch: broken links,
         inconsistent version references, and breaking public-API

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -1,0 +1,22 @@
+name: AI PR review
+
+# Temporary broad allowed-bots: '*' so this same PR triggers the review on
+# open. Tighten to the renovate/dependabot list before merging.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
+    with:
+      provider: openai
+      effort: low
+      outcome: pr-comment
+      allowed-bots: '*'
+      prompt: |
+        Review this PR for risk CI cannot catch: broken links,
+        inconsistent version references, and breaking public-API
+        claims in examples. Keep findings terse.
+    secrets:
+      openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -1,7 +1,5 @@
 name: AI PR review
 
-# Temporary broad allowed-bots: '*' so this same PR triggers the review on
-# open. Tighten to the renovate/dependabot list before merging.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -13,7 +11,6 @@ jobs:
       provider: openai
       effort: low
       outcome: pr-comment
-      allowed-bots: '*'
       prompt: |
         Review this PR for risk CI cannot catch: broken links,
         inconsistent version references, and breaking public-API

--- a/scripts/verify-ai-review.sh
+++ b/scripts/verify-ai-review.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verify the ai-pr-review smoke test outcome for a given commit on PR #1962.
+# Prints a single line: sha=… check=… comment=… comment_url=… age=…s
+#
+# Usage: scripts/verify-ai-review.sh [<sha>]
+#   default sha = git rev-parse HEAD
+#
+# Requires: gh (authenticated against github.com), jq.
+set -euo pipefail
+
+repo='loft-sh/vcluster-docs'
+pr='1962'
+sha="${1:-$(git rev-parse HEAD)}"
+short="${sha:0:9}"
+
+# Check conclusion of the `review / ai-review` job on this commit.
+check_json=$(gh api "repos/$repo/commits/$sha/check-runs" \
+  --jq '[.check_runs[] | select(.name=="review / ai-review")][0]')
+check=$(jq -r '.conclusion // "pending"' <<<"$check_json")
+completed=$(jq -r '.completed_at // empty' <<<"$check_json")
+
+# Latest `github-actions[bot]` comment newer than the check completion.
+if [ -n "$completed" ]; then
+  comment=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login==\"github-actions[bot]\") | select(.created_at > \"$completed\")] | sort_by(.created_at) | last")
+else
+  comment='null'
+fi
+
+if [ "$comment" = 'null' ] || [ -z "$comment" ]; then
+  comment_status='none'
+  comment_url=''
+  age='n/a'
+else
+  comment_status='posted'
+  comment_url=$(jq -r '.html_url' <<<"$comment")
+  created=$(jq -r '.created_at' <<<"$comment")
+  age=$(( $(date -u +%s) - $(date -u -d "$created" +%s) ))s
+fi
+
+printf 'sha=%s check=%s comment=%s url=%s age=%s\n' \
+  "$short" "$check" "$comment_status" "${comment_url:-none}" "$age"

--- a/scripts/verify-ai-review.sh
+++ b/scripts/verify-ai-review.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Verify the ai-pr-review smoke test outcome for a given commit on PR #1962.
-# Prints a single line: sha=… check=… comment=… comment_url=… age=…s
+# Prints a single line: sha=… check=… comment=posted|none comment_url=… age=…s
+#
+# A comment counts as "posted" when it comes from github-actions[bot], was
+# created after the check-run STARTED (not completed — the comment is posted
+# by a step inside the job, so created_at is strictly earlier than the job's
+# completed_at), and carries the ai-pr-review provenance marker in its body.
+# Looks across all three surfaces the action can post on: issue comments,
+# PR reviews (submit-body), and PR review (inline) comments.
 #
 # Usage: scripts/verify-ai-review.sh [<sha>]
 #   default sha = git rev-parse HEAD
@@ -13,30 +20,52 @@ pr='1962'
 sha="${1:-$(git rev-parse HEAD)}"
 short="${sha:0:9}"
 
-# Check conclusion of the `review / ai-review` job on this commit.
+# The provenance footer appended by every ai-pr-review comment contains this
+# substring. Scoping by it avoids false positives from other bots that share
+# the github-actions[bot] identity on this long-lived test-bed PR.
+marker='ai-pr-review'
+
 check_json=$(gh api "repos/$repo/commits/$sha/check-runs" \
   --jq '[.check_runs[] | select(.name=="review / ai-review")][0]')
 check=$(jq -r '.conclusion // "pending"' <<<"$check_json")
-completed=$(jq -r '.completed_at // empty' <<<"$check_json")
+started=$(jq -r '.started_at // empty' <<<"$check_json")
 
-# Latest `github-actions[bot]` comment newer than the check completion.
-if [ -n "$completed" ]; then
-  comment=$(gh api "repos/$repo/issues/$pr/comments" --paginate \
-    --jq "[.[] | select(.user.login==\"github-actions[bot]\") | select(.created_at > \"$completed\")] | sort_by(.created_at) | last")
-else
-  comment='null'
+if [ -z "$started" ]; then
+  printf 'sha=%s check=%s comment=n/a comment_url=none age=n/a\n' "$short" "$check"
+  exit 0
 fi
+
+# `gh api --paginate --jq '…'` applies the jq filter per page and
+# concatenates — so cross-page operators like `sort_by | last` break once
+# the PR grows past one page of comments. Drop --jq here, slurp every
+# page array, and apply the filter once after `add` flattens.
+paginate() { gh api "$1" --paginate 2>/dev/null || true; }
+
+comment=$(
+  {
+    paginate "repos/$repo/issues/$pr/comments"
+    paginate "repos/$repo/pulls/$pr/reviews"
+    paginate "repos/$repo/pulls/$pr/comments"
+  } | jq -s --arg started "$started" --arg marker "$marker" '
+    (add // [])
+    | map(select(.user.login == "github-actions[bot]")
+          | select((.body // "") | contains($marker))
+          | select(((.created_at // .submitted_at) // "") > $started))
+    | sort_by(.created_at // .submitted_at)
+    | last')
 
 if [ "$comment" = 'null' ] || [ -z "$comment" ]; then
   comment_status='none'
-  comment_url=''
+  comment_url='none'
   age='n/a'
 else
   comment_status='posted'
-  comment_url=$(jq -r '.html_url' <<<"$comment")
-  created=$(jq -r '.created_at' <<<"$comment")
-  age=$(( $(date -u +%s) - $(date -u -d "$created" +%s) ))s
+  comment_url=$(jq -r '.html_url // .url' <<<"$comment")
+  # jq's fromdateiso8601 is portable across GNU and BSD userland (`date -u -d`
+  # is GNU-only and breaks the script on macOS under `set -e`).
+  age=$(jq -r '(now - ((.created_at // .submitted_at) | fromdateiso8601)
+                | floor | tostring) + "s"' <<<"$comment")
 fi
 
-printf 'sha=%s check=%s comment=%s url=%s age=%s\n' \
-  "$short" "$check" "$comment_status" "${comment_url:-none}" "$age"
+printf 'sha=%s check=%s comment=%s comment_url=%s age=%s\n' \
+  "$short" "$check" "$comment_status" "$comment_url" "$age"

--- a/scripts/verify-ai-review.sh
+++ b/scripts/verify-ai-review.sh
@@ -16,9 +16,17 @@
 set -euo pipefail
 
 repo='loft-sh/vcluster-docs'
-pr='1962'
 sha="${1:-$(git rev-parse HEAD)}"
 short="${sha:0:9}"
+# Auto-detect the PR owning this sha. Multiple cells live on sibling
+# PRs now, so hardcoding a single PR number would surface comments
+# from the wrong PR.
+pr=$(gh api "repos/$repo/commits/$sha/pulls" --jq '.[0].number // empty')
+if [ -z "$pr" ]; then
+  printf 'sha=%s check=n/a comment=n/a comment_url=none age=n/a\n' "$short"
+  echo "no PR associated with sha $short" >&2
+  exit 1
+fi
 
 # The provenance footer appended by every ai-pr-review comment contains this
 # substring. Scoping by it avoids false positives from other bots that share


### PR DESCRIPTION
## Summary

Wires the new `ai-pr-review` reusable workflow (landed in loft-sh/github-actions#121) into this repo as a sibling to `auto-approve-bot-prs.yaml`, configured for `provider: openai`, `effort: low` (gpt-5.4-mini), `outcome: pr-comment`.

## Why this PR exists

End-to-end validation that the openai branch of the ai-pr-review action actually runs codex against a real PR and posts a summary comment back — not just the short-circuit path exercised by the in-repo smoke tests.

## Test plan

- [ ] On PR open, the review job fires (`allowed-bots: '*'` is set temporarily so this human PR passes the bot-author filter)
- [ ] `openai/codex-action@v1.6` runs with `gpt-5.4-mini` and `sandbox: read-only`
- [ ] A summary comment from the bot lands on this PR within ~1-2 minutes
- [ ] `continue-on-error: true` holds — no red check on the PR even if codex errors

## Rollback / tightening

Before merging, either:
- (a) tighten `allowed-bots` back to `renovate[bot],dependabot[bot],loft-bot,github-actions[bot]` to scope to real bots only, OR
- (b) delete this workflow if the live test reveals problems

References loft-sh/github-actions#121 (DEVOPS-793).