### PR TITLE
chore: fix broken links for vcluster-v0.29 archive

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -81,7 +81,7 @@ import Link from '@docusaurus/Link';
 ## Where do you want to start?
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '1.25rem', marginBottom: '3rem'}}>
-  <Link to="/vcluster/quick-start/standalone" className="audience-card">
+  <Link to="/vcluster/quick-start-guide" className="audience-card">
     <span className="audience-label">AI Cloud &amp; GPU Platforms</span>
     <h3>Build a managed Kubernetes platform</h3>
     <p>Deliver dedicated tenant clusters over GPU infrastructure. Full isolation, no cluster-per-tenant overhead.</p>
@@ -119,7 +119,7 @@ import Link from '@docusaurus/Link';
         <h4 style={{margin: 0, fontSize: '1rem'}}>Architecture</h4>
         <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Control plane, tenancy models, and syncer internals.</p>
       </Link>
-      <Link to="/vcluster/deploy/control-plane/kubernetes-pod/basics" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
+      <Link to="/vcluster/deploy/control-plane/container/basics" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Deploy</h4>
         <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Deploy tenant clusters with Helm, CLI, Terraform, or ArgoCD.</p>
       </Link>

--- a/platform/administer/clusters/advanced/external-database/deploy.mdx
+++ b/platform/administer/clusters/advanced/external-database/deploy.mdx
@@ -77,7 +77,7 @@ because the `gp2` storage class cannot provision volumes.
 />
 
 For more details on EKS prerequisites for running virtual clusters, see the
-[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/container/environment/eks).
 
 ### Note the EKS VPC ID and CIDR
 

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -484,4 +484,4 @@ Additional cloud-init configuration appended to the generated user data.
 
 ## Try it yourself
 
-The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints — no physical hardware required.
+The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/vcluster/deploy/control-plane/container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints — no physical hardware required.

--- a/platform/how-to/gitops-end-to-end.mdx
+++ b/platform/how-to/gitops-end-to-end.mdx
@@ -288,7 +288,7 @@ spec:
   title="vcluster-application.yaml"
 />
 
-For the full list of deployment options including CLI, Terraform, and Flux, see the [deploy vCluster guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/basics).
+For the full list of deployment options including CLI, Terraform, and Flux, see the [deploy vCluster guide](/docs/vcluster/deploy/control-plane/container/basics).
 
 ## Manage GitOps drift
 

--- a/platform/install/air-gapped/with-offline-license-key.mdx
+++ b/platform/install/air-gapped/with-offline-license-key.mdx
@@ -736,13 +736,13 @@ With your vCluster Platform now installed and configured for air-gapped environm
 
 :::tip Choose the Right Guide
 
-After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual virtual clusters](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped):
+After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual virtual clusters](/docs/vcluster/deploy/control-plane/container/security/air-gapped):
 
 **Continue with this platform air-gapped guide if you need to:**
 - Create virtual clusters and connect more host cluster agents without internet access.
 - Configure additional platform-wide private registry settings.
 
-**Use the [vCluster air-gapped deployment guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped) to:**
+**Use the [vCluster air-gapped deployment guide](/docs/vcluster/deploy/control-plane/container/security/air-gapped) to:**
 - Create virtual clusters after the platform is set up.
 - Review detailed vCluster configuration options for air-gapped environments.
 :::

--- a/platform/use-platform/virtual-clusters/key-features/sleep-mode.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/sleep-mode.mdx
@@ -36,7 +36,7 @@ To configure auto sleep in the Platform UI:
 
 You can also start sleep manually from the virtual cluster's ellipsis menu in the Platform UI.
 
-For detailed vCluster-specific sleep mode configuration and examples, including `vcluster.yaml` settings, scheduled sleep, and advanced configuration, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep).
+For detailed vCluster-specific sleep mode configuration and examples, including `vcluster.yaml` settings, scheduled sleep, and advanced configuration, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Configure auto-delete
 
@@ -50,7 +50,7 @@ To configure auto-delete in the Platform UI:
 4. Enable auto-delete and configure the inactivity timeout.
 5. Click **Save**.
 
-For detailed configuration options, see the [vCluster auto-delete documentation](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete).
+For detailed configuration options, see the [vCluster auto-delete documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode#configure-auto-delete).
 
 ## Inactivity detection
 
@@ -58,4 +58,4 @@ All requests that are made through the platform count as activity in the virtual
 
 The platform tracks activity based on requests that are proxied through the platform. Direct access to the virtual cluster API server (for example, via ingress access) is not tracked by the platform's inactivity detection.
 
-If you need more advanced activity detection, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep) for configuration options including custom activity annotations.
+If you need more advanced activity detection, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode) for configuration options including custom activity annotations.

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/metal3.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/metal3.mdx
@@ -484,4 +484,4 @@ Additional cloud-init configuration appended to the generated user data.
 
 ## Try it yourself
 
-The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints — no physical hardware required.
+The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/docs/vcluster/deploy/control-plane/container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints — no physical hardware required.

--- a/platform_versioned_docs/version-4.8.0/how-to/gitops-end-to-end.mdx
+++ b/platform_versioned_docs/version-4.8.0/how-to/gitops-end-to-end.mdx
@@ -288,7 +288,7 @@ spec:
   title="vcluster-application.yaml"
 />
 
-For the full list of deployment options including CLI, Terraform, and Flux, see the [deploy vCluster guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/basics).
+For the full list of deployment options including CLI, Terraform, and Flux, see the [deploy vCluster guide](/docs/vcluster/deploy/control-plane/container/basics).
 
 ## Manage GitOps drift
 

--- a/platform_versioned_docs/version-4.8.0/install/air-gapped/with-offline-license-key.mdx
+++ b/platform_versioned_docs/version-4.8.0/install/air-gapped/with-offline-license-key.mdx
@@ -736,13 +736,13 @@ With your vCluster Platform now installed and configured for air-gapped environm
 
 :::tip Choose the Right Guide
 
-After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual virtual clusters](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped):
+After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual virtual clusters](/docs/vcluster/deploy/control-plane/container/security/air-gapped):
 
 **Continue with this platform air-gapped guide if you need to:**
 - Create virtual clusters and connect more host cluster agents without internet access.
 - Configure additional platform-wide private registry settings.
 
-**Use the [vCluster air-gapped deployment guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped) to:**
+**Use the [vCluster air-gapped deployment guide](/docs/vcluster/deploy/control-plane/container/security/air-gapped) to:**
 - Create virtual clusters after the platform is set up.
 - Review detailed vCluster configuration options for air-gapped environments.
 :::

--- a/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/key-features/sleep-mode.mdx
+++ b/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/key-features/sleep-mode.mdx
@@ -36,7 +36,7 @@ To configure auto sleep in the Platform UI:
 
 You can also start sleep manually from the virtual cluster's ellipsis menu in the Platform UI.
 
-For detailed vCluster-specific sleep mode configuration and examples, including `vcluster.yaml` settings, scheduled sleep, and advanced configuration, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep).
+For detailed vCluster-specific sleep mode configuration and examples, including `vcluster.yaml` settings, scheduled sleep, and advanced configuration, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Configure auto-delete
 
@@ -50,7 +50,7 @@ To configure auto-delete in the Platform UI:
 4. Enable auto-delete and configure the inactivity timeout.
 5. Click **Save**.
 
-For detailed configuration options, see the [vCluster auto-delete documentation](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete).
+For detailed configuration options, see the [vCluster auto-delete documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode#configure-auto-delete).
 
 ## Inactivity detection
 
@@ -58,4 +58,4 @@ All requests that are made through the platform count as activity in the virtual
 
 The platform tracks activity based on requests that are proxied through the platform. Direct access to the virtual cluster API server (for example, via ingress access) is not tracked by the platform's inactivity detection.
 
-If you need more advanced activity detection, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep) for configuration options including custom activity annotations.
+If you need more advanced activity detection, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep-mode) for configuration options including custom activity annotations.

--- a/vcluster_versioned_docs/version-0.29.0/_fragments/private-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/_fragments/private-nodes.mdx
@@ -78,7 +78,7 @@ controlPlane:
 <PrivateNodeLimitations />
 
 ### Network policies
-If you are using [network policies](../configure/vcluster-yaml/policies/network-policy.mdx), private nodes traffic into the virtual cluster control plane must be allowed.
+If you are using [network policies](/docs/vcluster/configure/vcluster-yaml/policies/network-policy), private nodes traffic into the virtual cluster control plane must be allowed.
 
 ```yaml title="vcluster.yaml"
 privateNodes:

--- a/vcluster_versioned_docs/version-0.29.0/_fragments/sync-from-host-resources.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/_fragments/sync-from-host-resources.mdx
@@ -2,7 +2,7 @@ vCluster can sync certain resources from the host cluster to make them available
 synced, they are only synced in read-only mode. No changes to the resource in the virtual cluster syncs back to the host cluster as the
 resources are shared across the host cluster.
 
-A good example would be nodes, which are nice to view inside the virtual cluster and can be also used to enabled certain features such as [scheduling inside the vCluster](/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx),
+A good example would be nodes, which are nice to view inside the virtual cluster and can be also used to enabled certain features such as [scheduling inside the vCluster](/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler),
 but you wouldn't want your virtual cluster to change the node itself. Another benefit of only syncing from host is that vCluster itself only requires read-only RBAC permissions.
 
 vCluster also allows to sync custom resources via the [custom resource definitions syncer](../configure/vcluster-yaml/sync/from-host/custom-resources.mdx)

--- a/vcluster_versioned_docs/version-0.29.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -49,7 +49,7 @@ The connector method requires the vCluster Platform to be installed and properly
 
 1. [**vCluster Platform installation**](/platform/install/quick-start-guide): The platform must be installed and accessible in your Kubernetes cluster
 2. [**Database connector secret**](/platform/administer/connector/database): A platform administrator must create a database connector secret
-3. [**Platform API key**](/vcluster/configure/vcluster-yaml/platform): Your virtual cluster must be connected to the platform
+3. [**Platform API key**](/vcluster/configure/vcluster-yaml/external/platform): Your virtual cluster must be connected to the platform
 
 :::info
 The **connector** option provides automatic database provisioning, credential management, and cleanup when the virtual cluster is deleted. The **dataSource** option gives you direct control but requires manual database and user management.
@@ -92,7 +92,7 @@ controlPlane:
 ```
 
 :::note
-The virtual cluster must be [connected to the platform](/vcluster/configure/vcluster-yaml/platform) to use the connector. This enables centralized management and monitoring of virtual clusters.
+The virtual cluster must be [connected to the platform](/vcluster/configure/vcluster-yaml/external/platform) to use the connector. This enables centralized management and monitoring of virtual clusters.
 :::
 
 ## Config reference

--- a/vcluster_versioned_docs/version-0.29.0/deploy/control-plane/container/security/air-gapped.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/deploy/control-plane/container/security/air-gapped.mdx
@@ -264,7 +264,7 @@ Before deploying, it's recommended to review the set of configuration options th
 
 ## Create a platform access key {#create-platform-access-key}
 
-Before deploying vCluster, you must [create an access key](/vcluster/configure/vcluster-yaml/platform) to authenticate your virtual cluster. This step is essential for connecting your air-gapped vCluster to the platform.
+Before deploying vCluster, you must [create an access key](/vcluster/configure/vcluster-yaml/external/platform) to authenticate your virtual cluster. This step is essential for connecting your air-gapped vCluster to the platform.
 
 ## Deploy vCluster {#deploy-vcluster}
 

--- a/vcluster_versioned_docs/version-0.29.0/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/manage/migrate-etcd-backing-store.mdx
@@ -339,4 +339,4 @@ After successfully migrating to embedded etcd, you can further customize your co
 ## Related topics
 
 - [Backup and restore](/vcluster/manage/backup-restore/backup) - Create snapshots before and after migration
-- [High availability setup](/vcluster/deploy/control-plane/kubernetes-pod/high-availability) - Scale your embedded etcd for HA
+- [High availability setup](/vcluster/deploy/control-plane/container/high-availability) - Scale your embedded etcd for HA

--- a/vcluster_versioned_docs/version-0.29.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.29.0/manage/sleep-wakeup.mdx
@@ -13,7 +13,7 @@ import TenancySupport from '../_fragments/tenancy-support.mdx';
 
 The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs. 
 
-For more details on automating sleep mode operations in vCluster, see the [Sleep mode documentation](/vcluster/configure/vcluster-yaml/sleep).
+For more details on automating sleep mode operations in vCluster, see the [Sleep mode documentation](/vcluster/configure/vcluster-yaml/sleep-mode).
 
 
 ## Prerequisites


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Fixes broken links in the build of the 0.29 docs archive.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

