### PR TITLE
chore(generator): regenerate next config partials and cli docs (DEVOPS-830)

### DIFF
--- a/configsrc/vcluster/0.34.0/default_values.yaml
+++ b/configsrc/vcluster/0.34.0/default_values.yaml
@@ -1,0 +1,1290 @@
+# Sync describes how to sync resources from the virtual cluster to host cluster and back.
+sync:
+  # Configure resources to sync from the virtual cluster to the host cluster.
+  toHost:
+    # Services defines if services created within the virtual cluster should get synced to the host cluster.
+    services:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+    # Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
+    endpoints:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+    # EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster.
+    endpointSlices:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+    # PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
+    persistentVolumeClaims:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+    # ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
+    configMaps:
+      enabled: true
+      # All defines if all resources of that type should get synced or only the necessary ones that are needed.
+      all: false
+    # Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
+    secrets:
+      enabled: true
+      # All defines if all resources of that type should get synced or only the necessary ones that are needed.
+      all: false
+    # Pods defines if pods created within the virtual cluster should get synced to the host cluster.
+    pods:
+      # Enabled defines if pod syncing should be enabled.
+      enabled: true
+      # TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
+      # a certain image that is used within the virtual cluster to be another image on the host cluster
+      translateImage: {}
+      # EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
+      enforceTolerations: []
+      # HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
+      hybridScheduling:
+        # Enabled specifies if hybrid scheduling is enabled.
+        enabled: false
+        # HostSchedulers is a list of schedulers that are deployed on the host cluster.
+        hostSchedulers: []
+      # UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
+      # pod annotation.
+      useSecretsForSATokens: false
+      # RuntimeClassName is the runtime class to set for synced pods.
+      runtimeClassName: ""
+      # PriorityClassName is the priority class to set for synced pods.
+      priorityClassName: ""
+      # RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
+      # a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
+      # the virtual cluster.
+      rewriteHosts:
+        # Enabled specifies if rewriting stateful set pods should be enabled.
+        enabled: true
+        # InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
+        initContainer:
+          # Image is the image virtual cluster should use to rewrite this FQDN.
+          image:
+            # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+            # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+            registry: "mirror.gcr.io"
+            # Repository is the repository of the container image, e.g. my-repo/my-image
+            repository: library/alpine
+            # Tag is the tag of the container image, and is the default version.
+            tag: "3.20"
+          # Resources are the resources that should be assigned to the init container for each stateful set init container.
+          resources:
+            # Limits are resource limits for the container
+            limits:
+              cpu: 30m
+              memory: 64Mi
+            # Requests are minimal resources that will be consumed by the container
+            requests:
+              cpu: 30m
+              memory: 64Mi
+    # Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
+    ingresses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
+    priorityClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
+    networkPolicies:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
+    volumeSnapshots:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
+    volumeSnapshotContents:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
+    podDisruptionBudgets:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
+    serviceAccounts:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
+    storageClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
+    persistentVolumes:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
+    namespaces:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+      # MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
+      mappingsOnly: false
+    # ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster.
+    resourceClaims:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster.
+    resourceClaimTemplates:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+  
+  # Configure what resources vCluster should sync from the host cluster to the virtual cluster.
+  fromHost:
+    # Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
+    events:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+    # ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
+    configMaps:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+      # Mappings for Namespace and Object
+      mappings:
+        # ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+        # There are several wildcards supported:
+        # 1. To match all objects in host namespace and sync them to different namespace in vCluster:
+        # byName:
+        #   "foo/*": "foo-in-virtual/*"
+        # 2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+        # byName:
+        #   "foo/my-object": "foo/my-object"
+        # 3. To match specific object in the host namespace and sync it to the same namespace with different name:
+        # byName:
+        #   "foo/my-object": "foo/my-virtual-object"
+        # 4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+        # byName:
+        #   "": "my-virtual-namespace/*"
+        # 5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+        # byName:
+        #   "/my-object": "my-virtual-namespace/my-object"
+        byName: {}
+    # CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
+    csiDrivers:
+      # Enabled defines if this option should be enabled.
+      enabled: auto
+    # CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
+    csiNodes:
+      # Enabled defines if this option should be enabled.
+      enabled: auto
+    # CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
+    csiStorageCapacities:
+      # Enabled defines if this option should be enabled.
+      enabled: auto
+    # StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
+    storageClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: auto
+    # IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
+    ingressClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
+    runtimeClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
+    priorityClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
+    nodes:
+      # Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
+      enabled: false
+      # SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
+      syncBackChanges: false
+      # ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
+      clearImageStatus: false
+      # Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
+      selector:
+        # All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
+        all: false
+        labels: {}
+    # Secrets defines if secrets in the host should get synced to the virtual cluster.
+    secrets:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+      # Mappings for Namespace and Object
+      mappings:
+        # ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+        # There are several wildcards supported:
+        # 1. To match all objects in host namespace and sync them to different namespace in vCluster:
+        # byName:
+        #   "foo/*": "foo-in-virtual/*"
+        # 2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+        # byName:
+        #   "foo/my-object": "foo/my-object"
+        # 3. To match specific object in the host namespace and sync it to the same namespace with different name:
+        # byName:
+        #   "foo/my-object": "foo/my-virtual-object"
+        # 4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+        # byName:
+        #   "": "my-virtual-namespace/*"
+        # 5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+        # byName:
+        #   "/my-object": "my-virtual-namespace/my-object"
+        byName: {}
+    # VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
+    volumeSnapshotClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+    # DeviceClasses defines if device classes in the host should get synced to the virtual cluster
+    deviceClasses:
+      # Enabled defines if this option should be enabled.
+      enabled: false
+
+# Configure vCluster's control plane components and deployment.
+controlPlane:
+  # Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
+  distro:
+    # K8S holds K8s relevant configuration.
+    k8s:
+      # Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
+      enabled: false
+      # Version is the Kubernetes version to use.
+      version: ""
+      # ImagePullPolicy is the pull policy for the distro image
+      imagePullPolicy: ""
+      # Image is the distro image
+      image:
+        # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+        # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+        registry: ghcr.io
+        # Repository is the repository of the container image, e.g. my-repo/my-image
+        repository: "loft-sh/kubernetes"
+        # Tag is the tag of the container image, and is the default version.
+        tag: "v1.35.0"
+      # APIServer holds configuration specific to starting the api server.
+      apiServer:
+        enabled: true
+        # Command is the command to start the distro binary. This will override the existing command.
+        command: []
+        # ExtraArgs are additional arguments to pass to the distro binary.
+        extraArgs: []
+      # ControllerManager holds configuration specific to starting the controller manager.
+      controllerManager:
+        enabled: true
+        # Command is the command to start the distro binary. This will override the existing command.
+        command: []
+        # ExtraArgs are additional arguments to pass to the distro binary.
+        extraArgs: []
+      # Scheduler holds configuration specific to starting the scheduler.
+      scheduler:
+        enabled: false
+        # Command is the command to start the distro binary. This will override the existing command.
+        command: []
+        # ExtraArgs are additional arguments to pass to the distro binary.
+        extraArgs: []
+      # Env are extra environment variables to use for the main container and NOT the init container.
+      env: []
+      # Security options can be used for the distro init container
+      securityContext: {}
+      # Resources for the distro init container
+      resources:
+        limits:
+          cpu: 100m
+          memory: 256Mi
+        requests:
+          cpu: 40m
+          memory: 64Mi
+  
+  # BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
+  backingStore:
+    # Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
+    database:
+      # Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
+      embedded:
+        # Enabled defines if the database should be used.
+        enabled: false
+        # ExtraArgs are additional arguments to pass to Kine.
+        extraArgs: []
+      # External defines that an external database should be used as the backend for the virtual cluster
+      external:
+        # Enabled defines if the database should be used.
+        enabled: false
+        # DataSource is the kine dataSource to use for the database. This depends on the database format.
+        # This is optional for the external database. Examples:
+        # * mysql: mysql://username:password@tcp(hostname:3306)/vcluster
+        # * postgres: postgres://username:password@hostname:5432/vcluster
+        dataSource: ""
+        # Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
+        # to be used by Platform to create a database and database user for the vCluster.
+        # and non-privileged user. A kine endpoint should be created using the database and user on Platform registration.
+        # This is optional.
+        connector: ""
+        # IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.
+        # This is optional for the external database. Examples:
+        # * aws: RDS IAM Authentication
+        identityProvider: ""
+        # CertFile is the cert file to use for the database. This is optional.
+        certFile: ""
+        # KeyFile is the key file to use for the database. This is optional.
+        keyFile: ""
+        # CaFile is the ca file to use for the database. This is optional.
+        caFile: ""
+        # ExtraArgs are additional arguments to pass to Kine.
+        extraArgs: []
+    # Etcd defines that etcd should be used as the backend for the virtual cluster
+    etcd:
+      # Embedded defines to use embedded etcd as a storage backend for the virtual cluster
+      embedded:
+        # Enabled defines if the embedded etcd should be used.
+        enabled: false
+        # MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
+        migrateFromDeployedEtcd: false
+        # ExtraArgs are additional arguments to pass to the embedded etcd.
+        extraArgs: []
+      # External defines to use a self-hosted external etcd that is not deployed by the helm chart
+      external:
+        # Enabled defines if the external etcd should be used.
+        enabled: false
+        # Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
+        endpoint: ""
+        # TLS defines the tls configuration for the external etcd server
+        tls:
+          # CaFile is the path to the ca file
+          caFile: ""
+          # CertFile is the path to the cert file
+          certFile: ""
+          # KeyFile is the path to the key file
+          keyFile: ""
+      # Deploy defines to use an external etcd that is deployed by the helm chart
+      deploy:
+        # Enabled defines that an external etcd should be deployed.
+        enabled: false
+        # StatefulSet holds options for the external etcd statefulSet.
+        statefulSet:
+          # Enabled defines if the statefulSet should be deployed
+          enabled: true
+          # EnableServiceLinks for the StatefulSet pod
+          enableServiceLinks: true
+          annotations: {}
+          labels: {}
+          # Image is the image to use for the external etcd statefulSet
+          image:
+            # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+            # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+            registry: "registry.k8s.io"
+            # Repository is the repository of the container image, e.g. my-repo/my-image
+            repository: "etcd"
+            # Tag is the tag of the container image, and is the default version.
+            tag: "3.6.4-0"
+          # ImagePullPolicy is the pull policy for the external etcd image
+          imagePullPolicy: ""
+          # ExtraArgs are appended to the etcd command.
+          extraArgs: []
+          # Env are extra environment variables
+          env: []
+          # Resources the etcd can consume
+          resources:
+            # Requests are minimal resources that will be consumed by the container
+            requests:
+              cpu: 20m
+              memory: 150Mi
+          # Pods defines extra metadata for the etcd pods.
+          pods:
+            annotations: {}
+            labels: {}
+          # HighAvailability are high availability options
+          highAvailability:
+            # Replicas are the amount of pods to use.
+            replicas: 1
+          # Scheduling options for the etcd pods.
+          scheduling:
+            # PodManagementPolicy is the statefulSet pod management policy.
+            podManagementPolicy: Parallel
+            # NodeSelector is the node selector to apply to the pod.
+            nodeSelector: {}
+            # Affinity is the affinity to apply to the pod.
+            affinity: {}
+            # Tolerations are the tolerations to apply to the pod.
+            tolerations: []
+            # TopologySpreadConstraints are the topology spread constraints for the pod.
+            topologySpreadConstraints: []
+            # PriorityClassName is the priority class name for the the pod.
+            priorityClassName: ""
+          # Security options for the etcd pods.
+          security:
+            # PodSecurityContext specifies security context options on the pod level.
+            podSecurityContext: {}
+            # ContainerSecurityContext specifies security context options on the container level.
+            containerSecurityContext: {}
+          # Persistence options for the etcd pods.
+          persistence:
+            # VolumeClaim can be used to configure the persistent volume claim.
+            volumeClaim:
+              # Enabled enables deploying a persistent volume claim.
+              enabled: true
+              # RetentionPolicy is the persistent volume claim retention policy.
+              retentionPolicy: Retain
+              # Size is the persistent volume claim storage size.
+              size: 5Gi
+              # StorageClass is the persistent volume claim storage class.
+              storageClass: ""
+              # AccessModes are the persistent volume claim access modes.
+              accessModes: ["ReadWriteOnce"]
+            # VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
+            volumeClaimTemplates: []
+            # AddVolumes defines extra volumes for the pod
+            addVolumes: []
+            # AddVolumeMounts defines extra volume mounts for the container
+            addVolumeMounts: []
+        # Service holds options for the external etcd service.
+        service:
+          enabled: true
+          annotations: {}
+        # HeadlessService holds options for the external etcd headless service.
+        headlessService:
+          annotations: {}
+  
+  # Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
+  proxy:
+    # BindAddress under which vCluster will expose the proxy.
+    bindAddress: "0.0.0.0"
+    # Port under which vCluster will expose the proxy. Changing port is currently not supported.
+    port: 8443
+    # ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
+    extraSANs: []
+  
+  # CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
+  coredns:
+    # Enabled defines if coredns is enabled
+    enabled: true
+    # Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
+    embedded: false
+    # OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
+    overwriteManifests: ""
+    # OverwriteConfig can be used to overwrite the coredns config
+    overwriteConfig: ""
+    # PriorityClassName specifies the priority class name for the CoreDNS pods.
+    priorityClassName: ""
+    # Security defines pod or container security context.
+    security:
+      # PodSecurityContext specifies security context options on the pod level.
+      podSecurityContext: {}
+      # ContainerSecurityContext specifies security context options on the container level.
+      containerSecurityContext: {}
+    # Service holds extra options for the coredns service deployed within the virtual cluster
+    service:
+      annotations: {}
+      labels: {}
+      # Spec holds extra options for the coredns service
+      spec:
+        type: ClusterIP
+    # Deployment holds extra options for the coredns deployment deployed within the virtual cluster
+    deployment:
+      annotations: {}
+      labels: {}
+      # Image is the coredns image to use
+      image: ""
+      # Replicas is the amount of coredns pods to run.
+      replicas: 1
+      # Pods is additional metadata for the coredns pods.
+      pods:
+        labels: {}
+        annotations: {}
+      # NodeSelector is the node selector to use for coredns.
+      nodeSelector: {}
+      # Affinity is the affinity to apply to the pod.
+      affinity: {}
+      # Tolerations are the tolerations to apply to the pod.
+      tolerations: []
+      # Resources are the desired resources for coredns.
+      resources:
+        # Limits are resource limits for the container
+        limits:
+          cpu: 1000m
+          memory: 170Mi
+        # Requests are minimal resources that will be consumed by the container
+        requests:
+          cpu: 20m
+          memory: 64Mi
+      # TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              k8s-app: vcluster-kube-dns
+  
+  # Service defines options for vCluster service deployed by Helm.
+  service:
+    # Enabled defines if the control plane service should be enabled
+    enabled: true
+    labels: {}
+    annotations: {}
+    # KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
+    kubeletNodePort: 0
+    # HTTPSNodePort is the node port where https is exposed. Defaults to 0.
+    httpsNodePort: 0
+    # Spec allows you to configure extra service options.
+    spec:
+      type: ClusterIP
+  
+  # Ingress defines options for vCluster ingress deployed by Helm.
+  ingress:
+    # Enabled defines if the control plane ingress should be enabled
+    enabled: false
+    # Host is the host where vCluster will be reachable
+    host: "my-host.com"
+    # PathType is the path type of the ingress
+    pathType: ImplementationSpecific
+    labels: {}
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: HTTPS # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-passthrough: "true" # ingress-nginx has been deprecated
+      nginx.ingress.kubernetes.io/ssl-redirect: "true" # ingress-nginx has been deprecated
+    # Spec allows you to configure extra ingress options.
+    spec:
+      tls: []
+  
+  # TLSRoute defines options for vCluster TLS route deployed by Helm.
+  tlsRoute:
+    # Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
+    enabled: false
+    # APIVersion is the version of the gateway api tls route.
+    apiVersion: gateway.networking.k8s.io/v1
+    # Host is the host where vCluster will be reachable
+    host: "my-host.com"
+    # ParentRefs are the parent references for the TLS route
+    parentRefs: []
+    # Spec allows you to configure extra tls route options.
+    spec: {}
+    labels: {}
+    annotations: {}
+  
+  # Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
+  # also implies privateNodes.enabled.
+  standalone:
+    # DataDir defines the data directory for the standalone mode.
+    dataDir: "/var/lib/vcluster"
+    # JoinNode holds configuration for the standalone control plane node.
+    joinNode:
+      # Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
+      enabled: true
+      # Containerd holds configuration for the containerd join process.
+      containerd:
+        # Enabled defines if containerd should be installed and configured by vCluster.
+        enabled: true
+  
+  # StatefulSet defines options for vCluster statefulSet deployed by Helm.
+  statefulSet:
+    labels: {}
+    annotations: {}
+    # ImagePullPolicy is the policy how to pull the image.
+    imagePullPolicy: ""
+    # Image is the image for the controlPlane statefulSet container
+    # It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
+    # If you still want to use the pure OSS build, set the repository to 'loft-sh/vcluster-oss'.
+    image:
+      # Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+      # overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+      registry: "ghcr.io"
+      # Repository is the repository of the container image, e.g. my-repo/my-image
+      repository: "loft-sh/vcluster-pro"
+      # Tag is the tag of the container image, and is the default version.
+      tag: ""
+    # WorkingDir specifies in what folder the main process should get started.
+    workingDir: ""
+    # Command allows you to override the main command.
+    command: []
+    # Args allows you to override the main arguments.
+    args: []
+    # Env are additional environment variables for the statefulSet container.
+    env: []
+    # Resources are the resource requests and limits for the statefulSet container.
+    resources:
+      # Limits are resource limits for the container
+      limits:
+        ephemeral-storage: 10Gi
+        memory: 4Gi
+      # Requests are minimal resources that will be consumed by the container
+      requests:
+        ephemeral-storage: 1Gi
+        cpu: 200m
+        memory: 256Mi
+    # Additional labels or annotations for the statefulSet pods.
+    pods:
+      labels: {}
+      annotations: {}
+    # HighAvailability holds options related to high availability.
+    highAvailability:
+      # Replicas is the amount of replicas to use for the statefulSet.
+      replicas: 1
+      # LeaseDuration is the time to lease for the leader.
+      leaseDuration: 60
+      # RenewDeadline is the deadline to renew a lease for the leader.
+      renewDeadline: 40
+      # RetryPeriod is the time until a replica will retry to get a lease.
+      retryPeriod: 15
+    # Security defines pod or container security context.
+    security:
+      # PodSecurityContext specifies security context options on the pod level.
+      podSecurityContext: {}
+      # ContainerSecurityContext specifies security context options on the container level.
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        runAsUser: 0
+        runAsGroup: 0
+    # Persistence defines options around persistence for the statefulSet.
+    persistence:
+      # VolumeClaim can be used to configure the persistent volume claim.
+      volumeClaim:
+        # Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
+        # based on the chosen distro and other options if this is required.
+        enabled: auto
+        # RetentionPolicy is the persistent volume claim retention policy.
+        retentionPolicy: Retain
+        # Size is the persistent volume claim storage size.
+        size: 5Gi
+        # StorageClass is the persistent volume claim storage class.
+        storageClass: ""
+        # AccessModes are the persistent volume claim access modes.
+        accessModes: ["ReadWriteOnce"]
+      # VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
+      volumeClaimTemplates: []
+      # AddVolumeMounts defines extra volume mounts for the container
+      addVolumeMounts: []
+      # AddVolumes defines extra volumes for the pod
+      addVolumes: []
+      # Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
+      dataVolume: []
+      # BinariesVolume defines a binaries volume that is used to retrieve
+      # distro specific executables to be run by the syncer controller.
+      # This volume doesn't need to be persistent.
+      binariesVolume:
+        - name: binaries
+          emptyDir: {}
+    # EnableServiceLinks for the StatefulSet pod
+    enableServiceLinks: true
+    # Scheduling holds options related to scheduling.
+    scheduling:
+      # PodManagementPolicy is the statefulSet pod management policy.
+      podManagementPolicy: Parallel
+      # TopologySpreadConstraints are the topology spread constraints for the pod.
+      topologySpreadConstraints: []
+      # PriorityClassName is the priority class name for the the pod.
+      priorityClassName: ""
+      # NodeSelector is the node selector to apply to the pod.
+      nodeSelector: {}
+      # Affinity is the affinity to apply to the pod.
+      affinity: {}
+      # Tolerations are the tolerations to apply to the pod.
+      tolerations: []
+    # Probes enables or disables the main container probes.
+    probes:
+      # LivenessProbe specifies if the liveness probe for the container should be enabled
+      livenessProbe:
+        # Enabled defines if this option should be enabled.
+        enabled: true
+        # Number of consecutive failures for the probe to be considered failed
+        failureThreshold: 60
+        # Time (in seconds) to wait before starting the liveness probe
+        initialDelaySeconds: 60
+        # Maximum duration (in seconds) that the probe will wait for a response.
+        timeoutSeconds: 3
+        # Frequency (in seconds) to perform the probe
+        periodSeconds: 2
+      # ReadinessProbe specifies if the readiness probe for the container should be enabled
+      readinessProbe:
+        # Enabled defines if this option should be enabled.
+        enabled: true
+        # Number of consecutive failures for the probe to be considered failed
+        failureThreshold: 60
+        # Maximum duration (in seconds) that the probe will wait for a response.
+        timeoutSeconds: 3
+        # Frequency (in seconds) to perform the probe
+        periodSeconds: 2
+      # StartupProbe specifies if the startup probe for the container should be enabled
+      startupProbe:
+        # Enabled defines if this option should be enabled.
+        enabled: true
+        # Number of consecutive failures allowed before failing the pod
+        failureThreshold: 300
+        # Maximum duration (in seconds) that the probe will wait for a response.
+        timeoutSeconds: 3
+        # Frequency (in seconds) to perform the probe
+        periodSeconds: 6
+    # InitContainers are additional init containers for the statefulSet.
+    initContainers: []
+    # SidecarContainers are additional sidecar containers for the statefulSet.
+    sidecarContainers: []
+    # HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created.
+    hostAliases: []
+  
+  # ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
+  serviceMonitor:
+    # Enabled configures if Helm should create the service monitor.
+    enabled: false
+    labels: {}
+    annotations: {}
+  
+  # Advanced holds additional configuration for the vCluster control plane.
+  advanced:
+    # DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
+    # upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
+    defaultImageRegistry: ""
+    # VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
+    # Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
+    virtualScheduler:
+      enabled: false
+    # ServiceAccount specifies options for the vCluster control plane service account.
+    serviceAccount:
+      # Enabled specifies if the service account should get deployed.
+      enabled: true
+      # Name specifies what name to use for the service account.
+      name: ""
+      # ImagePullSecrets defines extra image pull secrets for the service account.
+      imagePullSecrets: []
+      labels: {}
+      annotations: {}
+    # WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
+    workloadServiceAccount:
+      # Enabled specifies if the service account for the workloads should get deployed.
+      enabled: true
+      # Name specifies what name to use for the service account for the virtual cluster workloads.
+      name: ""
+      # ImagePullSecrets defines extra image pull secrets for the workload service account.
+      imagePullSecrets: []
+      annotations: {}
+      labels: {}
+    # HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
+    headlessService:
+      labels: {}
+      annotations: {}
+    # Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
+    konnectivity:
+      # Server holds configuration for the konnectivity server.
+      server:
+        # Enabled defines if the konnectivity server should be enabled.
+        enabled: true
+        # ExtraArgs are additional arguments to pass to the konnectivity server.
+        extraArgs: []
+      # Agent holds configuration for the konnectivity agent.
+      agent:
+        # Enabled defines if the konnectivity agent should be enabled.
+        enabled: true
+        # Replicas is the number of replicas for the konnectivity agent.
+        replicas: 1
+        # Image is the image for the konnectivity agent.
+        image: ""
+        # ImagePullPolicy is the policy how to pull the image.
+        imagePullPolicy: ""
+        # NodeSelector is the node selector for the konnectivity agent.
+        nodeSelector: {}
+        # Tolerations is the tolerations for the konnectivity agent.
+        tolerations: []
+        # ExtraEnv is the extra environment variables for the konnectivity agent.
+        extraEnv: []
+        # ExtraArgs are additional arguments to pass to the konnectivity agent.
+        extraArgs: []
+    # CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.
+    # The cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata.
+    cloudControllerManager:
+      # Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use
+      # an external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well
+      # as the provider id for the node and other node metadata.
+      enabled: true
+    # Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
+    registry:
+      # Enabled defines if the embedded registry should be enabled.
+      enabled: false
+      # AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
+      anonymousPull: true
+      # Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
+      config: {}
+    # KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2.
+    kubeVip:
+      # Enabled defines if embedded kube-vip should be enabled.
+      enabled: false
+    # GlobalMetadata is metadata that will be added to all resources deployed by Helm.
+    globalMetadata:
+      annotations: {}
+    # PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once
+    # to ensure availability during maintenance or scaling operations.
+    podDisruptionBudget:
+      # Enabled defines if the pod disruption budget should be enabled.
+      enabled: false
+
+# PrivateNodes holds configuration for vCluster private nodes mode.
+privateNodes:
+  # Enabled defines if dedicated nodes should be enabled.
+  enabled: false
+  
+  # Kubelet holds kubelet configuration that is used for all nodes.
+  kubelet:
+    # Config is the config for the kubelet that will be merged into the default kubelet config. More information can be found here:
+    # https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration
+    config: {}
+  
+  # AutoUpgrade holds configuration for auto upgrade.
+  autoUpgrade:
+    # Enabled defines if auto upgrade should be enabled.
+    enabled: true
+    # Concurrency is the number of nodes that can be upgraded at the same time.
+    concurrency: 1
+    # PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+    podSecurityContext: {}
+    # ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+    containerSecurityContext: {}
+  
+  # JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
+  joinNode:
+    # Containerd holds configuration for the containerd join process.
+    containerd:
+      # Enabled defines if containerd should be installed and configured by vCluster.
+      enabled: true
+  
+  # AutoNodes stores auto nodes configuration.
+  autoNodes: []
+  
+  # VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or
+  # connect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work.
+  vpn:
+    # Enabled defines if the private nodes vpn should be enabled.
+    enabled: false
+    # NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network.
+    nodeToNode:
+      # Enabled defines if the node to node vpn should be enabled.
+      enabled: false
+  
+  # Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
+  daemon:
+    # Enabled defines if the private nodes daemon should be enabled.
+    enabled: false
+    # ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
+    # This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
+    controlPlaneLoadBalancer:
+      # Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
+      enabled: false
+      # KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
+      kubeProxy: true
+      # Port defines the port for the control plane load balancer.
+      port: 11343
+
+# Deploy holds configuration for the deployment of vCluster.
+deploy:
+  # LocalPathProvisioner holds dedicated local path provisioner configuration.
+  localPathProvisioner:
+    # Enabled defines if LocalPathProvisioner should be enabled.
+    enabled: true
+  
+  # CNI holds dedicated CNI configuration.
+  cni:
+    # Flannel holds dedicated Flannel configuration.
+    flannel:
+      # Enabled defines if Flannel should be enabled.
+      enabled: true
+  
+  # KubeProxy holds dedicated kube proxy configuration.
+  kubeProxy:
+    # Enabled defines if the kube proxy should be enabled.
+    enabled: true
+    # Image is the image for the kube-proxy.
+    image: ""
+    # ImagePullPolicy is the policy how to pull the image.
+    imagePullPolicy: ""
+    # NodeSelector is the node selector for the kube-proxy.
+    nodeSelector: {}
+    # Tolerations is the tolerations for the kube-proxy.
+    tolerations: []
+    # ExtraEnv is the extra environment variables for the kube-proxy.
+    extraEnv: []
+    # ExtraArgs are additional arguments to pass to the kube-proxy.
+    extraArgs: []
+    # Config is the config for the kube-proxy that will be merged into the default kube-proxy config. More information can be found here:
+    # https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration
+    config: {}
+  
+  # Metallb holds dedicated metallb configuration.
+  metallb:
+    # Enabled defines if metallb should be enabled.
+    enabled: false
+    # IPAddressPool is the IP address pool to use for metallb.
+    ipAddressPool:
+      # Addresses is a list of IP addresses to use for the IP address pool.
+      addresses: []
+      # L2Advertisement defines if L2 advertisement should be enabled for the IP address pool.
+      l2Advertisement: true
+  
+  # IngressNginx holds dedicated ingress-nginx configuration.
+  # Deprecated: We do not deploy ingress nginx and the project is being deprecated.
+  ingressNginx:
+    # Enabled defines if ingress-nginx should be enabled.
+    enabled: false
+    # DefaultIngressClass defines if the deployed ingress class should be the default ingress class.
+    defaultIngressClass: true
+  
+  # MetricsServer holds dedicated metrics server configuration.
+  metricsServer:
+    # Enabled defines if metrics server should be enabled.
+    enabled: false
+  
+  # VolumeSnapshotController holds dedicated CSI snapshot-controller configuration.
+  volumeSnapshotController:
+    # Enabled defines if the CSI volumes snapshot-controller should be enabled.
+    enabled: false
+
+# Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
+integrations:
+  # MetricsServer reuses the metrics server from the host cluster within the vCluster.
+  metricsServer:
+    # Enabled signals the metrics server integration should be enabled.
+    enabled: false
+    # Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
+    nodes: true
+    # Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
+    pods: true
+  
+  # ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
+  # - ExternalSecrets will be synced from the virtual cluster to the host cluster.
+  # - SecretStores will be synced from the virtual cluster to the host cluster and then bi-directionally.
+  # - ClusterSecretStores will be synced from the host cluster to the virtual cluster.
+  externalSecrets:
+    # Enabled defines whether the external secret integration is enabled or not
+    enabled: false
+    # Webhook defines whether the host webhooks are reused or not
+    webhook:
+      enabled: false
+    # Sync defines the syncing behavior for the integration
+    sync:
+      # ToHost defines what resources are synced from the virtual cluster to the host
+      toHost:
+        # ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
+        externalSecrets:
+          selector:
+            matchLabels: {}
+        # Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
+        stores:
+          # Enabled defines if this option should be enabled.
+          enabled: false
+          selector:
+            matchLabels: {}
+      # FromHost defines what resources are synced from the host cluster to the virtual cluster
+      fromHost:
+        # ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
+        clusterStores:
+          # Enabled defines if this option should be enabled.
+          enabled: false
+          selector:
+            matchLabels: {}
+  
+  # KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
+  kubeVirt:
+    # Enabled signals if the integration should be enabled
+    enabled: false
+    # Webhook holds configuration for enabling the webhook within the vCluster
+    webhook:
+      enabled: true
+    # Sync holds configuration on what resources to sync
+    sync:
+      # If DataVolumes should get synced
+      dataVolumes:
+        enabled: false
+      # If VirtualMachines should get synced
+      virtualMachines:
+        enabled: true
+      # If VirtualMachineInstances should get synced
+      virtualMachineInstances:
+        enabled: true
+      # If VirtualMachinePools should get synced
+      virtualMachinePools:
+        enabled: true
+      # If VirtualMachineClones should get synced
+      virtualMachineClones:
+        enabled: true
+      # If VirtualMachineInstanceMigrations should get synced
+      virtualMachineInstanceMigrations:
+        enabled: true
+  
+  # CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
+  # - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
+  # - ClusterIssuers will be synced from the host cluster to the virtual cluster.
+  certManager:
+    # Enabled defines if this option should be enabled.
+    enabled: false
+    # Sync contains advanced configuration for syncing cert-manager resources.
+    sync:
+      toHost:
+        # Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
+        certificates:
+          enabled: true
+        # Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
+        issuers:
+          enabled: true
+      fromHost:
+        # ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
+        clusterIssuers:
+          # Enabled defines if this option should be enabled.
+          enabled: true
+          # Selector defines what cluster issuers should be imported.
+          selector:
+            labels: {}
+  
+  # Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
+  istio:
+    # Enabled defines if this option should be enabled.
+    enabled: false
+    sync:
+      toHost:
+        destinationRules:
+          enabled: true
+        gateways:
+          enabled: true
+        virtualServices:
+          enabled: true
+
+# RBAC options for the virtual cluster.
+rbac:
+  # Role holds virtual cluster role configuration
+  role:
+    # Enabled defines if the role should be enabled or disabled.
+    enabled: true
+    # OverwriteRules will overwrite the role rules completely.
+    overwriteRules: []
+    # ExtraRules will add rules to the role.
+    extraRules: []
+  
+  # ClusterRole holds virtual cluster cluster role configuration
+  clusterRole:
+    # Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
+    enabled: auto
+    # OverwriteRules will overwrite the cluster role rules completely.
+    overwriteRules: []
+    # ExtraRules will add rules to the cluster role.
+    extraRules: []
+  
+  # EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and
+  # ClusterRole.
+  enableVolumeSnapshotRules:
+    # Enabled defines if this option should be enabled.
+    enabled: auto
+
+# Networking options related to the virtual cluster.
+networking:
+  # PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
+  podCIDR: "10.244.0.0/16"
+  
+  # ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
+  replicateServices:
+    # ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
+    # synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
+    # are required.
+    toHost: []
+    # FromHost defines the services that should get synced from the host to the virtual cluster.
+    fromHost: []
+  
+  # ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
+  resolveDNS: []
+  
+  # Advanced holds advanced network options.
+  advanced:
+    # ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
+    clusterDomain: "cluster.local"
+    # FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
+    # any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
+    fallbackHostCluster: false
+    # ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
+    # prometheus or other node exporters.
+    proxyKubelets:
+      # ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
+      # for all applications, e.g. Prometheus requires a node IP.
+      byHostname: true
+      # ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
+      # route traffic.
+      byIP: true
+
+# Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
+policies:
+  # ResourceQuota specifies resource quota options.
+  resourceQuota:
+    # Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
+    # the resourceQuota will be enabled as well.
+    enabled: auto
+    labels: {}
+    annotations: {}
+    # Quota are the quota options
+    quota:
+      requests.cpu: 10
+      requests.memory: 20Gi
+      requests.storage: "100Gi"
+      requests.ephemeral-storage: 60Gi
+      limits.cpu: 20
+      limits.memory: 40Gi
+      limits.ephemeral-storage: 160Gi
+      services.nodeports: 0
+      services.loadbalancers: 1
+      count/endpoints: 40
+      count/pods: 20
+      count/services: 20
+      count/secrets: 100
+      count/configmaps: 100
+      count/persistentvolumeclaims: 20
+    # ScopeSelector is the resource quota scope selector
+    scopeSelector:
+      matchExpressions: []
+    # Scopes are the resource quota scopes
+    scopes: []
+  
+  # LimitRange specifies limit range options.
+  limitRange:
+    # Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
+    # the limitRange will be enabled as well.
+    enabled: auto
+    labels: {}
+    annotations: {}
+    # Default are the default limits for the limit range
+    default:
+      ephemeral-storage: 8Gi
+      memory: 512Mi
+      cpu: "1"
+    # DefaultRequest are the default request options for the limit range
+    defaultRequest:
+      ephemeral-storage: 3Gi
+      memory: 128Mi
+      cpu: 100m
+    # Min are the min limits for the limit range
+    min: {}
+    # Max are the max limits for the limit range
+    max: {}
+  
+  # NetworkPolicy specifies network policy options.
+  networkPolicy:
+    # Enabled defines if the network policy should be deployed by vCluster.
+    enabled: false
+    labels: {}
+    annotations: {}
+    # FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
+    fallbackDns: 8.8.8.8
+    # ControlPlane network policy rules
+    controlPlane:
+      # Ingress rules for the vCluster control plane.
+      ingress: []
+      # Egress rules for the vCluster control plane.
+      egress: []
+    # Workload network policy rules
+    workload:
+      # PublicEgress holds the public outgoing connections options for the vCluster workloads.
+      publicEgress:
+        # Enabled defines if the workload public egress should be enabled or disabled.
+        enabled: true
+        # CIDR defines the allowed workload public egress destination.
+        # Valid examples are "0.0.0.0/0", "192.168.1.0/24" or "2001:db8::/64"
+        cidr: 0.0.0.0/0
+        # Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.
+        # Valid examples are "192.168.1.0/24" or "2001:db8::/64".
+        # +optional
+        except:
+          - 100.64.0.0/10
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+          - 172.16.0.0/12
+          - 192.168.0.0/16
+      # Ingress rules for the vCluster workloads.
+      ingress: []
+      # Egress rules for the vCluster workloads.
+      egress: []
+  
+  # CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
+  centralAdmission:
+    # ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
+    validatingWebhooks: []
+    # MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
+    mutatingWebhooks: []
+
+# ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
+exportKubeConfig:
+  # Context is the name of the context within the generated kubeconfig to use.
+  context: ""
+  
+  # Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
+  server: ""
+  
+  # If tls should get skipped for the server
+  insecure: false
+  
+  # ServiceAccount can be used to generate a service account token instead of the default certificates.
+  serviceAccount:
+    # Name of the service account to be used to generate a service account token instead of the default certificates.
+    name: ""
+    # Namespace of the service account to be used to generate a service account token instead of the default certificates.
+    # If omitted, will use the kube-system namespace.
+    namespace: ""
+    # ClusterRole to assign to the service account.
+    clusterRole: ""
+  
+  # Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
+  # If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
+  # vCluster creates the config in this other secret.
+
+  # Deprecated: Use AdditionalSecrets instead.
+  secret:
+    # Name is the name of the secret where the kubeconfig should get stored.
+    name: ""
+    # Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
+    # where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
+    namespace: ""
+  
+  # AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
+  # generated virtual cluster kubeconfigs.
+  additionalSecrets: []
+
+# Define which vCluster plugins to load.
+plugins: {}
+
+# Experimental features for vCluster. Configuration here might change, so be careful with this.
+experimental:
+  # Docker allows you to configure Docker related settings when deploying a vCluster using Docker.
+  docker:
+    # Defines if vCluster should configure load balancer services inside the vCluster. This might require
+    # sudo access on the host cluster for docker desktop or rancher desktop on macos.
+    loadBalancer:
+      # Enabled defines if this option should be enabled.
+      enabled: true
+      # ForwardPorts defines if the load balancer ips should be made available locally
+      # via port forwarding. This will be only done if necessary for example on macos when using docker desktop.
+      forwardPorts: true
+    # Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to
+    # use purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd
+    registryProxy:
+      enabled: true
+  
+  # Proxy enables vCluster-to-vCluster proxying of resources
+  proxy:
+    # CustomResources is a map of resource keys (format: "kind.apiGroup/version") to proxy configuration
+    customResources: {}
+  
+  # SyncSettings are advanced settings for the syncer controller.
+  syncSettings:
+    # SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
+    setOwner: true
+  
+  # Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
+  deploy:
+    # Host defines what manifests to deploy into the host cluster
+    host:
+      # Manifests are raw Kubernetes manifests that should get applied within the host cluster.
+      manifests: ""
+      # ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
+      manifestsTemplate: ""
+    # VCluster defines what manifests and charts to deploy into the vCluster
+    vcluster:
+      # Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
+      manifests: ""
+      # ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
+      manifestsTemplate: ""
+      # Helm are Helm charts that should get deployed into the virtual cluster
+      helm: []
+  
+  # NodeMonitors allows you to create a service monitor for each node.
+  nodeMonitors: []
+
+# Configuration related to telemetry gathered about vCluster usage.
+telemetry:
+  # Enabled specifies that the telemetry for the vCluster control plane should be enabled.
+  enabled: true
+
+# Logging provides structured logging options
+logging:
+  # Encoding specifies the format of vCluster logs, it can either be json or console.
+  encoding: console

--- a/configsrc/vcluster/0.34.0/vcluster.schema.json
+++ b/configsrc/vcluster/0.34.0/vcluster.schema.json
@@ -1,0 +1,5656 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vcluster.com/schemas/config",
+  "$defs": {
+    "APIService": {
+      "properties": {
+        "service": {
+          "$ref": "#/$defs/APIServiceService",
+          "description": "Service is a reference to the service for the API server."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "APIService holds configuration related to the api server"
+    },
+    "APIServiceService": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the host service of the apiservice."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace is the name of the host service of the apiservice."
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port is the target port on the host service to connect to."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "APIServiceService holds the service name and namespace of the host apiservice."
+    },
+    "AutoUpgrade": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if auto upgrade should be enabled."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes."
+        },
+        "binariesPath": {
+          "type": "string",
+          "description": "BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin"
+        },
+        "cniBinariesPath": {
+          "type": "string",
+          "description": "CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin"
+        },
+        "concurrency": {
+          "type": "integer",
+          "description": "Concurrency is the number of nodes that can be upgraded at the same time."
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "PodSecurityContext specifies security context options on the pod level for the upgrade pod."
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "ContainerSecurityContext specifies security context options on the container level for the upgrade container."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "BackingStore": {
+      "properties": {
+        "etcd": {
+          "$ref": "#/$defs/Etcd",
+          "description": "Etcd defines that etcd should be used as the backend for the virtual cluster"
+        },
+        "database": {
+          "$ref": "#/$defs/Database",
+          "description": "Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CNI": {
+      "properties": {
+        "flannel": {
+          "$ref": "#/$defs/CNIFlannel",
+          "description": "Flannel holds dedicated Flannel configuration."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CNIFlannel": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if Flannel should be enabled."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the image for Flannel main container."
+        },
+        "initImage": {
+          "type": "string",
+          "description": "InitImage is the image for Flannel init container."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CentralAdmission": {
+      "properties": {
+        "validatingWebhooks": {
+          "items": {
+            "$ref": "#/$defs/ValidatingWebhookConfiguration"
+          },
+          "type": "array",
+          "description": "ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster"
+        },
+        "mutatingWebhooks": {
+          "items": {
+            "$ref": "#/$defs/MutatingWebhookConfiguration"
+          },
+          "type": "array",
+          "description": "MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CertManager": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "sync": {
+          "$ref": "#/$defs/CertManagerSync",
+          "description": "Sync contains advanced configuration for syncing cert-manager resources."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster"
+    },
+    "CertManagerSync": {
+      "properties": {
+        "toHost": {
+          "$ref": "#/$defs/CertManagerSyncToHost"
+        },
+        "fromHost": {
+          "$ref": "#/$defs/CertManagerSyncFromHost"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CertManagerSyncFromHost": {
+      "properties": {
+        "clusterIssuers": {
+          "$ref": "#/$defs/ClusterIssuersSyncConfig",
+          "description": "ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CertManagerSyncToHost": {
+      "properties": {
+        "certificates": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Certificates defines if certificates should get synced from the virtual cluster to the host cluster."
+        },
+        "issuers": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Issuers defines if issuers should get synced from the virtual cluster to the host cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CloudControllerManager": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the embedded cloud controller manager should be enabled. This defaults to true, but can be disabled if you want to use\nan external cloud controller manager such as AWS or GCP. The cloud controller manager is responsible for setting the node's ip addresses as well\nas the provider id for the node and other node metadata."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ClusterIssuersSyncConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "selector": {
+          "$ref": "#/$defs/LabelSelector",
+          "description": "Selector defines what cluster issuers should be imported."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContainerdJoin": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if containerd should be installed and configured by vCluster."
+        },
+        "registry": {
+          "$ref": "#/$defs/ContainerdRegistry",
+          "description": "Registry holds configuration for how containerd should be configured to use a registries."
+        },
+        "pauseImage": {
+          "type": "string",
+          "description": "PauseImage is the image for the pause container."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContainerdMirror": {
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details."
+        },
+        "caCert": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "CACert are paths to CA certificates to use for the containerd registry mirror."
+        },
+        "skipVerify": {
+          "type": "boolean",
+          "description": "SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections."
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities."
+        },
+        "overridePath": {
+          "type": "boolean",
+          "description": "OverridePath is a boolean to override the path for the containerd registry mirror."
+        },
+        "hosts": {
+          "items": {
+            "$ref": "#/$defs/ContainerdMirrorHost"
+          },
+          "type": "array",
+          "description": "Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContainerdMirrorHost": {
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000."
+        },
+        "caCert": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "CACert are paths to CA certificates to use for the containerd registry mirror host."
+        },
+        "skipVerify": {
+          "type": "boolean",
+          "description": "SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections."
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities."
+        },
+        "overridePath": {
+          "type": "boolean",
+          "description": "OverridePath is a boolean to override the path for the containerd registry mirror."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContainerdRegistry": {
+      "properties": {
+        "configPath": {
+          "type": "string",
+          "description": "ConfigPath is the path to the containerd registry config."
+        },
+        "mirrors": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ContainerdMirror"
+          },
+          "type": "object",
+          "description": "Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details."
+        },
+        "auth": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ContainerdRegistryAuth"
+          },
+          "type": "object",
+          "description": "Auth holds configuration for the containerd registry auth. See https://github.com/containerd/containerd/blob/main/docs/cri/registry.md#configure-registry-credentials for more details."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ContainerdRegistryAuth": {
+      "properties": {
+        "username": {
+          "type": "string",
+          "description": "Username is the username for the containerd registry."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password is the password for the containerd registry."
+        },
+        "identityToken": {
+          "type": "string",
+          "description": "IdentityToken is the token for the containerd registry."
+        },
+        "auth": {
+          "type": "string",
+          "description": "Auth is the auth config for the containerd registry."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlane": {
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint is the endpoint of the virtual cluster. This is used to connect to the virtual cluster."
+        },
+        "distro": {
+          "$ref": "#/$defs/Distro",
+          "description": "Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed."
+        },
+        "standalone": {
+          "$ref": "#/$defs/Standalone",
+          "description": "Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and\nalso implies privateNodes.enabled."
+        },
+        "backingStore": {
+          "$ref": "#/$defs/BackingStore",
+          "description": "BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store."
+        },
+        "coredns": {
+          "$ref": "#/$defs/CoreDNS",
+          "description": "CoreDNS defines everything related to the coredns that is deployed and used within the vCluster."
+        },
+        "proxy": {
+          "$ref": "#/$defs/ControlPlaneProxy",
+          "description": "Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests."
+        },
+        "hostPathMapper": {
+          "$ref": "#/$defs/HostPathMapper",
+          "description": "HostPathMapper defines if vCluster should rewrite host paths.",
+          "pro": true
+        },
+        "ingress": {
+          "$ref": "#/$defs/ControlPlaneIngress",
+          "description": "Ingress defines options for vCluster ingress deployed by Helm."
+        },
+        "tlsRoute": {
+          "$ref": "#/$defs/ControlPlaneTLSRoute",
+          "description": "TLSRoute defines options for vCluster TLS route deployed by Helm."
+        },
+        "service": {
+          "$ref": "#/$defs/ControlPlaneService",
+          "description": "Service defines options for vCluster service deployed by Helm."
+        },
+        "statefulSet": {
+          "$ref": "#/$defs/ControlPlaneStatefulSet",
+          "description": "StatefulSet defines options for vCluster statefulSet deployed by Helm."
+        },
+        "serviceMonitor": {
+          "$ref": "#/$defs/ServiceMonitor",
+          "description": "ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself."
+        },
+        "advanced": {
+          "$ref": "#/$defs/ControlPlaneAdvanced",
+          "description": "Advanced holds additional configuration for the vCluster control plane."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneAdvanced": {
+      "properties": {
+        "defaultImageRegistry": {
+          "type": "string",
+          "description": "DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to\nupload all required vCluster images to a single private repository and set this value. Workload images are not affected by this."
+        },
+        "virtualScheduler": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.\nDeprecated: Use ControlPlane.Distro.K8S.Scheduler instead."
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/ControlPlaneServiceAccount",
+          "description": "ServiceAccount specifies options for the vCluster control plane service account."
+        },
+        "workloadServiceAccount": {
+          "$ref": "#/$defs/ControlPlaneWorkloadServiceAccount",
+          "description": "WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster."
+        },
+        "headlessService": {
+          "$ref": "#/$defs/ControlPlaneHeadlessService",
+          "description": "HeadlessService specifies options for the headless service used for the vCluster StatefulSet."
+        },
+        "konnectivity": {
+          "$ref": "#/$defs/Konnectivity",
+          "description": "Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true."
+        },
+        "registry": {
+          "$ref": "#/$defs/Registry",
+          "description": "Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images."
+        },
+        "cloudControllerManager": {
+          "$ref": "#/$defs/CloudControllerManager",
+          "description": "CloudControllerManager holds configuration for the embedded cloud controller manager. This is only available when private nodes are enabled.\nThe cloud controller manager is responsible for setting the node's ip addresses as well as the provider id for the node and other node metadata."
+        },
+        "globalMetadata": {
+          "$ref": "#/$defs/ControlPlaneGlobalMetadata",
+          "description": "GlobalMetadata is metadata that will be added to all resources deployed by Helm."
+        },
+        "kubeVip": {
+          "$ref": "#/$defs/KubeVip",
+          "description": "KubeVip holds configuration for embedded kube-vip that announces the virtual cluster endpoint IP on layer 2."
+        },
+        "podDisruptionBudget": {
+          "$ref": "#/$defs/PodDisruptionBudget",
+          "description": "PodDisruptionBudget limits how many pods of an application can be voluntarily disrupted at once\nto ensure availability during maintenance or scaling operations."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneGlobalMetadata": {
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneHeadlessService": {
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneHighAvailability": {
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "description": "Replicas is the amount of replicas to use for the statefulSet."
+        },
+        "leaseDuration": {
+          "type": "integer",
+          "description": "LeaseDuration is the time to lease for the leader."
+        },
+        "renewDeadline": {
+          "type": "integer",
+          "description": "RenewDeadline is the deadline to renew a lease for the leader."
+        },
+        "retryPeriod": {
+          "type": "integer",
+          "description": "RetryPeriod is the time until a replica will retry to get a lease."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneIngress": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane ingress should be enabled"
+        },
+        "host": {
+          "type": "string",
+          "description": "Host is the host where vCluster will be reachable"
+        },
+        "pathType": {
+          "type": "string",
+          "description": "PathType is the path type of the ingress"
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra ingress options."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneLoadBalancer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes."
+        },
+        "kubeProxy": {
+          "type": "boolean",
+          "description": "KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well."
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port defines the port for the control plane load balancer."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlanePersistence": {
+      "properties": {
+        "volumeClaim": {
+          "$ref": "#/$defs/VolumeClaim",
+          "description": "VolumeClaim can be used to configure the persistent volume claim."
+        },
+        "volumeClaimTemplates": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet"
+        },
+        "dataVolume": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false."
+        },
+        "binariesVolume": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "BinariesVolume defines a binaries volume that is used to retrieve\ndistro specific executables to be run by the syncer controller.\nThis volume doesn't need to be persistent."
+        },
+        "addVolumes": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "AddVolumes defines extra volumes for the pod"
+        },
+        "addVolumeMounts": {
+          "items": {
+            "$ref": "#/$defs/VolumeMount"
+          },
+          "type": "array",
+          "description": "AddVolumeMounts defines extra volume mounts for the container"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneProbes": {
+      "properties": {
+        "livenessProbe": {
+          "$ref": "#/$defs/LivenessProbe",
+          "description": "LivenessProbe specifies if the liveness probe for the container should be enabled"
+        },
+        "readinessProbe": {
+          "$ref": "#/$defs/ReadinessProbe",
+          "description": "ReadinessProbe specifies if the readiness probe for the container should be enabled"
+        },
+        "startupProbe": {
+          "$ref": "#/$defs/StartupProbe",
+          "description": "StartupProbe specifies if the startup probe for the container should be enabled"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneProxy": {
+      "properties": {
+        "bindAddress": {
+          "type": "string",
+          "description": "BindAddress under which vCluster will expose the proxy."
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port under which vCluster will expose the proxy. Changing port is currently not supported."
+        },
+        "extraSANs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraSANs are extra hostnames to sign the vCluster proxy certificate for."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneScheduling": {
+      "properties": {
+        "nodeSelector": {
+          "type": "object",
+          "description": "NodeSelector is the node selector to apply to the pod."
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity is the affinity to apply to the pod."
+        },
+        "tolerations": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Tolerations are the tolerations to apply to the pod."
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName is the priority class name for the the pod."
+        },
+        "podManagementPolicy": {
+          "type": "string",
+          "description": "PodManagementPolicy is the statefulSet pod management policy."
+        },
+        "topologySpreadConstraints": {
+          "items": true,
+          "type": "array",
+          "description": "TopologySpreadConstraints are the topology spread constraints for the pod."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneSecurity": {
+      "properties": {
+        "podSecurityContext": {
+          "type": "object",
+          "description": "PodSecurityContext specifies security context options on the pod level."
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "ContainerSecurityContext specifies security context options on the container level."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneService": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane service should be enabled"
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra service options."
+        },
+        "kubeletNodePort": {
+          "type": "integer",
+          "description": "KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0."
+        },
+        "httpsNodePort": {
+          "type": "integer",
+          "description": "HTTPSNodePort is the node port where https is exposed. Defaults to 0."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneServiceAccount": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if the service account should get deployed."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name specifies what name to use for the service account."
+        },
+        "imagePullSecrets": {
+          "items": {
+            "$ref": "#/$defs/ImagePullSecretName"
+          },
+          "type": "array",
+          "description": "ImagePullSecrets defines extra image pull secrets for the service account."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneStatefulSet": {
+      "properties": {
+        "highAvailability": {
+          "$ref": "#/$defs/ControlPlaneHighAvailability",
+          "description": "HighAvailability holds options related to high availability."
+        },
+        "resources": {
+          "$ref": "#/$defs/Resources",
+          "description": "Resources are the resource requests and limits for the statefulSet container."
+        },
+        "scheduling": {
+          "$ref": "#/$defs/ControlPlaneScheduling",
+          "description": "Scheduling holds options related to scheduling."
+        },
+        "security": {
+          "$ref": "#/$defs/ControlPlaneSecurity",
+          "description": "Security defines pod or container security context."
+        },
+        "probes": {
+          "$ref": "#/$defs/ControlPlaneProbes",
+          "description": "Probes enables or disables the main container probes."
+        },
+        "persistence": {
+          "$ref": "#/$defs/ControlPlanePersistence",
+          "description": "Persistence defines options around persistence for the statefulSet."
+        },
+        "enableServiceLinks": {
+          "type": "boolean",
+          "description": "EnableServiceLinks for the StatefulSet pod"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        },
+        "pods": {
+          "$ref": "#/$defs/LabelsAndAnnotations",
+          "description": "Additional labels or annotations for the statefulSet pods."
+        },
+        "image": {
+          "$ref": "#/$defs/Image",
+          "description": "Image is the image for the controlPlane statefulSet container\nIt defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.\nIf you still want to use the pure OSS build, set the repository to 'loft-sh/vcluster-oss'."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        },
+        "workingDir": {
+          "type": "string",
+          "description": "WorkingDir specifies in what folder the main process should get started."
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command allows you to override the main command."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args allows you to override the main arguments."
+        },
+        "env": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Env are additional environment variables for the statefulSet container."
+        },
+        "dnsPolicy": {
+          "type": "string",
+          "description": "Set DNS policy for the pod."
+        },
+        "dnsConfig": {
+          "$ref": "#/$defs/PodDNSConfig",
+          "description": "Specifies the DNS parameters of a pod."
+        },
+        "initContainers": {
+          "items": true,
+          "type": "array",
+          "description": "InitContainers are additional init containers for the statefulSet."
+        },
+        "sidecarContainers": {
+          "items": true,
+          "type": "array",
+          "description": "SidecarContainers are additional sidecar containers for the statefulSet."
+        },
+        "hostAliases": {
+          "items": {
+            "$ref": "#/$defs/HostAlias"
+          },
+          "type": "array",
+          "description": "HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created."
+        },
+        "runtimeClassName": {
+          "type": "string",
+          "description": "RuntimeClassName is the runtime class to set for the statefulSet pods."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneTLSRoute": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to \"Passthrough\""
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion is the version of the gateway api tls route."
+        },
+        "host": {
+          "type": "string",
+          "description": "Host is the host where vCluster will be reachable"
+        },
+        "parentRefs": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ParentRefs are the parent references for the TLS route"
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra tls route options."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneWorkloadServiceAccount": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if the service account for the workloads should get deployed."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name specifies what name to use for the service account for the virtual cluster workloads."
+        },
+        "imagePullSecrets": {
+          "items": {
+            "$ref": "#/$defs/ImagePullSecretName"
+          },
+          "type": "array",
+          "description": "ImagePullSecrets defines extra image pull secrets for the workload service account."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CoreDNS": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if coredns is enabled"
+        },
+        "embedded": {
+          "type": "boolean",
+          "description": "Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.",
+          "pro": true
+        },
+        "security": {
+          "$ref": "#/$defs/ControlPlaneSecurity",
+          "description": "Security defines pod or container security context."
+        },
+        "service": {
+          "$ref": "#/$defs/CoreDNSService",
+          "description": "Service holds extra options for the coredns service deployed within the virtual cluster"
+        },
+        "deployment": {
+          "$ref": "#/$defs/CoreDNSDeployment",
+          "description": "Deployment holds extra options for the coredns deployment deployed within the virtual cluster"
+        },
+        "overwriteConfig": {
+          "type": "string",
+          "description": "OverwriteConfig can be used to overwrite the coredns config"
+        },
+        "overwriteManifests": {
+          "type": "string",
+          "description": "OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns"
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName specifies the priority class name for the CoreDNS pods."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CoreDNSDeployment": {
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Image is the coredns image to use"
+        },
+        "replicas": {
+          "type": "integer",
+          "description": "Replicas is the amount of coredns pods to run."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector is the node selector to use for coredns."
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity is the affinity to apply to the pod."
+        },
+        "tolerations": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Tolerations are the tolerations to apply to the pod."
+        },
+        "resources": {
+          "$ref": "#/$defs/Resources",
+          "description": "Resources are the desired resources for coredns."
+        },
+        "pods": {
+          "$ref": "#/$defs/LabelsAndAnnotations",
+          "description": "Pods is additional metadata for the coredns pods."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        },
+        "topologySpreadConstraints": {
+          "items": true,
+          "type": "array",
+          "description": "TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CoreDNSService": {
+      "properties": {
+        "spec": {
+          "type": "object",
+          "description": "Spec holds extra options for the coredns service"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "CustomResourceProxy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this resource proxy should be enabled"
+        },
+        "targetVirtualCluster": {
+          "$ref": "#/$defs/VirtualClusterRef",
+          "description": "TargetVirtualCluster is the target virtual cluster for the custom resource proxy"
+        },
+        "accessResources": {
+          "type": "string",
+          "description": "AccessResources defines which resources should be accessible in the proxy."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Database": {
+      "properties": {
+        "embedded": {
+          "$ref": "#/$defs/DatabaseKine",
+          "description": "Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster"
+        },
+        "external": {
+          "$ref": "#/$defs/ExternalDatabaseKine",
+          "description": "External defines that an external database should be used as the backend for the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DatabaseKine": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the database should be used."
+        },
+        "dataSource": {
+          "type": "string",
+          "description": "DataSource is the kine dataSource to use for the database. This depends on the database format.\nThis is optional for the external database. Examples:\n* mysql: mysql://username:password@tcp(hostname:3306)/vcluster\n* postgres: postgres://username:password@hostname:5432/vcluster"
+        },
+        "identityProvider": {
+          "type": "string",
+          "description": "IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.\nThis is optional for the external database. Examples:\n* aws: RDS IAM Authentication"
+        },
+        "keyFile": {
+          "type": "string",
+          "description": "KeyFile is the key file to use for the database. This is optional."
+        },
+        "certFile": {
+          "type": "string",
+          "description": "CertFile is the cert file to use for the database. This is optional."
+        },
+        "caFile": {
+          "type": "string",
+          "description": "CaFile is the ca file to use for the database. This is optional."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to Kine."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Deletion": {
+      "properties": {
+        "prevent": {
+          "type": "boolean",
+          "description": "Prevent prevents the vCluster from being deleted\n+optional"
+        },
+        "auto": {
+          "$ref": "#/$defs/DeletionAuto",
+          "description": "Auto holds automatic deletion configuration\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Deletion holds configuration for automatic vCluster deletion."
+    },
+    "DeletionAuto": {
+      "properties": {
+        "afterInactivity": {
+          "type": "string",
+          "description": "AfterInactivity specifies after how long of inactivity the virtual cluster will be deleted.\nUses Go duration format (e.g., \"720h\" for 30 days).\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DeletionAuto holds automatic deletion configuration"
+    },
+    "DenyRule": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the check."
+        },
+        "namespaces": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Namespace describe a list of namespaces that will be affected by the check.\nAn empty list means that all namespaces will be affected.\nIn case of ClusterScoped rules, only the Namespace resource is affected."
+        },
+        "rules": {
+          "items": {
+            "$ref": "#/$defs/RuleWithVerbs"
+          },
+          "type": "array",
+          "description": "Rules describes on which verbs and on what resources/subresources the webhook is enforced.\nThe webhook is enforced if it matches any Rule.\nThe version of the request must match the rule version exactly. Equivalent matching is not supported."
+        },
+        "excludedUsers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExcludedUsers describe a list of users for which the checks will be skipped.\nImpersonation attempts on these users will still be subjected to the checks."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Deploy": {
+      "properties": {
+        "kubeProxy": {
+          "$ref": "#/$defs/KubeProxy",
+          "description": "KubeProxy holds dedicated kube proxy configuration."
+        },
+        "metallb": {
+          "$ref": "#/$defs/Metallb",
+          "description": "Metallb holds dedicated metallb configuration."
+        },
+        "cni": {
+          "$ref": "#/$defs/CNI",
+          "description": "CNI holds dedicated CNI configuration."
+        },
+        "localPathProvisioner": {
+          "$ref": "#/$defs/LocalPathProvisioner",
+          "description": "LocalPathProvisioner holds dedicated local path provisioner configuration."
+        },
+        "ingressNginx": {
+          "$ref": "#/$defs/IngressNginx",
+          "description": "IngressNginx holds dedicated ingress-nginx configuration.\nDeprecated: We do not deploy ingress nginx and the project is being deprecated."
+        },
+        "metricsServer": {
+          "$ref": "#/$defs/DeployMetricsServer",
+          "description": "MetricsServer holds dedicated metrics server configuration."
+        },
+        "volumeSnapshotController": {
+          "$ref": "#/$defs/VolumeSnapshotController",
+          "description": "VolumeSnapshotController holds dedicated CSI snapshot-controller configuration."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DeployMetricsServer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if metrics server should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Distro": {
+      "properties": {
+        "k8s": {
+          "$ref": "#/$defs/DistroK8s",
+          "description": "K8S holds K8s relevant configuration."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DistroContainerEnabled": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled signals this container should be enabled."
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command is the command to start the distro binary. This will override the existing command."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to the distro binary."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DistroK8s": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time."
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is the Kubernetes version to use."
+        },
+        "apiServer": {
+          "$ref": "#/$defs/DistroContainerEnabled",
+          "description": "APIServer holds configuration specific to starting the api server."
+        },
+        "controllerManager": {
+          "$ref": "#/$defs/DistroContainerEnabled",
+          "description": "ControllerManager holds configuration specific to starting the controller manager."
+        },
+        "scheduler": {
+          "$ref": "#/$defs/DistroContainerEnabled",
+          "description": "Scheduler holds configuration specific to starting the scheduler."
+        },
+        "image": {
+          "$ref": "#/$defs/Image",
+          "description": "Image is the distro image"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the pull policy for the distro image"
+        },
+        "env": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Env are extra environment variables to use for the main container and NOT the init container."
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources for the distro init container"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security options can be used for the distro init container"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DynamicNodePool": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of this NodePool"
+        },
+        "nodeTypeSelector": {
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          },
+          "type": "array",
+          "description": "NodeTypeSelector filters the types of nodes that can be provisioned by this pool.\nAll requirements must be met for a node type to be eligible."
+        },
+        "taints": {
+          "items": {
+            "$ref": "#/$defs/KubeletJoinTaint"
+          },
+          "type": "array",
+          "description": "Taints are the taints to apply to the nodes in this pool."
+        },
+        "nodeLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeLabels are the labels to apply to the nodes in this pool."
+        },
+        "limits": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Limits specify the maximum resources that can be provisioned by this node pool,\nmapping to the 'limits' field in Karpenter's NodePool API."
+        },
+        "disruption": {
+          "$ref": "#/$defs/DynamicNodePoolDisruption",
+          "description": "Disruption contains the parameters that relate to Karpenter's disruption logic"
+        },
+        "terminationGracePeriod": {
+          "type": "string",
+          "description": "TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.\n\nWarning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.\n\nThis field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.\nWhen set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.\n\nKarpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.\nIf a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,\nthat pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.\n\nThe feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.\nDefaults to 30s. Set to Never to wait indefinitely for pods to be drained."
+        },
+        "expireAfter": {
+          "type": "string",
+          "description": "The amount of time a Node can live on the cluster before being removed"
+        },
+        "weight": {
+          "type": "integer",
+          "description": "Weight is the weight of this node pool."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "DynamicNodePoolDisruption": {
+      "properties": {
+        "consolidateAfter": {
+          "type": "string",
+          "description": "ConsolidateAfter is the duration the controller will wait\nbefore attempting to terminate nodes that are underutilized.\nRefer to ConsolidationPolicy for how underutilization is considered."
+        },
+        "consolidationPolicy": {
+          "type": "string",
+          "description": "ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation\nalgorithm. This policy defaults to \"WhenEmptyOrUnderutilized\" if not specified"
+        },
+        "budgets": {
+          "items": {
+            "$ref": "#/$defs/DynamicNodePoolDisruptionBudget"
+          },
+          "type": "array",
+          "description": "Budgets is a list of Budgets.\nIf there are multiple active budgets, Karpenter uses\nthe most restrictive value. If left undefined,\nthis will default to one budget with a value to 10%."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DynamicNodePoolDisruptionBudget": {
+      "properties": {
+        "nodes": {
+          "type": "string",
+          "description": "Nodes dictates the maximum number of NodeClaims owned by this NodePool\nthat can be terminating at once. This is calculated by counting nodes that\nhave a deletion timestamp set, or are actively being deleted by Karpenter.\nThis field is required when specifying a budget."
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Schedule specifies when a budget begins being active, following\nthe upstream cronjob syntax. If omitted, the budget is always active.\nTimezones are not supported."
+        },
+        "duration": {
+          "type": "string",
+          "description": "Duration determines how long a Budget is active since each Schedule hit.\nOnly minutes and hours are accepted, as cron does not work in seconds.\nIf omitted, the budget is always active.\nThis is required if Schedule is set."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableAutoSwitch": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if this option should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableAutoSwitchWithPatches": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableAutoSwitchWithPatchesAndSelector": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "Selector defines the selector to use for the resource. If not set, all resources of that type will be synced."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitch": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitchSelector": {
+      "properties": {
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitchWithPatches": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitchWithPatchesAndSelector": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "Selector defines the selector to use for the resource. If not set, all resources of that type will be synced."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EnableSwitchWithResourcesMappings": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "mappings": {
+          "$ref": "#/$defs/FromHostMappings",
+          "description": "Mappings for Namespace and Object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Etcd": {
+      "properties": {
+        "embedded": {
+          "$ref": "#/$defs/EtcdEmbedded",
+          "description": "Embedded defines to use embedded etcd as a storage backend for the virtual cluster",
+          "pro": true
+        },
+        "deploy": {
+          "$ref": "#/$defs/EtcdDeploy",
+          "description": "Deploy defines to use an external etcd that is deployed by the helm chart"
+        },
+        "external": {
+          "$ref": "#/$defs/EtcdExternal",
+          "description": "External defines to use a self-hosted external etcd that is not deployed by the helm chart"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdDeploy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines that an external etcd should be deployed."
+        },
+        "statefulSet": {
+          "$ref": "#/$defs/EtcdDeployStatefulSet",
+          "description": "StatefulSet holds options for the external etcd statefulSet."
+        },
+        "service": {
+          "$ref": "#/$defs/EtcdDeployService",
+          "description": "Service holds options for the external etcd service."
+        },
+        "headlessService": {
+          "$ref": "#/$defs/EtcdDeployHeadlessService",
+          "description": "HeadlessService holds options for the external etcd headless service."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdDeployHeadlessService": {
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for the external etcd headless service"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdDeployService": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the etcd service should be deployed"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for the external etcd service"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdDeployStatefulSet": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the statefulSet should be deployed"
+        },
+        "enableServiceLinks": {
+          "type": "boolean",
+          "description": "EnableServiceLinks for the StatefulSet pod"
+        },
+        "image": {
+          "$ref": "#/$defs/Image",
+          "description": "Image is the image to use for the external etcd statefulSet"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the pull policy for the external etcd image"
+        },
+        "env": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "Env are extra environment variables"
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are appended to the etcd command."
+        },
+        "resources": {
+          "$ref": "#/$defs/Resources",
+          "description": "Resources the etcd can consume"
+        },
+        "pods": {
+          "$ref": "#/$defs/LabelsAndAnnotations",
+          "description": "Pods defines extra metadata for the etcd pods."
+        },
+        "highAvailability": {
+          "$ref": "#/$defs/ExternalEtcdHighAvailability",
+          "description": "HighAvailability are high availability options"
+        },
+        "scheduling": {
+          "$ref": "#/$defs/ControlPlaneScheduling",
+          "description": "Scheduling options for the etcd pods."
+        },
+        "security": {
+          "$ref": "#/$defs/ControlPlaneSecurity",
+          "description": "Security options for the etcd pods."
+        },
+        "persistence": {
+          "$ref": "#/$defs/ExternalEtcdPersistence",
+          "description": "Persistence options for the etcd pods."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdEmbedded": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the embedded etcd should be used.",
+          "pro": true
+        },
+        "migrateFromDeployedEtcd": {
+          "type": "boolean",
+          "description": "MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd."
+        },
+        "snapshotCount": {
+          "type": "integer",
+          "description": "SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to the embedded etcd."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdExternal": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the external etcd should be used."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379"
+        },
+        "tls": {
+          "$ref": "#/$defs/EtcdExternalTLS",
+          "description": "TLS defines the tls configuration for the external etcd server"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "EtcdExternalTLS": {
+      "properties": {
+        "caFile": {
+          "type": "string",
+          "description": "CaFile is the path to the ca file"
+        },
+        "certFile": {
+          "type": "string",
+          "description": "CertFile is the path to the cert file"
+        },
+        "keyFile": {
+          "type": "string",
+          "description": "KeyFile is the path to the key file"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EtcdExternalTLS defines tls for external etcd server"
+    },
+    "Experimental": {
+      "properties": {
+        "deploy": {
+          "$ref": "#/$defs/ExperimentalDeploy",
+          "description": "Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster."
+        },
+        "syncSettings": {
+          "$ref": "#/$defs/ExperimentalSyncSettings",
+          "description": "SyncSettings are advanced settings for the syncer controller."
+        },
+        "virtualClusterKubeConfig": {
+          "$ref": "#/$defs/VirtualClusterKubeConfig",
+          "description": "VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.\nDeprecated: Removed in 0.29.0."
+        },
+        "denyProxyRequests": {
+          "items": {
+            "$ref": "#/$defs/DenyRule"
+          },
+          "type": "array",
+          "description": "DenyProxyRequests denies certain requests in the vCluster proxy.",
+          "pro": true
+        },
+        "proxy": {
+          "$ref": "#/$defs/Proxy",
+          "description": "Proxy enables vCluster-to-vCluster proxying of resources"
+        },
+        "docker": {
+          "$ref": "#/$defs/ExperimentalDocker",
+          "description": "Docker allows you to configure Docker related settings when deploying a vCluster using Docker."
+        },
+        "nodeMonitors": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeMonitor"
+          },
+          "type": "array",
+          "description": "NodeMonitors allows you to create a service monitor for each node."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeploy": {
+      "properties": {
+        "host": {
+          "$ref": "#/$defs/ExperimentalDeployHost",
+          "description": "Host defines what manifests to deploy into the host cluster"
+        },
+        "vcluster": {
+          "$ref": "#/$defs/ExperimentalDeployVCluster",
+          "description": "VCluster defines what manifests and charts to deploy into the vCluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeployHelm": {
+      "properties": {
+        "chart": {
+          "$ref": "#/$defs/ExperimentalDeployHelmChart",
+          "description": "Chart defines what chart should get deployed."
+        },
+        "release": {
+          "$ref": "#/$defs/ExperimentalDeployHelmRelease",
+          "description": "Release defines what release should get deployed."
+        },
+        "values": {
+          "type": "string",
+          "description": "Values defines what values should get used."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Timeout defines the timeout for Helm"
+        },
+        "bundle": {
+          "type": "string",
+          "description": "Bundle allows to compress the Helm chart and specify this instead of an online chart"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeployHelmChart": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "repo": {
+          "type": "string"
+        },
+        "insecure": {
+          "type": "boolean"
+        },
+        "version": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeployHelmRelease": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the release"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the release"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeployHost": {
+      "properties": {
+        "manifests": {
+          "type": "string",
+          "description": "Manifests are raw Kubernetes manifests that should get applied within the host cluster."
+        },
+        "manifestsTemplate": {
+          "type": "string",
+          "description": "ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDeployVCluster": {
+      "properties": {
+        "manifests": {
+          "type": "string",
+          "description": "Manifests are raw Kubernetes manifests that should get applied within the virtual cluster."
+        },
+        "manifestsTemplate": {
+          "type": "string",
+          "description": "ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster."
+        },
+        "helm": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalDeployHelm"
+          },
+          "type": "array",
+          "description": "Helm are Helm charts that should get deployed into the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDocker": {
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container."
+        },
+        "ports": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Ports defines extra port mappings to be added to the container."
+        },
+        "volumes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Volumes defines extra volumes to be added to the container."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Env defines extra environment variables to be added to the container. Use key=value."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args defines extra arguments to be added to the docker run command of the container."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the vCluster was deployed using Docker. This is automatically set by vCluster and should not be set by the user."
+        },
+        "network": {
+          "type": "string",
+          "description": "Network defines the network to use for the vCluster. If not specified, the a network will be created for the vCluster."
+        },
+        "nodes": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalDockerNode"
+          },
+          "type": "array",
+          "description": "Nodes defines the nodes of the vCluster."
+        },
+        "registryProxy": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Defines if docker images should be pulled from the host docker daemon. This prevents pulling images again and allows to\nuse purely local images. Only works if containerd image storage is used. For more information, see https://docs.docker.com/engine/storage/containerd"
+        },
+        "loadBalancer": {
+          "$ref": "#/$defs/ExperimentalDockerLoadBalancer",
+          "description": "Defines if vCluster should configure load balancer services inside the vCluster. This might require\nsudo access on the host cluster for docker desktop or rancher desktop on macos."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDockerLoadBalancer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "forwardPorts": {
+          "type": "boolean",
+          "description": "ForwardPorts defines if the load balancer ips should be made available locally\nvia port forwarding. This will be only done if necessary for example on macos when using docker desktop."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalDockerNode": {
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Image defines the image to use for the container. Defaults to ghcr.io/loft-sh/vm-container."
+        },
+        "ports": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Ports defines extra port mappings to be added to the container."
+        },
+        "volumes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Volumes defines extra volumes to be added to the container."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Env defines extra environment variables to be added to the container. Use key=value."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args defines extra arguments to be added to the docker run command of the container."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name defines the name of the node. If not specified, a random name will be generated."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the monitor. It will be suffixed with the node name."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector defines the node selector for the service monitor."
+        },
+        "endpoints": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeServiceMonitorEndpoint"
+          },
+          "type": "array",
+          "description": "Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra service monitor options that will be merged into the spec."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeServiceMonitorEndpoint": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path."
+        },
+        "params": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object",
+          "description": "Params allows you to configure extra parameters to add to the endpoint."
+        },
+        "extraRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "metricsRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint."
+        },
+        "interval": {
+          "type": "string",
+          "description": "Interval is the interval at which to scrape the endpoint."
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "ScrapeTimeout is the timeout for the scrape of the endpoint."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalSyncSettings": {
+      "properties": {
+        "setOwner": {
+          "type": "boolean",
+          "description": "SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection."
+        },
+        "hostMetricsBindAddress": {
+          "type": "string",
+          "description": "HostMetricsBindAddress is the bind address for the local manager"
+        },
+        "virtualMetricsBindAddress": {
+          "type": "string",
+          "description": "VirtualMetricsBindAddress is the bind address for the virtual manager"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExportKubeConfig": {
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "Context is the name of the context within the generated kubeconfig to use."
+        },
+        "server": {
+          "type": "string",
+          "description": "Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "If tls should get skipped for the server"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/ExportKubeConfigServiceAccount",
+          "description": "ServiceAccount can be used to generate a service account token instead of the default certificates."
+        },
+        "secret": {
+          "$ref": "#/$defs/ExportKubeConfigSecretReference",
+          "description": "Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.\nIf this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,\nvCluster creates the config in this other secret.\n\nDeprecated: Use AdditionalSecrets instead."
+        },
+        "additionalSecrets": {
+          "items": {
+            "$ref": "#/$defs/ExportKubeConfigAdditionalSecretReference"
+          },
+          "type": "array",
+          "description": "AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the\ngenerated virtual cluster kubeconfigs."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExportKubeConfig describes how vCluster should export the vCluster kubeconfig."
+    },
+    "ExportKubeConfigAdditionalSecretReference": {
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "Context is the name of the context within the generated kubeconfig to use."
+        },
+        "server": {
+          "type": "string",
+          "description": "Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "If tls should get skipped for the server"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/ExportKubeConfigServiceAccount",
+          "description": "ServiceAccount can be used to generate a service account token instead of the default certificates."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the secret where the kubeconfig is stored."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace\nwhere you deployed vCluster, you need to make sure vCluster has access to this other namespace."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExportKubeConfigAdditionalSecretReference defines the additional host cluster secret in which vCluster stores the generated virtual cluster kubeconfigs."
+    },
+    "ExportKubeConfigSecretReference": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the secret where the kubeconfig should get stored."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace\nwhere you deployed vCluster, you need to make sure vCluster has access to this other namespace."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig."
+    },
+    "ExportKubeConfigServiceAccount": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the service account to be used to generate a service account token instead of the default certificates."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace of the service account to be used to generate a service account token instead of the default certificates.\nIf omitted, will use the kube-system namespace."
+        },
+        "clusterRole": {
+          "type": "string",
+          "description": "ClusterRole to assign to the service account."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalDatabaseKine": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the database should be used."
+        },
+        "dataSource": {
+          "type": "string",
+          "description": "DataSource is the kine dataSource to use for the database. This depends on the database format.\nThis is optional for the external database. Examples:\n* mysql: mysql://username:password@tcp(hostname:3306)/vcluster\n* postgres: postgres://username:password@hostname:5432/vcluster"
+        },
+        "identityProvider": {
+          "type": "string",
+          "description": "IdentityProvider is the kine identity provider to use when generating temporary authentication tokens for enhanced security.\nThis is optional for the external database. Examples:\n* aws: RDS IAM Authentication"
+        },
+        "keyFile": {
+          "type": "string",
+          "description": "KeyFile is the key file to use for the database. This is optional."
+        },
+        "certFile": {
+          "type": "string",
+          "description": "CertFile is the cert file to use for the database. This is optional."
+        },
+        "caFile": {
+          "type": "string",
+          "description": "CaFile is the ca file to use for the database. This is optional."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to Kine."
+        },
+        "connector": {
+          "type": "string",
+          "description": "Connector specifies a secret located in a connected vCluster Platform that contains database server connection information\nto be used by Platform to create a database and database user for the vCluster.\nand non-privileged user. A kine endpoint should be created using the database and user on Platform registration.\nThis is optional."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalEtcdHighAvailability": {
+      "properties": {
+        "replicas": {
+          "type": "integer",
+          "description": "Replicas are the amount of pods to use."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalEtcdPersistence": {
+      "properties": {
+        "volumeClaim": {
+          "$ref": "#/$defs/ExternalEtcdPersistenceVolumeClaim",
+          "description": "VolumeClaim can be used to configure the persistent volume claim."
+        },
+        "volumeClaimTemplates": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet"
+        },
+        "addVolumes": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "AddVolumes defines extra volumes for the pod"
+        },
+        "addVolumeMounts": {
+          "items": {
+            "$ref": "#/$defs/VolumeMount"
+          },
+          "type": "array",
+          "description": "AddVolumeMounts defines extra volume mounts for the container"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalEtcdPersistenceVolumeClaim": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled enables deploying a persistent volume claim."
+        },
+        "accessModes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AccessModes are the persistent volume claim access modes."
+        },
+        "retentionPolicy": {
+          "type": "string",
+          "description": "RetentionPolicy is the persistent volume claim retention policy."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size is the persistent volume claim storage size."
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "StorageClass is the persistent volume claim storage class."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalSecrets": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines whether the external secret integration is enabled or not"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version defines the version of the external secrets operator to use. If empty, the storage version will be used."
+        },
+        "webhook": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Webhook defines whether the host webhooks are reused or not"
+        },
+        "sync": {
+          "$ref": "#/$defs/ExternalSecretsSync",
+          "description": "Sync defines the syncing behavior for the integration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster"
+    },
+    "ExternalSecretsSync": {
+      "properties": {
+        "toHost": {
+          "$ref": "#/$defs/ExternalSecretsSyncToHostConfig",
+          "description": "ToHost defines what resources are synced from the virtual cluster to the host"
+        },
+        "fromHost": {
+          "$ref": "#/$defs/ExternalSecretsSyncFromHostConfig",
+          "description": "FromHost defines what resources are synced from the host cluster to the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalSecretsSyncFromHostConfig": {
+      "properties": {
+        "clusterStores": {
+          "$ref": "#/$defs/EnableSwitchSelector",
+          "description": "ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExternalSecretsSyncToHostConfig": {
+      "properties": {
+        "externalSecrets": {
+          "$ref": "#/$defs/SelectorConfig",
+          "description": "ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster."
+        },
+        "stores": {
+          "$ref": "#/$defs/EnableSwitchSelector",
+          "description": "Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "FromHostMappings": {
+      "properties": {
+        "byName": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.\nThere are several wildcards supported:\n1. To match all objects in host namespace and sync them to different namespace in vCluster:\nbyName:\n  \"foo/*\": \"foo-in-virtual/*\"\n2. To match specific object in the host namespace and sync it to the same namespace with the same name:\nbyName:\n  \"foo/my-object\": \"foo/my-object\"\n3. To match specific object in the host namespace and sync it to the same namespace with different name:\nbyName:\n  \"foo/my-object\": \"foo/my-virtual-object\"\n4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:\nbyName:\n  \"\": \"my-virtual-namespace/*\"\n5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:\nbyName:\n  \"/my-object\": \"my-virtual-namespace/my-object\""
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HostAlias": {
+      "properties": {
+        "ip": {
+          "type": "string"
+        },
+        "hostnames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HostPathMapper": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if the host path mapper will be used"
+        },
+        "central": {
+          "type": "boolean",
+          "description": "Central specifies if the central host path mapper will be used"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "HybridScheduling": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if hybrid scheduling is enabled."
+        },
+        "hostSchedulers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "HostSchedulers is a list of schedulers that are deployed on the host cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "IPBlock": {
+      "properties": {
+        "cidr": {
+          "type": "string",
+          "description": "CIDR defines the allowed workload public egress destination.\nValid examples are \"0.0.0.0/0\", \"192.168.1.0/24\" or \"2001:db8::/64\""
+        },
+        "except": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.\nValid examples are \"192.168.1.0/24\" or \"2001:db8::/64\".\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "IPBlock describes a particular CIDR (Ex."
+    },
+    "Image": {
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally\noverridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub."
+        },
+        "repository": {
+          "type": "string",
+          "description": "Repository is the repository of the container image, e.g. my-repo/my-image"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Tag is the tag of the container image, and is the default version."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ImagePullSecretName": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the image pull secret to use."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "IngressNginx": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if ingress-nginx should be enabled."
+        },
+        "defaultIngressClass": {
+          "type": "boolean",
+          "description": "DefaultIngressClass defines if the deployed ingress class should be the default ingress class."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Integrations": {
+      "properties": {
+        "metricsServer": {
+          "$ref": "#/$defs/MetricsServer",
+          "description": "MetricsServer reuses the metrics server from the host cluster within the vCluster."
+        },
+        "kubeVirt": {
+          "$ref": "#/$defs/KubeVirt",
+          "description": "KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster"
+        },
+        "externalSecrets": {
+          "$ref": "#/$defs/ExternalSecrets",
+          "description": "ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.\n- ExternalSecrets will be synced from the virtual cluster to the host cluster.\n- SecretStores will be synced from the virtual cluster to the host cluster and then bi-directionally.\n- ClusterSecretStores will be synced from the host cluster to the virtual cluster."
+        },
+        "certManager": {
+          "$ref": "#/$defs/CertManager",
+          "description": "CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.\n- Certificates and Issuers will be synced from the virtual cluster to the host cluster.\n- ClusterIssuers will be synced from the host cluster to the virtual cluster."
+        },
+        "istio": {
+          "$ref": "#/$defs/Istio",
+          "description": "Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host."
+        },
+        "netris": {
+          "$ref": "#/$defs/NetrisIntegration",
+          "description": "Netris integration helps configuring netris networking for vCluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Integrations holds config for vCluster integrations with other operators or tools running on the host cluster"
+    },
+    "Istio": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "sync": {
+          "$ref": "#/$defs/IstioSync"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "IstioSync": {
+      "properties": {
+        "toHost": {
+          "$ref": "#/$defs/IstioSyncToHost"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "IstioSyncToHost": {
+      "properties": {
+        "destinationRules": {
+          "$ref": "#/$defs/EnableSwitch"
+        },
+        "gateways": {
+          "$ref": "#/$defs/EnableSwitch"
+        },
+        "virtualServices": {
+          "$ref": "#/$defs/EnableSwitch"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JoinConfiguration": {
+      "properties": {
+        "preInstallCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed."
+        },
+        "preJoinCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreJoinCommands are commands that will be executed before kubeadm join is executed."
+        },
+        "postJoinCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PostJoinCommands are commands that will be executed after kubeadm join is executed."
+        },
+        "containerd": {
+          "$ref": "#/$defs/ContainerdJoin",
+          "description": "Containerd holds configuration for the containerd join process."
+        },
+        "caCertPath": {
+          "type": "string",
+          "description": "CACertPath is the path to the SSL certificate authority used to\nsecure communications between node and control-plane.\nDefaults to \"/etc/kubernetes/pki/ca.crt\"."
+        },
+        "skipPhases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SkipPhases is a list of phases to skip during command execution.\nThe list of phases can be obtained with the \"kubeadm join --help\" command."
+        },
+        "nodeRegistration": {
+          "$ref": "#/$defs/NodeRegistration",
+          "description": "NodeRegistration holds configuration for the node registration similar to the kubeadm node registration."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Konnectivity": {
+      "properties": {
+        "server": {
+          "$ref": "#/$defs/KonnectivityServer",
+          "description": "Server holds configuration for the konnectivity server."
+        },
+        "agent": {
+          "$ref": "#/$defs/KonnectivityAgent",
+          "description": "Agent holds configuration for the konnectivity agent."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KonnectivityAgent": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the konnectivity agent should be enabled."
+        },
+        "replicas": {
+          "type": "integer",
+          "description": "Replicas is the number of replicas for the konnectivity agent."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the image for the konnectivity agent."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector is the node selector for the konnectivity agent."
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName is the priority class name for the konnectivity agent."
+        },
+        "tolerations": {
+          "items": true,
+          "type": "array",
+          "description": "Tolerations is the tolerations for the konnectivity agent."
+        },
+        "extraEnv": {
+          "items": true,
+          "type": "array",
+          "description": "ExtraEnv is the extra environment variables for the konnectivity agent."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to the konnectivity agent."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KonnectivityServer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the konnectivity server should be enabled."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to the konnectivity server."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KubeProxy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the kube proxy should be enabled."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the image for the kube-proxy."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector is the node selector for the kube-proxy."
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName is the priority class name for the kube-proxy."
+        },
+        "tolerations": {
+          "items": true,
+          "type": "array",
+          "description": "Tolerations is the tolerations for the kube-proxy."
+        },
+        "extraEnv": {
+          "items": true,
+          "type": "array",
+          "description": "ExtraEnv is the extra environment variables for the kube-proxy."
+        },
+        "extraArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ExtraArgs are additional arguments to pass to the kube-proxy."
+        },
+        "config": {
+          "type": "object",
+          "description": "Config is the config for the kube-proxy that will be merged into the default kube-proxy config. More information can be found here:\nhttps://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/#kubeproxy-config-k8s-io-v1alpha1-KubeProxyConfiguration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KubeVip": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if embedded kube-vip should be enabled."
+        },
+        "interface": {
+          "type": "string",
+          "description": "Interface is the network interface on which the VIP is announced."
+        },
+        "gateway": {
+          "type": "string",
+          "description": "Gateway is the gateway address in CIDR notation (e.g., 10.100.0.1/24).\nThis is used to configure policy-based routing for the VIP and must include the subnet prefix."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KubeVirt": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled signals if the integration should be enabled"
+        },
+        "apiService": {
+          "$ref": "#/$defs/APIService",
+          "description": "APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt."
+        },
+        "webhook": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "Webhook holds configuration for enabling the webhook within the vCluster"
+        },
+        "sync": {
+          "$ref": "#/$defs/KubeVirtSync",
+          "description": "Sync holds configuration on what resources to sync"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster"
+    },
+    "KubeVirtSync": {
+      "properties": {
+        "dataVolumes": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If DataVolumes should get synced"
+        },
+        "virtualMachineInstanceMigrations": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If VirtualMachineInstanceMigrations should get synced"
+        },
+        "virtualMachineInstances": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If VirtualMachineInstances should get synced"
+        },
+        "virtualMachines": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If VirtualMachines should get synced"
+        },
+        "virtualMachineClones": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If VirtualMachineClones should get synced"
+        },
+        "virtualMachinePools": {
+          "$ref": "#/$defs/EnableSwitch",
+          "description": "If VirtualMachinePools should get synced"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "KubeVirtSync are the crds that are supported by this integration"
+    },
+    "Kubelet": {
+      "properties": {
+        "config": {
+          "type": "object",
+          "description": "Config is the config for the kubelet that will be merged into the default kubelet config. More information can be found here:\nhttps://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "KubeletExtraArg": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the argument."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value is the value of the argument."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "KubeletExtraArg represents an argument with a name and a value."
+    },
+    "KubeletJoinTaint": {
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Required. The taint key to be applied to a node."
+        },
+        "value": {
+          "type": "string",
+          "description": "The taint value corresponding to the taint key.\n+optional"
+        },
+        "effect": {
+          "type": "string",
+          "description": "Required. The effect of the taint on pods\nthat do not tolerate the taint.\nValid effects are NoSchedule, PreferNoSchedule and NoExecute."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LabelSelector": {
+      "properties": {
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels defines what labels should be looked for"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LabelSelectorRequirement": {
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "operator": {
+          "type": "string"
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LabelsAndAnnotations": {
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LimitRange": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if the limit range should be deployed by vCluster. \"auto\" means that if resourceQuota is enabled,\nthe limitRange will be enabled as well."
+        },
+        "default": {
+          "type": "object",
+          "description": "Default are the default limits for the limit range"
+        },
+        "defaultRequest": {
+          "type": "object",
+          "description": "DefaultRequest are the default request options for the limit range"
+        },
+        "max": {
+          "type": "object",
+          "description": "Max are the max limits for the limit range"
+        },
+        "min": {
+          "type": "object",
+          "description": "Min are the min limits for the limit range"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "LivenessProbe": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Number of consecutive failures for the probe to be considered failed"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Time (in seconds) to wait before starting the liveness probe"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Maximum duration (in seconds) that the probe will wait for a response."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Frequency (in seconds) to perform the probe"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "LivenessProbe defines the configuration for the liveness probe."
+    },
+    "LocalPathProvisioner": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if LocalPathProvisioner should be enabled."
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the image for local path provisioner."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the policy how to pull the image."
+        },
+        "nodePath": {
+          "type": "string",
+          "description": "NodePath is the path on the node where to create the persistent volume directories."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Logging": {
+      "properties": {
+        "encoding": {
+          "type": "string",
+          "description": "Encoding specifies the format of vCluster logs, it can either be json or console."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Logging holds the log encoding details"
+    },
+    "Metallb": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if metallb should be enabled."
+        },
+        "controllerImage": {
+          "type": "string",
+          "description": "ControllerImage is the image for metallb controller."
+        },
+        "speakerImage": {
+          "type": "string",
+          "description": "SpeakerImage is the image for metallb speaker."
+        },
+        "ipAddressPool": {
+          "$ref": "#/$defs/MetallbIPAddressPool",
+          "description": "IPAddressPool is the IP address pool to use for metallb."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetallbIPAddressPool": {
+      "properties": {
+        "addresses": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Addresses is a list of IP addresses to use for the IP address pool."
+        },
+        "l2Advertisement": {
+          "type": "boolean",
+          "description": "L2Advertisement defines if L2 advertisement should be enabled for the IP address pool."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricsServer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled signals the metrics server integration should be enabled."
+        },
+        "apiService": {
+          "$ref": "#/$defs/APIService",
+          "description": "APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system."
+        },
+        "nodes": {
+          "type": "boolean",
+          "description": "Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster."
+        },
+        "pods": {
+          "type": "boolean",
+          "description": "Pods defines if metrics-server pods api should get proxied from host to virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "MetricsServer reuses the metrics server from the host cluster within the vCluster."
+    },
+    "MutatingWebhook": {
+      "properties": {
+        "reinvocationPolicy": {
+          "type": "string",
+          "description": "reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.\nAllowed values are \"Never\" and \"IfNeeded\"."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the admission webhook.\nName should be fully qualified, e.g., imagepolicy.kubernetes.io, where\n\"imagepolicy\" is the name of the webhook, and kubernetes.io is the name\nof the organization."
+        },
+        "clientConfig": {
+          "$ref": "#/$defs/ValidatingWebhookClientConfig",
+          "description": "ClientConfig defines how to communicate with the hook."
+        },
+        "rules": {
+          "items": true,
+          "type": "array",
+          "description": "Rules describes what operations on what resources/subresources the webhook cares about.\nThe webhook cares about an operation if it matches _any_ Rule."
+        },
+        "failurePolicy": {
+          "type": "string",
+          "description": "FailurePolicy defines how unrecognized errors from the admission endpoint are handled -\nallowed values are Ignore or Fail. Defaults to Fail."
+        },
+        "matchPolicy": {
+          "type": "string",
+          "description": "matchPolicy defines how the \"rules\" list is used to match incoming requests.\nAllowed values are \"Exact\" or \"Equivalent\"."
+        },
+        "namespaceSelector": {
+          "description": "NamespaceSelector decides whether to run the webhook on an object based\non whether the namespace for that object matches the selector. If the\nobject itself is a namespace, the matching is performed on\nobject.metadata.labels. If the object is another cluster scoped resource,\nit never skips the webhook."
+        },
+        "objectSelector": {
+          "description": "ObjectSelector decides whether to run the webhook based on if the\nobject has matching labels. objectSelector is evaluated against both\nthe oldObject and newObject that would be sent to the webhook, and\nis considered to match if either object matches the selector."
+        },
+        "sideEffects": {
+          "type": "string",
+          "description": "SideEffects states whether this webhook has side effects."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "TimeoutSeconds specifies the timeout for this webhook."
+        },
+        "admissionReviewVersions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`\nversions the Webhook expects."
+        },
+        "matchConditions": {
+          "items": true,
+          "type": "array",
+          "description": "MatchConditions is a list of conditions that must be met for a request to be sent to this\nwebhook. Match conditions filter requests that have already been matched by the rules,\nnamespaceSelector, and objectSelector. An empty list of matchConditions matches all requests.\nThere are a maximum of 64 match conditions allowed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MutatingWebhookConfiguration": {
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to."
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values."
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "webhooks": {
+          "items": {
+            "$ref": "#/$defs/MutatingWebhook"
+          },
+          "type": "array",
+          "description": "Webhooks is a list of webhooks and the affected resources and operations."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetrisIntegration": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if netris integration is enabled\n+optional"
+        },
+        "connector": {
+          "type": "string",
+          "description": "Connector specifies the netris connector name\n+optional"
+        },
+        "kubeVip": {
+          "$ref": "#/$defs/NetrisKubeVipConfig",
+          "description": "KubeVip holds kube-vip configuration for netris\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetrisIntegration holds netris integration configuration."
+    },
+    "NetrisKubeVipConfig": {
+      "properties": {
+        "serverCluster": {
+          "type": "string",
+          "description": "ServerCluster specifies the server cluster name\n+optional"
+        },
+        "bridge": {
+          "type": "string",
+          "description": "Bridge specifies the bridge interface name\n+optional"
+        },
+        "ipRange": {
+          "type": "string",
+          "description": "IPRange specifies the IP range for kube-vip\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetrisKubeVipConfig holds kube-vip configuration for netris integration"
+    },
+    "NetworkPolicy": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the network policy should be deployed by vCluster."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        },
+        "fallbackDns": {
+          "type": "string",
+          "description": "FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server."
+        },
+        "controlPlane": {
+          "$ref": "#/$defs/NetworkPolicyControlPlane",
+          "description": "ControlPlane network policy rules"
+        },
+        "workload": {
+          "$ref": "#/$defs/NetworkPolicyWorkload",
+          "description": "Workload network policy rules"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetworkPolicyControlPlane": {
+      "properties": {
+        "ingress": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyIngressRule"
+          },
+          "type": "array",
+          "description": "Ingress rules for the vCluster control plane."
+        },
+        "egress": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyEgressRule"
+          },
+          "type": "array",
+          "description": "Egress rules for the vCluster control plane."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetworkPolicyEgressRule": {
+      "properties": {
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyPort"
+          },
+          "type": "array",
+          "description": "ports is a list of destination ports for outgoing traffic.\nEach item in this list is combined using a logical OR. If this field is\nempty or missing, this rule matches all ports (traffic not restricted by port).\nIf this field is present and contains at least one item, then this rule allows\ntraffic only if the traffic matches at least one port in the list.\n+optional\n+listType=atomic"
+        },
+        "to": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyPeer"
+          },
+          "type": "array",
+          "description": "to is a list of destinations for outgoing traffic of pods selected for this rule.\nItems in this list are combined using a logical OR operation. If this field is\nempty or missing, this rule matches all destinations (traffic not restricted by\ndestination). If this field is present and contains at least one item, this rule\nallows traffic only if the traffic matches at least one item in the to list.\n+optional\n+listType=atomic"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector."
+    },
+    "NetworkPolicyIngressRule": {
+      "properties": {
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyPort"
+          },
+          "type": "array",
+          "description": "ports is a list of ports which should be made accessible on the pods selected for\nthis rule. Each item in this list is combined using a logical OR. If this field is\nempty or missing, this rule matches all ports (traffic not restricted by port).\nIf this field is present and contains at least one item, then this rule allows\ntraffic only if the traffic matches at least one port in the list.\n+optional\n+listType=atomic"
+        },
+        "from": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyPeer"
+          },
+          "type": "array",
+          "description": "from is a list of sources which should be able to access the pods selected for this rule.\nItems in this list are combined using a logical OR operation. If this field is\nempty or missing, this rule matches all sources (traffic not restricted by\nsource). If this field is present and contains at least one item, this rule\nallows traffic only if the traffic matches at least one item in the from list.\n+optional\n+listType=atomic"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector."
+    },
+    "NetworkPolicyPeer": {
+      "properties": {
+        "podSelector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "podSelector is a label selector which selects pods. This field follows standard label\nselector semantics; if present but empty, it selects all pods.\n\nIf namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects\nthe pods matching podSelector in the Namespaces selected by NamespaceSelector.\nOtherwise it selects the pods matching podSelector in the policy's own namespace.\n+optional"
+        },
+        "namespaceSelector": {
+          "$ref": "#/$defs/StandardLabelSelector",
+          "description": "namespaceSelector selects namespaces using cluster-scoped labels. This field follows\nstandard label selector semantics; if present but empty, it selects all namespaces.\n\nIf podSelector is also set, then the NetworkPolicyPeer as a whole selects\nthe pods matching podSelector in the namespaces selected by namespaceSelector.\nOtherwise it selects all pods in the namespaces selected by namespaceSelector.\n+optional"
+        },
+        "ipBlock": {
+          "$ref": "#/$defs/IPBlock",
+          "description": "ipBlock defines policy on a particular IPBlock. If this field is set then\nneither of the other fields can be.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetworkPolicyPeer describes a peer to allow traffic to/from."
+    },
+    "NetworkPolicyPort": {
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.\nIf not specified, this field defaults to TCP.\n+optional"
+        },
+        "port": {
+          "description": "port represents the port on the given protocol. This can either be a numerical or named\nport on a pod. If this field is not provided, this matches all port names and\nnumbers.\nIf present, only traffic on the specified protocol AND port will be matched.\n+optional"
+        },
+        "endPort": {
+          "type": "integer",
+          "description": "endPort indicates that the range of ports from port to endPort if set, inclusive,\nshould be allowed by the policy. This field cannot be defined if the port field\nis not defined or if the port field is defined as a named (string) port.\nThe endPort must be equal or greater than port.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "NetworkPolicyPort describes a port to allow traffic on"
+    },
+    "NetworkPolicyWorkload": {
+      "properties": {
+        "publicEgress": {
+          "$ref": "#/$defs/NetworkPolicyWorkloadPublicEgress",
+          "description": "PublicEgress holds the public outgoing connections options for the vCluster workloads."
+        },
+        "ingress": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyIngressRule"
+          },
+          "type": "array",
+          "description": "Ingress rules for the vCluster workloads."
+        },
+        "egress": {
+          "items": {
+            "$ref": "#/$defs/NetworkPolicyEgressRule"
+          },
+          "type": "array",
+          "description": "Egress rules for the vCluster workloads."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetworkPolicyWorkloadPublicEgress": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the workload public egress should be enabled or disabled."
+        },
+        "cidr": {
+          "type": "string",
+          "description": "CIDR defines the allowed workload public egress destination.\nValid examples are \"0.0.0.0/0\", \"192.168.1.0/24\" or \"2001:db8::/64\""
+        },
+        "except": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Except is a slice of CIDRs that should not be included. Items outside the cidr range will be rejected.\nValid examples are \"192.168.1.0/24\" or \"2001:db8::/64\".\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetworkProxyKubelets": {
+      "properties": {
+        "byHostname": {
+          "type": "boolean",
+          "description": "ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work\nfor all applications, e.g. Prometheus requires a node IP."
+        },
+        "byIP": {
+          "type": "boolean",
+          "description": "ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to\nroute traffic."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Networking": {
+      "properties": {
+        "serviceCIDR": {
+          "type": "string",
+          "description": "ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr."
+        },
+        "podCIDR": {
+          "type": "string",
+          "description": "PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true."
+        },
+        "replicateServices": {
+          "$ref": "#/$defs/ReplicateServices",
+          "description": "ReplicateServices allows replicating services from the host within the virtual cluster or the other way around."
+        },
+        "resolveDNS": {
+          "items": {
+            "$ref": "#/$defs/ResolveDNS"
+          },
+          "type": "array",
+          "description": "ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.",
+          "pro": true
+        },
+        "advanced": {
+          "$ref": "#/$defs/NetworkingAdvanced",
+          "description": "Advanced holds advanced network options."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NetworkingAdvanced": {
+      "properties": {
+        "clusterDomain": {
+          "type": "string",
+          "description": "ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster."
+        },
+        "fallbackHostCluster": {
+          "type": "boolean",
+          "description": "FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without\nany other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace"
+        },
+        "proxyKubelets": {
+          "$ref": "#/$defs/NetworkProxyKubelets",
+          "description": "ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to \"fake\" this for applications such as\nprometheus or other node exporters."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "NodeRegistration": {
+      "properties": {
+        "criSocket": {
+          "type": "string",
+          "description": "CRI socket is the socket for the CRI."
+        },
+        "kubeletExtraArgs": {
+          "items": {
+            "$ref": "#/$defs/KubeletExtraArg"
+          },
+          "type": "array",
+          "description": "KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file\nkubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap\nFlags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.\nAn argument name in this list is the flag name as it appears on the command line except without leading dash(es).\nExtra arguments will override existing default arguments. Duplicate extra arguments are allowed."
+        },
+        "taints": {
+          "items": {
+            "$ref": "#/$defs/KubeletJoinTaint"
+          },
+          "type": "array",
+          "description": "Taints are additional taints to set for the kubelet."
+        },
+        "ignorePreflightErrors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.\nValue 'all' ignores errors from all checks."
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy specifies the policy for image pulling during kubeadm \"init\" and \"join\" operations.\nThe value of this field must be one of \"Always\", \"IfNotPresent\" or \"Never\".\nIf this field is unset kubeadm will default it to \"IfNotPresent\", or pull the required images if not present on the host."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ObjectMeta": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Platform": {
+      "properties": {
+        "apiKey": {
+          "$ref": "#/$defs/PlatformAPIKey",
+          "description": "APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:\n* environment variable called LICENSE\n* secret specified under platform.apiKey.secretName\n* secret called \"vcluster-platform-api-key\" in the vCluster namespace"
+        },
+        "project": {
+          "type": "string",
+          "description": "Project specifies which platform project the vcluster should be imported to\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Platform holds vCluster Platform specific configuration."
+    },
+    "PlatformAPIKey": {
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "description": "SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.\n+optional"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace\nwhere the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.\n+optional"
+        },
+        "createRBAC": {
+          "type": "boolean",
+          "description": "CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified\nin the above namespace, if specified.\nThis defaults to true.\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PlatformAPIKey defines where to find the platform access key."
+    },
+    "Plugin": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the init-container and NOT the plugin name"
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the container image that should be used for the plugin"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the pull policy to use for the container image"
+        },
+        "config": {
+          "type": "object",
+          "description": "Config is the plugin config to use. This can be arbitrary config used for the plugin."
+        },
+        "rbac": {
+          "$ref": "#/$defs/PluginsRBAC",
+          "description": "RBAC holds additional rbac configuration for the plugin"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command is the command that should be used for the init container"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args are the arguments that should be used for the init container"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "SecurityContext is the container security context used for the init container"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources are the container resources used for the init container"
+        },
+        "volumeMounts": {
+          "items": true,
+          "type": "array",
+          "description": "VolumeMounts are extra volume mounts for the init container"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version is the plugin version, this is only needed for legacy plugins."
+        },
+        "env": {
+          "items": true,
+          "type": "array"
+        },
+        "envFrom": {
+          "items": true,
+          "type": "array"
+        },
+        "lifecycle": {
+          "type": "object"
+        },
+        "livenessProbe": {
+          "type": "object"
+        },
+        "readinessProbe": {
+          "type": "object"
+        },
+        "startupProbe": {
+          "type": "object"
+        },
+        "workingDir": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Plugins": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the init-container and NOT the plugin name"
+        },
+        "image": {
+          "type": "string",
+          "description": "Image is the container image that should be used for the plugin"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "description": "ImagePullPolicy is the pull policy to use for the container image"
+        },
+        "config": {
+          "type": "object",
+          "description": "Config is the plugin config to use. This can be arbitrary config used for the plugin."
+        },
+        "rbac": {
+          "$ref": "#/$defs/PluginsRBAC",
+          "description": "RBAC holds additional rbac configuration for the plugin"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Command is the command that should be used for the init container"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args are the arguments that should be used for the init container"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "SecurityContext is the container security context used for the init container"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources are the container resources used for the init container"
+        },
+        "volumeMounts": {
+          "items": true,
+          "type": "array",
+          "description": "VolumeMounts are extra volume mounts for the init container"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PluginsExtraRules": {
+      "properties": {
+        "extraRules": {
+          "items": {
+            "$ref": "#/$defs/RBACPolicyRule"
+          },
+          "type": "array",
+          "description": "ExtraRules are extra rbac permissions roles that will be added to role or cluster role"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PluginsRBAC": {
+      "properties": {
+        "role": {
+          "$ref": "#/$defs/PluginsExtraRules",
+          "description": "Role holds extra virtual cluster role permissions for the plugin"
+        },
+        "clusterRole": {
+          "$ref": "#/$defs/PluginsExtraRules",
+          "description": "ClusterRole holds extra virtual cluster cluster role permissions required for the plugin"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PodDNSConfig": {
+      "properties": {
+        "nameservers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.\n+optional\n+listType=atomic"
+        },
+        "searches": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.\n+optional\n+listType=atomic"
+        },
+        "options": {
+          "items": {
+            "$ref": "#/$defs/PodDNSConfigOption"
+          },
+          "type": "array",
+          "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.\n+optional\n+listType=atomic"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy."
+    },
+    "PodDNSConfigOption": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required."
+        },
+        "value": {
+          "type": "string",
+          "description": "+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PodDNSConfigOption defines DNS resolver options of a pod."
+    },
+    "PodDisruptionBudget": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the pod disruption budget should be enabled."
+        },
+        "minAvailable": {
+          "description": "MinAvailable describes the minimal number or percentage of available pods."
+        },
+        "maxUnavailable": {
+          "description": "MaxUnavailable describes the minimal number or percentage of unavailable pods."
+        },
+        "unhealthyPodEvictionPolicy": {
+          "type": "string",
+          "description": "UnhealthyPodEvictionPolicy defines the criteria when unhealthy pods should be considered for eviction.\nCurrently supported values are:\n* IfHealthyBudget - pods that are in the Running phase but not yet healthy are considered disrupted\n\tand may be evicted even if the PodDisruptionBudget criteria are not met.\n* AlwaysAllow - pods that are in the Running phase but not yet healthy are considered disrupted\n\tand can be evicted regardless of whether the criteria in a PDB is met."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Policies": {
+      "properties": {
+        "networkPolicy": {
+          "$ref": "#/$defs/NetworkPolicy",
+          "description": "NetworkPolicy specifies network policy options."
+        },
+        "podSecurityStandard": {
+          "type": "string",
+          "description": "PodSecurityStandard that can be enforced can be one of: empty (\"\"), baseline, restricted or privileged"
+        },
+        "resourceQuota": {
+          "$ref": "#/$defs/ResourceQuota",
+          "description": "ResourceQuota specifies resource quota options."
+        },
+        "limitRange": {
+          "$ref": "#/$defs/LimitRange",
+          "description": "LimitRange specifies limit range options."
+        },
+        "centralAdmission": {
+          "$ref": "#/$defs/CentralAdmission",
+          "description": "CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.",
+          "pro": true
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PrivateNodes": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if dedicated nodes should be enabled."
+        },
+        "kubelet": {
+          "$ref": "#/$defs/Kubelet",
+          "description": "Kubelet holds kubelet configuration that is used for all nodes."
+        },
+        "autoUpgrade": {
+          "$ref": "#/$defs/AutoUpgrade",
+          "description": "AutoUpgrade holds configuration for auto upgrade."
+        },
+        "joinNode": {
+          "$ref": "#/$defs/JoinConfiguration",
+          "description": "JoinNode holds configuration specifically used during joining the node (see \"kubeadm join\")."
+        },
+        "autoNodes": {
+          "items": {
+            "$ref": "#/$defs/PrivateNodesAutoNodes"
+          },
+          "type": "array",
+          "description": "AutoNodes stores auto nodes configuration."
+        },
+        "vpn": {
+          "$ref": "#/$defs/PrivateNodesVPN",
+          "description": "VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or\nconnect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work."
+        },
+        "daemon": {
+          "$ref": "#/$defs/PrivateNodesDaemon",
+          "description": "Daemon holds configuration for the private nodes daemon that is deployed on the nodes."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PrivateNodes enables private nodes for vCluster."
+    },
+    "PrivateNodesAutoNodes": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the node provider of the nodes in this pool."
+        },
+        "properties": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Properties are the node provider properties. This is a simple key value map and can contain things\nlike region, subscription, etc. that is then used by the node provider to create the nodes and node environment."
+        },
+        "static": {
+          "items": {
+            "$ref": "#/$defs/StaticNodePool"
+          },
+          "type": "array",
+          "description": "Static defines static node pools. Static node pools have a fixed size and are not scaled automatically."
+        },
+        "dynamic": {
+          "items": {
+            "$ref": "#/$defs/DynamicNodePool"
+          },
+          "type": "array",
+          "description": "Dynamic defines dynamic node pools. Dynamic node pools are scaled automatically based on the requirements within the cluster.\nKarpenter is used under the hood to handle the scheduling of the nodes."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "provider"
+      ],
+      "description": "PrivateNodesAutoNodes defines auto nodes"
+    },
+    "PrivateNodesDaemon": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the private nodes daemon should be enabled."
+        },
+        "controlPlaneLoadBalancer": {
+          "$ref": "#/$defs/ControlPlaneLoadBalancer",
+          "description": "ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.\nThis is useful to achieve true high availability for the control plane without having to deploy a separate load balancer."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PrivateNodesVPN": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the private nodes vpn should be enabled."
+        },
+        "nodeToNode": {
+          "$ref": "#/$defs/PrivateNodesVPNNodeToNode",
+          "description": "NodeToNode holds configuration for the node to node vpn. This can be used to connect the private nodes to each other if they are not running in the same network."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "PrivateNodesVPNNodeToNode": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the node to node vpn should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Proxy": {
+      "properties": {
+        "customResources": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CustomResourceProxy"
+          },
+          "type": "object",
+          "description": "CustomResources is a map of resource keys (format: \"kind.apiGroup/version\") to proxy configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RBAC": {
+      "properties": {
+        "role": {
+          "$ref": "#/$defs/RBACRole",
+          "description": "Role holds virtual cluster role configuration"
+        },
+        "clusterRole": {
+          "$ref": "#/$defs/RBACClusterRole",
+          "description": "ClusterRole holds virtual cluster cluster role configuration"
+        },
+        "enableVolumeSnapshotRules": {
+          "$ref": "#/$defs/EnableAutoSwitch",
+          "description": "EnableVolumeSnapshotRules enables all required volume snapshot rules in the Role and\nClusterRole."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RBACClusterRole": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role."
+        },
+        "extraRules": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ExtraRules will add rules to the cluster role."
+        },
+        "overwriteRules": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "OverwriteRules will overwrite the cluster role rules completely."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RBACPolicyRule": {
+      "properties": {
+        "verbs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs."
+        },
+        "apiGroups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of\nthe enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups."
+        },
+        "resources": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Resources is a list of resources this rule applies to. '*' represents all resources."
+        },
+        "resourceNames": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed."
+        },
+        "nonResourceURLs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path\nSince non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.\nRules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RBACRole": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the role should be enabled or disabled."
+        },
+        "extraRules": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ExtraRules will add rules to the role."
+        },
+        "overwriteRules": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "OverwriteRules will overwrite the role rules completely."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ReadinessProbe": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Number of consecutive failures for the probe to be considered failed"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Maximum duration (in seconds) that the probe will wait for a response."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Frequency (in seconds) to perform the probe"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ReadinessProbe defines the configuration for the readiness probe."
+    },
+    "Registry": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the embedded registry should be enabled."
+        },
+        "anonymousPull": {
+          "type": "boolean",
+          "description": "AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication."
+        },
+        "config": {
+          "description": "Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ReplicateServices": {
+      "properties": {
+        "toHost": {
+          "items": {
+            "$ref": "#/$defs/ServiceMapping"
+          },
+          "type": "array",
+          "description": "ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are\nsynced to a different namespace than the virtual cluster is in, additional permissions for the other namespace\nare required."
+        },
+        "fromHost": {
+          "items": {
+            "$ref": "#/$defs/ServiceMapping"
+          },
+          "type": "array",
+          "description": "FromHost defines the services that should get synced from the host to the virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Requirement": {
+      "properties": {
+        "property": {
+          "type": "string",
+          "description": "Property is the property on the node type to select."
+        },
+        "operator": {
+          "type": "string",
+          "description": "Operator is the comparison operator, such as \"In\", \"NotIn\", \"Exists\". If empty, defaults to \"In\"."
+        },
+        "values": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Values is the list of values to use for comparison. This is mutually exclusive with value."
+        },
+        "value": {
+          "type": "string",
+          "description": "Value is the value to use for comparison. This is mutually exclusive with values."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "property"
+      ],
+      "description": "KarpenterRequirement defines a scheduling requirement for a dynamic node pool."
+    },
+    "ResolveDNS": {
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Hostname is the hostname within the vCluster that should be resolved from."
+        },
+        "service": {
+          "type": "string",
+          "description": "Service is the virtual cluster service that should be resolved from."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace is the virtual cluster namespace that should be resolved from."
+        },
+        "target": {
+          "$ref": "#/$defs/ResolveDNSTarget",
+          "description": "Target is the DNS target that should get mapped to"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ResolveDNSTarget": {
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Hostname to use as a DNS target"
+        },
+        "ip": {
+          "type": "string",
+          "description": "IP to use as a DNS target"
+        },
+        "hostService": {
+          "type": "string",
+          "description": "HostService to target, format is hostNamespace/hostService"
+        },
+        "hostNamespace": {
+          "type": "string",
+          "description": "HostNamespace to target"
+        },
+        "vClusterService": {
+          "type": "string",
+          "description": "VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ResourceQuota": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled defines if the resource quota should be enabled. \"auto\" means that if limitRange is enabled,\nthe resourceQuota will be enabled as well."
+        },
+        "quota": {
+          "type": "object",
+          "description": "Quota are the quota options"
+        },
+        "scopeSelector": {
+          "type": "object",
+          "description": "ScopeSelector is the resource quota scope selector"
+        },
+        "scopes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Scopes are the resource quota scopes"
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Resources": {
+      "properties": {
+        "limits": {
+          "type": "object",
+          "description": "Limits are resource limits for the container"
+        },
+        "requests": {
+          "type": "object",
+          "description": "Requests are minimal resources that will be consumed by the container"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RuleWithVerbs": {
+      "properties": {
+        "apiGroups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "APIGroups is the API groups the resources belong to. '*' is all groups."
+        },
+        "apiVersions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "APIVersions is the API versions the resources belong to. '*' is all versions."
+        },
+        "resources": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Resources is a list of resources this rule applies to."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope specifies the scope of this rule."
+        },
+        "operations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.\nFor non-resource requests, this is the lowercase http verb.\nIf '*' is present, the length of the slice must be one."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SelectorConfig": {
+      "properties": {
+        "selector": {
+          "$ref": "#/$defs/StandardLabelSelector"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ServiceMapping": {
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "From is the service that should get synced. Can be either in the form name or namespace/name."
+        },
+        "to": {
+          "type": "string",
+          "description": "To is the target service that it should get synced to. Can be either in the form name or namespace/name."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ServiceMonitor": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled configures if Helm should create the service monitor."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are the extra labels to add to the service monitor."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are the extra annotations to add to the service monitor."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Sleep": {
+      "properties": {
+        "auto": {
+          "$ref": "#/$defs/SleepAuto",
+          "description": "Auto holds automatic sleep configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Sleep holds configuration for automatically putting the virtual cluster to sleep."
+    },
+    "SleepAuto": {
+      "properties": {
+        "afterInactivity": {
+          "type": "string",
+          "description": "AfterInactivity represents how long a vCluster can be idle before workloads are automatically put to sleep"
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Schedule represents a cron schedule for when to sleep workloads"
+        },
+        "exclude": {
+          "$ref": "#/$defs/SleepAutoExclusion",
+          "description": "Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep"
+        },
+        "wakeup": {
+          "$ref": "#/$defs/SleepAutoWakeup",
+          "description": "Wakeup holds configuration for waking the vCluster on a schedule"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone specifies time zone used for scheduled sleep operations. Defaults to UTC.\nAccepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).\nThe value should be a location name corresponding to a file in the IANA Time Zone database, such as \"America/New_York\".\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SleepAuto holds configuration for automatic sleep and wakeup"
+    },
+    "SleepAutoExclusion": {
+      "properties": {
+        "selector": {
+          "$ref": "#/$defs/LabelSelector"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SleepAutoExclusion holds conifiguration for excluding workloads from sleeping by label(s)"
+    },
+    "SleepAutoWakeup": {
+      "properties": {
+        "schedule": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SleepAutoWakeup holds the cron schedule to wake workloads automatically"
+    },
+    "SnapshotRetention": {
+      "properties": {
+        "period": {
+          "type": "integer",
+          "description": "Period defines the number of days a snapshot will be kept\n+optional"
+        },
+        "maxSnapshots": {
+          "type": "integer",
+          "description": "MaxSnapshots defines the number of snapshots that can be taken\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotRetention holds snapshot retention configuration"
+    },
+    "SnapshotSecretCredential": {
+      "properties": {
+        "secretName": {
+          "type": "string",
+          "description": "SecretName is the secret name with credential\n+optional"
+        },
+        "secretNamespace": {
+          "type": "string",
+          "description": "SecretNamespace is the secret namespace with credential\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotSecretCredential holds secret reference for credentials"
+    },
+    "SnapshotStorage": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type specifies supported type of storage services for a snapshot S3/OCI/Container, see https://www.vcluster.com/docs/vcluster/manage/backup-restore#store-snapshots-in-s3-buckets\n+optional"
+        },
+        "s3": {
+          "$ref": "#/$defs/SnapshotStorageS3",
+          "description": "S3 holds configuration for storing snapshots in S3-compatible bucket\n+optional"
+        },
+        "oci": {
+          "$ref": "#/$defs/SnapshotStorageOCI",
+          "description": "OCI holds configuration for storing snapshots in OCI image registries\n+optional"
+        },
+        "container": {
+          "$ref": "#/$defs/SnapshotStorageContainer",
+          "description": "Container holds configuration for storing snapshots as local files inside a vCluster container\n+optional"
+        },
+        "azure": {
+          "$ref": "#/$defs/SnapshotStorageAzure",
+          "description": "Azure holds configuration for storing snapshots in Azure Blob Storage\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorage holds snapshot storage configuration"
+    },
+    "SnapshotStorageAzure": {
+      "properties": {
+        "blobUrl": {
+          "type": "string",
+          "description": "BlobURL specifies the Azure Blob Storage URL in the format https://{account}.blob.core.windows.net/{container}/{path}\n+optional"
+        },
+        "credential": {
+          "$ref": "#/$defs/SnapshotSecretCredential",
+          "description": "Credential secret with the Azure credentials. The secret should contain either:\nAZURE_STORAGE_KEY (storage account access key), or\nAZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP (service principal)\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageAzure holds Azure Blob Storage configuration."
+    },
+    "SnapshotStorageContainer": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path specifies directory to store the snapshot\n+optional"
+        },
+        "volume": {
+          "$ref": "#/$defs/SnapshotStorageContainerVolume",
+          "description": "Volume specifies which volume needs to be mounted into the container to store the snapshot\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageContainer holds container local storage configuration"
+    },
+    "SnapshotStorageContainerVolume": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name to be used to mount the volume\n+optional"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the volume mount\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageContainerVolume holds volume mount configuration"
+    },
+    "SnapshotStorageOCI": {
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Repository OCI repository to store the snapshot\n+optional"
+        },
+        "credential": {
+          "$ref": "#/$defs/SnapshotSecretCredential",
+          "description": "Credential secret with the OCI Credentials\n+optional"
+        },
+        "username": {
+          "type": "string",
+          "description": "Username to authenticate with the OCI registry\n+optional"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password to authenticate with the OCI registry\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageOCI holds OCI registry storage configuration"
+    },
+    "SnapshotStorageS3": {
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Url specifies url to the storage service\n+optional"
+        },
+        "credential": {
+          "$ref": "#/$defs/SnapshotSecretCredential",
+          "description": "Credential secret with the S3 Credentials, it should contain AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageS3 holds S3 storage configuration"
+    },
+    "SnapshotVolumes": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies whether a snapshot should also include volumes in the snapshot\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotVolumes holds volume snapshot configuration"
+    },
+    "Snapshots": {
+      "properties": {
+        "auto": {
+          "$ref": "#/$defs/SnapshotsAuto",
+          "description": "Auto holds automatic snapshot configuration\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Snapshots holds configuration for automatic vCluster snapshots."
+    },
+    "SnapshotsAuto": {
+      "properties": {
+        "schedule": {
+          "type": "string",
+          "description": "Schedule specifies a scheduled time in Cron format, see https://en.wikipedia.org/wiki/Cron for a virtual cluster snapshot to be taken\n+optional"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone specifies time zone used for scheduled snapshot operations. Defaults to UTC.\nAccepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).\nThe value should be a location name corresponding to a file in the IANA Time Zone database, such as \"America/New_York\".\n+optional"
+        },
+        "retention": {
+          "$ref": "#/$defs/SnapshotRetention",
+          "description": "Retention specifies how long snapshots will be kept\n+optional"
+        },
+        "storage": {
+          "$ref": "#/$defs/SnapshotStorage",
+          "description": "Storage specifies where the snapshot will be stored\n+optional"
+        },
+        "volumes": {
+          "$ref": "#/$defs/SnapshotVolumes",
+          "description": "Volumes specifies configuration for volume snapshots\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotsAuto holds automatic snapshot scheduling and retention configuration"
+    },
+    "Standalone": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if standalone mode should be enabled."
+        },
+        "dataDir": {
+          "type": "string",
+          "description": "DataDir defines the data directory for the standalone mode."
+        },
+        "autoNodes": {
+          "$ref": "#/$defs/StandaloneAutoNodes",
+          "description": "AutoNodes automatically deploys nodes for standalone mode."
+        },
+        "joinNode": {
+          "$ref": "#/$defs/StandaloneJoinNode",
+          "description": "JoinNode holds configuration for the standalone control plane node."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StandaloneAutoNodes": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Provider is the node provider of the nodes in this pool."
+        },
+        "quantity": {
+          "type": "integer",
+          "description": "Quantity is the number of nodes to deploy for standalone mode."
+        },
+        "nodeTypeSelector": {
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          },
+          "type": "array",
+          "description": "NodeTypeSelector filters the types of nodes that can be provisioned by this pool.\nAll requirements must be met for a node type to be eligible."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StandaloneJoinNode": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster."
+        },
+        "preInstallCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreInstallCommands are commands that will be executed before containerd, kubelet etc. is installed."
+        },
+        "preJoinCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PreJoinCommands are commands that will be executed before kubeadm join is executed."
+        },
+        "postJoinCommands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "PostJoinCommands are commands that will be executed after kubeadm join is executed."
+        },
+        "containerd": {
+          "$ref": "#/$defs/ContainerdJoin",
+          "description": "Containerd holds configuration for the containerd join process."
+        },
+        "caCertPath": {
+          "type": "string",
+          "description": "CACertPath is the path to the SSL certificate authority used to\nsecure communications between node and control-plane.\nDefaults to \"/etc/kubernetes/pki/ca.crt\"."
+        },
+        "skipPhases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "SkipPhases is a list of phases to skip during command execution.\nThe list of phases can be obtained with the \"kubeadm join --help\" command."
+        },
+        "nodeRegistration": {
+          "$ref": "#/$defs/NodeRegistration",
+          "description": "NodeRegistration holds configuration for the node registration similar to the kubeadm node registration."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StandardLabelSelector": {
+      "properties": {
+        "matchLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "matchExpressions": {
+          "items": {
+            "$ref": "#/$defs/LabelSelectorRequirement"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "StartupProbe": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Number of consecutive failures allowed before failing the pod"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Maximum duration (in seconds) that the probe will wait for a response."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Frequency (in seconds) to perform the probe"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StartupProbe defines the configuration for the startup probe."
+    },
+    "StaticNodePool": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of this static nodePool"
+        },
+        "nodeTypeSelector": {
+          "items": {
+            "$ref": "#/$defs/Requirement"
+          },
+          "type": "array",
+          "description": "NodeTypeSelector filters the types of nodes that can be provisioned by this pool.\nAll requirements must be met for a node type to be eligible."
+        },
+        "taints": {
+          "items": {
+            "$ref": "#/$defs/KubeletJoinTaint"
+          },
+          "type": "array",
+          "description": "Taints are the taints to apply to the nodes in this pool."
+        },
+        "nodeLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeLabels are the labels to apply to the nodes in this pool."
+        },
+        "terminationGracePeriod": {
+          "type": "string",
+          "description": "TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.\n\nWarning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.\n\nThis field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.\nWhen set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.\n\nKarpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.\nIf a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,\nthat pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.\n\nThe feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.\nDefaults to 30s. Set to Never to wait indefinitely for pods to be drained."
+        },
+        "quantity": {
+          "type": "integer",
+          "description": "Quantity is the number of desired nodes in this pool."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "quantity"
+      ]
+    },
+    "Sync": {
+      "properties": {
+        "toHost": {
+          "$ref": "#/$defs/SyncToHost",
+          "description": "Configure resources to sync from the virtual cluster to the host cluster."
+        },
+        "fromHost": {
+          "$ref": "#/$defs/SyncFromHost",
+          "description": "Configure what resources vCluster should sync from the host cluster to the virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncAllResource": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "all": {
+          "type": "boolean",
+          "description": "All defines if all resources of that type should get synced or only the necessary ones that are needed."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncFromHost": {
+      "properties": {
+        "nodes": {
+          "$ref": "#/$defs/SyncNodes",
+          "description": "Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back."
+        },
+        "events": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "Events defines if events should get synced from the host cluster to the virtual cluster, but not back."
+        },
+        "ingressClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
+          "description": "IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back."
+        },
+        "runtimeClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
+          "description": "RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back."
+        },
+        "priorityClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
+          "description": "PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back."
+        },
+        "storageClasses": {
+          "$ref": "#/$defs/EnableAutoSwitchWithPatchesAndSelector",
+          "description": "StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled."
+        },
+        "csiNodes": {
+          "$ref": "#/$defs/EnableAutoSwitchWithPatches",
+          "description": "CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled."
+        },
+        "csiDrivers": {
+          "$ref": "#/$defs/EnableAutoSwitchWithPatches",
+          "description": "CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled."
+        },
+        "csiStorageCapacities": {
+          "$ref": "#/$defs/EnableAutoSwitchWithPatches",
+          "description": "CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled."
+        },
+        "customResources": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SyncFromHostCustomResource"
+          },
+          "type": "object",
+          "description": "CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role."
+        },
+        "volumeSnapshotClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster."
+        },
+        "configMaps": {
+          "$ref": "#/$defs/EnableSwitchWithResourcesMappings",
+          "description": "ConfigMaps defines if config maps in the host should get synced to the virtual cluster."
+        },
+        "secrets": {
+          "$ref": "#/$defs/EnableSwitchWithResourcesMappings",
+          "description": "Secrets defines if secrets in the host should get synced to the virtual cluster."
+        },
+        "deviceClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatchesAndSelector",
+          "description": "DeviceClasses defines if device classes in the host should get synced to the virtual cluster"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncFromHostCustomResource": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope defines the scope of the resource"
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "mappings": {
+          "$ref": "#/$defs/FromHostMappings",
+          "description": "Mappings for Namespace and Object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled",
+        "scope"
+      ]
+    },
+    "SyncNodeSelector": {
+      "properties": {
+        "all": {
+          "type": "boolean",
+          "description": "All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncNodes": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead."
+        },
+        "syncBackChanges": {
+          "type": "boolean",
+          "description": "SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node."
+        },
+        "clearImageStatus": {
+          "type": "boolean",
+          "description": "ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node."
+        },
+        "selector": {
+          "$ref": "#/$defs/SyncNodeSelector",
+          "description": "Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncPods": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if pod syncing should be enabled."
+        },
+        "translateImage": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite\na certain image that is used within the virtual cluster to be another image on the host cluster"
+        },
+        "enforceTolerations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster."
+        },
+        "useSecretsForSATokens": {
+          "type": "boolean",
+          "description": "UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a\npod annotation."
+        },
+        "runtimeClassName": {
+          "type": "string",
+          "description": "RuntimeClassName is the runtime class to set for synced pods."
+        },
+        "priorityClassName": {
+          "type": "string",
+          "description": "PriorityClassName is the priority class to set for synced pods."
+        },
+        "rewriteHosts": {
+          "$ref": "#/$defs/SyncRewriteHosts",
+          "description": "RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add\na small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by\nthe virtual cluster."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "hybridScheduling": {
+          "$ref": "#/$defs/HybridScheduling",
+          "description": "HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncRewriteHosts": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies if rewriting stateful set pods should be enabled."
+        },
+        "initContainer": {
+          "$ref": "#/$defs/SyncRewriteHostsInitContainer",
+          "description": "InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncRewriteHostsInitContainer": {
+      "properties": {
+        "image": {
+          "$ref": "#/$defs/Image",
+          "description": "Image is the image virtual cluster should use to rewrite this FQDN."
+        },
+        "resources": {
+          "$ref": "#/$defs/Resources",
+          "description": "Resources are the resources that should be assigned to the init container for each stateful set init container."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncToHost": {
+      "properties": {
+        "pods": {
+          "$ref": "#/$defs/SyncPods",
+          "description": "Pods defines if pods created within the virtual cluster should get synced to the host cluster."
+        },
+        "secrets": {
+          "$ref": "#/$defs/SyncAllResource",
+          "description": "Secrets defines if secrets created within the virtual cluster should get synced to the host cluster."
+        },
+        "configMaps": {
+          "$ref": "#/$defs/SyncAllResource",
+          "description": "ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster."
+        },
+        "ingresses": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster."
+        },
+        "services": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "Services defines if services created within the virtual cluster should get synced to the host cluster."
+        },
+        "endpoints": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster."
+        },
+        "endpointSlices": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "EndpointSlices defines if endpointslices created within the virtual cluster should get synced to the host cluster."
+        },
+        "networkPolicies": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster."
+        },
+        "persistentVolumeClaims": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster."
+        },
+        "persistentVolumes": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster."
+        },
+        "volumeSnapshots": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster."
+        },
+        "volumeSnapshotContents": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster."
+        },
+        "storageClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster."
+        },
+        "serviceAccounts": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster."
+        },
+        "podDisruptionBudgets": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster."
+        },
+        "priorityClasses": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster."
+        },
+        "customResources": {
+          "additionalProperties": {
+            "$ref": "#/$defs/SyncToHostCustomResource"
+          },
+          "type": "object",
+          "description": "CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.\nvCluster will also automatically add any required RBAC permissions to the vCluster role for this to work."
+        },
+        "namespaces": {
+          "$ref": "#/$defs/SyncToHostNamespaces",
+          "description": "Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster."
+        },
+        "resourceClaims": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "ResourceClaim defines if resource claims created within the virtual cluster should get synced to the host cluster."
+        },
+        "resourceClaimTemplates": {
+          "$ref": "#/$defs/EnableSwitchWithPatches",
+          "description": "ResourceClaimTemplates defines if resourceClaimTemplates created within the virtual cluster should get synced to the host cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "SyncToHostCustomResource": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "scope": {
+          "type": "string",
+          "description": "Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ]
+    },
+    "SyncToHostNamespaces": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if this option should be enabled."
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/TranslatePatch"
+          },
+          "type": "array",
+          "description": "Patches patch the resource according to the provided specification."
+        },
+        "mappings": {
+          "$ref": "#/$defs/FromHostMappings",
+          "description": "Mappings for Namespace and Object"
+        },
+        "mappingsOnly": {
+          "type": "boolean",
+          "description": "MappingsOnly defines if creation of namespaces not matched by mappings should be allowed."
+        },
+        "extraLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "ExtraLabels are additional labels to add to the namespace in the host cluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ],
+      "description": "SyncToHostNamespaces defines how namespaces should be synced from the virtual cluster to the host cluster."
+    },
+    "Telemetry": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled specifies that the telemetry for the vCluster control plane should be enabled."
+        },
+        "instanceCreator": {
+          "type": "string"
+        },
+        "machineID": {
+          "type": "string"
+        },
+        "platformUserID": {
+          "type": "string"
+        },
+        "platformInstanceID": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TranslatePatch": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied."
+        },
+        "expression": {
+          "type": "string",
+          "description": "Expression transforms the value according to the given JavaScript expression."
+        },
+        "reverseExpression": {
+          "type": "string",
+          "description": "ReverseExpression transforms the value according to the given JavaScript expression."
+        },
+        "reference": {
+          "$ref": "#/$defs/TranslatePatchReference",
+          "description": "Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode\nautomatically. In single-namespace mode this will translate the name to \"vxxxxxxxxx\" to avoid conflicts with\nother names, in multi-namespace mode this will not translate the name."
+        },
+        "labels": {
+          "$ref": "#/$defs/TranslatePatchLabels",
+          "description": "Labels treats the path value as a labels selector."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    },
+    "TranslatePatchLabels": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "TranslatePatchReference": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion is the apiVersion of the referenced object."
+        },
+        "apiVersionPath": {
+          "type": "string",
+          "description": "APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion."
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind is the kind of the referenced object."
+        },
+        "kindPath": {
+          "type": "string",
+          "description": "KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind."
+        },
+        "namePath": {
+          "type": "string",
+          "description": "NamePath is the optional relative path to the reference name within the object."
+        },
+        "namespacePath": {
+          "type": "string",
+          "description": "NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the\nmetadata.namespace path of the object."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "kind"
+      ]
+    },
+    "ValidatingWebhook": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the admission webhook.\nName should be fully qualified, e.g., imagepolicy.kubernetes.io, where\n\"imagepolicy\" is the name of the webhook, and kubernetes.io is the name\nof the organization."
+        },
+        "clientConfig": {
+          "$ref": "#/$defs/ValidatingWebhookClientConfig",
+          "description": "ClientConfig defines how to communicate with the hook."
+        },
+        "rules": {
+          "items": true,
+          "type": "array",
+          "description": "Rules describes what operations on what resources/subresources the webhook cares about.\nThe webhook cares about an operation if it matches _any_ Rule."
+        },
+        "failurePolicy": {
+          "type": "string",
+          "description": "FailurePolicy defines how unrecognized errors from the admission endpoint are handled -\nallowed values are Ignore or Fail. Defaults to Fail."
+        },
+        "matchPolicy": {
+          "type": "string",
+          "description": "matchPolicy defines how the \"rules\" list is used to match incoming requests.\nAllowed values are \"Exact\" or \"Equivalent\"."
+        },
+        "namespaceSelector": {
+          "description": "NamespaceSelector decides whether to run the webhook on an object based\non whether the namespace for that object matches the selector. If the\nobject itself is a namespace, the matching is performed on\nobject.metadata.labels. If the object is another cluster scoped resource,\nit never skips the webhook."
+        },
+        "objectSelector": {
+          "description": "ObjectSelector decides whether to run the webhook based on if the\nobject has matching labels. objectSelector is evaluated against both\nthe oldObject and newObject that would be sent to the webhook, and\nis considered to match if either object matches the selector."
+        },
+        "sideEffects": {
+          "type": "string",
+          "description": "SideEffects states whether this webhook has side effects."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "TimeoutSeconds specifies the timeout for this webhook."
+        },
+        "admissionReviewVersions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`\nversions the Webhook expects."
+        },
+        "matchConditions": {
+          "items": true,
+          "type": "array",
+          "description": "MatchConditions is a list of conditions that must be met for a request to be sent to this\nwebhook. Match conditions filter requests that have already been matched by the rules,\nnamespaceSelector, and objectSelector. An empty list of matchConditions matches all requests.\nThere are a maximum of 64 match conditions allowed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ValidatingWebhookClientConfig": {
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL gives the location of the webhook, in standard URL form\n(`scheme://host:port/path`). Exactly one of `url` or `service`\nmust be specified."
+        },
+        "service": {
+          "$ref": "#/$defs/ValidatingWebhookServiceReference",
+          "description": "Service is a reference to the service for this webhook. Either\n`service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`."
+        },
+        "caBundle": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.\nIf unspecified, system trust roots on the apiserver are used."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ValidatingWebhookClientConfig contains the information to make a TLS connection with the webhook"
+    },
+    "ValidatingWebhookConfiguration": {
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to."
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values."
+        },
+        "metadata": {
+          "$ref": "#/$defs/ObjectMeta",
+          "description": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata."
+        },
+        "webhooks": {
+          "items": {
+            "$ref": "#/$defs/ValidatingWebhook"
+          },
+          "type": "array",
+          "description": "Webhooks is a list of webhooks and the affected resources and operations."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ValidatingWebhookServiceReference": {
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace is the namespace of the service."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the service."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path is an optional URL path which will be sent in any request to\nthis service."
+        },
+        "port": {
+          "type": "integer",
+          "description": "If specified, the port on the service that hosting webhook.\nDefault to 443 for backward compatibility.\n`port` should be a valid port number (1-65535, inclusive)."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VirtualClusterKubeConfig": {
+      "properties": {
+        "kubeConfig": {
+          "type": "string",
+          "description": "KubeConfig is the virtual cluster kubeconfig path."
+        },
+        "serverCAKey": {
+          "type": "string",
+          "description": "ServerCAKey is the server ca key path."
+        },
+        "serverCACert": {
+          "type": "string",
+          "description": "ServerCAKey is the server ca cert path."
+        },
+        "clientCACert": {
+          "type": "string",
+          "description": "ServerCAKey is the client ca cert path."
+        },
+        "requestHeaderCACert": {
+          "type": "string",
+          "description": "RequestHeaderCACert is the request header ca cert path."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VirtualClusterRef": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "description": "Name is the name of the target virtual cluster."
+        },
+        "project": {
+          "type": "string",
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "description": "Project is the project of the target virtual cluster. If empty, defaults to the same project as the source vCluster."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "description": "VirtualClusterRef is a reference to a virtual cluster within the platform."
+    },
+    "VolumeClaim": {
+      "properties": {
+        "enabled": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "description": "Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine\nbased on the chosen distro and other options if this is required."
+        },
+        "accessModes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "AccessModes are the persistent volume claim access modes."
+        },
+        "retentionPolicy": {
+          "type": "string",
+          "description": "RetentionPolicy is the persistent volume claim retention policy."
+        },
+        "size": {
+          "type": "string",
+          "description": "Size is the persistent volume claim storage size."
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "StorageClass is the persistent volume claim storage class."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "VolumeMount": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "This must match the Name of a Volume."
+        },
+        "readOnly": {
+          "type": "boolean",
+          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false."
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'."
+        },
+        "subPath": {
+          "type": "string",
+          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root)."
+        },
+        "mountPropagation": {
+          "type": "string",
+          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10."
+        },
+        "subPathExpr": {
+          "type": "string",
+          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "VolumeMount describes a mounting of a Volume within a container."
+    },
+    "VolumeSnapshotController": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the CSI volumes snapshot-controller should be enabled."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "VolumeSnapshotController defines CSI volumes snapshot-controller configuration."
+    }
+  },
+  "properties": {
+    "global": {
+      "description": "Global values shared across all (sub)charts"
+    },
+    "exportKubeConfig": {
+      "$ref": "#/$defs/ExportKubeConfig",
+      "description": "ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file."
+    },
+    "sync": {
+      "$ref": "#/$defs/Sync",
+      "description": "Sync describes how to sync resources from the virtual cluster to host cluster and back."
+    },
+    "integrations": {
+      "$ref": "#/$defs/Integrations",
+      "description": "Integrations holds config for vCluster integrations with other operators or tools running on the host cluster"
+    },
+    "deploy": {
+      "$ref": "#/$defs/Deploy",
+      "description": "Deploy holds configuration for the deployment of vCluster."
+    },
+    "networking": {
+      "$ref": "#/$defs/Networking",
+      "description": "Networking options related to the virtual cluster."
+    },
+    "policies": {
+      "$ref": "#/$defs/Policies",
+      "description": "Policies to enforce for the virtual cluster deployment as well as within the virtual cluster."
+    },
+    "controlPlane": {
+      "$ref": "#/$defs/ControlPlane",
+      "description": "Configure vCluster's control plane components and deployment."
+    },
+    "privateNodes": {
+      "$ref": "#/$defs/PrivateNodes",
+      "description": "PrivateNodes holds configuration for vCluster private nodes mode."
+    },
+    "rbac": {
+      "$ref": "#/$defs/RBAC",
+      "description": "RBAC options for the virtual cluster."
+    },
+    "plugins": {
+      "anyOf": [
+        {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "additionalProperties": {
+        "$ref": "#/$defs/Plugins"
+      },
+      "description": "Define which vCluster plugins to load."
+    },
+    "experimental": {
+      "$ref": "#/$defs/Experimental",
+      "description": "Experimental features for vCluster. Configuration here might change, so be careful with this."
+    },
+    "telemetry": {
+      "$ref": "#/$defs/Telemetry",
+      "description": "Configuration related to telemetry gathered about vCluster usage."
+    },
+    "serviceCIDR": {
+      "type": "string",
+      "description": "ServiceCIDR holds the service cidr for the virtual cluster. Do not use this option anymore."
+    },
+    "pro": {
+      "type": "boolean",
+      "description": "Specifies whether to use vCluster Pro. This is automatically inferred in newer versions. Do not use that option anymore."
+    },
+    "plugin": {
+      "anyOf": [
+        {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "additionalProperties": {
+        "$ref": "#/$defs/Plugin"
+      },
+      "description": "Plugin specifies which vCluster plugins to enable. Use \"plugins\" instead. Do not use this option anymore."
+    },
+    "logging": {
+      "$ref": "#/$defs/Logging",
+      "description": "Logging provides structured logging options"
+    },
+    "sleep": {
+      "$ref": "#/$defs/Sleep",
+      "description": "Sleep holds configuration for automatically putting the virtual cluster to sleep."
+    },
+    "snapshots": {
+      "$ref": "#/$defs/Snapshots",
+      "description": "Snapshots holds configuration for automatic vCluster snapshots."
+    },
+    "deletion": {
+      "$ref": "#/$defs/Deletion",
+      "description": "Deletion holds configuration for automatic vCluster deletion."
+    },
+    "platform": {
+      "$ref": "#/$defs/Platform",
+      "description": "Platform holds vCluster Platform specific configuration."
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "description": "Config is the vCluster config."
+}

--- a/configsrc/vcluster/main/default_values.yaml
+++ b/configsrc/vcluster/main/default_values.yaml
@@ -538,6 +538,21 @@ controlPlane:
     spec:
       tls: []
   
+  # TLSRoute defines options for vCluster TLS route deployed by Helm.
+  tlsRoute:
+    # Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
+    enabled: false
+    # APIVersion is the version of the gateway api tls route.
+    apiVersion: gateway.networking.k8s.io/v1
+    # Host is the host where vCluster will be reachable
+    host: "my-host.com"
+    # ParentRefs are the parent references for the TLS route
+    parentRefs: []
+    # Spec allows you to configure extra tls route options.
+    spec: {}
+    labels: {}
+    annotations: {}
+  
   # Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
   # also implies privateNodes.enabled.
   standalone:
@@ -808,6 +823,10 @@ privateNodes:
     enabled: true
     # Concurrency is the number of nodes that can be upgraded at the same time.
     concurrency: 1
+    # PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+    podSecurityContext: {}
+    # ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+    containerSecurityContext: {}
   
   # JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
   joinNode:
@@ -828,6 +847,20 @@ privateNodes:
     nodeToNode:
       # Enabled defines if the node to node vpn should be enabled.
       enabled: false
+  
+  # Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
+  daemon:
+    # Enabled defines if the private nodes daemon should be enabled.
+    enabled: false
+    # ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
+    # This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
+    controlPlaneLoadBalancer:
+      # Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
+      enabled: false
+      # KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
+      kubeProxy: true
+      # Port defines the port for the control plane load balancer.
+      port: 11343
 
 # Deploy holds configuration for the deployment of vCluster.
 deploy:
@@ -1242,6 +1275,9 @@ experimental:
       manifestsTemplate: ""
       # Helm are Helm charts that should get deployed into the virtual cluster
       helm: []
+  
+  # NodeMonitors allows you to create a service monitor for each node.
+  nodeMonitors: []
 
 # Configuration related to telemetry gathered about vCluster usage.
 telemetry:

--- a/configsrc/vcluster/main/vcluster.schema.json
+++ b/configsrc/vcluster/main/vcluster.schema.json
@@ -64,6 +64,14 @@
         "concurrency": {
           "type": "integer",
           "description": "Concurrency is the number of nodes that can be upgraded at the same time."
+        },
+        "podSecurityContext": {
+          "type": "object",
+          "description": "PodSecurityContext specifies security context options on the pod level for the upgrade pod."
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "description": "ContainerSecurityContext specifies security context options on the container level for the upgrade container."
         }
       },
       "additionalProperties": false,
@@ -380,6 +388,10 @@
           "$ref": "#/$defs/ControlPlaneIngress",
           "description": "Ingress defines options for vCluster ingress deployed by Helm."
         },
+        "tlsRoute": {
+          "$ref": "#/$defs/ControlPlaneTLSRoute",
+          "description": "TLSRoute defines options for vCluster TLS route deployed by Helm."
+        },
         "service": {
           "$ref": "#/$defs/ControlPlaneService",
           "description": "Service defines options for vCluster service deployed by Helm."
@@ -536,6 +548,24 @@
           },
           "type": "object",
           "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneLoadBalancer": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes."
+        },
+        "kubeProxy": {
+          "type": "boolean",
+          "description": "KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well."
+        },
+        "port": {
+          "type": "integer",
+          "description": "Port defines the port for the control plane load balancer."
         }
       },
       "additionalProperties": false,
@@ -849,6 +879,53 @@
           },
           "type": "array",
           "description": "HostAliases allows you to add custom entries to the /etc/hosts file of each Pod created."
+        },
+        "runtimeClassName": {
+          "type": "string",
+          "description": "RuntimeClassName is the runtime class to set for the statefulSet pods."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ControlPlaneTLSRoute": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to \"Passthrough\""
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "APIVersion is the version of the gateway api tls route."
+        },
+        "host": {
+          "type": "string",
+          "description": "Host is the host where vCluster will be reachable"
+        },
+        "parentRefs": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ParentRefs are the parent references for the TLS route"
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra tls route options."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
         }
       },
       "additionalProperties": false,
@@ -1748,6 +1825,13 @@
         "docker": {
           "$ref": "#/$defs/ExperimentalDocker",
           "description": "Docker allows you to configure Docker related settings when deploying a vCluster using Docker."
+        },
+        "nodeMonitors": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeMonitor"
+          },
+          "type": "array",
+          "description": "NodeMonitors allows you to create a service monitor for each node."
         }
       },
       "additionalProperties": false,
@@ -1978,6 +2062,90 @@
         "name": {
           "type": "string",
           "description": "Name defines the name of the node. If not specified, a random name will be generated."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeMonitor": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the monitor. It will be suffixed with the node name."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "NodeSelector defines the node selector for the service monitor."
+        },
+        "endpoints": {
+          "items": {
+            "$ref": "#/$defs/ExperimentalNodeServiceMonitorEndpoint"
+          },
+          "type": "array",
+          "description": "Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "spec": {
+          "type": "object",
+          "description": "Spec allows you to configure extra service monitor options that will be merged into the spec."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Annotations are extra annotations for this resource."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Labels are extra labels for this resource."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ExperimentalNodeServiceMonitorEndpoint": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path."
+        },
+        "params": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object",
+          "description": "Params allows you to configure extra parameters to add to the endpoint."
+        },
+        "extraRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name."
+        },
+        "metricsRelabelings": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array",
+          "description": "MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint."
+        },
+        "interval": {
+          "type": "string",
+          "description": "Interval is the interval at which to scrape the endpoint."
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "ScrapeTimeout is the timeout for the scrape of the endpoint."
         }
       },
       "additionalProperties": false,
@@ -3706,6 +3874,10 @@
         "vpn": {
           "$ref": "#/$defs/PrivateNodesVPN",
           "description": "VPN holds configuration for the private nodes vpn. This can be used to connect the private nodes to the control plane or\nconnect the private nodes to each other if they are not running in the same network. Platform connection is required for the vpn to work."
+        },
+        "daemon": {
+          "$ref": "#/$defs/PrivateNodesDaemon",
+          "description": "Daemon holds configuration for the private nodes daemon that is deployed on the nodes."
         }
       },
       "additionalProperties": false,
@@ -3746,6 +3918,20 @@
         "provider"
       ],
       "description": "PrivateNodesAutoNodes defines auto nodes"
+    },
+    "PrivateNodesDaemon": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if the private nodes daemon should be enabled."
+        },
+        "controlPlaneLoadBalancer": {
+          "$ref": "#/$defs/ControlPlaneLoadBalancer",
+          "description": "ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.\nThis is useful to achieve true high availability for the control plane without having to deploy a separate load balancer."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "PrivateNodesVPN": {
       "properties": {
@@ -4285,11 +4471,30 @@
         "container": {
           "$ref": "#/$defs/SnapshotStorageContainer",
           "description": "Container holds configuration for storing snapshots as local files inside a vCluster container\n+optional"
+        },
+        "azure": {
+          "$ref": "#/$defs/SnapshotStorageAzure",
+          "description": "Azure holds configuration for storing snapshots in Azure Blob Storage\n+optional"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "SnapshotStorage holds snapshot storage configuration"
+    },
+    "SnapshotStorageAzure": {
+      "properties": {
+        "blobUrl": {
+          "type": "string",
+          "description": "BlobURL specifies the Azure Blob Storage URL in the format https://{account}.blob.core.windows.net/{container}/{path}\n+optional"
+        },
+        "credential": {
+          "$ref": "#/$defs/SnapshotSecretCredential",
+          "description": "Credential secret with the Azure credentials. The secret should contain either:\nAZURE_STORAGE_KEY (storage account access key), or\nAZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP (service principal)\n+optional"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "SnapshotStorageAzure holds Azure Blob Storage configuration."
     },
     "SnapshotStorageContainer": {
       "properties": {

--- a/hack/redirect-allowlist.txt
+++ b/hack/redirect-allowlist.txt
@@ -8,3 +8,12 @@
 # llms.txt is auto-generated at build time by @signalwire/docusaurus-plugin-llms-txt
 /docs/llms.txt
 
+# PR #2001 (DEVOPS-830): added vcluster/cli/vcluster_platform_add_standalone.md via
+# the hack/vcluster-cli generator. Not a missing-redirect case — this is a latent
+# bug in check-redirects.sh: line 217 (`[[ -n "$pos" ]] && ADDED_BY_POS=...`) exits
+# 1 under `set -eo pipefail` when a newly-added .md lacks `sidebar_position:`
+# frontmatter, killing the checker mid-loop. Existing CLI files also lack
+# sidebar_position, so this trap fires for every new CLI file. Fix belongs in the
+# script (append `|| true` to that line), not here.
+/docs/vcluster/cli/vcluster_platform_add_standalone
+

--- a/vcluster/_partials/config/controlPlane.mdx
+++ b/vcluster/_partials/config/controlPlane.mdx
@@ -31,7 +31,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 
 ### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
 
 </summary>
 

--- a/vcluster/_partials/config/controlPlane.mdx
+++ b/vcluster/_partials/config/controlPlane.mdx
@@ -31,7 +31,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 
 ### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
 </summary>
 
@@ -3097,6 +3097,126 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
+### `tlsRoute` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
+
+TLSRoute defines options for vCluster TLS route deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
+
+Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
+
+APIVersion is the version of the gateway api tls route.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
+
+Host is the host where vCluster will be reachable
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `parentRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
+
+ParentRefs are the parent references for the TLS route
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
+
+Spec allows you to configure extra tls route options.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
 ### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
@@ -4427,6 +4547,21 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 
 
 </details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
+
+RuntimeClassName is the runtime class to set for the statefulSet pods.
+
+</summary>
+
 
 
 </details>

--- a/vcluster/_partials/config/controlPlane/distro.mdx
+++ b/vcluster/_partials/config/controlPlane/distro.mdx
@@ -4,7 +4,7 @@
 
 ## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
 </summary>
 

--- a/vcluster/_partials/config/controlPlane/distro.mdx
+++ b/vcluster/_partials/config/controlPlane/distro.mdx
@@ -4,7 +4,7 @@
 
 ## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
 
 </summary>
 

--- a/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
+++ b/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
@@ -20,7 +20,16 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 
 </summary>
 
+:::warning Security consideration
+When `joinNode.enabled` is `true`, the control-plane node also runs kubelet as a worker.
+Tenant workloads scheduled onto this node share the machine with the vCluster control-plane
+process and its platform credentials. A tenant with sufficient privileges (such as `hostPID`,
+hostPath volumes, or `nodes/proxy` access) can read the platform access key from the process
+environment.
 
+For production deployments, keep the control-plane node dedicated by setting
+`joinNode.enabled: false` and use separate worker nodes for tenant workloads.
+:::
 
 </details>
 

--- a/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
+++ b/vcluster/_partials/config/controlPlane/standalone/joinNode.mdx
@@ -20,16 +20,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 
 </summary>
 
-:::warning Security consideration
-When `joinNode.enabled` is `true`, the control-plane node also runs kubelet as a worker.
-Tenant workloads scheduled onto this node share the machine with the vCluster control-plane
-process and its platform credentials. A tenant with sufficient privileges (such as `hostPID`,
-hostPath volumes, or `nodes/proxy` access) can read the platform access key from the process
-environment.
 
-For production deployments, keep the control-plane node dedicated by setting
-`joinNode.enabled: false` and use separate worker nodes for tenant workloads.
-:::
 
 </details>
 

--- a/vcluster/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster/_partials/config/controlPlane/statefulSet.mdx
@@ -1232,4 +1232,19 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
+
+RuntimeClassName is the runtime class to set for the statefulSet pods.
+
+</summary>
+
+
+
+</details>
+
+
 </details>

--- a/vcluster/_partials/config/experimental.mdx
+++ b/vcluster/_partials/config/experimental.mdx
@@ -1041,4 +1041,199 @@ via port forwarding. This will be only done if necessary for example on macos wh
 </details>
 
 
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `nodeMonitors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
+
+NodeMonitors allows you to create a service monitor for each node.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
+
+Name is the name of the monitor. It will be suffixed with the node name.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
+
+NodeSelector defines the node selector for the service monitor.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
+
+Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
+
+Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `params` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
+
+Params allows you to configure extra parameters to add to the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
+
+ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `metricsRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
+
+MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `interval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
+
+Interval is the interval at which to scrape the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `scrapeTimeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
+
+ScrapeTimeout is the timeout for the scrape of the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
+
+Spec allows you to configure extra service monitor options that will be merged into the spec.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
 </details>

--- a/vcluster/_partials/config/privateNodes.mdx
+++ b/vcluster/_partials/config/privateNodes.mdx
@@ -173,6 +173,36 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+
+</summary>
+
+
+
+</details>
+
+
 </details>
 
 
@@ -1467,6 +1497,97 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 ##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `daemon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
+
+Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
+
+Enabled defines if the private nodes daemon should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
+
+ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
+This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
+
+Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
+
+KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
+
+Port defines the port for the control plane load balancer.
 
 </summary>
 

--- a/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
@@ -115,4 +115,34 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+
+</summary>
+
+
+
+</details>
+
+
 </details>

--- a/vcluster/_partials/config/snapshots.mdx
+++ b/vcluster/_partials/config/snapshots.mdx
@@ -381,6 +381,83 @@ Path to the volume mount
 </details>
 
 
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `azure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
+
+Azure holds configuration for storing snapshots in Azure Blob Storage
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `blobUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
+
+BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account&#125;.blob.core.windows.net/&#123;container&#125;/&#123;path&#125;
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
+
+Credential secret with the Azure credentials. The secret should contain either:
+AZURE_STORAGE_KEY (storage account access key), or
+AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP (service principal)
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
+
+SecretName is the secret name with credential
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
+
+SecretNamespace is the secret namespace with credential
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
 </details>
 
 

--- a/vcluster/cli/vcluster_platform_add_standalone.md
+++ b/vcluster/cli/vcluster_platform_add_standalone.md
@@ -1,0 +1,50 @@
+---
+title: "vcluster platform add standalone --help"
+sidebar_label: vcluster platform add standalone
+---
+
+
+Adds an existing vCluster Standalone cluster to the vCluster platform
+
+## Synopsis
+
+```
+vcluster platform add standalone [flags]
+```
+
+```
+################################################
+####### vcluster platform add standalone #######
+################################################
+Adds a vCluster Standalone cluster to the vCluster platform.
+
+Example:
+vcluster platform add standalone my-cluster --project my-project --access-key my-access-key --host https://my-vcluster-platform.com
+
+################################################
+```
+
+
+## Flags
+
+```
+      --access-key string   The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
+  -h, --help                help for standalone
+      --host string         The host where to reach the platform
+      --insecure            If the platform host is insecure
+      --project string      The project to import the vCluster into
+      --skip-config-sync    If true, will skip syncing the config from the platform
+```
+
+
+## Global and inherited flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --context string      The kubernetes config context to use
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -n, --namespace string    The kubernetes namespace to use
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster/cli/vcluster_platform_start.md
+++ b/vcluster/cli/vcluster_platform_start.md
@@ -27,6 +27,10 @@ before running this command:
 2. Helm v3 must be installed
 3. kubectl must be installed
 
+NOTE: TLS certificate verification is disabled by default
+during platform startup because the platform uses a self-signed
+certificate. Use --secure to enable TLS verification.
+
 ########################################################
 ```
 
@@ -51,6 +55,7 @@ before running this command:
       --password string      The password to use for the admin account. (If empty this will be the namespace UID)
       --reset                If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform
       --reuse-values         Reuse previous vCluster platform helm values on upgrade (default true)
+      --secure               If true, verify TLS certificates when connecting to the platform (by default, TLS verification is skipped during bootstrap because the platform starts with a self-signed certificate)
       --upgrade              If true, vCluster platform will try to upgrade the release
       --values string        Path to a file for extra vCluster platform helm chart values
       --version string       The vCluster platform version to install (default "latest")

--- a/vcluster/cli/vcluster_restore.md
+++ b/vcluster/cli/vcluster_restore.md
@@ -25,6 +25,10 @@ vcluster restore my-vcluster oci://ghcr.io/my-user/my-repo:my-tag
 vcluster restore my-vcluster s3://my-bucket/my-bucket-key
 # Restore from vCluster container filesystem
 vcluster restore my-vcluster container:///data/my-local-snapshot.tar.gz
+# Restore a Docker-based vCluster from a local snapshot file
+vcluster restore my-vcluster ./my-snapshot.tar.gz --driver docker
+# Restore with a different name
+vcluster restore my-new-name ./my-snapshot.tar.gz --driver docker
 #######################################################
 ```
 
@@ -32,6 +36,9 @@ vcluster restore my-vcluster container:///data/my-local-snapshot.tar.gz
 ## Flags
 
 ```
+      --azure-resource-group string         Azure resource group where the storage account is located
+      --azure-subscription-id string        Azure subscription ID where the storage account is located
+      --driver string                       The driver to use for managing the virtual cluster, can be either helm, platform, or docker.
   -h, --help                                help for restore
       --pod-env stringArray                 Additional environment variables for the created pod. Use key=value. E.g.: MY_ENV=my-value
       --pod-image string                    Image to use for the created pod
@@ -39,6 +46,7 @@ vcluster restore my-vcluster container:///data/my-local-snapshot.tar.gz
       --pod-mount stringArray               Additional mounts for the created pod. Use form <type>:<name>/<key>:<mount>. Supported types are: pvc, secret, configmap. E.g.: pvc:my-pvc:/path-in-pod or secret:my-secret/my-key:/path-in-pod
       --pod-service-account string          Service account to use for the created pod
       --restore-volumes                     Restore volumes from volume snapshots
+      --standalone                          Target the local standalone vCluster on this host
 ```
 
 

--- a/vcluster/cli/vcluster_snapshot.md
+++ b/vcluster/cli/vcluster_snapshot.md
@@ -32,6 +32,8 @@ vcluster snapshot my-vcluster container:///data/my-local-snapshot.tar.gz
 ## Flags
 
 ```
+      --azure-resource-group string           Azure resource group where the storage account is located
+      --azure-subscription-id string          Azure subscription ID where the storage account is located
       --customer-key-encryption-file string   AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id
   -h, --help                                  help for snapshot
       --include-volumes                       Create CSI volume snapshots (shared and private nodes only)
@@ -43,6 +45,7 @@ vcluster snapshot my-vcluster container:///data/my-local-snapshot.tar.gz
       --pod-mount stringArray                 Additional mounts for the created pod. Use form <type>:<name>/<key>:<mount>. Supported types are: pvc, secret, configmap. E.g.: pvc:my-pvc:/path-in-pod or secret:my-secret/my-key:/path-in-pod
       --pod-service-account string            Service account to use for the created pod
       --server-side-encryption string         AWS Server-Side encryption algorithm
+      --standalone                            Target the local standalone vCluster on this host
 ```
 
 

--- a/vcluster/cli/vcluster_snapshot_create.md
+++ b/vcluster/cli/vcluster_snapshot_create.md
@@ -27,6 +27,10 @@ vcluster snapshot create my-vcluster oci://ghcr.io/my-user/my-repo:my-tag
 vcluster snapshot create my-vcluster s3://my-bucket/my-bucket-key
 # Snapshot to vCluster container filesystem
 vcluster snapshot create my-vcluster container:///data/my-local-snapshot.tar.gz
+# Snapshot a Docker-based vCluster to a local file
+vcluster snapshot create my-vcluster ./my-snapshot.tar.gz --driver docker
+# Snapshot with auto-generated filename (my-vcluster-snapshot-<timestamp>.tar.gz)
+vcluster snapshot create my-vcluster --driver docker
 ##############################################################
 ```
 
@@ -34,11 +38,15 @@ vcluster snapshot create my-vcluster container:///data/my-local-snapshot.tar.gz
 ## Flags
 
 ```
+      --azure-resource-group string           Azure resource group where the storage account is located
+      --azure-subscription-id string          Azure subscription ID where the storage account is located
       --customer-key-encryption-file string   AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id
+      --driver string                         The driver to use for managing the virtual cluster, can be either helm, platform, or docker.
   -h, --help                                  help for create
       --include-volumes                       Create CSI volume snapshots (shared and private nodes only)
       --kms-key-id string                     AWS KMS key ID that is configured for given S3 bucket. If set, aws-kms SSE will be used
       --server-side-encryption string         AWS Server-Side encryption algorithm
+      --standalone                            Target the local standalone vCluster on this host
 ```
 
 

--- a/vcluster/cli/vcluster_snapshot_get.md
+++ b/vcluster/cli/vcluster_snapshot_get.md
@@ -32,11 +32,14 @@ vcluster snapshot get my-vcluster container:///data/my-local-snapshot.tar.gz
 ## Flags
 
 ```
+      --azure-resource-group string           Azure resource group where the storage account is located
+      --azure-subscription-id string          Azure subscription ID where the storage account is located
       --customer-key-encryption-file string   AWS customer key encryption file used for SSE-C. Mutually exclusive with kms-key-id
   -h, --help                                  help for get
       --include-volumes                       Create CSI volume snapshots (shared and private nodes only)
       --kms-key-id string                     AWS KMS key ID that is configured for given S3 bucket. If set, aws-kms SSE will be used
       --server-side-encryption string         AWS Server-Side encryption algorithm
+      --standalone                            Target the local standalone vCluster on this host
 ```
 
 

--- a/vcluster/cli/vcluster_version.md
+++ b/vcluster/cli/vcluster_version.md
@@ -3,28 +3,21 @@ title: "vcluster version --help"
 sidebar_label: vcluster version
 ---
 
+## vcluster version
 
-Print the version number of vcluster
-
-## Synopsis
+Print the vCluster version
 
 ```
 vcluster version [flags]
 ```
 
-```
-All software has versions. This is Vcluster's.
-```
-
-
-## Flags
+### Options
 
 ```
   -h, --help   help for version
 ```
 
-
-## Global and inherited flags
+### Options inherited from parent commands
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
@@ -35,3 +28,10 @@ All software has versions. This is Vcluster's.
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
 
+```
+
+```
+
+
+## Flags
+## Global and inherited flags

--- a/vcluster/cli/vcluster_version.md
+++ b/vcluster/cli/vcluster_version.md
@@ -27,11 +27,3 @@ vcluster version [flags]
   -n, --namespace string    The kubernetes namespace to use
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
-
-```
-
-```
-
-
-## Flags
-## Global and inherited flags

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane.mdx
@@ -31,7 +31,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 
 ### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
 
 </summary>
 

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane.mdx
@@ -31,7 +31,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 
 ### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
-Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s is supported. For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).
+Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
 </summary>
 
@@ -3097,6 +3097,126 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
+### `tlsRoute` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute}
+
+TLSRoute defines options for vCluster TLS route deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-enabled}
+
+Enabled defines if the control plane should be exposed via a gateway api tls route. Make sure to enable tls passthrough in the gateway via tls.mode to "Passthrough"
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">gateway.networking.k8s.io/v1</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-apiVersion}
+
+APIVersion is the version of the gateway api tls route.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-host}
+
+Host is the host where vCluster will be reachable
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `parentRefs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-parentRefs}
+
+ParentRefs are the parent references for the TLS route
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-spec}
+
+Spec allows you to configure extra tls route options.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-tlsRoute-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
 ### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
@@ -4427,6 +4547,21 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 
 
 </details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-runtimeClassName}
+
+RuntimeClassName is the runtime class to set for the statefulSet pods.
+
+</summary>
+
 
 
 </details>

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/controlPlane/statefulSet.mdx
@@ -1232,4 +1232,19 @@ HostAliases allows you to add custom entries to the /etc/hosts file of each Pod 
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-runtimeClassName}
+
+RuntimeClassName is the runtime class to set for the statefulSet pods.
+
+</summary>
+
+
+
+</details>
+
+
 </details>

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/experimental.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/experimental.mdx
@@ -1041,4 +1041,199 @@ via port forwarding. This will be only done if necessary for example on macos wh
 </details>
 
 
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `nodeMonitors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors}
+
+NodeMonitors allows you to create a service monitor for each node.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-name}
+
+Name is the name of the monitor. It will be suffixed with the node name.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-nodeSelector}
+
+NodeSelector defines the node selector for the service monitor.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints}
+
+Endpoints is a list of endpoints to add to the service monitor. By default, vCluster will relabel the node and instance label to the node name.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-path}
+
+Path is the kubelet path of the endpoint. vCluster will prepend /api/v1/nodes/NODE_NAME to the path.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `params` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-params}
+
+Params allows you to configure extra parameters to add to the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-extraRelabelings}
+
+ExtraRelabelings allows you to configure extra relabelings to add to the endpoint. By default, vCluster will relabel the node and instance label to the node name.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `metricsRelabelings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-metricsRelabelings}
+
+MetricsRelabelings allows you to configure extra metrics relabelings to add to the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `interval` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-interval}
+
+Interval is the interval at which to scrape the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `scrapeTimeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-endpoints-scrapeTimeout}
+
+ScrapeTimeout is the timeout for the scrape of the endpoint.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-spec}
+
+Spec allows you to configure extra service monitor options that will be merged into the spec.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-nodeMonitors-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
 </details>

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/privateNodes.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/privateNodes.mdx
@@ -173,6 +173,36 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+
+</summary>
+
+
+
+</details>
+
+
 </details>
 
 
@@ -1467,6 +1497,97 @@ NodeToNode holds configuration for the node to node vpn. This can be used to con
 ##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-vpn-nodeToNode-enabled}
 
 Enabled defines if the node to node vpn should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `daemon` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon}
+
+Daemon holds configuration for the private nodes daemon that is deployed on the nodes.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-enabled}
+
+Enabled defines if the private nodes daemon should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `controlPlaneLoadBalancer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer}
+
+ControlPlaneLoadBalancer holds configuration for the control plane load balancer. This is used to load balance the control plane traffic on the node to the control plane nodes.
+This is useful to achieve true high availability for the control plane without having to deploy a separate load balancer.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-enabled}
+
+Enabled defines if the control plane load balancer should be enabled. The control plane load balancer is used to load balance the control plane traffic on the node to the control plane nodes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeProxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-kubeProxy}
+
+KubeProxy defines if the kube proxy should be proxied through the control plane load balancer as well.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">11343</span> <span className="config-field-enum"></span> {#privateNodes-daemon-controlPlaneLoadBalancer-port}
+
+Port defines the port for the control plane load balancer.
 
 </summary>
 

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/privateNodes/autoUpgrade.mdx
@@ -115,4 +115,34 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 </details>
 
 
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level for the upgrade pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#autoUpgrade-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level for the upgrade container.
+
+</summary>
+
+
+
+</details>
+
+
 </details>

--- a/vcluster_versioned_docs/version-0.34.0/_partials/config/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/_partials/config/snapshots.mdx
@@ -381,6 +381,83 @@ Path to the volume mount
 </details>
 
 
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `azure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure}
+
+Azure holds configuration for storing snapshots in Azure Blob Storage
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `blobUrl` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-blobUrl}
+
+BlobURL specifies the Azure Blob Storage URL in the format https://&#123;account&#125;.blob.core.windows.net/&#123;container&#125;/&#123;path&#125;
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `credential` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential}
+
+Credential secret with the Azure credentials. The secret should contain either:
+AZURE_STORAGE_KEY (storage account access key), or
+AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP (service principal)
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretName}
+
+SecretName is the secret name with credential
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `secretNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#snapshots-auto-storage-azure-credential-secretNamespace}
+
+SecretNamespace is the secret namespace with credential
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
 </details>
 
 


### PR DESCRIPTION
# Content Description

Regenerated the 'next' vCluster config partials and CLI docs using the three
generators under `hack/`. The release-triggered automation only updates the
latest versioned folder on RC/stable events and skips alpha/next — so
`vcluster/_partials/config/` and `vcluster/cli/` drift between releases and
need periodic manual regeneration.

- **Config partials** (`hack/vcluster/partials`, 8 files): regenerated from
  vcluster main schema (commit `4c05278c9`, `v0.34.0-alpha.5-8-g4c05278c9`).
  Output is byte-identical to the loft-bot 0.34.0 versioned PR (#1998),
  confirming determinism. #1998 handles the 0.34 backport; this catches up
  the next-docs source that feeds future versioning.
- **CLI docs** (`hack/vcluster-cli`, 6 modified + 1 new): picks up
  `vcluster platform add standalone` subcommand, new `snapshot create` flags
  (`--driver`, `--standalone`, `--azure-resource-group`, `--azure-subscription-id`),
  and a `version` command format catch-up that matches 6 existing files already
  on cobra default.
- **Platform API** (`hack/platform/partials`): ran; produced zero diff in
  `platform/api/` — already in sync with current schema + vendored
  `loft-sh/api v4.8.2-rc.1`. Nothing to commit on that side.

## Preview Link

- CLI new subcommand: https://deploy-preview-2001--vcluster-docs-site.netlify.app/docs/vcluster/next/cli/vcluster_platform_add_standalone
- CLI snapshot create (new flags): https://deploy-preview-2001--vcluster-docs-site.netlify.app/docs/vcluster/next/cli/vcluster_snapshot_create
- CLI version (format catch-up): https://deploy-preview-2001--vcluster-docs-site.netlify.app/docs/vcluster/next/cli/vcluster_version
- Config partials are imported into vcluster/configure/vcluster-yaml/ pages: https://deploy-preview-2001--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml

## Internal Reference

Closes DEVOPS-830

AI review: mention \`@claude\` in a comment to request a review or changes.

@netlify /docs