### PR TITLE
docs(oss-vs-free): apply repositioning terminology and framing

### DIFF
--- a/vcluster/introduction/oss-vs-free.mdx
+++ b/vcluster/introduction/oss-vs-free.mdx
@@ -13,7 +13,7 @@ vCluster is available as open source under the Apache 2.0 license and in several
 
 ## Overview
 
-**vCluster Open Source** is the foundation of the project. It provides core virtual cluster capabilities: isolated Kubernetes environments, resource syncing, multiple backing stores, and support for k3s, k0s, vanilla Kubernetes, and EKS distributions. OSS requires no license and no Platform connectivity.
+**vCluster Open Source** is the foundation of the project. It provides full-stack tenant cluster isolation: dedicated Kubernetes control planes, resource syncing, multiple backing stores, and support for k3s, k0s, vanilla Kubernetes, and EKS distributions. OSS requires no license and no Platform connectivity.
 
 **vCluster Free tier** adds capabilities on top of OSS at no cost, including embedded etcd, Private Nodes, custom resource syncing, sync patches, and HostPath Mapper. The Free tier requires connecting to the vCluster Platform for license validation but needs no credit card.
 
@@ -37,44 +37,44 @@ The following table lists tier-gated features and the plans they apply to. Open 
 
 ## How licensing works
 
-The Free tier requires connecting your virtual cluster to the vCluster Platform for license validation. The Platform handles all license management automatically - you don't need to manually configure license keys.
+The Free tier requires connecting your tenant cluster to the vCluster Platform for license validation. The Platform handles all license management automatically - you don't need to manually configure license keys.
 
 ### License validation flow
 
-License validation happens at the Platform level, not within individual virtual clusters:
+License validation happens at the Platform level, not within individual tenant clusters:
 
-1. **Platform retrieves license**: The vCluster Platform periodically contacts the Loft License API (`admin.loft.sh`) to retrieve and validate its license. This determines which features are available across all connected virtual clusters.
+1. **Platform retrieves license**: The vCluster Platform periodically contacts the Loft License API (`admin.loft.sh`) to retrieve and validate its license. This determines which features are available across all connected tenant clusters.
 
-2. **Virtual cluster connects to Platform**: Each virtual cluster authenticates with the Platform using an access key stored in a Kubernetes Secret. The Platform then provides license information to the virtual cluster.
+2. **Tenant cluster connects to Platform**: Each tenant cluster authenticates with the Platform using an access key stored in a Kubernetes Secret. The Platform then provides license information to the tenant cluster.
 
-3. **Features are enabled**: Based on the Platform's license tier (Free, Dev, Prod, or Scale), the virtual cluster enables the appropriate features.
+3. **Features are enabled**: Based on the Platform's license tier (Free, Dev, Prod, or Scale), the tenant cluster enables the appropriate features.
 
 :::info Network requirements
-The Platform requires outbound HTTPS access to `admin.loft.sh` for license retrieval. Virtual clusters only need connectivity to the Platform, not to the external license API. For air-gapped environments, see the [air-gapped installation guide](/docs/platform/install/air-gapped).
+The Platform requires outbound HTTPS access to `admin.loft.sh` for license retrieval. Tenant clusters only need connectivity to the Platform, not to the external license API. For air-gapped environments, see the [air-gapped installation guide](/docs/platform/install/air-gapped).
 :::
 
 ### What happens during validation
 
-When a virtual cluster starts or reconnects to the Platform:
+When a tenant cluster starts or reconnects to the Platform:
 
-- The virtual cluster reads its access key from the configured Secret (defaults to `vcluster-platform-api-key` in the virtual cluster's namespace)
+- The tenant cluster reads its access key from the configured Secret (defaults to `vcluster-platform-api-key` in the tenant cluster's namespace)
 - It establishes a secure connection to the Platform
 - The Platform validates the access key and returns the current license status
-- The virtual cluster enables or disables features based on the license tier
+- The tenant cluster enables or disables features based on the license tier
 
 For details on configuring the access key, see [Platform API Key configuration](../configure/vcluster-yaml/platform.mdx).
 
 ### Graceful degradation
 
 :::note
-Virtual clusters never stop functioning due to license issues. In the worst case, they fall back to the OSS feature set, ensuring your workloads continue running.
+Tenant clusters never stop functioning due to license issues. In the worst case, they fall back to the OSS feature set, ensuring your workloads continue running.
 :::
 
 If license validation fails:
 
-- **Temporary connectivity issues**: The virtual cluster continues operating with cached license information during brief outages.
+- **Temporary connectivity issues**: The tenant cluster continues operating with cached license information during brief outages.
 - **Expired or invalid license**: Features revert to the OSS tier. Your workloads continue running, but tier-specific features become unavailable.
-- **No Platform connection**: Virtual clusters deployed without Platform connectivity operate as OSS from the start.
+- **No Platform connection**: Tenant clusters deployed without Platform connectivity operate as OSS from the start.
 
 ## Activate the free tier
 
@@ -82,7 +82,7 @@ Activate the vCluster Free tier using these steps:
 
 ### Prerequisites
 
-- A Kubernetes cluster (host cluster) where you'll deploy virtual clusters
+- A Kubernetes cluster (Control Plane Cluster) where you'll deploy tenant clusters
 - kubectl installed and configured
 - The vCluster CLI installed
 
@@ -90,11 +90,11 @@ Activate the vCluster Free tier using these steps:
 
 Install the vCluster Platform in your Kubernetes cluster. See the [Platform installation guide](/docs/platform/install/quick-start-guide) for detailed instructions. No credit card is required for the Free tier.
 
-### Step 2: Connect your virtual cluster
+### Step 2: Connect your tenant cluster
 
-After installing the Platform, connect existing virtual clusters or create new ones.
+After installing the Platform, connect existing tenant clusters or create new ones.
 
-**For existing virtual clusters:**
+**For existing tenant clusters:**
 
 ```bash
 # Log in to the Platform
@@ -104,11 +104,11 @@ vcluster platform login
 vcluster platform add vcluster my-vcluster
 ```
 
-**For new virtual clusters**, create them through the Platform UI or CLI - Free tier features are automatically enabled.
+**For new tenant clusters**, create them through the Platform UI or CLI - Free tier features are automatically enabled.
 
 ### Step 3: Deploy with Free tier features
 
-When creating virtual clusters through the Platform, Free tier features like embedded etcd are automatically available:
+When creating tenant clusters through the Platform, Free tier features like embedded etcd are automatically available:
 
 ```yaml title="vcluster.yaml"
 # Use embedded etcd (Free tier feature)
@@ -119,7 +119,7 @@ controlPlane:
         enabled: true
 ```
 
-Deploy your virtual cluster:
+Deploy your tenant cluster:
 
 ```bash
 vcluster create my-vcluster --values vcluster.yaml
@@ -127,14 +127,14 @@ vcluster create my-vcluster --values vcluster.yaml
 
 ### Step 4: Verify Free tier activation
 
-Check that your virtual cluster is connected and licensed in the Platform UI, or use the CLI:
+Check that your tenant cluster is connected and licensed in the Platform UI, or use the CLI:
 
 ```bash
 # List virtual clusters managed by Platform
 vcluster platform list vclusters
 ```
 
-You should see your virtual cluster listed with the Free tier license status.
+You should see your tenant cluster listed with the Free tier license status.
 
 ## Frequently asked questions
 
@@ -144,15 +144,15 @@ Yes, the Free tier is completely free. Creating a vCluster Platform account is r
 
 ### Can OSS be used in production?
 
-Yes, vCluster OSS is production-ready and many organizations run it successfully. However, paid tiers offer additional features like high availability, advanced security, and enterprise support that are often required for production deployments.
+Yes, vCluster OSS is production-ready and deployed by platform teams worldwide. Paid tiers add high availability, external database support, SSO, audit logging, and enterprise support — capabilities that larger-scale platform deployments typically require.
 
 ### What happens if a Free tier license expires?
 
-Free tier licenses don't expire as long as the Platform account remains active. If connectivity issues prevent license validation, virtual clusters continue operating with a grace period.
+Free tier licenses don't expire as long as the Platform account remains active. If connectivity issues prevent license validation, tenant clusters continue operating with a grace period.
 
 ### Can you upgrade from Free to a paid tier?
 
-Yes, upgrades are possible at any time from the vCluster Platform account settings. Existing virtual clusters automatically receive the new license without requiring redeployment.
+Yes, upgrades are possible at any time from the vCluster Platform account settings. Existing tenant clusters automatically receive the new license without requiring redeployment.
 
 ### Does OSS require platform connectivity?
 
@@ -160,7 +160,7 @@ No, vCluster OSS operates completely independently without requiring any connect
 
 ## Next steps
 
-- [Deploy your first virtual cluster](../quick-start/index.mdx)
+- [Deploy your first tenant cluster](../quick-start/index.mdx)
 - [Understand vCluster architecture](./architecture.mdx)
 - [Configure embedded etcd](../configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx)
 - [Explore the vCluster Platform](https://www.vcluster.com/platform)

--- a/vcluster/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster/introduction/what-are-virtual-clusters.mdx
@@ -21,7 +21,7 @@ Two questions determine your deployment path.
 **Yes** — your existing cluster becomes the <GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm> that hosts tenant cluster control planes. You need no additional infrastructure to get started.
 
 **No** — choose one of:
-- **vCluster Standalone** — a zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Suited for AI cloud providers and neoclouds building from bare metal, as well as edge and air-gapped production deployments.
+- **vCluster Standalone** — a zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Suited for AI cloud providers building from bare metal, as well as edge and air-gapped production deployments.
 - **vind (vCluster in Docker)** — runs a complete cluster in Docker containers with no Kubernetes dependency. Suited for local development and CI/CD pipelines.
 
 ### 2. How will worker nodes run?

--- a/vcluster/quick-start/standalone.mdx
+++ b/vcluster/quick-start/standalone.mdx
@@ -12,7 +12,7 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 The first problem is always the same. To run vCluster, you need a Kubernetes cluster. But getting a Kubernetes cluster onto bare metal normally requires another tool first. vCluster Standalone breaks this loop. It installs a complete Kubernetes control plane directly on a Linux machine as a binary, with no existing distribution required.
 
-This guide takes you from a bare Linux machine to a running Control Plane Cluster with vCluster Platform installed on it. Once Platform is running, you can provision tenant clusters with dedicated private nodes in seconds. That's the path GPU clouds and neoclouds use to deliver hyperscaler-grade isolation to their customers.
+This guide takes you from a bare Linux machine to a running Control Plane Cluster with vCluster Platform installed on it. Once Platform is running, you can provision tenant clusters with dedicated private nodes in seconds. That's the path AI clouds use to deliver hyperscaler-grade isolation to their customers.
 
 ## Prerequisites
 
@@ -143,4 +143,4 @@ The UI opens automatically. Create your administrator account and you are logged
 - [Node providers](/docs/platform/administer/node-providers/overview) — automate worker node provisioning through Platform (AWS, GCP, bare metal)
 - [High availability](../deploy/control-plane/binary/high-availability.mdx) — add control plane nodes for production resilience
 - [Manage Standalone](../deploy/control-plane/binary/manage.mdx) — upgrade versions and manage configuration through Platform
-- [Building a GPU cloud platform](../introduction/gpu-cloud-platform.mdx) — end-to-end architecture for AI cloud and neocloud deployments
+- [Building a GPU cloud platform](../introduction/gpu-cloud-platform.mdx) — end-to-end architecture for AI cloud deployments


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Update oss-vs-free.mdx with current terminology: virtual cluster → tenant cluster, host cluster → Control Plane Cluster. Strengthen OSS description to lead with isolation, improve production FAQ framing.

## Preview Link 
<!-- The preview link or links to the documents-->
- https://deploy-preview-1980--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/oss-vs-free
- https://deploy-preview-1980--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/what-are-virtual-clusters
- https://deploy-preview-1980--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/standalone

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1333


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

