### PR TITLE
fix(llms): remove doubled /docs/docs/ prefix from generated markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "docusaurus start",
     "prebuild": "npm run validate-glossary",
     "build": "docusaurus build",
+    "postbuild": "node scripts/fix-llms-doubled-docs-path.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/fix-llms-doubled-docs-path.js
+++ b/scripts/fix-llms-doubled-docs-path.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Post-build fix for DOC-1330.
+ *
+ * Why this exists
+ * ---------------
+ * The `@signalwire/docusaurus-plugin-llms-txt@1.2.2` plugin, when configured
+ * with `relativePaths: false` (required by ENGAI-58 / PR #1914 so that
+ * `llms-full.txt` carries absolute URLs for the R2R RAG pipeline), is not
+ * idempotent when the site lives under a non-root `baseUrl`.
+ *
+ * For this site:
+ *   - `url`     = https://www.vcluster.com
+ *   - `baseUrl` = /docs/
+ *   - `siteUrl` (derived) = https://www.vcluster.com/docs
+ *
+ * Docusaurus feeds the plugin route paths that already include the
+ * `baseUrl` prefix (e.g. `/docs/vcluster/.../sleep`). The plugin then
+ * joins that with the derived `siteUrl`, producing
+ * `https://www.vcluster.com/docs/docs/vcluster/.../sleep.md` — a doubled
+ * `/docs/docs/` segment that 404s when followed.
+ *
+ * Upstream stable 1.x has no config option to disable the extra join,
+ * and the only newer release is `2.0.0-alpha.*`, a major-version rewrite
+ * with a breaking options schema. Bumping to 2.x or patching upstream is
+ * the long-term path; this script is the minimal, surgical fix that
+ * unblocks agents today.
+ *
+ * What this script does
+ * ---------------------
+ * 1. Walk the Docusaurus build output and rewrite the literal substring
+ *    `/docs/docs/` → `/docs/` inside `.md` page bodies and the top-level
+ *    `llms.txt` / `llms-full.txt` files. No other files are touched —
+ *    HTML, JS, and assets are left alone.
+ * 2. After rewriting, re-scan the same files to confirm no `/docs/docs/`
+ *    substring remains. Exits non-zero if any is left, so a future
+ *    plugin change that emits the bug in a new shape breaks CI
+ *    immediately instead of shipping silently. This doubles as the
+ *    DOC-1330 regression check.
+ *
+ * Safety
+ * ------
+ * The pattern `/docs/docs/` is only ever produced by the doubled-prefix
+ * bug; a repo-wide grep across `.md` and `.mdx` source files confirms
+ * zero legitimate matches (see DOC-1330 for the full analysis).
+ * Absolute URLs of the form `https://www.vcluster.com/docs/...` continue
+ * to work, so the ENGAI-58 regression check still passes.
+ *
+ * Remove this script when the plugin is upgraded past the doubled-prefix
+ * bug and the `postbuild` hook in `package.json` is dropped.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BUILD_DIR = path.resolve(__dirname, '..', 'build');
+const DOUBLED = '/docs/docs/';
+const FIXED = '/docs/';
+
+// Files we touch: generated markdown pages and the llms index files.
+// Anything else (HTML, JS, CSS, assets) is left untouched.
+function shouldRewrite(filePath) {
+  if (filePath.endsWith('.md')) return true;
+  const base = path.basename(filePath);
+  return base === 'llms.txt' || base === 'llms-full.txt';
+}
+
+function* walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile()) {
+      yield full;
+    }
+  }
+}
+
+function rewriteFile(filePath) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  if (!original.includes(DOUBLED)) return 0;
+  // Global literal replacement — `/docs/docs/` only ever appears as the
+  // plugin's doubled-prefix bug output.
+  const updated = original.split(DOUBLED).join(FIXED);
+  const occurrences = (original.length - updated.length) / (DOUBLED.length - FIXED.length);
+  fs.writeFileSync(filePath, updated);
+  return occurrences;
+}
+
+function main() {
+  if (!fs.existsSync(BUILD_DIR)) {
+    console.error(`[fix-llms-doubled-docs-path] build dir not found: ${BUILD_DIR}`);
+    process.exit(1);
+  }
+
+  let filesScanned = 0;
+  let filesModified = 0;
+  let totalReplacements = 0;
+
+  for (const filePath of walk(BUILD_DIR)) {
+    if (!shouldRewrite(filePath)) continue;
+    filesScanned += 1;
+    const count = rewriteFile(filePath);
+    if (count > 0) {
+      filesModified += 1;
+      totalReplacements += count;
+    }
+  }
+
+  console.log(
+    `[fix-llms-doubled-docs-path] scanned ${filesScanned} file(s), ` +
+      `modified ${filesModified} with ${totalReplacements} replacement(s)`,
+  );
+
+  // Regression check: after the rewrite pass, no eligible file should
+  // still contain `/docs/docs/`. If this ever fails, either the rewrite
+  // logic regressed or the plugin started emitting the bug in a new
+  // shape — either way, we want CI red, not a silent 404 in prod.
+  const stragglers = [];
+  for (const filePath of walk(BUILD_DIR)) {
+    if (!shouldRewrite(filePath)) continue;
+    const contents = fs.readFileSync(filePath, 'utf8');
+    if (contents.includes(DOUBLED)) {
+      stragglers.push(path.relative(BUILD_DIR, filePath));
+    }
+  }
+  if (stragglers.length > 0) {
+    console.error(
+      `[fix-llms-doubled-docs-path] regression: ${stragglers.length} file(s) ` +
+        `still contain "${DOUBLED}" after rewrite:`,
+    );
+    for (const rel of stragglers.slice(0, 10)) console.error(`  - ${rel}`);
+    if (stragglers.length > 10) {
+      console.error(`  ... and ${stragglers.length - 10} more`);
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
<!--
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it.
In this case, follow the instructions from vale and fix the linting issues.
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

The `@signalwire/docusaurus-plugin-llms-txt@1.2.2` plugin emits a doubled `/docs/docs/` prefix inside generated `.md` page bodies when `relativePaths: false` (required by ENGAI-58 / PR #1914 for absolute URLs in `llms-full.txt`) is combined with a non-root `baseUrl` like `/docs/`. Humans reading HTML never hit this; AI agents following `.md` links (surfaced by the DOC-1321 content-negotiation rollout) 404.

This PR adds a small `postbuild` hook (`scripts/fix-llms-doubled-docs-path.js`) that rewrites `/docs/docs/` -> `/docs/` across every generated `.md` and across `llms.txt` / `llms-full.txt`. The script also self-verifies after the rewrite pass and exits non-zero if any `/docs/docs/` remains, which doubles as the DOC-1330 regression check.

### Why option 3 (post-build rewrite)

- **Plugin config (option 1):** `1.2.2` has no idempotent-join option; `2.0.0-alpha.*` is a breaking rewrite with a new options schema.
- **Upstream PR (option 2):** correct long-term path, but does not unblock agent traffic today.
- **Post-build rewrite (option 3):** surgical, reversible, touches only `.md` + `llms*.txt`, and carries its own regression check. Drop the `postbuild` line and this script when the plugin is upgraded past the bug.

A repo-wide grep confirms `/docs/docs/` has zero legitimate uses in any source `.md` / `.mdx`, so the rewrite cannot collide with real content.

### Local verification

```
npm run build
# [fix-llms-doubled-docs-path] scanned 394 file(s), modified 291 with 2756 replacement(s)

grep -rc '/docs/docs/' build/ --include='*.md' --include='*.txt' | awk -F: '$2>0'   # empty -> pass
grep -c 'vcluster\.com/docs/' build/llms-full.txt                                    # 1815 abs URLs preserved (ENGAI-58)
grep -c '/docs/docs/' build/vcluster/configure/vcluster-yaml/sleep.md               # 0
```

## Preview Link
<!-- The preview link or links to the documents-->

Netlify deploy preview will be posted below by the bot once the build finishes. Sample affected page to spot-check on the preview (fetch with `Accept: text/markdown`):

- `https://deploy-preview-<N>--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/sleep`

Expected: no `/docs/docs/` in the returned markdown body.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1330

References:
- PR #1914 / ENGAI-58 (introduced `relativePaths: false`, surfaced the bug)
- DOC-1321 / PR #1960 (content negotiation, surfaced the bug during verification)
- DOC-1317, DOC-1318 (ticket chain whose goal this bug undercuts)


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs