### PR TITLE
docs(node-requirements): add rocky 9 and 10 to supported oses

### DIFF
--- a/vcluster/deploy/control-plane/binary/node-requirements.mdx
+++ b/vcluster/deploy/control-plane/binary/node-requirements.mdx
@@ -69,12 +69,14 @@ Log into each node and manually increase the watchers limit.
 |---|---|---|
 | Ubuntu | 24.04 | |
 | Ubuntu | 22.04 | |
-| RHEL (RedHat Enterprise Linux) | 10 | Disable SElinux |
-| RHEL (RedHat Enterprise Linux) | 9 | Disable SElinux |
-| CentOS Stream | 9 | Disable SElinux and install `iptables` |
+| RHEL (RedHat Enterprise Linux) | 10 | Disable SELinux |
+| RHEL (RedHat Enterprise Linux) | 9 | Disable SELinux |
+| CentOS Stream | 9 | Disable SELinux and install `iptables` |
+| Rocky | 10 | Disable SELinux and install `iptables` |
+| Rocky | 9 | Disable SELinux and install `iptables` |
 
 
-### CentOS Stream Support
+### CentOS Stream and Rocky support
 
 ```shell title="Install iptables"
 yum install iptables-services


### PR DESCRIPTION
# Content Description

Adds Rocky Linux 9 and 10 to the supported OS table for vCluster node requirements. Both versions require iptables to be installed manually (not present by default) in addition to disabling SELinux, consistent with CentOS Stream 9.

Also fixes SELinux capitalization (`SElinux` → `SELinux`) in all RHEL-family rows, and expands the iptables install section header to cover Rocky alongside CentOS Stream.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2015--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary/node-requirements#supported-oses

## Internal Reference

Closes DOC-1342

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs