### PR TITLE
docs(repositioning): phase 1-2 terminology — tenant isolation and high-leverage fragments

### DIFF
--- a/docs/_partials/platform/virtual-cluster-content.mdx
+++ b/docs/_partials/platform/virtual-cluster-content.mdx
@@ -1,19 +1,19 @@
-A virtual cluster is a fully functional Kubernetes cluster that runs inside a namespace of
-another Kubernetes cluster. Typically, the cluster that the virtual cluster is installed in is
-referred to as the "host" cluster, or the "parent" cluster.
+A tenant cluster is a fully functional Kubernetes cluster that runs inside a namespace of
+another Kubernetes cluster. Typically, the cluster that the tenant cluster is installed in is
+referred to as the Control Plane Cluster.
 
-Virtual clusters, being fully functional Kubernetes clusters in their own right, can be a very
+Tenant clusters, being fully functional Kubernetes clusters in their own right, can be a very
 useful tool if you are running into issues with the limitations of traditional Kubernetes
-namespaces. Often administrator do not want to make, or cannot make any special exceptions to the
-multi-tenancy configuration of the underlying parent cluster in to accommodate user requests.
+namespaces. Often administrators do not want to make, or cannot make any special exceptions to the
+tenant isolation configuration of the underlying parent cluster to accommodate user requests.
 For example, some users may need to create their own Custom Resource Definitions (CRDs) which
 could potentially impact any other users in the cluster. Another user may need pods from two
 separate namespaces to communicate with each other, despite the standard NetworkPolicy not
-permitting this. In both of these (and many more!) scenarios, a virtual cluster may be a perfect
+permitting this. In both of these (and many more!) scenarios, a tenant cluster may be a perfect
 solution.
 
-The diagram below briefly outlines the attributes of virtual clusters as compared to using
-namespaces or physical clusters for isolation and multi-tenancy.
+The diagram below briefly outlines the attributes of tenant clusters as compared to using
+namespaces or physical clusters for isolation.
 
 <figure>
 <img
@@ -23,22 +23,22 @@ namespaces or physical clusters for isolation and multi-tenancy.
   <figcaption>vcluster - Comparison</figcaption>
 </figure>
 
-The virtual cluster capability of vCluster Platform comes from the popular open source project
-[vcluster](https://vcluster.com). vCluster Platform provides a centralized management layer for virtual
-clusters, allowing users to provision virtual clusters in any vCluster Platform managed cluster (or virtual
-cluster!). vCluster Platform also offers the capability to import existing virtual clusters such that they
+The tenant cluster capability of vCluster Platform comes from the popular open source project
+[vcluster](https://vcluster.com). vCluster Platform provides a centralized management layer for tenant
+clusters, allowing users to provision tenant clusters in any vCluster Platform managed cluster (or tenant
+cluster!). vCluster Platform also offers the capability to import existing tenant clusters such that they
 can then be managed from the central vCluster Platform instance.
 
-## Why use virtual kubernetes clusters?
+## Why use tenant Kubernetes clusters?
 
-Virtual clusters can be used to partition a single physical cluster into multiple logical,
-virtual clusters. This partitioning process still allows for leveraging the benefits of Kubernetes
+Tenant clusters can be used to partition a single physical cluster into multiple logical,
+isolated environments. This partitioning process still allows for leveraging the benefits of Kubernetes
 itself, such as optimal resource distribution and workload management.
 
 While partitioning via Kubernetes namespaces has always been an option, traditional namespaces
 are limited in terms of cluster-scoped resources and control-plane usage.
 
-- **Cluster-Scoped Resources**: Certain resources live globally in the cluster, and you can’t
+- **Cluster-Scoped Resources**: Certain resources live globally in the cluster, and you can't
   isolate them using namespaces. For example, installing an operator in different versions at the
   same time is not possible within a single cluster.
 
@@ -47,56 +47,56 @@ are limited in terms of cluster-scoped resources and control-plane usage.
   rate-limiting based on a namespace is very hard to enforce and faulty configuration might bring
   down the whole cluster.
 
-Virtual clusters handily address these challenges by providing a dedicated Kubernetes API server
-per virtual cluster, thus bypassing the challenges of cluster-scoped resources and sharing a
+Tenant clusters handily address these challenges by providing a dedicated Kubernetes API server
+per tenant cluster, thus bypassing the challenges of cluster-scoped resources and sharing a
 single control plane.
 
-Virtual clusters also provide more stability than namespaces in many situations. The virtual
+Tenant clusters also provide more stability than namespaces in many situations. The tenant
 cluster creates its own Kubernetes resource objects, which are stored in its own data store. The
-host cluster has no knowledge of these resources.
+Control Plane Cluster has no knowledge of these resources.
 
 Isolation like this is excellent for resiliency. Engineers who use namespace-based isolation
 often still need access to cluster-scoped resources like cluster roles, shared CRDs or
 persistent volumes. If an engineer breaks something in one of these shared resources, it will
 likely fail for all the teams that rely on it.
 
-Virtual clusters are not only highly functional, they can often be a huge cost saver for
+Tenant clusters are not only highly functional, they can often be a huge cost saver for
 organizations. Many teams scale to address the problems outlined here by simply adding
-additional physical Kubernetes clusters. With virtual clusters, administrators are able to have
-many virtual clusters within a single physical cluster, this results in big savings by not
+additional physical Kubernetes clusters. With tenant clusters, administrators are able to have
+many tenant clusters within a single physical cluster, this results in big savings by not
 having to pay for multiple control planes, and more often than not results in vastly simplified
-cluster maintenance. This makes virtual clusters ideal for running experiments, continuous
+cluster maintenance. This makes tenant clusters ideal for running experiments, continuous
 integration, and setting up sandbox environments.
 
-Finally, virtual clusters can be configured independently of the physical cluster. This is great
-for multi-tenancy, like giving your customers the ability to spin up a new environment or
+Finally, tenant clusters can be configured independently of the physical cluster. This is great
+for tenant isolation, like giving your customers the ability to spin up a new environment or
 quickly setting up demo applications for your sales team.
 
 
 ## Benefits of vCluster
 
-Virtual clusters provide immense benefits for large-scale Kubernetes deployments and multi-tenancy.
+Tenant clusters provide immense benefits for large-scale Kubernetes deployments and tenant isolation.
 
 <!-- vale off -->
 - **Full Admin Access**:
 <!-- vale on -->
     - Deploy operators with CRDs, create namespaces and other cluster-scoped resources that you normally can't create inside a namespace.
-    - Taint and label nodes without influencing the host cluster.
-    - Reuse and share services across multiple virtual clusters with ease.
+    - Taint and label nodes without influencing the Control Plane Cluster.
+    - Reuse and share services across multiple tenant clusters with ease.
 - **Cost Savings:**
-    - Create lightweight vCluster instances that share the underlying host cluster instead of creating separate "real" clusters.
+    - Create lightweight vCluster instances that share the underlying Control Plane Cluster instead of creating separate "real" clusters.
     - Auto-scale, purge, snapshot, and move your vCluster instances, since they are Kubernetes deployments.
 - **Low Overhead:**
     - vCluster instances are super lightweight and only reside in a single namespace.
     - vCluster instances run with [AWS EKS](https://aws.amazon.com/eks/).
     - The vCluster control plane runs inside a single pod. Open source vCluster also uses a CoreDNS pod for vCluster-internal DNS capabilities. With vCluster Platform, however, you can enable the integrated CoreDNS so you don't need the additional pod.
 - **No Network Degradation:**
-    - Since the pods and services inside a vCluster are actually being synchronized down to the host cluster, they are effectively using the underlying cluster's pod and service networking. The vCluster pods are as fast as other pods in the underlying host cluster.
+    - Since the pods and services inside a vCluster are actually being synchronized down to the Control Plane Cluster, they are effectively using the underlying cluster's pod and service networking. The vCluster pods are as fast as other pods in the underlying Control Plane Cluster.
 - **API Server Compatibility:**
     - vCluster instances run with the API server from the Kubernetes distribution that you choose to use. This ensures 100% Kubernetes API server compliance.
     - vCluster manages its API server, controller-manager, and a separate, isolated data store. Use the embedded SQLite or a full-blown etcd if that's what you need.
 - **Security:**
-    - vCluster users need fewer permissions in the underlying host cluster / host namespace.
+    - vCluster users need fewer permissions in the underlying Control Plane Cluster.
     - vCluster users can manage their own CRDs independently and can even modify RBAC inside their own vCluster instances.
     - vCluster instances provide an extra layer of isolation. Each vCluster manages its own API server and control plane, which means that fewer requests to the underlying cluster need to be secured.
 - **Scalability:**

--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -1,19 +1,19 @@
 vcluster:
   term: "vCluster"
-  definition: "An open-source software product that creates and manages virtual Kubernetes clusters inside a host Kubernetes cluster. vCluster improves isolation and multi-tenancy capabilities while reducing infrastructure costs."
-  related: ["virtual-cluster", "host-cluster"]
+  definition: "An open-source software product that creates and manages tenant clusters within Kubernetes infrastructure. vCluster provides tenant isolation capabilities while reducing infrastructure costs."
+  related: ["tenant-cluster", "control-plane-cluster"]
   type: "vcluster"
 
 virtual-cluster:
-  term: "Virtual Cluster"
-  definition: "A certified Kubernetes distribution that runs as an isolated, virtual environment nested inside a physical host cluster. Virtual clusters run inside host cluster namespaces but operate as independent Kubernetes environments, each with its own API server, control plane, syncer, and set of resources."
-  related: ["vcluster", "host-cluster"]
+  term: "Tenant Cluster"
+  definition: "A certified Kubernetes distribution that runs as an isolated environment with a virtualized control plane hosted on a Control Plane Cluster. Tenant clusters operate as independent Kubernetes environments, each with its own API server, control plane, syncer, and set of resources."
+  related: ["vcluster", "control-plane-cluster"]
   type: "vcluster"
 
 host-cluster:
-  term: "Host Cluster"
-  definition: "The physical Kubernetes cluster where virtual clusters are deployed and run. The host cluster provides the infrastructure resources (CPU, memory, storage, networking) that virtual clusters leverage, while maintaining isolation between different virtual environments."
-  related: ["virtual-cluster", "control-plane-cluster"]
+  term: "Control Plane Cluster"
+  definition: "The Kubernetes cluster that hosts the virtualized control planes for tenant clusters. The Control Plane Cluster is operated by the platform provider and is completely invisible to tenants. There are no shared control plane nodes, no in-cluster agent pods, and no lateral path between tenant environments. With shared nodes, this cluster also runs tenant workloads alongside the control plane pods — the same node pool is used for both."
+  related: ["tenant-cluster", "control-plane-cluster"]
   type: "vcluster"
 
 control-plane-cluster:
@@ -37,47 +37,47 @@ pseudo-nodes:
 
 syncer:
   term: "Syncer"
-  definition: "A component in vCluster that synchronizes resources between the virtual cluster and the host cluster, enabling virtual clusters to function while maintaining isolation."
-  related: ["vcluster", "virtual-cluster"]
+  definition: "A component in vCluster that synchronizes resources between the tenant cluster and the Control Plane Cluster, enabling tenant clusters to function while maintaining isolation."
+  related: ["vcluster", "tenant-cluster"]
   type: "vcluster"
   url: "/docs/vcluster/configure/vcluster-yaml/sync/"
 
 multi-tenancy:
-  term: "Multi-tenancy"
-  definition: "The capability to host multiple separate users, teams, or workloads on the same infrastructure while providing isolation between them. Virtual clusters enhance multi-tenancy in Kubernetes environments."
-  related: ["virtual-cluster"]
+  term: "Tenant Isolation"
+  definition: "The capability to host multiple separate users, teams, or workloads on the same infrastructure while providing strong isolation between them. vCluster delivers tenant isolation through dedicated control planes, isolated resource namespaces, and optional private nodes per tenant."
+  related: ["tenant-cluster"]
   type: "vcluster"
 
 k3s:
   term: "K3s"
-  definition: "A lightweight, certified Kubernetes distribution often used as the default distribution for virtual clusters due to its minimal resource requirements and fast startup time."
+  definition: "A lightweight, certified Kubernetes distribution often used as the default distribution for tenant clusters due to its minimal resource requirements and fast startup time."
   related: ["k8s", "k0s"]
   type: ["vcluster", "platform"]
   url: "https://k3s.io/"
 
 k8s:
   term: "K8s"
-  definition: "The standard Kubernetes distribution that can be used in virtual clusters, offering full compatibility with upstream Kubernetes features."
+  definition: "The standard Kubernetes distribution that can be used in tenant clusters, offering full compatibility with upstream Kubernetes features."
   related: ["k3s", "k0s"]
   type: ["vcluster", "platform"]
   url: "https://kubernetes.io/"
 
 k0s:
   term: "K0s"
-  definition: "A lightweight, certified Kubernetes distribution that can be used in virtual clusters as an alternative to K3s or standard Kubernetes."
+  definition: "A lightweight, certified Kubernetes distribution that can be used in tenant clusters as an alternative to K3s or standard Kubernetes."
   related: ["k3s", "k8s"]
   type: ["vcluster", "platform"]
   url: "https://k0sproject.io/"
 
 platform:
   term: "The Platform"
-  definition: "The vCluster Platform that provides management, access control, and operational features for virtual clusters across multiple physical host clusters."
+  definition: "The vCluster Platform that provides management, access control, and operational features for tenant clusters across multiple Control Plane Clusters."
   related: ["project"]
   type: "platform"
 
 project:
   term: "Project"
-  definition: "A logical grouping of resources in the platform that provides team isolation and resource quotas. Projects help organize virtual clusters and namespace resources."
+  definition: "A logical grouping of resources in the platform that provides team isolation and resource quotas. Projects help organize tenant clusters and namespace resources."
   related: ["platform", "team"]
   type: "platform"
 
@@ -95,13 +95,13 @@ user:
 
 template:
   term: "Template"
-  definition: "A reusable configuration pattern in the platform that defines the settings and resources for creating new virtual clusters or namespaces."
+  definition: "A reusable configuration pattern in the platform that defines the settings and resources for creating new tenant clusters or namespaces."
   related: ["platform", "virtual-cluster-template"]
   type: "platform"
 
 virtual-cluster-template:
-  term: "Virtual Cluster Template"
-  definition: "A predefined configuration in the platform for creating virtual clusters with consistent settings, policies, and resources."
+  term: "Tenant Cluster Template"
+  definition: "A predefined configuration in the platform for creating tenant clusters with consistent settings, policies, and resources."
   related: ["template"]
   type: "platform"
 
@@ -119,13 +119,13 @@ access-key:
 
 sleep-mode:
   term: "Auto Sleep"
-  definition: "A platform feature that allows virtual clusters or namespaces to be paused when inactive, conserving resources and reducing costs."
+  definition: "A platform feature that allows tenant clusters or namespaces to be paused when inactive, conserving resources and reducing costs."
   related: ["platform"]
   type: "platform"
 
 sleep:
   term: "Auto Sleep"
-  definition: "A platform feature that allows virtual clusters or namespaces to be paused when inactive, conserving resources and reducing costs."
+  definition: "A platform feature that allows tenant clusters or namespaces to be paused when inactive, conserving resources and reducing costs."
   related: ["platform"]
   type: "platform"
 
@@ -138,7 +138,7 @@ api-server:
 
 control-plane:
   term: "Control Plane"
-  definition: "The container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers. In vCluster, each virtual cluster has its own control plane components."
+  definition: "The container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers. In vCluster, each tenant cluster has its own control plane components."
   related: ["api-server", "vcluster"]
   type: ["vcluster", "platform"]
 

--- a/vcluster/_fragments/how-does-syncing-work.mdx
+++ b/vcluster/_fragments/how-does-syncing-work.mdx
@@ -1,4 +1,4 @@
-Since a virtual cluster lacks actual worker nodes and its own network, syncing is the process by which vCluster replicates resources between the virtual cluster and the host cluster. 
+Since a tenant cluster lacks actual worker nodes and its own network, syncing is the process by which vCluster replicates resources between the tenant cluster and the Control Plane Cluster. 
 This capability is handled by a component called the syncer, deployed by vCluster. The syncer is the core mechanism that enables vCluster to emulate a fully functional Kubernetes cluster. 
 When the syncer fails or malfunctions, it can lead to resource inconsistencies, application failures, state drift, and operational errors.
 
@@ -7,26 +7,26 @@ enable many other resources for all use cases. vCluster control plane runs with 
 extra permissions to sync, which are automatically given to the vCluster ServiceAccount if you enable a resource that requires additional 
 permissions. 
 
-All fields of a resources are synced from either the virtual cluster to the host cluster or the inverse (i.e. from the host cluster to the virtual cluster). The direction on how
+All fields of a resources are synced from either the tenant cluster to the Control Plane Cluster or the inverse (i.e. from the Control Plane Cluster to the tenant cluster). The direction on how
 the sync of the resources is based on what section the resource is part of in the `vcluster.yaml`. There 
 are a few exceptions for each resource where specific fields are kept in sync in both directions (i.e. bi-directional sync). 
 
-If the resource is being asked to sync from the virtual cluster to the host cluster, vCluster copies the resources from the vCluster and sends it to the host cluster to be created. There are 
-a couple of additional labels added to the host cluster resource object for vCluster to keep it in sync. The syncer starts watching for changes to the resource on either side. When the resource
-is updated in the virtual cluster, the syncer copies those changes in host cluster. 
+If the resource is being asked to sync from the tenant cluster to the Control Plane Cluster, vCluster copies the resources from the tenant cluster and sends it to the Control Plane Cluster to be created. There are 
+a couple of additional labels added to the Control Plane Cluster resource object for vCluster to keep it in sync. The syncer starts watching for changes to the resource on either side. When the resource
+is updated in the tenant cluster, the syncer copies those changes in the Control Plane Cluster. 
 
 :::warning Syncing will overwrite resources
-When you enable a sync, the syncer will usually copy changes in one direction. For example, if you are syncing pods from the virtual cluster to the host cluster, when changes
-are made to one of the pods in the host cluster, those fields are overwritten when the sync occurs. There are a couple of fields that are exceptions that are supported due to bi-directional sync. 
+When you enable a sync, the syncer will usually copy changes in one direction. For example, if you are syncing pods from the tenant cluster to the Control Plane Cluster, when changes
+are made to one of the pods in the Control Plane Cluster, those fields are overwritten when the sync occurs. There are a couple of fields that are exceptions that are supported due to bi-directional sync. 
 :::
 
-If the resource is being asked to sync from the host cluster to the virtual cluster, as soon as that resource is created in the host cluster, vCluster copies it to the virtual cluster. 
-Any changes to the resource in the host cluster are automatically applied to the resource in the virtual cluster.
+If the resource is being asked to sync from the Control Plane Cluster to the tenant cluster, as soon as that resource is created in the Control Plane Cluster, vCluster copies it to the tenant cluster. 
+Any changes to the resource in the Control Plane Cluster are automatically applied to the resource in the tenant cluster.
 
 When syncing resources, vCluster stores the mapping of the `VIRTUAL NAME <-> HOST NAME` for the actual resource, and the references of the other resources used by this resource. 
-Tracking references helps the vCluster to understand what resources are still needed in the host cluster. This important for secrets and configmaps because by default only the secrets and configmaps used by pods are actually synced to the host cluster.
+Tracking references helps the vCluster to understand what resources are still needed in the Control Plane Cluster. This important for secrets and configmaps because by default only the secrets and configmaps used by pods are actually synced to the Control Plane Cluster.
 
-Assume you've started your vCluster with ingress syncing to the host enabled. The `sync` field will automatically deploy syncer to sync resources between virtual cluster and the host cluster.
+Assume you've started your vCluster with ingress syncing to the host enabled. The `sync` field will automatically deploy syncer to sync resources between the tenant cluster and the Control Plane Cluster.
 
 ``` vcluster.yaml
 sync:
@@ -35,7 +35,7 @@ sync:
       enabled: true
 ```
 
-After the virtual cluster is up, the user creates an ingress in the virtual cluster.
+After the tenant cluster is up, the user creates an ingress in the tenant cluster.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -59,12 +59,12 @@ spec:
               number: 80
 ```
 
-When vCluster copies the ingress to the host cluster, the vCluster creates an ingress in the namespace of the virtual cluster with the following changes:
+When vCluster copies the ingress to the Control Plane Cluster, the vCluster creates an ingress in the namespace of the tenant cluster with the following changes:
 
-* **Name Rewritten**: vCluster rewrites the name of the resource to avoid conflicts in the host cluster. The name is rewritten in the form of `NAME-x-NAMESPACE-x-VCLUSTER_NAME`
-* **Namespace Rewritten**: vCluster rewrites the namespace of the resource to sync everything into the namespace of the deployed virtual cluster control plane.
-* **Annotations / Labels Added**: vCluster adds annotations and labels to identify the resource in the host cluster, which are pre-fixed with `vcluster.loft.sh/`.
-* **References Rewritten**: vCluster rewrites the `spec.rules[*].http.paths[*].backend.service.name` and `spec.tls[*].secretName` to match the rewritten names of the resources in the host cluster.
+* **Name Rewritten**: vCluster rewrites the name of the resource to avoid conflicts in the Control Plane Cluster. The name is rewritten in the form of `NAME-x-NAMESPACE-x-VCLUSTER_NAME`
+* **Namespace Rewritten**: vCluster rewrites the namespace of the resource to sync everything into the namespace of the deployed tenant cluster control plane.
+* **Annotations / Labels Added**: vCluster adds annotations and labels to identify the resource in the Control Plane Cluster, which are pre-fixed with `vcluster.loft.sh/`.
+* **References Rewritten**: vCluster rewrites the `spec.rules[*].http.paths[*].backend.service.name` and `spec.tls[*].secretName` to match the rewritten names of the resources in the Control Plane Cluster.
 
 
 ```yaml
@@ -100,12 +100,12 @@ spec:
     secretName: testsecret-tls-x-default-x-vcluster
 ```
 
-### Sync labels to the host cluster
+### Sync labels to the Control Plane Cluster
 
-When syncing labels to the host cluster, vCluster rewrites the following labels to avoid conflicts:
+When syncing labels to the Control Plane Cluster, vCluster rewrites the following labels to avoid conflicts:
 
 * `release` - This label must be rewritten when pods are synced to the single namespace where the vCluster control plane pod is running, but 
-not rewritten when the pod is synced in a namespace that is synced from the virtual cluster to the host cluster. 
+not rewritten when the pod is synced in a namespace that is synced from the tenant cluster to the Control Plane Cluster. 
 * `vcluster.loft.sh/namespace`
 * `vcluster.loft.sh/managed-by`
 * `vcluster.loft.sh/controlled-by`

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -5,14 +5,14 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx';
 
 Patches override the default resource syncing rules in your `vcluster.yaml` configurations.
 
-By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sync/) between virtual and host clusters. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
+By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sync/) between tenant clusters and the Control Plane Cluster. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
 
-For example, vCluster can mirror resources from the virtual cluster to the host cluster—any changes made in the virtual cluster are automatically applied to the host cluster. The same applies in the other direction if syncing is set up from host to virtual cluster.
+For example, vCluster can mirror resources from the tenant cluster to the Control Plane Cluster—any changes made in the tenant cluster are automatically applied to the Control Plane Cluster. The same applies in the other direction if syncing is set up from the Control Plane Cluster to the tenant cluster.
 
 vCluster supports two patch types:
 
-- [JavaScript expression patch](#javascript-expression-patch): Uses JavaScript ES6 expressions to dynamically modify fields during syncing. You can define how a field changes when syncing from a virtual cluster to a host cluster, or from a host cluster to a virtual cluster.
-- [Reference patch](#reference-patch): Modifies specific fields within a resource to point to different resources. If the referenced resource exists in the host cluster, vCluster automatically imports it into the virtual cluster. If the referenced resource exists in the virtual cluster and syncing is configured, vCluster can import it into the host cluster.
+- [JavaScript expression patch](#javascript-expression-patch): Uses JavaScript ES6 expressions to dynamically modify fields during syncing. You can define how a field changes when syncing from a tenant cluster to the Control Plane Cluster, or from the Control Plane Cluster to a tenant cluster.
+- [Reference patch](#reference-patch): Modifies specific fields within a resource to point to different resources. If the referenced resource exists in the Control Plane Cluster, vCluster automatically imports it into the tenant cluster. If the referenced resource exists in the tenant cluster and syncing is configured, vCluster can import it into the Control Plane Cluster.
 
 :::info Using wildcards in patches
 You can apply a wildcard, using an asterisk (`*`) in a specified path, to modify all elements of an array or object.
@@ -22,7 +22,7 @@ When using the asterisk (`*`) notation, vCluster applies changes individually to
 
 ### JavaScript expression patch
 
-A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters.
+A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between tenant clusters and the Control Plane Cluster.
 This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
 :::note JavaScript Runtime
@@ -40,18 +40,18 @@ You can define a path for <code>{props.path}</code> field in `vcluster.yaml` usi
       patches:
       - path: ${props.path}
         expression: '"my-prefix-"+value'
-        # optional reverseExpression to reverse the change from the host cluster
+        # optional reverseExpression to reverse the change from the Control Plane Cluster
         # reverseExpression: 'value.slice("my-prefix".length)'`}
 </CodeBlock>
 
 In the example:
 
-  - The path targets the <code>{props.path}</code> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
-  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{props.path}</code> field in the host cluster.
+  - The path targets the <code>{props.path}</code> field to override when syncing to the Control Plane Cluster. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{props.path}</code> field in the Control Plane Cluster.
 
 :::note Reverse sync
-You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
-For example, add `reverseExpression: {"value.slice('my-prefix'.length)"}` to `vcluster.yaml` to remove the `"my-prefix-"` prefix when syncing back from the host cluster to the virtual cluster in the previous example.
+You can use the `reverseExpression` field to define how to revert changes when syncing from the Control Plane Cluster back to the tenant cluster.
+For example, add `reverseExpression: {"value.slice('my-prefix'.length)"}` to `vcluster.yaml` to remove the `"my-prefix-"` prefix when syncing back from the Control Plane Cluster to the tenant cluster in the previous example.
 :::
 
 To replace value with a hardcoded one, put the desired value in the quotation marks:
@@ -97,16 +97,16 @@ These functions are useful for encoding/decoding values or translating services 
 :::
 
 There are two kinds of expression categories in the configuration:
-- `expression` — Specifies the synchronization rules from virtual clusters to the host cluster.
-Use this to control which resources, fields, or attributes in the virtual clusters are reflected in the host cluster.
-- `reverseExpression` — Specifies the synchronization rules from the host cluster to the virtual clusters.
-Use this to control how updates or resources in the host cluster are propagated back to the virtual clusters.
+- `expression` — Specifies the synchronization rules from tenant clusters to the Control Plane Cluster.
+Use this to control which resources, fields, or attributes in the tenant clusters are reflected in the Control Plane Cluster.
+- `reverseExpression` — Specifies the synchronization rules from the Control Plane Cluster to the tenant clusters.
+Use this to control how updates or resources in the Control Plane Cluster are propagated back to the tenant clusters.
 :::warning
-If `expression` is not defined, no patches will be applied during synchronization from the virtual clusters to the host cluster. 
-Likewise, if `reverseExpression` is not defined, no patches will be applied during synchronization from the host cluster back to the virtual clusters.
+If `expression` is not defined, no patches will be applied during synchronization from the tenant clusters to the Control Plane Cluster. 
+Likewise, if `reverseExpression` is not defined, no patches will be applied during synchronization from the Control Plane Cluster back to the tenant clusters.
 
-For example, when `expression` is used to apply patches and modify an object in a virtual cluster, the corresponding `reverseExpression` should
- also be defined. This ensures that when the modified object is synchronized from the host cluster back to the virtual clusters,
+For example, when `expression` is used to apply patches and modify an object in a tenant cluster, the corresponding `reverseExpression` should
+ also be defined. This ensures that when the modified object is synchronized from the Control Plane Cluster back to the tenant clusters,
   the `reverseExpression` patches can transform it back to its original form.
 
 To prevent unintended modifications of the synced objects in either direction, define both `expression` and `reverseExpression`,
@@ -127,26 +127,26 @@ sync:
 
 #### Context variable
 
-The context variable is an object supported in JavaScript expression patches, that provides access to virtual cluster data during syncing. The context object includes the following properties:
+The context variable is an object supported in JavaScript expression patches, that provides access to tenant cluster data during syncing. The context object includes the following properties:
 
-* `context.vcluster.name`: Name of the virtual cluster.
-* `context.vcluster.namespace`: Namespace of the virtual cluster.
-* `context.vcluster.config`: Configuration of the virtual cluster, basically `vcluster.yaml` merged with the defaults.
+* `context.vcluster.name`: Name of the tenant cluster.
+* `context.vcluster.namespace`: Namespace of the tenant cluster.
+* `context.vcluster.config`: Configuration of the tenant cluster, basically `vcluster.yaml` merged with the defaults.
 * `context.hostObject`: Host object (`null` if not available).
 * `context.virtualObject`: Virtual object (`null` if not available).
 * `context.path`: Matched path on the object, useful when using wildcard path selectors (`*`).
 
 ### Reference patch
 
-A reference patch links a field in one resource to another resource. During syncing, vCluster updates the reference and imports the linked resource from the virtual cluster to the host cluster or from the host cluster to the virtual cluster, depending on the sync direction and whether the resource exists.
+A reference patch links a field in one resource to another resource. During syncing, vCluster updates the reference and imports the linked resource from the tenant cluster to the Control Plane Cluster or from the Control Plane Cluster to the tenant cluster, depending on the sync direction and whether the resource exists.
 
 You can use reference patches to share resources, such as `Secrets` or `ConfigMaps`, between clusters without manually recreating or duplicating them.
 
-For example, if the host cluster contains a secret named `"my-example-secret"`, vCluster automatically imports it into the virtual cluster.
+For example, if the Control Plane Cluster contains a secret named `"my-example-secret"`, vCluster automatically imports it into the tenant cluster.
 
-Workloads in the virtual cluster can then use the secret without manual syncing.
+Workloads in the tenant cluster can then use the secret without manual syncing.
 
-You can sync between the virtual cluster and the host cluster by mapping `spec.secretName` to a secret in the host cluster:
+You can sync between the tenant cluster and the Control Plane Cluster by mapping `spec.secretName` to a secret in the Control Plane Cluster:
 
 <CodeBlock language="yaml">
 {`sync:
@@ -163,7 +163,7 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 In the example:
 
 - The code uses a patch to add `metadata.annotations["my-secret-ref"]`
-- It references a Secret in the host cluster using the patch and ensures <code>{props.resource}</code> in the host cluster links to the correct Secret.
+- It references a Secret in the Control Plane Cluster using the patch and ensures <code>{props.resource}</code> in the Control Plane Cluster links to the correct Secret.
 
 :::note Reference Patches with Namespace Syncing
 If you have enabled syncing namespaces, reference patches are only required if the namespace is part of the patch. You can use the `namespacePath` option to specify the path of the namespace of the reference.

--- a/vcluster/_partials/what-are-virtual-clusters.mdx
+++ b/vcluster/_partials/what-are-virtual-clusters.mdx
@@ -1,7 +1,7 @@
 import GlossaryTerm from '@site/src/components/GlossaryTerm'
 
 <!-- vale off -->
-<GlossaryTerm term="virtual-cluster">Virtual clusters</GlossaryTerm> are certified Kubernetes distributions that run as isolated, virtual environments nested inside a physical <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>. They improve isolation and flexibility for <GlossaryTerm term="multi-tenancy">multi-tenancy</GlossaryTerm> by allowing multiple teams to operate independently on the same infrastructure, minimizing conflicts, increasing autonomy, and reducing costs.
+<GlossaryTerm term="virtual-cluster">Virtual clusters</GlossaryTerm> are certified Kubernetes distributions that run as isolated, virtual environments nested inside a physical <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>. They improve isolation and flexibility for <GlossaryTerm term="multi-tenancy">tenant isolation</GlossaryTerm> by allowing multiple teams to operate independently on the same infrastructure, minimizing conflicts, increasing autonomy, and reducing costs.
 
 <figure>
 <img
@@ -16,7 +16,7 @@ Virtual clusters run inside host cluster namespaces but operate as independent K
 Although they rely on the host cluster for resource scheduling and networking, virtual clusters maintain a level of abstraction that isolates their operations from the host cluster's global state.
 
 ## Benefits
-Virtual clusters provide immense benefits for large-scale Kubernetes deployments and multi-tenancy.
+Virtual clusters provide immense benefits for large-scale Kubernetes deployments and tenant isolation.
 
 <figure>
 <img
@@ -45,7 +45,7 @@ Virtual clusters provide immense benefits for large-scale Kubernetes deployments
 
   - **Lightweight infrastructure:** Virtual clusters are significantly more lightweight than physical clusters and can spin up in seconds, contrasting sharply with the lengthy provisioning times often seen in environments like EKS (~45 minutes).
   - **Resource efficiency:** By sharing the underlying host cluster's resources, virtual clusters minimize the need for additional physical infrastructure, reducing costs and environmental impact.
-  - **Simplified management:** The vCluster control plane, running inside a single pod along with optional integrated CoreDNS, minimizes operational overhead, making virtual clusters especially suitable for large-scale deployments and multi-tenancy scenarios.
+  - **Simplified management:** The vCluster control plane, running inside a single pod along with optional integrated CoreDNS, minimizes operational overhead, making virtual clusters especially suitable for large-scale deployments and tenant isolation scenarios.
 
 
 ### Enhanced flexibility and compatibility

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -42,7 +42,7 @@ controlPlane:
         tag: v1.32.1                # Default: v1.32.1 (or matches host Kubernetes version)
 ```
 
-The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>'s Kubernetes version.
+The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm>'s Kubernetes version.
 
 :::note
 The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.
@@ -50,7 +50,7 @@ The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.dis
 
 ## Configure API server rate limiting {#api-server-rate-limiting}
 
-You can configure rate limiting for the vCluster API server to control the maximum number of requests it handles. This helps prevent the <GlossaryTerm term="virtual-cluster">virtual cluster</GlossaryTerm> from being overwhelmed and ensures stable performance under high load.
+You can configure rate limiting for the vCluster API server to control the maximum number of requests it handles. This helps prevent the <GlossaryTerm term="virtual-cluster">tenant cluster</GlossaryTerm> from being overwhelmed and ensures stable performance under high load.
 
 Use the `extraArgs` field to pass rate limiting flags to the API server:
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
@@ -36,7 +36,7 @@ It also gives you centralized control over which DeviceClass teams can access.
 This approach is useful in scenarios where selective access to DeviceClass configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the DeviceClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own DeviceClass resources while sharing a single host cluster.
+- **Tenant isolation**: Enable teams to use their own DeviceClass resources while sharing a single Control Plane Cluster.
 - **Security**: Restrict the DeviceClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 <EnableSyncing resourceClass="DeviceClass" pluralResourceClass="deviceClasses" />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -25,7 +25,7 @@ This saves resources since you don't need separate ingress controllers in every 
 This approach is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the IngressClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own IngressClass resources while sharing a single host cluster.
+- **Tenant isolation**: Enable teams to use their own IngressClass resources while sharing a single Control Plane Cluster.
 - **Security**: Restrict the IngressClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 <ClassSyncing showResource="true" lowercaseResource="ingress" resource="Ingress" pluralResource="ingresses" lowercaseResourceClass="ingressclass" resourceClass="IngressClass" pluralResourceClass="ingressClasses" resourceClassName="IngressClassName" expressionKey="kubernetes.io/ingress.class" expressionValue1="istio" expressionValue2="traefik" />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -29,7 +29,7 @@ This approach provides centralized control over runtime configurations and ensur
 
 - **Development environments**: Sync only required RuntimeClasses to reduce noise and avoid unnecessary exposure to production runtime configurations.
 
-- **Multi-tenancy**: Enable teams to use specific runtime configurations while preventing access to incompatible or resource-intensive runtimes that could affect other tenants. Each team gets only the runtime classes appropriate for their workloads and security requirements.
+- **Tenant isolation**: Enable teams to use specific runtime configurations while preventing access to incompatible or resource-intensive runtimes that could affect other tenants. Each team gets only the runtime classes appropriate for their workloads and security requirements.
 
 - **Compliance**: Maintain strict control over container runtime configurations by defining runtime classes once in the host cluster and making only approved runtime configurations available to virtual clusters. All workloads use compliant runtime settings.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -24,7 +24,7 @@ You can enable this feature to sync StorageClass resources from the host cluster
 
 - **Cost control**: Restrict access to specific storage classes based on cost or performance characteristics.
 - **Compliance**: Control which storage backends and configurations are available to virtual clusters.
-- **Multi-tenancy**: Provide different storage options to different teams while preventing access to restricted storage types.
+- **Tenant isolation**: Provide different storage options to different teams while preventing access to restricted storage types.
 - **Simplified management**: Update storage class configurations in the host cluster rather than in each virtual cluster.
 - **Security**: Control access to storage backends and encryption options.
 

--- a/vcluster/third-party-integrations/pod-identity/eks-pod-identity.mdx
+++ b/vcluster/third-party-integrations/pod-identity/eks-pod-identity.mdx
@@ -29,7 +29,7 @@ import TenancySupport from '../../_fragments/tenancy-support.mdx';
 This tutorial guides you through the process of integrating AWS Service Accounts with your <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> using Pod Identity.
 
 Setting up Pod Identity requires you to link an AWS Service Account with the Kubernetes Service Account (KSA) used by your workloads.
-This KSA needs to be available in the <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm> in which your vCluster instance runs.
+This KSA needs to be available in the <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm> in which your vCluster instance runs.
 
 To achieve this setup, use the [sync.toHost feature][sync-toHost-docs] to expose the KSA in the host cluster together with the <GlossaryTerm term="platform">platform</GlossaryTerm> API to retrieve the updated name of the KSA in the host cluster.
 

--- a/vcluster/third-party-integrations/scheduler/kai-scheduler.mdx
+++ b/vcluster/third-party-integrations/scheduler/kai-scheduler.mdx
@@ -20,7 +20,7 @@ NVIDIA KAI scheduler is the open source version of NVIDIA Run:ai's scheduler tec
 
 ## Prerequisites {#prerequisites}
 <BasePrerequisites />
-- KAI scheduler installed in the <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>
+- KAI scheduler installed in the <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm>
 
 ## Understand the challenge {#understand-the-challenge}
 

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -54,7 +54,7 @@ The `NOSPACE` alarm occurs due to two common conditions:
 
 - **Excessive etcd data growth:** A large number of objects—such as Deployments, ConfigMaps, and Secrets—can fill etcd’s storage if regular <GlossaryTerm term="compaction">compaction</GlossaryTerm> is not performed.
 
-- **Synchronization conflicts:** Conflicting objects between the vCluster and <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm> can trigger continuous sync loops. For example, a Custom Resource Definition (CRD) modified by the host cluster might sync back to the vCluster repeatedly. This behavior quickly fills etcd’s backend storage.
+- **Synchronization conflicts:** Conflicting objects between the vCluster and <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm> can trigger continuous sync loops. For example, a Custom Resource Definition (CRD) modified by the Control Plane Cluster might sync back to the vCluster repeatedly. This behavior quickly fills etcd’s backend storage.
 
 ## Solution
 

--- a/vcluster/understand/volume-snapshots.mdx
+++ b/vcluster/understand/volume-snapshots.mdx
@@ -20,27 +20,27 @@ This section start with describing who or what is responsible for which part of 
 
 **Host cluster user**:
 - Runs the vCluster CLI commands;
-- Installs snapshot-controller and CSI driver in the host or in the virtual cluster, depending on the multi-tenancy model.
+- Installs snapshot-controller and CSI driver in the host or in the virtual cluster, depending on the tenancy model.
 
 **vCluster CLI**:
 - Creates snapshot requests in the host cluster.
 
 **vCluster**:
 - Processes and updates snapshot request that are created in the host cluster;
-- Creates dynamic VolumeSnapshots in the host or in the virtual cluster, depending on the multi-tenancy model.
+- Creates dynamic VolumeSnapshots in the host or in the virtual cluster, depending on the tenancy model.
 
 **Kubernetes snapshot-controller**:
-- Runs in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs in the host or in the virtual cluster, depending on the tenancy model;
 - Processes and updates dynamic VolumeSnapshots;
 - Creates VolumeSnapshotContent resources.
 
 **External snapshotter CSI driver sidecar**:
-- Runs as a sidecar container in the CSI driver pod in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs as a sidecar container in the CSI driver pod in the host or in the virtual cluster, depending on the tenancy model;
 - Processes VolumeSnapshotContent resources;
 - Makes calls to the CSI driver via RPCs (CreateSnapshot, DeleteSnapshot, and, optionally, the ListSnapshots).
 
 **CSI Driver**:
-- Runs in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs in the host or in the virtual cluster, depending on the tenancy model;
 - Makes provider-specific API calls to create, delete, or list provider-specific disk snapshots.
 
 ### Create volume snapshots with shared host nodes
@@ -160,7 +160,7 @@ This section describes who or what is responsible for which part of the volume r
 
 **Host cluster user**:
 - Runs the vCluster CLI commands;
-- Installs snapshot-controller and CSI driver in the host or in the virtual cluster, depending on the multi-tenancy model.
+- Installs snapshot-controller and CSI driver in the host or in the virtual cluster, depending on the tenancy model.
 
 **vCluster CLI**:
 - Downloads previously created snapshot archive from the snapshot location;
@@ -169,21 +169,21 @@ This section describes who or what is responsible for which part of the volume r
 
 **vCluster**:
 - Processes and updates restore request that are created in the host cluster;
-- Creates pre-provisioned VolumeSnapshotContent and VolumeSnapshot in the host or in the virtual cluster, depending on the multi-tenancy model. The pre-provisioned VolumeSnapshotContent references a volume snapshot that has been already created when vCluster snapshot was taken.
+- Creates pre-provisioned VolumeSnapshotContent and VolumeSnapshot in the host or in the virtual cluster, depending on the tenancy model. The pre-provisioned VolumeSnapshotContent references a volume snapshot that has been already created when vCluster snapshot was taken.
 - Creates PersistentVolumeClaims that reference the pre-provisioned VolumeSnapshot, so created volumes have data restored from the snapshot.
 - Syncs virtual PersistentVolumeClaims with restored PersistentVolumeClaims in the host cluster, if using shared nodes.
 
 **Kubernetes snapshot-controller**:
-- Runs in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs in the host or in the virtual cluster, depending on the tenancy model;
 - Processes and updates dynamic VolumeSnapshots;
 
 **External snapshotter CSI driver sidecar**:
-- Runs as a sidecar container in the CSI driver pod in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs as a sidecar container in the CSI driver pod in the host or in the virtual cluster, depending on the tenancy model;
 - Processes and updates VolumeSnapshotContent resources;
 - Makes calls to the CSI driver via RPCs (ListSnapshots, if implemented).
 
 **CSI Driver**:
-- Runs in the host or in the virtual cluster, depending on the multi-tenancy model;
+- Runs in the host or in the virtual cluster, depending on the tenancy model;
 - Makes provider-specific API calls to list provider-specific disk snapshots.
 
 ### Restore volumes with shared host nodes


### PR DESCRIPTION
# Content Description

Applies current terminology across high-impact shared files as part of the docs repositioning project (DOC-1286). Phase 1 fixes `multi-tenancy` → `tenant isolation` and updates foundational data files. Phase 2 updates the three highest-leverage fragment/partial files that are imported across hundreds of pages.

**Phase 1 — multi-tenancy and foundational data:**
- `multi-tenancy` → `tenant isolation` in `volume-snapshots.mdx`, four sync class pages, and `_partials/what-are-virtual-clusters.mdx`
- `glossary.yaml`: all term definitions updated to current terminology (tenant cluster, Control Plane Cluster, tenant isolation); `host-cluster` and `virtual-cluster` display terms updated
- `features.yaml`: skipped — upstream-synced from `admin-apis`; requires a coordinated upstream change

**Phase 2 — high-leverage fragments (propagate to all importing pages):**
- `_fragments/patches.mdx`: `virtual cluster` → `tenant cluster`, `host cluster` → `Control Plane Cluster` throughout all prose
- `_fragments/how-does-syncing-work.mdx`: same
- `docs/_partials/platform/virtual-cluster-content.mdx`: full update including all three term types

## Preview Link

Base: `https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs`

- [`/docs/vcluster/next/understand/volume-snapshots`](https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs/vcluster/next/understand/volume-snapshots)
- [`/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/storage-classes`](https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/storage-classes)
- [`/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/runtime-classes`](https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/runtime-classes)
- [`/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/ingress-classes`](https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/ingress-classes)
- [`/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/device-classes`](https://deploy-preview-{PR}--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/device-classes)

Fragment changes propagate to all pages importing `patches.mdx` and `how-does-syncing-work.mdx` (sync config docs throughout `configure/vcluster-yaml/sync/`).

## Internal Reference

Partially addresses DOC-1286


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs