### PR TITLE
docs(quick-start): add intro paragraph to vCluster landing page

### DIFF
--- a/vcluster/quick-start/index.mdx
+++ b/vcluster/quick-start/index.mdx
@@ -10,6 +10,8 @@ pagination_prev: null
 
 import Link from '@docusaurus/Link';
 
+vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can go on your existing infrastructure, or they can be built from scratch on bare metal and VMs. Each tenant gets a full Kubernetes API experience while the virtualized control plane stays completely invisible to them. Choose the path that fits your environment.
+
 **Do you have a Kubernetes cluster?**
 
 - **Yes** — What are you building? 


### PR DESCRIPTION
# Content Description
Adds a brief introductory paragraph to the quick-start routing page before the "Do you have a Kubernetes cluster?" question, giving readers and LLM crawlers context on what vCluster is before they're asked to choose a deployment path.

## Preview Link
<!-- The preview link or links to the documents-->

## Internal Reference
Closes DOC-1323

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs