### PR TITLE
feat(seo): noindex non-current doc versions and drop them from sitemap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,52 @@ The review checks documentation style, validates vCluster YAML configurations,
 and identifies broken links. The AI review is meant to assist, not replace,
 human review.
 
+## SEO and crawler policy
+
+The docs site exposes multiple versions (current stable, prior supported,
+EOS/EOL, and the `next` preview). Only the current stable version should
+compete for search engine and AI crawler attention; older versions remain
+reachable for users who need them, but must not outrank or dilute the
+current docs. See DOC-1325 for background.
+
+### What the current setup does
+
+- **`lastVersion`** in `docusaurus.config.js` makes unversioned URLs (for
+  example `/docs/vcluster/deploy/...`) serve the current stable release.
+  Those unversioned URLs are the canonical, indexable entry points.
+- **noindex on non-current versions** is emitted by
+  `src/theme/DocItem/Layout/index.js`. The swizzle reads
+  `useActivePluginAndVersion()` and injects
+  `<meta name="robots" content="noindex,follow">` whenever `isLast` is
+  false. That covers EOS, EOL, any prior stable version still in
+  `onlyIncludeVersions`, and the `current` (next/main) preview.
+- **Sitemap** (`docusaurus.config.js`, sitemap plugin) lists only
+  unversioned URLs. Any path matching `/vcluster/<X.Y.Z>/` or
+  `/platform/<X.Y.Z>/` — plus the `next` previews — is stripped by both
+  `ignorePatterns` and a post-filter in `createSitemapItems`.
+- **`llms.txt`** already excludes versioned docs via
+  `includeVersionedDocs: false` on the `docusaurus-plugin-llms-txt` plugin.
+  That stays as-is.
+- **`static/robots.txt`** is intentionally permissive. `Disallow` would
+  block crawlers from fetching the page and therefore from ever seeing the
+  `noindex` meta tag, which is the opposite of what we want. Note that the
+  production host `vcluster.com/robots.txt` is served by the main site
+  repo, not this one; this file applies to the Netlify preview domain.
+- **Canonical tags** are not emitted automatically. Only add a `<link
+  rel="canonical">` when the content at a versioned URL is effectively
+  identical to the current version. Do not point version-specific content
+  (release notes, deprecated APIs, migration guides) at the current docs.
+
+### When adding or removing a version
+
+1. Update `onlyIncludeVersions` in `docusaurus.config.js` for the affected
+   docs plugin (vcluster or platform). No SEO code changes are required —
+   the swizzle derives `isLast` from the plugin config.
+2. When bumping `lastVersion`, the previous stable version automatically
+   starts emitting `noindex,follow`. No per-version list to edit.
+3. Regenerate the lifecycle JSON (`npm run generate-lifecycle-json`) so
+   the supported-versions partial stays in sync with the config.
+
 ## Style guide
 
 Most of the style guide rules is enforced by `vale` linter. See the

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -92,44 +92,45 @@ const config = {
         sitemap: {
           changefreq: 'weekly',
           priority: 0.5,
-          ignorePatterns: ['/tags/**', '/search/**', '*/page/*'],
+          ignorePatterns: [
+            '/tags/**',
+            '/search/**',
+            '*/page/*',
+            // Exclude versioned URLs from the sitemap. Unversioned paths (served
+            // by lastVersion) are the canonical entry points for search engines.
+            // The matching `noindex,follow` meta tag is emitted by the DocItem
+            // swizzle at src/theme/DocItem/Layout/index.js. See DOC-1325.
+            '/vcluster/[0-9]*.[0-9]*.[0-9]*/**',
+            '/platform/[0-9]*.[0-9]*.[0-9]*/**',
+            '/vcluster/next/**',
+            '/platform/next/**',
+          ],
           filename: 'sitemap.xml',
           createSitemapItems: async (params) => {
             const { defaultCreateSitemapItems, ...rest } = params;
             const items = await defaultCreateSitemapItems(rest);
 
-            // Filter out pagination and unwanted pages
-            const filteredItems = items.filter((item) => !item.url.includes('/page/'));
+            // Filter out pagination and any remaining versioned URLs that
+            // slipped past ignorePatterns. Belt-and-braces: the version regex
+            // here catches any X.Y.Z path segment under /vcluster/ or /platform/.
+            const filteredItems = items.filter((item) => {
+              if (item.url.includes('/page/')) return false;
+              if (item.url.match(/\/vcluster\/\d+\.\d+\.\d+\//)) return false;
+              if (item.url.match(/\/platform\/\d+\.\d+\.\d+\//)) return false;
+              if (item.url.match(/\/vcluster\/next(\/|$)/)) return false;
+              if (item.url.match(/\/platform\/next(\/|$)/)) return false;
+              return true;
+            });
 
-            // Enhance items with custom priorities and change frequencies
+            // Landing pages get highest priority; everything else stays
+            // on the default sitemap priority.
             return filteredItems.map((item) => {
-              // Main landing pages get highest priority
               if (item.url === 'https://vcluster.com/docs/' ||
                   item.url === 'https://vcluster.com/docs/vcluster/' ||
                   item.url === 'https://vcluster.com/docs/platform/') {
                 return { ...item, priority: 1.0, changefreq: 'daily' };
               }
-
-              // Latest stable versions get highest priority (0.33.0 for vCluster, 4.8.0 for platform)
-              if (item.url.match(/\/vcluster\/0\.33\.0\//) ||
-                  item.url.match(/\/platform\/4\.8\.0\//)) {
-                return { ...item, priority: 1.0, changefreq: 'daily' };
-              }
-
-              // Current/next versions (non-versioned URLs) get high priority
-              if ((item.url.includes('/vcluster/') && !item.url.match(/\/vcluster\/\d+\.\d+\.\d+\//)) ||
-                  (item.url.includes('/platform/') && !item.url.match(/\/platform\/\d+\.\d+\.\d+\//))) {
-                return { ...item, priority: 0.8, changefreq: 'weekly' };
-              }
-
-              // ALL other versioned docs get very low priority (0.19-0.31 for vCluster, older platform versions)
-              if (item.url.match(/\/vcluster\/\d+\.\d+\.\d+\//) ||
-                  item.url.match(/\/platform\/\d+\.\d+\.\d+\//)) {
-                return { ...item, priority: 0.1, changefreq: 'yearly' };
-              }
-
-              // Default priority for other pages
-              return item;
+              return { ...item, priority: 0.8, changefreq: 'weekly' };
             });
           },
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,6 +94,7 @@ const config = {
           priority: 0.5,
           ignorePatterns: [
             '/tags/**',
+            '/search',
             '/search/**',
             '*/page/*',
             // Exclude versioned URLs from the sitemap. Unversioned paths (served

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,6 +1,7 @@
-import React from 'react';
 import DocItemLayout from '@theme-original/DocItem/Layout';
+import Head from '@docusaurus/Head';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import {useActivePluginAndVersion} from '@docusaurus/plugin-content-docs/client';
 
 /**
  * Wraps every doc page with a visually-hidden directive pointing to llms.txt.
@@ -11,11 +12,26 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
  *
  * Satisfies the `llms-txt-directive` check from the agent-docs spec:
  * https://agentdocsspec.com/spec/#llms-txt-directive
+ *
+ * Also emits `<meta name="robots" content="noindex,follow">` on any doc page
+ * that is not the current stable version. Unversioned URLs (served by
+ * lastVersion) stay indexable; every versioned path — including the stable
+ * version's versioned URL, prior stable/EOS versions, and the `current`
+ * (next/main) preview — is marked noindex so search engines prefer the
+ * canonical unversioned routes. See DOC-1325.
  */
 export default function DocItemLayoutWrapper(props) {
   const llmsTxtUrl = useBaseUrl('/llms.txt');
+  const activePluginAndVersion = useActivePluginAndVersion();
+  const isLast = activePluginAndVersion?.activeVersion?.isLast ?? true;
+
   return (
     <>
+      {!isLast && (
+        <Head>
+          <meta name="robots" content="noindex,follow" />
+        </Head>
+      )}
       <div
         aria-hidden="true"
         style={{

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,25 +1,18 @@
 User-agent: *
+Allow: /
 
-# Discourage crawling of old vCluster versions (0.19-0.24)
-# These versions are outdated and should not appear in search results
-Disallow: /docs/vcluster/0.19.0/
-Disallow: /docs/vcluster/0.20.0/
-Disallow: /docs/vcluster/0.21.0/
-Disallow: /docs/vcluster/0.22.0/
-Disallow: /docs/vcluster/0.23.0/
-Disallow: /docs/vcluster/0.24.0/
-
-# Block old v0.x versions with generic pattern
-Disallow: /docs/v0.19/
-Disallow: /docs/v0.20/
-Disallow: /docs/v0.21/
-Disallow: /docs/v0.22/
-Disallow: /docs/v0.23/
-Disallow: /docs/v0.24/
-
-# Currently supported versions are allowed to crawl:
-# - vCluster 0.25.0, 0.26.0, 0.27.0, and current
-# - Platform 4.2.0, 4.3.0, and current
-# These have proper priority settings in sitemap
+# SEO policy for vcluster-docs
+#
+# Crawlers are welcome on the current stable docs (unversioned URLs). Older
+# versioned paths (e.g. /docs/vcluster/0.32.0/, /docs/platform/4.7.0/) and the
+# `next` preview emit `<meta name="robots" content="noindex,follow">` via the
+# DocItem swizzle at src/theme/DocItem/Layout/index.js, so this robots.txt
+# does not Disallow them — Google must be able to fetch the page to see the
+# noindex signal. Versioned URLs are also excluded from sitemap.xml.
+#
+# Note: the production host vcluster.com serves /robots.txt from the main
+# site repo (not this file). This file is served on the Netlify preview
+# domain (vcluster-docs-site.netlify.app) and is primarily defensive.
+# See DOC-1325 and CONTRIBUTING.md (SEO / crawler policy).
 
 Sitemap: https://vcluster.com/docs/sitemap.xml


### PR DESCRIPTION
# Content Description

Adds stronger crawler/SEO signals so the current stable docs aren't outranked by older versioned pages in Google and other crawlers. Injects `<meta name="robots" content="noindex,follow">` on any doc where the active version is not `lastVersion` (covers EOS/EOL, prior stable, and the `next` preview), strips versioned URLs from the sitemap, and documents the policy in CONTRIBUTING.md.

Extends the earlier fix in DOC-982 under the new AEO/GEO for vCluster initiative led by Rahul.

**What changes:**
- `src/theme/DocItem/Layout/index.js` — swizzle now calls `useActivePluginAndVersion()` and emits `noindex,follow` when `!activeVersion.isLast`.
- `docusaurus.config.js` — sitemap `ignorePatterns` + `createSitemapItems` post-filter exclude `/vcluster/<X.Y.Z>/*`, `/platform/<X.Y.Z>/*`, `/vcluster/next/*`, `/platform/next/*`. Landing pages keep priority 1.0; everything else stays at 0.8.
- `static/robots.txt` — removed stale 0.19-0.24 Disallow list. `Disallow` would block crawlers from fetching the page and seeing the noindex, so the file is now intentionally permissive with a policy comment.
- `CONTRIBUTING.md` — new "SEO and crawler policy" section explaining the mechanism and what to do when bumping `lastVersion`.

**Verified locally (`npm run build`):**
- Sitemap: 485 URLs, all unversioned; 0 matches for `/vcluster/X.Y.Z/`, `/platform/X.Y.Z/`, `/vcluster/next/`, `/platform/next/`.
- `noindex,follow` present on `vcluster/0.32.0/index.html`, `platform/4.7.0/index.html`, `platform/4.6.0/index.html`, `platform/next/index.html`, `vcluster/next/index.html`.
- `noindex` absent from `vcluster/index.html`, `platform/index.html`, and the docs root (indexable unversioned paths).

**Note:** production `vcluster.com/robots.txt` is served by the main `vcluster.com` (Hugo) repo, not this one, so a companion update to that repo's robots.txt is optional defense-in-depth but not required — the `noindex` meta served inline in HTML is the primary and effective signal.

## Preview Link

Deploy preview root: https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs

Spot-check targets (replace `PR` with the PR number once assigned):
- `https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs/vcluster/` — unversioned lastVersion, should NOT carry `noindex`
- `https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs/vcluster/0.32.0/` — versioned, should carry `noindex,follow`
- `https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs/platform/` — unversioned lastVersion, should NOT carry `noindex`
- `https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs/platform/4.7.0/` — versioned, should carry `noindex,follow`
- `https://deploy-preview-PR--vcluster-docs-site.netlify.app/docs/sitemap.xml` — verify no versioned URLs appear

## Internal Reference

Closes DOC-1325

Related:
- Extends DOC-982 ("Prevent old docs pages from appearing at top in Google searches", completed Feb 2026)
- Part of the [AEO/GEO for vCluster](https://linear.app/loft/project/aeogeo-for-vcluster-5251ed6db0ff) project (Rahul Patwardhan, DevRel+Marketing, due 2026-06-30)

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs