### PR TITLE
Update connection instructions for standalone clusters

### DIFF
--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/basics.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/basics.mdx
@@ -213,4 +213,4 @@ After provisioning completes, <Link to="/docs/platform">vCluster Platform</Link>
 
 To access a Standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the platform UI and click `Connect`.
 
-If you have a manually provisioned standalone cluster - you use the [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) command to attach it to the platform for management.
+If you have a manually provisioned standalone cluster, use [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) to attach it to the platform for management.

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/basics.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/basics.mdx
@@ -213,4 +213,4 @@ After provisioning completes, <Link to="/docs/platform">vCluster Platform</Link>
 
 To access a Standalone cluster managed by <Link to="/docs/platform">vCluster Platform</Link>, open the vCluster in the platform UI and click `Connect`.
 
-As an alternative, use the [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) command.
+If you have a manually provisioned standalone cluster - you use the [`vcluster platform connect vcluster`](../../../cli/vcluster_platform_connect_vcluster) command to attach it to the platform for management.


### PR DESCRIPTION
Clarified instructions for connecting to a manually provisioned standalone cluster.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

