### PR TITLE
adds: docs for snapshot support for standalone

### DIFF
--- a/vcluster/manage/backup-restore/backup.mdx
+++ b/vcluster/manage/backup-restore/backup.mdx
@@ -12,7 +12,7 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-There are multiple ways to back up and restore a virtual cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
+There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
 
 :::tip Scheduled snapshots with vCluster Platform
 Need automated, scheduled snapshots? [vCluster Platform AutoSnapshots](../../configure/vcluster-yaml/snapshots.mdx) lets you configure automatic snapshot creation on a cron schedule with retention policies—no need to write custom Kubernetes jobs.
@@ -61,6 +61,28 @@ The vCluster snapshot controller automatically determines the configured backing
 - If the snapshot was created with `--include-volumes` flag:
   - List of PVCs for which the snapshots were created
   - Volume snapshot identifiers
+
+### Standalone
+
+Standalone vCluster run as a systemd service directly on a Linux host, without a Kubernetes Control Plane Cluster. Use the `--standalone` flag instead of a cluster name to target the local standalone installation:
+
+```bash title="Create a snapshot on a standalone vCluster"
+vcluster snapshot create --standalone "s3://my-s3-bucket/my-bucket-key"
+```
+
+Check snapshot status with:
+
+```bash title="Check snapshot status on a standalone vCluster"
+vcluster snapshot get --standalone "s3://my-s3-bucket/my-bucket-key"
+```
+
+:::note
+`--standalone` cannot be used with `--driver docker`.
+:::
+
+:::tip External storage for cross-node recovery
+The `container://` protocol stores the snapshot on the local filesystem of the standalone node. For disaster recovery scenarios where you need to restore to a different node, use an external storage backend such as [OCI](#store-snapshots-in-oci-image-registries), [S3](#store-snapshots-in-s3-buckets), or [Azure Blob Storage](#store-snapshots-in-azure-blob-storage).
+:::
 
 ### Snapshot URL
 
@@ -351,13 +373,16 @@ vcluster snapshot create my-vcluster "container:///data/my-snapshot.tar.gz"
 
 ## Limitations
 
-When taking snapshots and restoring virtual clusters, there are limitations:
+When taking snapshots and restoring tenant clusters, there are limitations:
 
-**Sleeping virtual clusters**
-- Snapshots require a running vCluster control plane and do not work with sleeping virtual clusters.
+**Sleeping tenant clusters**
+- Snapshots require a running vCluster control plane and do not work with sleeping tenant clusters.
 
-**Virtual clusters using an external database**
-- Virtual clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
+**Tenant clusters using an external database**
+- Tenant clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
 
 **Distribution**
 - Snapshots work only with K8s
+
+**Cluster Certificates**
+- Cluster certificates are not included in the snapshot

--- a/vcluster/manage/backup-restore/backup.mdx
+++ b/vcluster/manage/backup-restore/backup.mdx
@@ -15,27 +15,26 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
 
 :::tip Scheduled snapshots with vCluster Platform
-Need automated, scheduled snapshots? [vCluster Platform AutoSnapshots](../../configure/vcluster-yaml/snapshots.mdx) lets you configure automatic snapshot creation on a cron schedule with retention policies—no need to write custom Kubernetes jobs.
+Need automated, scheduled snapshots? [vCluster Platform AutoSnapshots](../../configure/vcluster-yaml/snapshots.mdx) lets you configure automatic snapshot creation on a cron schedule with retention policies. No need to write custom Kubernetes jobs.
 :::
 
 :::warning
-If you use an external database, such as MySQL or PostgreSQL, that does **not** run in the same namespace as vCluster, you must create a separate backup for the datastore. For more information, refer to the relevant database documentation.
+External databases such as MySQL or PostgreSQL that run outside the vCluster namespace require a separate backup. Refer to the relevant database documentation.
 :::
 
 ## Create a snapshot
 
-We recommend using the vCluster CLI `vcluster snapshot create` command to back up the etcd datastore. Optionally, you can
-also create snapshots of your CSI volumes by running `vcluster snapshot create` with `--include-volumes` flag. 
+We recommend using the vCluster CLI `vcluster snapshot create` command to back up the etcd datastore. Optionally, you can also create snapshots of your CSI volumes by running `vcluster snapshot create` with the `--include-volumes` flag.
 
 :::warning
-Without the `--include-volumes` flag, no persistent volumes backup will be created.
+Without the `--include-volumes` flag, vCluster doesn't back up persistent volumes.
 :::
 
 :::info
 The vCluster snapshot feature currently only supports creating snapshots for CSI persistent volumes. See [Volume snapshots](./volume-snapshots/setup.mdx) for more details. To back up non-CSI persistent volumes (e.g. local volumes), use the [Velero backup method](./velero.mdx).
 :::
 
-When you run the command to create a snapshot, vCluster CLI creates a snapshot request, which is then processed in the background by the vCluster snapshot controller. Here is an example:
+When you run `vcluster snapshot create`, the CLI submits a snapshot request. The vCluster snapshot controller processes it in the background. Here is an example:
 
 ```bash
 vcluster snapshot create myvcluster "container:///data/my-snapshot.tar.gz"
@@ -58,27 +57,27 @@ The vCluster snapshot controller automatically determines the configured backing
 - Backing store data (for example, etcd or SQLite)
 - vCluster Helm release information
 - vCluster configuration (for example, `vcluster.yaml`)
-- If the snapshot was created with `--include-volumes` flag:
-  - List of PVCs for which the snapshots were created
+- If you used the `--include-volumes` flag:
+  - List of PVCs with snapshots
   - Volume snapshot identifiers
 
 ### Standalone
 
-Standalone vCluster run as a systemd service directly on a Linux host, without a Kubernetes Control Plane Cluster. Use the `--standalone` flag instead of a cluster name to target the local standalone installation:
+Standalone vCluster runs as a systemd service directly on a Linux host, without a Kubernetes cluster. Use the `--standalone` flag instead of a cluster name to target the local standalone installation. This flag can't be used with `--driver docker`.
 
-```bash title="Create a snapshot on a standalone vCluster"
-vcluster snapshot create --standalone "s3://my-s3-bucket/my-bucket-key"
-```
+<InterpolatedCodeBlock
+  code={`vcluster snapshot create --standalone "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:SNAPSHOT_KEY:my-bucket-key]]"`}
+  language="bash"
+  title="Create a snapshot on a standalone vCluster"
+/>
 
-Check snapshot status with:
+Check the snapshot status with:
 
-```bash title="Check snapshot status on a standalone vCluster"
-vcluster snapshot get --standalone "s3://my-s3-bucket/my-bucket-key"
-```
-
-:::note
-`--standalone` cannot be used with `--driver docker`.
-:::
+<InterpolatedCodeBlock
+  code={`vcluster snapshot get --standalone "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:SNAPSHOT_KEY:my-bucket-key]]"`}
+  language="bash"
+  title="Check snapshot status on a standalone vCluster"
+/>
 
 :::tip External storage for cross-node recovery
 The `container://` protocol stores the snapshot on the local filesystem of the standalone node. For disaster recovery scenarios where you need to restore to a different node, use an external storage backend such as [OCI](#store-snapshots-in-oci-image-registries), [S3](#store-snapshots-in-s3-buckets), or [Azure Blob Storage](#store-snapshots-in-azure-blob-storage).
@@ -105,25 +104,29 @@ The following protocols are supported for storing snapshots:
 
 For example, the following snapshot URL saves the snapshot to an OCI image registry:
 
-```bash title="Snapshot and push to an OCI image registry"
-vcluster snapshot create my-vcluster "oci://ghcr.io/my-user/my-repo:my-tag"
-```
+<InterpolatedCodeBlock
+  code={`vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_REPO:my-user/my-repo]]:[[VAR:OCI_TAG:my-tag]]"`}
+  language="bash"
+  title="Snapshot and push to an OCI image registry"
+/>
 
 #### Store snapshots in OCI image registries
 
-You can save snapshots to OCI image registries. You can authenticate in two ways: by using locally stored OCI credentials or by passing credentials directly in the snapshot URL.
+You can save snapshots to OCI image registries. Authenticate using locally stored OCI credentials, or pass credentials directly in the snapshot URL.
 
 To authenticate with local credentials, log in to your OCI registry and create the snapshot:
 
-```bash title="Authenticate with local OCI credentials and create a snapshot"
-# Log in to the OCI registry using a password access token.
-echo $PASSWORD_ACCESS_TOKEN | docker login ghcr.io -u $USERNAME --password-stdin
+<InterpolatedCodeBlock
+  code={`# Log in to the OCI registry using a password access token.
+echo $PASSWORD_ACCESS_TOKEN | docker login [[VAR:OCI_REGISTRY:ghcr.io]] -u $USERNAME --password-stdin
 
 # Create a snapshot and push it to an OCI image registry.
-vcluster snapshot create my-vcluster "oci://ghcr.io/my-user/my-repo:my-tag"
-```
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_REPO:my-user/my-repo]]:[[VAR:OCI_TAG:my-tag]]"`}
+  language="bash"
+  title="Authenticate with local OCI credentials and create a snapshot"
+/>
 
-Alternatively, you can pass authentication credentials directly in the snapshot URL and create the snapshot. The following options are supported to configure authentication when passing credentials directly in the URL:
+Alternatively, pass credentials directly in the snapshot URL. The following parameters configure authentication:
 
 | Parameter | Description | Required |
 |-----------|-------------|----------|
@@ -132,28 +135,32 @@ Alternatively, you can pass authentication credentials directly in the snapshot 
 | `skip-client-credentials` | When set to `true`, ignores local Docker credentials | No, defaults to `false` |
 
 
-```bash title="Pass OCI credentials directly in the snapshot URL"
-# Pass authentication credentials directly in the URL and create a snapshot.
-export OCI_USERNAME=my-username
-export OCI_PASSWORD=$(echo -n "my-password" | base64)
-vcluster snapshot create my-vcluster "oci://ghcr.io/my-user/my-repo:my-tag?username=$OCI_USERNAME&password=$OCI_PASSWORD&skip-client-credentials=true"
-```
+<InterpolatedCodeBlock
+  code={`# Pass authentication credentials directly in the URL and create a snapshot.
+export OCI_USERNAME=[[VAR:OCI_USERNAME:my-username]]
+export OCI_PASSWORD=$(echo -n "[[VAR:OCI_PASSWORD:my-password]]" | base64)
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_REPO:my-user/my-repo]]:[[VAR:OCI_TAG:my-tag]]?username=$OCI_USERNAME&password=$OCI_PASSWORD&skip-client-credentials=true"`}
+  language="bash"
+  title="Pass OCI credentials directly in the snapshot URL"
+/>
 
 #### Store snapshots in S3 buckets
 
-Store snapshots in an S3-compatible bucket using the `s3` protocol. This works with AWS S3 and S3-compatible providers such as MinIO or Ceph, which are common in on-premise and air-gapped environments where cloud storage isn't available.
+Store snapshots in an S3-compatible bucket using the `s3` protocol. This works with AWS S3 and S3-compatible providers such as MinIO or Ceph. These are common in on-premise and air-gapped environments where cloud storage isn't available.
 
 You can authenticate in two ways: by using local environment credentials or by passing credentials directly in the URL.
 
 To use local environment credentials, log in to AWS CLI, then create and save the snapshot:
 
-```bash title="Create and store a snapshot in an S3 bucket using AWS CLI credentials"
-# Check if you are logged in.
+<InterpolatedCodeBlock
+  code={`# Check if you are logged in.
 aws sts get-caller-identity
 
 # Create a snapshot and store it in an S3 bucket.
-vcluster snapshot create my-vcluster "s3://my-s3-bucket/my-bucket-key"
-```
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:SNAPSHOT_KEY:my-bucket-key]]"`}
+  language="bash"
+  title="Create and store a snapshot in an S3 bucket using AWS CLI credentials"
+/>
 
 Alternatively, you can pass options directly in the snapshot URL. The following options are supported:
 
@@ -186,29 +193,33 @@ Run the following command to create a snapshot and store it in an S3 bucket:
 
 <TabItem value="macos">
 
-```bash title="Pass S3 credentials directly in the URL to create a snapshot"
-# Read the AWS credentials from files and encode them with base64
+<InterpolatedCodeBlock
+  code={`# Read the AWS credentials from files and encode them with base64
 # This allows them to be safely included in the S3 URL
 export ACCESS_KEY_ID=$(cat my-access-key-id.txt | base64)
 export SECRET_ACCESS_KEY=$(cat my-secret-access-key.txt | base64)
 export SESSION_TOKEN=$(cat my-session-token.txt | base64)
 
-vcluster snapshot create my-vcluster "s3://my-s3-bucket/my-bucket-key?access-key-id=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY&session-token=$SESSION_TOKEN"
-```
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:SNAPSHOT_KEY:my-bucket-key]]?access-key-id=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY&session-token=$SESSION_TOKEN"`}
+  language="bash"
+  title="Pass S3 credentials directly in the URL to create a snapshot"
+/>
 
 </TabItem>
 
 <TabItem value="linux">
 
-```bash title="Pass S3 credentials directly in the URL to create a snapshot"
-# Read the AWS credentials from files and encode them with base64
+<InterpolatedCodeBlock
+  code={`# Read the AWS credentials from files and encode them with base64
 # On Linux, the -w 0 flag prevents line wrapping of the encoded output
 export ACCESS_KEY_ID=$(cat my-access-key-id.txt | base64 -w 0)
 export SECRET_ACCESS_KEY=$(cat my-secret-access-key.txt | base64 -w 0)
 export SESSION_TOKEN=$(cat my-session-token.txt | base64 -w 0)
 
-vcluster snapshot create my-vcluster "s3://my-s3-bucket/my-bucket-key?access-key-id=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY&session-token=$SESSION_TOKEN"
-```
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:SNAPSHOT_KEY:my-bucket-key]]?access-key-id=$ACCESS_KEY_ID&secret-access-key=$SECRET_ACCESS_KEY&session-token=$SESSION_TOKEN"`}
+  language="bash"
+  title="Pass S3 credentials directly in the URL to create a snapshot"
+/>
 
 </TabItem>
 </Tabs>
@@ -262,15 +273,17 @@ vCluster supports server-side encryption for S3 snapshots to meet security requi
 
 **SSE-S3 (AES256)**
 
-```bash
-vcluster snapshot create my-vcluster "s3://my-bucket/key" --server-side-encryption AES256
-```
+<InterpolatedCodeBlock
+  code={`vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-bucket]]/[[VAR:SNAPSHOT_KEY:my-snapshot-key]]" --server-side-encryption AES256`}
+  language="bash"
+/>
 
 **SSE-KMS**
 
-```bash
-vcluster snapshot create my-vcluster "s3://my-bucket/key" --kms-key-id "12345678-1234-1234-1234-123456789012"
-```
+<InterpolatedCodeBlock
+  code={`vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-bucket]]/[[VAR:SNAPSHOT_KEY:my-snapshot-key]]" --kms-key-id "[[VAR:KMS_KEY_ID:12345678-1234-1234-1234-123456789012]]"`}
+  language="bash"
+/>
 
 **Example: Bucket policy requiring encryption**
 
@@ -314,7 +327,7 @@ vCluster supports three ways to authenticate:
 
 <TabItem value="azure-cli">
 
-Log in with `az login` before running the snapshot command. You must also provide the subscription ID and resource group where the storage account is located, either as CLI flags or as environment variables (`AZURE_SUBSCRIPTION_ID` and `AZURE_RESOURCE_GROUP`):
+Log in with `az login` before running the snapshot command. You must also provide the subscription ID and resource group for the storage account as CLI flags or environment variables (`AZURE_SUBSCRIPTION_ID` and `AZURE_RESOURCE_GROUP`):
 
 <InterpolatedCodeBlock
   code={`# Log in to Azure.
@@ -358,7 +371,7 @@ vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAG
 </Tabs>
 
 :::warning Security
-When you run `vcluster snapshot create` using Azure CLI credentials or a storage account key, the vCluster CLI generates a short-lived SAS token and saves it temporarily in a Kubernetes Secret. The vCluster controller reads this token to upload the snapshot to Azure Blob Storage. The Secret is removed once the snapshot completes.
+When using Azure CLI credentials or a storage account key, the vCluster CLI generates a short-lived SAS token and stores it in a Kubernetes Secret. The snapshot controller reads this token to upload the snapshot to Azure Blob Storage. vCluster deletes the Secret once the snapshot completes.
 :::
 
 #### Store snapshots in containers
@@ -366,23 +379,25 @@ When you run `vcluster snapshot create` using Azure CLI credentials or a storage
 Use the `container` protocol to save snapshots as local files inside a vCluster container.
 Run the following command to create a snapshot and store it in the specified path inside a container:
 
-```bash title="Create snapshots inside a vCluster container"
-# Create a snapshot to local vCluster PVC (if using embedded storage).
-vcluster snapshot create my-vcluster "container:///data/my-snapshot.tar.gz"
-```
+<InterpolatedCodeBlock
+  code={`# Create a snapshot to local vCluster PVC (if using embedded storage).
+vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "container://[[VAR:SNAPSHOT_PATH:/data/my-snapshot.tar.gz]]"`}
+  language="bash"
+  title="Create snapshots inside a vCluster container"
+/>
 
 ## Limitations
 
 When taking snapshots and restoring tenant clusters, there are limitations:
 
 **Sleeping tenant clusters**
-- Snapshots require a running vCluster control plane and do not work with sleeping tenant clusters.
+- Snapshots require a running vCluster control plane and don't work with sleeping tenant clusters.
 
 **Tenant clusters using an external database**
 - Tenant clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
 
 **Distribution**
-- Snapshots work only with K8s
+- Snapshots work only with K8s.
 
 **Cluster Certificates**
-- Cluster certificates are not included in the snapshot
+- vCluster doesn't include cluster certificates in snapshots.

--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -1,8 +1,8 @@
 ---
-title: Restore snapshots
+sidebar_class_name: host-nodes private-nodes
 sidebar_label: Restore Snapshots
 sidebar_position: 3
-sidebar_class_name: host-nodes
+title: Restore snapshots
 ---
 
 import Tabs from '@theme/Tabs';
@@ -12,7 +12,7 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-There are multiple ways to back up and restore a virtual cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
+There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
 
 :::warning
 If you use an external database, such as MySQL or PostgreSQL, that does **not** run in the same namespace as vCluster, you must restore based on the relevant database documentation.
@@ -25,34 +25,34 @@ A vCluster snapshot includes:
 - vCluster configuration (for example, `vcluster.yaml`)
 
 :::info Extra Steps for Private Nodes
-For virtual clusters with private nodes, [additional steps](#use-snapshots-with-private-nodes) may be required.
+For tenant clusters with private nodes, [additional steps](#use-snapshots-with-private-nodes) may be required.
 :::
 
-## Restore existing virtual cluster from a snapshot
+## Restore existing tenant cluster from a snapshot
 
 Restoring from a snapshot pauses the vCluster, scales down all workload pods to 0, and launches a temporary restore pod. Once the restore completes, the vCluster resumes, and all workload pods are scaled back up. This process results in temporary downtime while the restore is in progress.
 
 :::warning Failed Restore
-If the restore fails while using `vcluster restore` commands, the process stops. You must retry the restore to avoid leaving the virtual cluster in an inconsistent or broken state.
+If the restore fails while using `vcluster restore` commands, the process stops. You must retry the restore to avoid leaving the tenant cluster in an inconsistent or broken state.
 :::
 
 Restore a vCluster using the following commands. You can use any snapshot option and set the snapshot URL with different credentials.
 
-### Restore virtual clusters from OCI
+### Restore tenant clusters from OCI
 
 <Tabs
-  defaultValue="local-credentials"
-  values={[
-    {label: 'Local credentials', value: 'local-credentials'},
-    {label: 'URL credentials', value: 'url-credentials'},
-  ]}>
+defaultValue="local-credentials"
+values={[
+{label: 'Local credentials', value: 'local-credentials'},
+{label: 'URL credentials', value: 'url-credentials'},
+]}>
 
 <TabItem value="local-credentials">
 
 <InterpolatedCodeBlock
-  code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]"`}
-  language="bash"
-  title="Restore from an OCI snapshot using local credentials"
+code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]"`}
+language="bash"
+title="Restore from an OCI snapshot using local credentials"
 />
 
 </TabItem>
@@ -60,42 +60,42 @@ Restore a vCluster using the following commands. You can use any snapshot option
 <TabItem value="url-credentials">
 
 <InterpolatedCodeBlock
-  code={`export OCI_USERNAME=my-username
+code={`export OCI_USERNAME=my-username
 export OCI_PASSWORD=$(echo -n "my-password" | base64)
 vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]?username=$OCI_USERNAME&password=$OCI_PASSWORD&skip-client-credentials=true"`}
-  language="bash"
-  title="Restore from an OCI snapshot using URL credentials"
+language="bash"
+title="Restore from an OCI snapshot using URL credentials"
 />
 
 </TabItem>
 </Tabs>
 
-### Restore virtual clusters from S3
+### Restore tenant clusters from S3
 
 <InterpolatedCodeBlock
-  code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:KEY:my-snapshot-key]]"`}
-  language="bash"
-  title="Restore from an S3 snapshot using local credentials"
+code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "s3://[[VAR:BUCKET:my-s3-bucket]]/[[VAR:KEY:my-snapshot-key]]"`}
+language="bash"
+title="Restore from an S3 snapshot using local credentials"
 />
 
-### Restore virtual clusters from Azure Blob
+### Restore tenant clusters from Azure Blob
 
 <Tabs
-  defaultValue="azure-cli"
-  values={[
-    {label: 'Azure CLI', value: 'azure-cli'},
-    {label: 'SAS token', value: 'sas-token'},
-    {label: 'Storage account key', value: 'storage-key'},
-  ]}>
+defaultValue="azure-cli"
+values={[
+{label: 'Azure CLI', value: 'azure-cli'},
+{label: 'SAS token', value: 'sas-token'},
+{label: 'Storage account key', value: 'storage-key'},
+]}>
 
 <TabItem value="azure-cli">
 
 <InterpolatedCodeBlock
-  code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAGE_ACCOUNT:myaccount]].blob.core.windows.net/[[VAR:CONTAINER:my-container]]/[[VAR:BLOB_PATH:my-snapshot.tar.gz]]" \\
-  --azure-subscription-id [[VAR:SUBSCRIPTION_ID:my-subscription-id]] \\
-  --azure-resource-group [[VAR:RESOURCE_GROUP:my-resource-group]]`}
-  language="bash"
-  title="Restore from an Azure Blob Storage snapshot using Azure CLI credentials"
+code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAGE_ACCOUNT:myaccount]].blob.core.windows.net/[[VAR:CONTAINER:my-container]]/[[VAR:BLOB_PATH:my-snapshot.tar.gz]]" \\
+--azure-subscription-id [[VAR:SUBSCRIPTION_ID:my-subscription-id]] \\
+--azure-resource-group [[VAR:RESOURCE_GROUP:my-resource-group]]`}
+language="bash"
+title="Restore from an Azure Blob Storage snapshot using Azure CLI credentials"
 />
 
 </TabItem>
@@ -103,9 +103,9 @@ vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghc
 <TabItem value="sas-token">
 
 <InterpolatedCodeBlock
-  code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAGE_ACCOUNT:myaccount]].blob.core.windows.net/[[VAR:CONTAINER:my-container]]/[[VAR:BLOB_PATH:my-snapshot.tar.gz]]?sv=2022-11-02&ss=b&srt=co&sp=rwlacuptfx&se=2027-01-01T00:00:00Z&sig=YOUR_SAS_SIGNATURE"`}
-  language="bash"
-  title="Restore from an Azure Blob Storage snapshot using a SAS token"
+code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAGE_ACCOUNT:myaccount]].blob.core.windows.net/[[VAR:CONTAINER:my-container]]/[[VAR:BLOB_PATH:my-snapshot.tar.gz]]?sv=2022-11-02&ss=b&srt=co&sp=rwlacuptfx&se=2027-01-01T00:00:00Z&sig=YOUR_SAS_SIGNATURE"`}
+language="bash"
+title="Restore from an Azure Blob Storage snapshot using a SAS token"
 />
 
 </TabItem>
@@ -113,67 +113,129 @@ vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghc
 <TabItem value="storage-key">
 
 <InterpolatedCodeBlock
-  code={`export AZURE_STORAGE_KEY=my-storage-account-key
+code={`export AZURE_STORAGE_KEY=my-storage-account-key
 vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "https://[[VAR:STORAGE_ACCOUNT:myaccount]].blob.core.windows.net/[[VAR:CONTAINER:my-container]]/[[VAR:BLOB_PATH:my-snapshot.tar.gz]]"`}
-  language="bash"
-  title="Restore from an Azure Blob Storage snapshot using a storage account key"
+language="bash"
+title="Restore from an Azure Blob Storage snapshot using a storage account key"
 />
 
 </TabItem>
 </Tabs>
 
-### Restore virtual clusters from container
+### Restore tenant clusters from container
 
 <InterpolatedCodeBlock
-  code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "container://[[VAR:PATH:/data/my-snapshot.tar.gz]]"`}
-  language="bash"
-  title="Restore from a local container snapshot"
+code={`vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "container://[[VAR:PATH:/data/my-snapshot.tar.gz]]"`}
+language="bash"
+title="Restore from a local container snapshot"
 />
 
-When restoring your virtual cluster, you can also restore CSI-provisioned PVCs by specifying `--restore-volumes` flag:
+When restoring your tenant cluster, you can also restore CSI-provisioned PVCs by specifying `--restore-volumes` flag:
 
-```bash tittle="Restore PVC data when restoring a virtual cluster"
+```bash
 # Restore from a local pvc snapshot (if using embedded storage).
 vcluster restore my-vcluster "container:///data/my-snapshot.tar.gz" --restore-volumes
 ```
 
 See [Volume snapshots](./volume-snapshots/setup.mdx) for more details.
 
-## Clone a virtual cluster to a new virtual cluster
+## Restore a standalone vCluster
 
-You can use snapshots to clone an existing virtual cluster and create a new virtual cluster from that snapshot. When creating a new virtual cluster from a snapshot, it also restores all workloads in the virtual cluster.
+For standalone vCluster running as a systemd service, use the `--standalone` flag instead of a cluster name. The CLI automatically stops the vCluster service, restores the backing store data from the snapshot, and restarts the service.
 
-:::warning Restore Failures
-If the restore failes while using `vcluster create`, the new virtual cluster is automatically deleted.
+```bash
+vcluster restore --standalone "container:///var/lib/vcluster/my-snapshot.tar.gz"
+```
+
+You can also restore from any external storage backend:
+
+```bash
+vcluster restore --standalone "oci://ghcr.io/my-user/my-repo:my-tag"
+```
+
+:::note
+`--standalone` cannot be used with `--driver docker`.
 :::
 
-```bash title="Create a new virtual cluster from an OCI snapshot"
-# Create a new virtual cluster from an OCI snapshot (uses local credentials).
+:::warning Migrating or cloning snapshots to a new machine will have limitations.
+Restoring to a different machine will leave stale node details in etcd that require manual cleanup. To make the snapshot file available on another node, use an external storage backend (OCI, S3, or Azure Blob Storage) — but expect to manually remove stale node resources after restore.
+:::
+
+### Restore a standalone vCluster in HA mode
+
+Restoring a standalone vCluster configured with multiple etcd peers (HA mode) requires manual intervention. Shut down all nodes except the one where the restore will be performed, then run the restore on that node.
+
+The following steps assume a three-node setup where the restore is performed on node A:
+
+1. Stop the vCluster service on all nodes except the restore node:
+
+```bash
+# Run on nodes B and C
+systemctl stop vcluster
+```
+
+2. Run the restore on node A:
+
+```bash
+vcluster restore --standalone "<snapshot-url>"
+```
+
+3. Delete the stale node objects for the stopped nodes from the restored cluster:
+
+```bash
+kubectl delete node <node-B> <node-C>
+```
+
+4. On nodes B and C, move the old vCluster state aside so they rejoin cleanly:
+
+```bash
+# Run on nodes B and C
+mv /var/lib/vcluster /var/lib/vcluster-bcp
+```
+
+5. On node A, create a join token:
+
+```bash
+vcluster token create --control-plane
+```
+
+6. Use the join script output to rejoin nodes B and C **one at a time**, waiting for each node to reach `Ready` before joining the next, so etcd quorum is rebuilt sequentially.
+
+## Clone a tenant cluster to a new tenant cluster
+
+You can use snapshots to clone an existing tenent cluster and create a new tenant cluster from that snapshot. When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
+
+:::warning Restore Failures
+If the restore fails while using `vcluster create`, the new tenant cluster is automatically deleted.
+:::
+
+```bash
+# Create a new tenant cluster from an OCI snapshot (uses local credentials).
 vcluster create my-vcluster --restore oci://ghcr.io/my-user/my-repo:my-tag
 ```
 
 :::info New name or namespace updates certificates
-vCluster certificates change when you create the virtual cluster with a new name or in a new namespace, which is expected as virtual clusters shouldn't share the same certificates.
+vCluster certificates change when you create the tenant cluster with a new name or in a new namespace, which is expected as tenant clusters shouldn't share the same certificates.
 :::
 
-## Migrate and override vCluster configuration options to create a new vCluster
+## Migrate and override vCluster configuration options to create a new tenant cluster
 
-When upgrading virtual clusters, there are a couple of configuration options that are not supported to change on an existing virtual cluster. For example, the backing store cannot be changed. To change other configuration options, you can migrate the virtual cluster by creating a new virtual cluster from a snapshot and applying new configuration options.
+When upgrading tenant clusters, there are a couple of configuration options that are not supported to change on an existing tenant cluster. For example, the backing store cannot be changed. To change other configuration options, you can migrate the tenant cluster by creating a new tenant cluster from a snapshot and applying new configuration options.
 
-When creating a new virtual cluster from a snapshot, it also restores all workloads in the virtual cluster.
+When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
 
 :::warning Restore failures
-If the restore fails while using `vcluster create`, the new virtual cluster is automatically deleted.
+If the restore fails while using `vcluster create`, the new tenant cluster is automatically deleted.
 :::
 
-```bash title="Migrate a virtual cluster by restoring from a snapshot"
+```bash
 # Upgrade an existing vCluster by restoring from a snapshot and applying a new vcluster.yaml.
 # Configuration options in the vcluster.yaml override the options from the snapshot.
 vcluster create my-vcluster --upgrade -f vcluster.yaml --restore oci://ghcr.io/my-user/my-repo:my-tag
 ```
 
 :::info New name or namespace updates certificates
-vCluster certificates change when you create a virtual cluster with a new name or in a different namespace. This behavior is expected, as virtual clusters should not share the same certificates.
+vCluster certificates change when you create a tenant cluster with a new name or in a different namespace. This behavior is expected, as tenant clusters should not share the same certificates.
 :::
 
 ### Supported migration options
@@ -187,53 +249,65 @@ Change your data store to improve efficiency, scalability, and Kubernetes compat
 - Embedded database (SQLite) -> Embedded database (etcd)
 - Embedded database (SQLite) -> External database
 
-All other configuration options are overridden, similar to upgrading a virtual cluster and applying changes.
+All other configuration options are overridden, similar to upgrading a tenant cluster and applying changes.
 
 ### Limitations
 
-When taking snapshots and restoring virtual clusters, there are limitations:
+When taking snapshots and restoring tenant clusters, there are limitations:
 
-**Sleeping virtual clusters**
-- Snapshots require a running vCluster control plane and do not work with sleeping virtual clusters.
+**Sleeping tenant clusters**
 
-**Virtual clusters using the k0s distro**
-- Use the `--pod-exec` flag to take a snapshot of a k0s virtual cluster.
-- k0s virtual clusters do not support restore or clone operations. Migrate them to k8s instead.
+- Snapshots require a running vCluster control plane and do not work with sleeping tenant clusters.
 
-**Virtual clusters using an external database**
-- Virtual clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
+**Tenant clusters using the k0s distro**
+
+- Use the `--pod-exec` flag to take a snapshot of a k0s tenant cluster.
+- k0s tenant clusters do not support restore or clone operations. Migrate them to k8s instead.
+
+**Tenant clusters using an external database**
+
+- Tenant clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
 
 **vcluster.yaml configuration**
-- Although the vcluster.yaml configuration is backed up, it is not automatically restored. After restoring a virtual cluster, you must manually reapply your vcluster.yaml configuration. This limitation will be fixed in a future release.
+
+- Although the vcluster.yaml configuration is backed up, it is not automatically restored. After restoring a tenant cluster, you must manually reapply your vcluster.yaml configuration.
+
+**Standalone: restore to a new Control Plane Cluster**
+
+- If you restore a snapshot on a different node, the Control Plane Cluster's etcd will contain node details from the original machine. You must manually clean up stale node resources after restore (see [Use snapshots with private nodes](#use-snapshots-with-private-nodes)).
+
+**Standalone: tenant cluster workloads are not restored**
+
+- Restoring the standalone Control Plane Cluster snapshot only restores the Control Plane Cluster's own etcd data. Each tenant cluster running on the Control Plane Cluster has its own etcd, so workloads deployed inside tenant clusters are not restored by a standalone snapshot.
 
 ## Use snapshots with private nodes
 
-Node resources are also included in the etcd snapshot. If you are restoring to a virtual cluster with
-a different set of nodes, manual intervention is required for virtual clusters using [private nodes](../../deploy/worker-nodes/private-nodes/README.mdx). When using snapshots with [host nodes](../../deploy/worker-nodes/host-nodes/README.mdx),
+Node resources are also included in the etcd snapshot. If you are restoring to a tenant cluster with
+a different set of nodes, manual intervention is required for tenant clusters using [private nodes](../../deploy/worker-nodes/private-nodes/README.mdx). When using snapshots with [host nodes](../../deploy/worker-nodes/host-nodes/README.mdx),
 if the nodes change between the snapshot and restore, vCluster is able to automatically
 update information about the nodes.
 
 ### Nodes removed between snapshot and restore
 
-When nodes exist in the snapshot, but don't exist in the current virtual cluster, you need to manually delete the node(s) from the restored virtual cluster.
+When nodes exist in the snapshot, but don't exist in the current tenant cluster, you need to manually delete the node(s) from the restored tenant cluster.
 
-The node shows up in `kubectl get nodes`, but the node does not physically exist in the virtual cluster.
+The node shows up in `kubectl get nodes`, but the node does not physically exist in the tenant cluster.
 
-For each node that no longer exists, you need to run `kubectl delete node [name]` to delete the node resource from the virtual cluster.
+For each node that no longer exists, you need to run `kubectl delete node [name]` to delete the node resource from the tenant cluster.
 
-```bash title="Manually delete nodes that no longer exist"
+```bash
 export NODE_NAME=my-node
 kubectl delete node $NODE_NAME
 ```
 
 ### Nodes added between snapshot and restore
 
-When nodes were added after the snapshot was taken, the node resource does not exist in the restored virtual cluster. If you run
+When nodes were added after the snapshot was taken, the node resource does not exist in the restored tenant cluster. If you run
 `kubectl get nodes`, then those node(s) are missing.
 
 You need to re-join each private node with the `--force-join` flag.
 
-```bash title="Create a token for worker nodes"
+```bash
 export VCLUSTER_NAME=my-vcluster
 
 # Connect to your vcluster
@@ -245,6 +319,6 @@ vcluster token create --expires=1h
 
 The output provides a command to run on your worker node, and you need to append the `--force-join` flag.
 
