### PR TITLE
docs(vcluster): replace duplicate deployment cards with expanded how it works section

### DIFF
--- a/vcluster/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster/introduction/what-are-virtual-clusters.mdx
@@ -12,91 +12,24 @@ vCluster provisions fully isolated Kubernetes environments, called <GlossaryTerm
 
 The control plane is completely invisible to tenants. There are no shared control plane nodes, no in-cluster agent pods, and no lateral path between environments. vCluster suits any environment where isolation is a hard requirement, from developer platforms and CI/CD pipelines to GPU cloud infrastructure serving paying tenants.
 
-## How to start
-
-Two questions determine your deployment path.
-
-### 1. Do you already have a Kubernetes cluster?
-
-**Yes** — your existing cluster becomes the <GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm> that hosts tenant cluster control planes. You need no additional infrastructure to get started.
-
-**No** — choose one of:
-- **vCluster Standalone** — a zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Suited for AI cloud providers building from bare metal, as well as edge and air-gapped production deployments.
-- **vind (vCluster in Docker)** — runs a complete cluster in Docker containers with no Kubernetes dependency. Suited for local development and CI/CD pipelines.
-
-### 2. How will worker nodes run?
-
-**Shared nodes** — Tenant workloads run on the same cluster that hosts the control planes, sharing the existing node pool. Multiple tenant clusters run side by side on the same physical nodes. Lower overhead, fastest to set up. Suited for developer environments, CI/CD, and high-density internal platforms.
-
-**Private nodes** — Each tenant cluster gets dedicated nodes that join through a token-based process. The network, storage, and compute are fully isolated per tenant. No cross-tenant visibility exists at the infrastructure level. This is the isolation model GPU workloads, regulated industries, and multi-tenant AI cloud platforms require. Nodes can come from any Linux infrastructure. Join nodes to your vCluster from bare metal servers using [vMetal](/docs/platform/administer/bare-metal/overview), cloud VMs through a Terraform node provider, or any manually joined Linux machine, including nodes from other cloud environments.
-
-## Deployment paths
-
-import Link from '@docusaurus/Link';
-
-<style dangerouslySetInnerHTML={{__html: `
-  .deploy-card { transition: background-color 0.15s ease, border-color 0.15s ease; }
-  .deploy-card:hover { background-color: var(--ifm-color-emphasis-100); }
-`}} />
-
-<div style={{display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '1rem', marginBottom: '1.5rem', marginTop: '1rem'}}>
-  <Link to="../quick-start/shared-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{marginBottom: '0.5rem'}}>
-      <rect x="2" y="4" width="9" height="7" rx="1.5" fill="#FF6600"/>
-      <rect x="13" y="4" width="9" height="7" rx="1.5" fill="#FF6600" opacity="0.4"/>
-      <rect x="2" y="13" width="9" height="7" rx="1.5" fill="#FF6600" opacity="0.4"/>
-      <rect x="13" y="13" width="9" height="7" rx="1.5" fill="#FF6600" opacity="0.4"/>
-    </svg>
-    <h4 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Shared nodes</h4>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Existing Kubernetes cluster. Tenant workloads share the node pool. Fast setup, OSS CLI or Platform.</p>
-  </Link>
-  <Link to="../quick-start/private-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{marginBottom: '0.5rem'}}>
-      <rect x="2" y="4" width="9" height="7" rx="1.5" fill="#FF6600"/>
-      <rect x="13" y="4" width="9" height="7" rx="1.5" fill="#FF6600"/>
-      <rect x="2" y="13" width="9" height="7" rx="1.5" fill="#FF6600"/>
-      <rect x="13" y="13" width="9" height="7" rx="1.5" fill="#FF6600"/>
-    </svg>
-    <h4 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Private nodes</h4>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Existing cluster or Standalone. Dedicated nodes per tenant. GPU workloads and regulated environments. Requires Platform.</p>
-  </Link>
-  <Link to="../quick-start/standalone" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{marginBottom: '0.5rem'}}>
-      <rect x="4" y="3" width="16" height="3" rx="1" fill="#FF6600"/>
-      <rect x="4" y="7.5" width="16" height="3" rx="1" fill="#FF6600" opacity="0.6"/>
-      <rect x="4" y="12" width="16" height="3" rx="1" fill="#FF6600" opacity="0.3"/>
-      <circle cx="7" cy="4.5" r="0.75" fill="white"/>
-      <circle cx="7" cy="9" r="0.75" fill="white"/>
-      <circle cx="7" cy="13.5" r="0.75" fill="white"/>
-      <path d="M12 17V21M9 21H15" stroke="#FF6600" strokeWidth="1.5" strokeLinecap="round"/>
-    </svg>
-    <h4 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Standalone</h4>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>No cluster yet. Bootstrap a Control Plane Cluster from bare metal or VMs, then add private nodes per tenant.</p>
-  </Link>
-  <Link to="../quick-start/docker" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" style={{marginBottom: '0.5rem'}}>
-      <rect x="2" y="8" width="4" height="3" rx="0.75" fill="#FF6600"/>
-      <rect x="7" y="8" width="4" height="3" rx="0.75" fill="#FF6600"/>
-      <rect x="12" y="8" width="4" height="3" rx="0.75" fill="#FF6600"/>
-      <rect x="7" y="13" width="4" height="3" rx="0.75" fill="#FF6600"/>
-      <rect x="12" y="13" width="4" height="3" rx="0.75" fill="#FF6600"/>
-      <path d="M18 12.5C18.8 11.5 20.5 11.8 21 13C21.5 14.2 20.8 15.5 20 16C19 17 16 17 14 16.5C13.5 16.3 13.2 15.8 13.5 15.3C14 14.5 16 14 18 12.5Z" fill="#FF6600" opacity="0.5"/>
-      <path d="M3 12H13" stroke="#FF6600" strokeWidth="1.5" strokeLinecap="round"/>
-    </svg>
-    <h4 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Docker (vind)</h4>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>No Kubernetes required. Full cluster in Docker containers. Local development and CI pipelines.</p>
-  </Link>
-</div>
+Ready to deploy? See the [Quick Start](/docs/vcluster) to choose the path that fits your environment.
 
 ## How it works
 
-Each tenant cluster runs a dedicated virtualized control plane as a containerized process on the Control Plane Cluster. The control plane manages all operations within the tenant cluster and cannot be accessed by other tenants.
+vCluster works across a range of infrastructure configurations. Each tenant cluster is backed by a dedicated virtualized control plane. Tenant clusters are certified Kubernetes distributions. Any conformant tool works against them without modification: `kubectl`, Helm, Argo, Crossplane, and others.
 
-With **shared nodes**, a <GlossaryTerm term="syncer">syncer</GlossaryTerm> component translates workload resources (Pods, Secrets, ConfigMaps, Services) from each tenant cluster into a dedicated namespace on the underlying cluster. Tenants see their own resources. The translated copies are invisible to them.
+**Where the control plane runs**
 
-With **private nodes**, vCluster synchronizes only control plane state. Workloads run directly on dedicated infrastructure with no sync overhead. Tenants see an environment identical to a dedicated single-tenant cluster.
+- **On an existing Kubernetes cluster** — the control plane runs as a pod in a dedicated namespace. Your existing cluster becomes the Control Plane Cluster and no additional infrastructure is required.
+- **Standalone** — a complete, zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Use it as a full Kubernetes environment for any workload. When you need tenant isolation on top, it becomes the Control Plane Cluster. No external Kubernetes dependency required.
+- **vind** — the full stack runs in Docker containers with no Kubernetes dependency. Suited for local development and CI/CD pipelines.
 
-Tenant clusters are certified Kubernetes distributions. Any conformant tool works against them without modification: `kubectl`, Helm, Argo, Crossplane, and others.
+**How tenant workloads run**
+
+On cluster-based deployments, you choose how tenant workloads land on compute:
+
+- **Shared nodes** — tenants share the existing node pool. Multiple tenant clusters run on the same physical nodes with full API-level isolation. Suited for developer platforms, CI environments, and internal tooling where compute density matters.
+- **Private nodes** — each tenant cluster gets dedicated nodes enrolled through a token-based process. Network, storage, and compute are fully isolated per tenant, with no cross-tenant visibility at the infrastructure level. This is the isolation model for GPU workloads, regulated industries, and AI cloud platforms serving paying tenants. Nodes can come from bare metal ([vMetal](/docs/platform/administer/bare-metal/overview)), cloud VMs, or any Linux machine.
 
 ## Features and plans
 

--- a/vcluster/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster/introduction/what-are-virtual-clusters.mdx
@@ -21,7 +21,7 @@ vCluster works across a range of infrastructure configurations. Each tenant clus
 **Where the control plane runs**
 
 - **On an existing Kubernetes cluster** — the control plane runs as a pod in a dedicated namespace. Your existing cluster becomes the Control Plane Cluster and no additional infrastructure is required.
-- **Standalone** — a complete, zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Use it as a full Kubernetes environment for any workload. When you need tenant isolation on top, it becomes the Control Plane Cluster. No external Kubernetes dependency required.
+- **Standalone** — a complete, zero-dependency Kubernetes distribution that runs as a self-contained binary on bare metal or VMs. Use it as a full Kubernetes environment for any workload. When connected to vCluster Platform, it can act as a Control Plane Cluster for tenant isolation.
 - **vind** — the full stack runs in Docker containers with no Kubernetes dependency. Suited for local development and CI/CD pipelines.
 
 **How tenant workloads run**


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Removes the duplicate deployment path card grid and routing prose from `what-are-virtual-clusters.mdx` — that content already lives on the Quick Start index page. Replaces it with an expanded "How it works" section that covers all three control plane hosting options (existing cluster, Standalone, vind) and adds a Quick Start CTA after the intro.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2026--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/what-are-virtual-clusters

## Internal Reference
Closes DOC-1314


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs