### PR TITLE
docs(skills): retarget vcluster-docs-writer dependency to vcluster-brand plugin

### DIFF
--- a/.claude/skills/vcluster-docs-writer/SKILL.md
+++ b/.claude/skills/vcluster-docs-writer/SKILL.md
@@ -10,7 +10,7 @@ Specialized knowledge and workflows for writing vCluster documentation in Docusa
 
 ## Dependencies
 
-When this skill is loaded, also invoke: `vcluster-skills-shared:vcluster-branding`
+When this skill is loaded, also invoke: `vcluster-brand:vcluster-brand`
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

`vcluster-docs-writer/SKILL.md` line 13 auto-invokes `vcluster-skills-shared:vcluster-branding`. That shared skill is being removed in loft-sh/ai-skills#75 in favour of the standalone `vcluster-brand` plugin (voice + visual + bundled assets).

Retarget the dependency so docs writers keep getting brand guidance once ai-skills#75 merges.

## Merge order

Land loft-sh/ai-skills#75 first, then this.

- If this merges first → reference still points at a skill that exists (harmless)
- If ai-skills#75 merges first → reference is broken until this lands

## Test plan

- [ ] After ai-skills#75 merges, pulling main here loads `vcluster-brand:vcluster-brand` successfully
- [ ] Editing any `.mdx` in vcluster-docs triggers both `vcluster-docs-writer` and the brand skill