### PR TITLE
chore: add brand skill dependency to docs-writer, ignore audits dir

### DIFF
--- a/.claude/skills/vcluster-docs-writer/SKILL.md
+++ b/.claude/skills/vcluster-docs-writer/SKILL.md
@@ -8,6 +8,10 @@ context: fork
 
 Specialized knowledge and workflows for writing vCluster documentation in Docusaurus.
 
+## Dependencies
+
+When this skill is loaded, also invoke: `vcluster-skills-shared:vcluster-branding`
+
 ## When to Use
 
 Trigger when:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .docusaurus/
 .idea/
 build/
+audits/
 justfile
 # Local Netlify folder
 .netlify


### PR DESCRIPTION
## Summary

- Adds a `Dependencies` section to `.claude/skills/vcluster-docs-writer/SKILL.md` so that the `vcluster-skills-shared:vcluster-branding` skill is automatically loaded alongside the docs-writer skill
- Adds `audits/` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)