-```bash title="Example output from creating a token with --force-join"
+```bash
 curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh - -- --force-join
 ```

--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -1,8 +1,8 @@
 ---
+title: Restore snapshots
 sidebar_class_name: host-nodes private-nodes
 sidebar_label: Restore Snapshots
 sidebar_position: 3
-title: Restore snapshots
 ---
 
 import Tabs from '@theme/Tabs';
@@ -15,7 +15,7 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
 
 :::warning
-If you use an external database, such as MySQL or PostgreSQL, that does **not** run in the same namespace as vCluster, you must restore based on the relevant database documentation.
+External databases such as MySQL or PostgreSQL running outside the vCluster namespace require a separate restore procedure. Refer to the relevant database documentation.
 :::
 
 A vCluster snapshot includes:
@@ -25,12 +25,12 @@ A vCluster snapshot includes:
 - vCluster configuration (for example, `vcluster.yaml`)
 
 :::info Extra Steps for Private Nodes
-For tenant clusters with private nodes, [additional steps](#use-snapshots-with-private-nodes) may be required.
+For tenant clusters with private nodes, you may need to follow [additional steps](#use-snapshots-with-private-nodes).
 :::
 
 ## Restore existing tenant cluster from a snapshot
 
-Restoring from a snapshot pauses the vCluster, scales down all workload pods to 0, and launches a temporary restore pod. Once the restore completes, the vCluster resumes, and all workload pods are scaled back up. This process results in temporary downtime while the restore is in progress.
+Restoring from a snapshot pauses the vCluster, scales down all workload pods to 0, and launches a temporary restore pod. Once the restore completes, vCluster resumes and scales all workload pods back up. This process results in temporary downtime while the restore is in progress.
 
 :::warning Failed Restore
 If the restore fails while using `vcluster restore` commands, the process stops. You must retry the restore to avoid leaving the tenant cluster in an inconsistent or broken state.
@@ -132,40 +132,39 @@ title="Restore from a local container snapshot"
 
 When restoring your tenant cluster, you can also restore CSI-provisioned PVCs by specifying `--restore-volumes` flag:
 
-```bash
-# Restore from a local pvc snapshot (if using embedded storage).
-vcluster restore my-vcluster "container:///data/my-snapshot.tar.gz" --restore-volumes
-```
+<InterpolatedCodeBlock
+  code={`# Restore from a local PVC snapshot (if using embedded storage).
+vcluster restore [[VAR:VCLUSTER_NAME:my-vcluster]] "container://[[VAR:SNAPSHOT_PATH:/data/my-snapshot.tar.gz]]" --restore-volumes`}
+  language="bash"
+/>
 
 See [Volume snapshots](./volume-snapshots/setup.mdx) for more details.
 
 ## Restore a standalone vCluster
 
-For standalone vCluster running as a systemd service, use the `--standalone` flag instead of a cluster name. The CLI automatically stops the vCluster service, restores the backing store data from the snapshot, and restarts the service.
+For standalone vCluster running as a systemd service, use the `--standalone` flag instead of a cluster name. This flag can't be used with `--driver docker`. The CLI automatically stops the vCluster service, restores the backing store data from the snapshot, and restarts the service.
 
-```bash
-vcluster restore --standalone "container:///var/lib/vcluster/my-snapshot.tar.gz"
-```
+<InterpolatedCodeBlock
+  code={`vcluster restore --standalone "container://[[VAR:SNAPSHOT_PATH:/var/lib/vcluster/my-snapshot.tar.gz]]"`}
+  language="bash"
+/>
 
 You can also restore from any external storage backend:
 
-```bash
-vcluster restore --standalone "oci://ghcr.io/my-user/my-repo:my-tag"
-```
+<InterpolatedCodeBlock
+  code={`vcluster restore --standalone "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]"`}
+  language="bash"
+/>
 
-:::note
-`--standalone` cannot be used with `--driver docker`.
-:::
-
-:::warning Migrating or cloning snapshots to a new machine will have limitations.
-Restoring to a different machine will leave stale node details in etcd that require manual cleanup. To make the snapshot file available on another node, use an external storage backend (OCI, S3, or Azure Blob Storage) — but expect to manually remove stale node resources after restore.
+:::tip Cross-node recovery
+Restoring to a different machine leaves stale node details in etcd that require manual cleanup. To make the snapshot available on another node, use an external storage backend (OCI, S3, or Azure Blob Storage). Plan to manually remove stale node resources after restore.
 :::
 
 ### Restore a standalone vCluster in HA mode
 
-Restoring a standalone vCluster configured with multiple etcd peers (HA mode) requires manual intervention. Shut down all nodes except the one where the restore will be performed, then run the restore on that node.
+Restoring a standalone vCluster configured with multiple etcd peers (HA mode) requires manual intervention. Shut down all nodes except the restore node, then run the restore on that node.
 
-The following steps assume a three-node setup where the restore is performed on node A:
+The following steps assume a three-node setup where you run the restore on node A:
 
 1. Stop the vCluster service on all nodes except the restore node:
 
@@ -176,9 +175,10 @@ systemctl stop vcluster
 
 2. Run the restore on node A:
 
-```bash
-vcluster restore --standalone "<snapshot-url>"
-```
+<InterpolatedCodeBlock
+  code={`vcluster restore --standalone "[[VAR:SNAPSHOT_URL:snapshot-url]]"`}
+  language="bash"
+/>
 
 3. Delete the stale node objects for the stopped nodes from the restored cluster:
 
@@ -199,48 +199,50 @@ mv /var/lib/vcluster /var/lib/vcluster-bcp
 vcluster token create --control-plane
 ```
 
-6. Use the join script output to rejoin nodes B and C **one at a time**, waiting for each node to reach `Ready` before joining the next, so etcd quorum is rebuilt sequentially.
+6. Use the join script output to rejoin nodes B and C **one at a time**. Wait for each node to reach `Ready` before joining the next to rebuild etcd quorum sequentially.
 
 ## Clone a tenant cluster to a new tenant cluster
 
-You can use snapshots to clone an existing tenent cluster and create a new tenant cluster from that snapshot. When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
+You can use snapshots to clone an existing tenant cluster and create a new tenant cluster from that snapshot. When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
 
 :::warning Restore Failures
-If the restore fails while using `vcluster create`, the new tenant cluster is automatically deleted.
+If the restore fails while using `vcluster create`, vCluster automatically deletes the new tenant cluster.
 :::
 
-```bash
-# Create a new tenant cluster from an OCI snapshot (uses local credentials).
-vcluster create my-vcluster --restore oci://ghcr.io/my-user/my-repo:my-tag
-```
+<InterpolatedCodeBlock
+  code={`# Create a new tenant cluster from an OCI snapshot (uses local credentials).
+vcluster create [[VAR:VCLUSTER_NAME:my-vcluster]] --restore oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]`}
+  language="bash"
+/>
 
 :::info New name or namespace updates certificates
-vCluster certificates change when you create the tenant cluster with a new name or in a new namespace, which is expected as tenant clusters shouldn't share the same certificates.
+vCluster certificates change when you create a tenant cluster with a new name or namespace. This is expected, as tenant clusters shouldn't share certificates.
 :::
 
 ## Migrate and override vCluster configuration options to create a new tenant cluster
 
-When upgrading tenant clusters, there are a couple of configuration options that are not supported to change on an existing tenant cluster. For example, the backing store cannot be changed. To change other configuration options, you can migrate the tenant cluster by creating a new tenant cluster from a snapshot and applying new configuration options.
+When upgrading tenant clusters, there are a couple of configuration options that aren't supported to change on an existing tenant cluster. For example, the backing store can't be changed. To change other options, migrate the tenant cluster by creating a new one from a snapshot and applying updated configuration.
 
 When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
 
 :::warning Restore failures
-If the restore fails while using `vcluster create`, the new tenant cluster is automatically deleted.
+If the restore fails while using `vcluster create`, vCluster automatically deletes the new tenant cluster.
 :::
 
-```bash
-# Upgrade an existing vCluster by restoring from a snapshot and applying a new vcluster.yaml.
+<InterpolatedCodeBlock
+  code={`# Upgrade an existing vCluster by restoring from a snapshot and applying a new vcluster.yaml.
 # Configuration options in the vcluster.yaml override the options from the snapshot.
-vcluster create my-vcluster --upgrade -f vcluster.yaml --restore oci://ghcr.io/my-user/my-repo:my-tag
-```
+vcluster create [[VAR:VCLUSTER_NAME:my-vcluster]] --upgrade -f vcluster.yaml --restore oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]`}
+  language="bash"
+/>
 
 :::info New name or namespace updates certificates
-vCluster certificates change when you create a tenant cluster with a new name or in a different namespace. This behavior is expected, as tenant clusters should not share the same certificates.
+vCluster certificates change when you create a tenant cluster with a new name or namespace. This is expected, as tenant clusters shouldn't share certificates.
 :::
 
 ### Supported migration options
 
-vCluster supports migration paths based on your setup. The following are the available migration options for Kubernetes distributions and backing stores.
+vCluster supports migration paths based on your setup. The following migration options are available for Kubernetes distributions and backing stores.
 
 #### Change the backing store
 
@@ -249,7 +251,7 @@ Change your data store to improve efficiency, scalability, and Kubernetes compat
 - Embedded database (SQLite) -> Embedded database (etcd)
 - Embedded database (SQLite) -> External database
 
-All other configuration options are overridden, similar to upgrading a tenant cluster and applying changes.
+vCluster overrides all other configuration options, similar to upgrading a tenant cluster and applying changes.
 
 ### Limitations
 
@@ -257,12 +259,12 @@ When taking snapshots and restoring tenant clusters, there are limitations:
 
 **Sleeping tenant clusters**
 
-- Snapshots require a running vCluster control plane and do not work with sleeping tenant clusters.
+- Snapshots require a running vCluster control plane and don't work with sleeping tenant clusters.
 
 **Tenant clusters using the k0s distro**
 
 - Use the `--pod-exec` flag to take a snapshot of a k0s tenant cluster.
-- k0s tenant clusters do not support restore or clone operations. Migrate them to k8s instead.
+- k0s tenant clusters don't support restore or clone operations. Migrate them to k8s instead.
 
 **Tenant clusters using an external database**
 
@@ -270,55 +272,54 @@ When taking snapshots and restoring tenant clusters, there are limitations:
 
 **vcluster.yaml configuration**
 
-- Although the vcluster.yaml configuration is backed up, it is not automatically restored. After restoring a tenant cluster, you must manually reapply your vcluster.yaml configuration.
+- Although the vcluster.yaml configuration is backed up, it isn't automatically restored. After restoring a tenant cluster, you must manually reapply your vcluster.yaml configuration.
 
-**Standalone: restore to a new Control Plane Cluster**
+**Standalone: restore to a new node**
 
-- If you restore a snapshot on a different node, the Control Plane Cluster's etcd will contain node details from the original machine. You must manually clean up stale node resources after restore (see [Use snapshots with private nodes](#use-snapshots-with-private-nodes)).
+- If you restore a snapshot on a different node, the standalone instance's etcd contains node details from the original machine. You must manually clean up stale node resources after restore (see [Use snapshots with private nodes](#use-snapshots-with-private-nodes)).
 
-**Standalone: tenant cluster workloads are not restored**
+**Standalone: tenant cluster workloads aren't restored**
 
-- Restoring the standalone Control Plane Cluster snapshot only restores the Control Plane Cluster's own etcd data. Each tenant cluster running on the Control Plane Cluster has its own etcd, so workloads deployed inside tenant clusters are not restored by a standalone snapshot.
+- A standalone snapshot only restores the standalone instance's own etcd data. Each tenant cluster running on the standalone instance has its own etcd, so workloads deployed inside tenant clusters aren't restored by a standalone snapshot.
 
 ## Use snapshots with private nodes
 
-Node resources are also included in the etcd snapshot. If you are restoring to a tenant cluster with
-a different set of nodes, manual intervention is required for tenant clusters using [private nodes](../../deploy/worker-nodes/private-nodes/README.mdx). When using snapshots with [host nodes](../../deploy/worker-nodes/host-nodes/README.mdx),
-if the nodes change between the snapshot and restore, vCluster is able to automatically
-update information about the nodes.
+The snapshot also includes node resources. Restoring to a different set of nodes requires manual steps for tenant clusters using [private nodes](../../deploy/worker-nodes/private-nodes/README.mdx). With [host nodes](../../deploy/worker-nodes/host-nodes/README.mdx), vCluster automatically updates node information when nodes change between snapshot and restore.
 
 ### Nodes removed between snapshot and restore
 
-When nodes exist in the snapshot, but don't exist in the current tenant cluster, you need to manually delete the node(s) from the restored tenant cluster.
+When nodes exist in the snapshot but don't exist in the current tenant cluster, manually delete those nodes from the restored tenant cluster.
 
-The node shows up in `kubectl get nodes`, but the node does not physically exist in the tenant cluster.
+The node shows up in `kubectl get nodes` but doesn't physically exist in the tenant cluster.
 
-For each node that no longer exists, you need to run `kubectl delete node [name]` to delete the node resource from the tenant cluster.
+Run `kubectl delete node [name]` for each removed node.
 
-```bash
-export NODE_NAME=my-node
-kubectl delete node $NODE_NAME
-```
+<InterpolatedCodeBlock
+  code={`export NODE_NAME=[[VAR:NODE_NAME:my-node]]
+kubectl delete node $NODE_NAME`}
+  language="bash"
+/>
 
 ### Nodes added between snapshot and restore
 
-When nodes were added after the snapshot was taken, the node resource does not exist in the restored tenant cluster. If you run
-`kubectl get nodes`, then those node(s) are missing.
+When nodes joined the cluster after the snapshot, they don't exist in the restored tenant cluster and aren't listed in `kubectl get nodes`.
 
-You need to re-join each private node with the `--force-join` flag.
+Re-join each private node with the `--force-join` flag.
 
-```bash
-export VCLUSTER_NAME=my-vcluster
+<InterpolatedCodeBlock
+  code={`export VCLUSTER_NAME=[[VAR:VCLUSTER_NAME:my-vcluster]]
 
 # Connect to your vcluster
 vcluster connect $VCLUSTER_NAME
 
 # Create a token
-vcluster token create --expires=1h
-```
+vcluster token create --expires=1h`}
+  language="bash"
+/>
 
-The output provides a command to run on your worker node, and you need to append the `--force-join` flag.
+Append the `--force-join` flag to the output command before running it on the worker node.
 
-```bash
-curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh - -- --force-join
-```
+<InterpolatedCodeBlock
+  code={`curl -sfLk https://[[VAR:VCLUSTER_ENDPOINT:vcluster-endpoint]]/node/join?token=[[VAR:TOKEN:token]] | sh - -- --force-join`}
+  language="bash"
+/>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds documentation for snapshot and restore standalone control plane clusters


## Preview Link 
<!-- The preview link or links to the documents-->
- [Backup](https://deploy-preview-2040--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/backup#standalone)
- [Restore](https://deploy-preview-2040--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/restore)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-744


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

