### PR TITLE
docs(oss-vs-free): remove distro list from OSS description in v0.33

### DIFF
--- a/vcluster_versioned_docs/version-0.33.0/introduction/oss-vs-free.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/introduction/oss-vs-free.mdx
@@ -13,7 +13,7 @@ vCluster is available as open source under the Apache 2.0 license and in several
 
 ## Overview
 
-**vCluster Open Source** is the foundation of the project. It provides full-stack tenant cluster isolation: dedicated Kubernetes control planes, resource syncing, multiple backing stores, and support for k3s, k0s, vanilla Kubernetes, and EKS distributions. OSS requires no license and no Platform connectivity.
+**vCluster Open Source** is the foundation of the project. It provides full-stack tenant cluster isolation: dedicated Kubernetes control planes, resource syncing, and multiple backing stores. OSS requires no license and no Platform connectivity.
 
 **vCluster Free tier** adds capabilities on top of OSS at no cost, including embedded etcd, Private Nodes, custom resource syncing, sync patches, and HostPath Mapper. The Free tier requires connecting to the vCluster Platform for license validation but needs no credit card.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Removes the distribution list (k3s, k0s, vanilla Kubernetes, EKS) from the vCluster Open Source description in the v0.33 oss-vs-free page to align with the updated distro's.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

