### PR TITLE
docs(platform): restore sections dropped from configure refactor

### DIFF
--- a/platform/configure/installation-options/domain.mdx
+++ b/platform/configure/installation-options/domain.mdx
@@ -461,3 +461,25 @@ This must be configured outside of the platform deployment.
 </Flow>
 
 </details>
+
+
+## Import tenant clusters with certificate validation {#importing-existing-tenant-clusters}
+
+When importing externally managed tenant clusters, you can enable secure communication by using the same certificate authority configured for the platform.
+
+1. Get the current certificate authority value from your platform:
+
+```bash title="Get the certificate authority value"
+helm get values --namespace $RELEASE_NAMESPACE $RELEASE_NAME --all | grep additionalCA
+```
+
+2. Import the tenant cluster with certificate validation:
+
+```bash title="Import a tenant cluster with certificate validation"
+vcluster platform add vcluster <VCLUSTER_NAME> \
+  --namespace=<VCLUSTER_NAMESPACE> \
+  --project=<PROJECT_NAME> \
+  --ca-data <BASE64_CA_VALUE>
+```
+
+The imported tenant cluster restarts and reports `Ready` once it establishes a secure connection to the platform.

--- a/platform/configure/introduction.mdx
+++ b/platform/configure/introduction.mdx
@@ -118,3 +118,7 @@ Using `helm` values allows you to manage configuration declaratively and enables
   language="bash"
   title="Apply platform configuration using Helm"
 />
+
+:::info Reconnect clusters after key value changes
+After changing `config.loftHost`, `additionalCA`, or `insecureSkipVerify`, you must reconnect all clusters to the platform. Run the same connection commands in each Kubernetes context. See [connecting clusters](../administer/clusters/connect-cluster.mdx) for instructions.
+:::

--- a/platform/configure/platform-configs/overview.mdx
+++ b/platform/configure/platform-configs/overview.mdx
@@ -32,6 +32,48 @@ vault:
   enabled: true
 ```
 
+## Manage sensitive information {#managing-sensitive-information}
+
+Many configuration options require sensitive information such as API keys or tokens. Rather than storing these directly in your `values.yaml` file, use environment variable placeholders.
+
+### Use secret references {#using-secret-references}
+
+Store sensitive values in a Kubernetes secret and reference it in your configuration using `envValueFrom`:
+
+```yaml title="Store sensitive values using Kubernetes secrets"
+# Secret references
+envValueFrom:
+  CLIENT_ID:
+    secretKeyRef:
+      name: github-auth-secret
+      key: client_id
+  CLIENT_SECRET:
+    secretKeyRef:
+      name: github-auth-secret
+      key: client_secret
+
+# Platform configuration
+config:
+  auth:
+    github:
+      clientId: $CLIENT_ID
+      clientSecret: $CLIENT_SECRET
+      redirectURI: https://my-platform.example.com/auth/github/callback
+```
+
+## Configure custom HTTP headers {#custom-http-headers}
+
+You can configure the platform to add custom HTTP headers to all API responses. This is useful for security-related headers or when integrating with specific environments.
+
+```yaml title="Adding custom HTTP headers"
+config:
+  auth:
+    customHttpHeaders:
+      X-Frame-Options: SAMEORIGIN
+      X-XSS-Protection: 1; mode=block
+      Content-Security-Policy: default-src 'self'
+```
+
 ## Reference
 The complete list of platform configuration fields is as follows:
 <VClusterProConfig />


### PR DESCRIPTION
# Content Description
Restores four sections that were removed without replacement when `config.mdx` was split into subsections in PR #1499:

- **Manage sensitive information** — `envValueFrom`/`secretKeyRef` pattern for keeping API keys out of `values.yaml` → `platform-configs/overview.mdx`
- **Configure custom HTTP headers** — `config.auth.customHttpHeaders` → `platform-configs/overview.mdx`
- **Reconnect clusters warning** — required after changing `config.loftHost`, `additionalCA`, or `insecureSkipVerify` → `configure/introduction.mdx`
- **Import tenant clusters with certificate validation** — `vcluster platform add vcluster ... --ca-data` → `installation-options/domain.mdx`

> [!NOTE]
> DOC-1344 specifically requested restoring the "Manage sensitive information" section. While auditing PR #1499, we found three additional sections that were also dropped without being migrated anywhere. We intentionally expanded scope to restore all four missing sections in one PR rather than leave the others for follow-up.

## Preview Link
<!-- The preview link or links to the documents-->
- https://deploy-preview-2016--vcluster-docs-site.netlify.app/docs/platform/next/configure/introduction (see note at bottom of the page)
- https://deploy-preview-2016--vcluster-docs-site.netlify.app/docs/platform/next/configure/installation-options/domain#importing-existing-tenant-clusters
- https://deploy-preview-2016--vcluster-docs-site.netlify.app/docs/platform/next/configure/platform-configs/overview#managing-sensitive-information (What the reported issue actually asked for)

## Internal Reference
Closes DOC-1344

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs