### PR TITLE
fix(llms): exclude oversized aggregate pages from llms.txt

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -183,6 +183,9 @@ const config = {
             // includes the site baseUrl (`/docs/`) because the signalwire
             // plugin matches against the full route path.
             '/docs/vcluster/cli/**',
+            // Aggregate config reference renders to ~380K — well above the
+            // 100K agent truncation limit. Sub-pages are indexed individually.
+            '/docs/vcluster/configure/vcluster-yaml$',
           ],
           // Emit absolute URLs (https://www.vcluster.com/docs/...) instead of
           // site-relative paths. Downstream consumers (R2R RAG, LLM agents)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,6 +186,11 @@ const config = {
             // Aggregate config reference renders to ~380K — well above the
             // 100K agent truncation limit. Sub-pages are indexed individually.
             '/docs/vcluster/configure/vcluster-yaml$',
+            // Aggregate sync reference renders to ~161K; sub-pages are indexed.
+            '/docs/vcluster/configure/vcluster-yaml/sync$',
+            // Platform API reference renders to ~116K; no sub-pages exist.
+            // Silent truncation on a dense API reference causes incorrect answers.
+            '/docs/platform/api/resources/project/templates$',
           ],
           // Emit absolute URLs (https://www.vcluster.com/docs/...) instead of
           // site-relative paths. Downstream consumers (R2R RAG, LLM agents)


### PR DESCRIPTION
# Content Description
Excludes three aggregate config/API reference pages from `llms.txt` that exceed the 100K character agent truncation limit. Sub-pages and conceptual docs for each remain indexed.

| Page | Rendered size | Reason excluded |
|------|--------------|-----------------|
| `vcluster/configure/vcluster-yaml` | ~380K | Sub-pages indexed individually |
| `vcluster/configure/vcluster-yaml/sync` | ~161K | Sub-pages indexed individually |
| `platform/api/resources/project/templates` | ~116K | No sub-pages; silent truncation risks incorrect answers |

## Preview Link
<!-- The preview link or links to the documents-->

## Internal Reference
Closes DOC-1320

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs