### PR TITLE
test(ci): ai-pr-review cell 9 — anthropic medium inline-review

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -1,0 +1,17 @@
+name: AI PR review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
+    with:
+      provider: anthropic
+      effort: medium
+      outcome: inline-review
+      prompt: |
+        Review this PR for risk CI cannot catch: broken links, inconsistent version references, and breaking public-API claims in examples. Keep findings terse.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@devops-793/ai-pr-review-anthropic-subdir
+    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
     with:
       provider: anthropic
       effort: medium

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   review:
-    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
+    uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@devops-793/ai-pr-review-anthropic-subdir
     with:
       provider: anthropic
       effort: medium


### PR DESCRIPTION
## Test-bed cell

Part of the ai-pr-review smoke-test matrix tracked on #1962. **Do not merge.**

- provider: `anthropic`
- effort: `medium`
- outcome: `inline-review`
- prompt variant: `default`

Verifies the `loft-sh/github-actions` ai-pr-review reusable workflow end-to-end
for this configuration. Will be closed + deleted after verdict is recorded.