### PR TITLE
fix(gtm): restore GTM loading via Docusaurus on production deploys

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,8 @@ description: Brief description of the document
 Write your content here...
 `;
 
+const isNetlifyProduction = process.env.CONTEXT === 'production';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Tenant cluster management",
@@ -327,10 +329,17 @@ const config = {
 
   scripts: [
     {
-      src:
-        "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
+      src: "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
       async: true,
     },
+    ...(isNetlifyProduction
+      ? [
+          {
+            src: "https://www.googletagmanager.com/gtm.js?id=GTM-KGZ3TLD",
+            async: true,
+          },
+        ]
+      : []),
   ],
   clientModules: [
     './src/client/MermaidPolyfillsClient.js',


### PR DESCRIPTION
# Content Description

The Netlify snippet injection for GTM was only inserting the `<noscript>` body fallback, not the main `<script>` tag that loads the GTM container. This meant `GTM-KGZ3TLD` was silently not executing on the current docs site, so CookieBot, Lemlist, GA4, and any other tags inside the container were all inactive.

This fix adds the GTM script directly to `docusaurus.config.js`, gated on `CONTEXT === 'production'` so it only fires on the real production deploy — not on Netlify preview builds or local dev.

Once deployed, Marketing should remove the broken GTM snippet from Netlify's snippet injection settings to avoid duplicate loading.

## Preview Link
<!-- The preview link or links to the documents-->


## Internal Reference

Closes DOC-1352
Closes DOC-1353

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs