### PR TITLE
docs: release day config flip for vcluster 0.34 and platform 4.9

### DIFF
--- a/.github/workflows/update-lifecycle-json.yml
+++ b/.github/workflows/update-lifecycle-json.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: |
           git add static/api/lifecycle/*.json
-          if ! git diff-index --quiet HEAD --; then
+          if ! git diff --cached --quiet; then
             git config user.name "Loft Bot"
             git config user.email "loft-bot@users.noreply.github.com"
             git commit -m "chore: regenerate lifecycle JSON from MDX partials"

--- a/.github/workflows/update-lifecycle-json.yml
+++ b/.github/workflows/update-lifecycle-json.yml
@@ -36,6 +36,5 @@ jobs:
             git fetch origin ${{ github.head_ref }}
             git rebase origin/${{ github.head_ref }}
             git push origin HEAD:refs/heads/${{ github.head_ref }}
-          else
-            echo "No changes to commit"
           fi
+          exit 0

--- a/.github/workflows/update-lifecycle-json.yml
+++ b/.github/workflows/update-lifecycle-json.yml
@@ -29,13 +29,13 @@ jobs:
         if: github.event.pull_request.head.repo.fork != true
         run: |
           git add static/api/lifecycle/*.json
-          if git diff-index --quiet HEAD --; then
-            echo "No changes"
-            exit 0
+          if ! git diff-index --quiet HEAD --; then
+            git config user.name "Loft Bot"
+            git config user.email "loft-bot@users.noreply.github.com"
+            git commit -m "chore: regenerate lifecycle JSON from MDX partials"
+            git fetch origin ${{ github.head_ref }}
+            git rebase origin/${{ github.head_ref }}
+            git push origin HEAD:refs/heads/${{ github.head_ref }}
+          else
+            echo "No changes to commit"
           fi
-          git config user.name "Loft Bot"
-          git config user.email "loft-bot@users.noreply.github.com"
-          git commit -m "chore: regenerate lifecycle JSON from MDX partials"
-          git fetch origin ${{ github.head_ref }}
-          git rebase origin/${{ github.head_ref }}
-          git push origin HEAD:refs/heads/${{ github.head_ref }}

--- a/.github/workflows/update-lifecycle-json.yml
+++ b/.github/workflows/update-lifecycle-json.yml
@@ -36,4 +36,4 @@ jobs:
           git config user.name "Loft Bot"
           git config user.email "loft-bot@users.noreply.github.com"
           git commit -m "chore: regenerate lifecycle JSON from MDX partials"
-          git push
+          git push origin HEAD:refs/heads/${{ github.head_ref }}

--- a/.github/workflows/update-lifecycle-json.yml
+++ b/.github/workflows/update-lifecycle-json.yml
@@ -36,4 +36,6 @@ jobs:
           git config user.name "Loft Bot"
           git config user.email "loft-bot@users.noreply.github.com"
           git commit -m "chore: regenerate lifecycle JSON from MDX partials"
+          git fetch origin ${{ github.head_ref }}
+          git rebase origin/${{ github.head_ref }}
           git push origin HEAD:refs/heads/${{ github.head_ref }}

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -18,9 +18,9 @@ Any previous versions which are not on the following list, are no longer in any 
   <tbody>
     <tr>
       <td>v4.9</td>
-      <td>April 27, 2026</td>
-      <td>October 27, 2026</td>
-      <td>January 27, 2027</td>
+      <td>April 29, 2026</td>
+      <td>October 29, 2026</td>
+      <td>January 29, 2027</td>
     </tr>
     <tr>
       <td>v4.8</td>

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -20,9 +20,9 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
   <tbody>
     <tr>
       <td>v0.34</td>
-      <td>April 27, 2026</td>
-      <td>July 27, 2026</td>
-      <td>October 27, 2026</td>
+      <td>April 29, 2026</td>
+      <td>July 29, 2026</td>
+      <td>October 29, 2026</td>
     </tr>
     <tr>
       <td>v0.33</td>
@@ -43,13 +43,13 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
       <td>July 29, 2026</td>
     </tr>
     <tr>
+      <td colspan="4" align="center"><i>Versions below are no longer supported</i></td>
+    </tr>
+    <tr>
       <td>v0.30</td>
       <td>October 28, 2025</td>
       <td>January 28, 2026</td>
       <td>April 28, 2026</td>
-    </tr>
-    <tr>
-      <td colspan="4" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.29</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -247,20 +247,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "0.33.0",
+        lastVersion: "0.34.0",
         onlyIncludeVersions: ["current", "0.34.0", "0.33.0", "0.32.0", "0.31.0", "0.30.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "0.34.0": {
-            label: "v0.34",
-            banner: "unreleased",
+            label: "v0.34 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "0.33.0": {
-            label: "v0.33 Stable",
+            label: "v0.33",
             banner: "none",
             badge: true,
           },
@@ -295,20 +294,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "4.8.0",
+        lastVersion: "4.9.0",
         onlyIncludeVersions: ["current", "4.9.0", "4.8.0", "4.7.0", "4.6.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "4.9.0": {
-            label: "v4.9",
-            banner: "unreleased",
+            label: "v4.9 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "4.8.0": {
-            label: "v4.8 Stable",
+            label: "v4.8",
             banner: "none",
             badge: true,
           },
@@ -469,9 +467,9 @@ const config = {
         additionalLanguages: ["bash", "hcl"],
       },
       announcementBar: {
-        id: "vcluster-0-33-platform-4-8-release",
+        id: "vcluster-0-34-platform-4-9-release",
         content:
-          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.8 and vCluster 0.33</a></strong>',
+          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.9 and vCluster 0.34</a></strong>',
         backgroundColor: "#4a90e2",
         textColor: "#ffffff",
         isCloseable: true,

--- a/hack/test-vcluster-0.34.hurl
+++ b/hack/test-vcluster-0.34.hurl
@@ -1,0 +1,394 @@
+# vCluster 0.34 Comprehensive Redirect Tests
+# Generated from netlify.toml redirects
+# Usage: hurl --test --variable BASE_URL=https://deploy-preview-XXXX--vcluster-docs-site.netlify.app hack/test-vcluster-0.34.hurl
+
+# =====================================================
+# Legacy paths redirects
+# =====================================================
+
+# Test 1: Legacy architecture paths
+GET {{BASE_URL}}/docs/architecture/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/architecture/"
+
+# Test 2: CLI paths redirect to vcluster.com
+GET {{BASE_URL}}/docs/cli/vcluster_create
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/cli/vcluster_create"
+
+# Test 3: Deploying vclusters legacy
+GET {{BASE_URL}}/docs/deploying-vclusters/basics
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/deploy/control-plane/kubernetes-pod/basics/basics"
+
+# Test 4: Get started redirect
+GET {{BASE_URL}}/docs/get-started
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 5: Getting started wildcard
+GET {{BASE_URL}}/docs/getting-started/setup
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 6: Networking redirect
+GET {{BASE_URL}}/docs/networking/ingress
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/networking/ingress"
+
+# Test 7: Security redirect
+GET {{BASE_URL}}/docs/security/overview
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/platform/understand/what-are-virtual-clusters#robust-security-and-isolation"
+
+# Test 8: Syncer redirect
+GET {{BASE_URL}}/docs/syncer/overview
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/0.20.0/introduction/architecture#syncer"
+
+# Test 9: Using vclusters redirect
+GET {{BASE_URL}}/docs/using-vclusters/kube-context
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#common-use-cases"
+
+# Test 10: Config reference redirect
+GET {{BASE_URL}}/docs/config-reference/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/vcluster-yaml/"
+
+# Test 11: Storage redirect
+GET {{BASE_URL}}/docs/storage/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/category/storage"
+
+# Test 12: What are virtual clusters redirect
+GET {{BASE_URL}}/docs/what-are-virtual-clusters/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# Test 13: Help & tutorials redirect
+GET {{BASE_URL}}/docs/help&tutorials/faq
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/"
+
+# =====================================================
+# Platform UI links for vCluster
+# =====================================================
+
+# Test 14: Backup restore migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backup-restore-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+
+# Test 15: Supported migration options
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/supported-migration-options
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore#supported-migration-options"
+
+# Test 16: Control plane
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/category/components"
+
+# Test 17: Backing store
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backing-store
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/"
+
+# Test 18: Control plane distro
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane-distro
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/distro/"
+
+# Test 19: Resource quota
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/resource-quota
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/policies/resource-quota"
+
+# Test 20: 0.20 migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/0-20-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/reference/migrations/0-20-migration"
+
+# Test 21: Sync from host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-from-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/"
+
+# Test 22: Nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/nodes"
+
+# Test 23: Sync to host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-to-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/"
+
+# Test 24: Hybrid scheduling
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/hybrid-scheduling
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling"
+
+# Test 25: Private nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes"
+
+# Test 26: Private nodes node requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-node-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes/node-requirements"
+
+# Test 27: Private nodes auto nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes"
+
+# Test 28: Private nodes auto nodes requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes/#requirements"
+
+# Test 29: vcluster.yaml
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/vcluster-yaml
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
+
+# =====================================================
+# Deploy redirects
+# =====================================================
+
+# Test 30: Deploy control-plane wildcard
+GET {{BASE_URL}}/docs/deploy/control-plane/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/basics"
+
+# Test 31: Deploy wildcard
+GET {{BASE_URL}}/docs/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/basics"
+
+# =====================================================
+# vCluster 0.34.0 redirect
+# =====================================================
+
+# Test 32: vCluster 0.34.0 wildcard redirect
+GET {{BASE_URL}}/docs/vcluster/0.34.0/introduction/what-are-virtual-clusters
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# =====================================================
+# vCluster v0.27 restructure redirects
+# =====================================================
+
+# Test 33: Enable debug logging (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 34: Enable debug logging (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 35: Configure kai scheduler (next with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 36: Configure kai scheduler (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 37: Configure kai scheduler (current with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 38: Configure kai scheduler (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 39: Control node IP visibility (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 40: Control node IP visibility (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 41: Integrations wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/integrations/metrics/prometheus
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/metrics/prometheus"
+
+# Test 42: Integrations wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/integrations/pod-identity/eks-pod-identity
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/pod-identity/eks-pod-identity"
+
+# Test 43: Deploy environment wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/environment/eks
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks"
+
+# Test 44: Deploy environment wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/environment/gke
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/gke"
+
+# Test 45: Deploy topologies wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/topologies/multi-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/multi-namespace-mode"
+
+# Test 46: Deploy topologies wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/topologies/single-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/single-namespace-mode"
+
+# Test 47: Deploy basics (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics"
+
+# Test 48: Deploy basics (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/basics"
+
+# =====================================================
+# Verification tests - pages that should load
+# =====================================================
+
+# Test 49: vCluster main page should load (serves 0.34.0 as lastVersion)
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "Virtual Clusters"
+
+# Test 50: vCluster 0.33.0 should be accessible as versioned doc
+GET {{BASE_URL}}/docs/vcluster/0.33.0/
+HTTP 200
+[Asserts]
+body contains "Virtual Clusters"
+
+# Test 51: vCluster 0.32.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.32.0/
+HTTP 200
+[Asserts]
+body contains "Virtual Clusters"
+
+# Test 52: vCluster 0.31.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.31.0/
+HTTP 200
+[Asserts]
+body contains "Virtual Clusters"
+
+# Test 53: vCluster 0.30.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.30.0/
+HTTP 200
+[Asserts]
+body contains "Virtual Clusters"
+
+# Test 55: vCluster CLI pages should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_create/
+HTTP 200
+[Asserts]
+body contains "vcluster create"
+
+# Test 55: vCluster CLI certs page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_certs/
+HTTP 200
+[Asserts]
+body contains "vcluster certs"
+
+# Test 56: vCluster CLI node page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_node/
+HTTP 200
+[Asserts]
+body contains "vcluster node"
+
+# Test 57: vCluster CLI registry page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_registry/
+HTTP 200
+[Asserts]
+body contains "vcluster registry"
+
+# Test 58: vCluster CLI token page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_token/
+HTTP 200
+[Asserts]
+body contains "vcluster token"
+
+# Test 59: Documentation home page should load
+GET {{BASE_URL}}/docs/
+HTTP 200
+[Asserts]
+body contains "vCluster 0.34"
+body contains "Platform 4.9"
+
+# Test 60: vCluster main page should show v0.34 as stable
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "v0.34 Stable"
+
+# Test 61: Platform main page should show v4.9 as stable
+GET {{BASE_URL}}/docs/platform/
+HTTP 200
+[Asserts]
+body contains "v4.9 Stable"

--- a/hack/test-vcluster-0.34.hurl
+++ b/hack/test-vcluster-0.34.hurl
@@ -52,7 +52,7 @@ header "Location" contains "https://www.vcluster.com/docs/platform/understand/wh
 GET {{BASE_URL}}/docs/syncer/overview
 HTTP 301
 [Asserts]
-header "Location" contains "https://www.vcluster.com/docs/vcluster/0.20.0/introduction/architecture#syncer"
+header "Location" contains "/docs/vcluster/introduction/architecture#syncer"
 
 # Test 9: Using vclusters redirect
 GET {{BASE_URL}}/docs/using-vclusters/kube-context
@@ -64,7 +64,7 @@ header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/
 GET {{BASE_URL}}/docs/config-reference/
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/vcluster/vcluster-yaml/"
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
 
 # Test 11: Storage redirect
 GET {{BASE_URL}}/docs/storage/
@@ -92,13 +92,13 @@ header "Location" contains "https://www.vcluster.com/docs/vcluster/"
 GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backup-restore-migration
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/vcluster/manage/backup-restore#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
 
 # Test 15: Supported migration options
 GET {{BASE_URL}}/docs/platform-ui-link/vcluster/supported-migration-options
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/vcluster/manage/backup-restore#supported-migration-options"
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#supported-migration-options"
 
 # Test 16: Control plane
 GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane
@@ -318,31 +318,31 @@ header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/b
 GET {{BASE_URL}}/docs/vcluster/
 HTTP 200
 [Asserts]
-body contains "Virtual Clusters"
+body contains "vCluster"
 
-# Test 50: vCluster 0.33.0 should be accessible as versioned doc
-GET {{BASE_URL}}/docs/vcluster/0.33.0/
+# Test 50: vCluster 0.32.0 should be accessible as versioned doc
+GET {{BASE_URL}}/docs/vcluster/0.32.0/
 HTTP 200
 [Asserts]
-body contains "Virtual Clusters"
+body contains "vCluster"
 
 # Test 51: vCluster 0.32.0 should still be accessible
 GET {{BASE_URL}}/docs/vcluster/0.32.0/
 HTTP 200
 [Asserts]
-body contains "Virtual Clusters"
+body contains "vCluster"
 
 # Test 52: vCluster 0.31.0 should still be accessible
 GET {{BASE_URL}}/docs/vcluster/0.31.0/
 HTTP 200
 [Asserts]
-body contains "Virtual Clusters"
+body contains "vCluster"
 
 # Test 53: vCluster 0.30.0 should still be accessible
 GET {{BASE_URL}}/docs/vcluster/0.30.0/
 HTTP 200
 [Asserts]
-body contains "Virtual Clusters"
+body contains "vCluster"
 
 # Test 55: vCluster CLI pages should load
 GET {{BASE_URL}}/docs/vcluster/cli/vcluster_create/

--- a/netlify.toml
+++ b/netlify.toml
@@ -744,8 +744,20 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 
 
 [[redirects]]
+  from = "/docs/vcluster/0.34.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/docs/vcluster/0.33.0/*"
   to = "/docs/vcluster/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/platform/4.9.0/*"
+  to = "/docs/platform/:splat"
   status = 301
   force = true
 

--- a/src/config/docsearch.js
+++ b/src/config/docsearch.js
@@ -5,14 +5,14 @@ export const DOCSEARCH_PRODUCTS = {
   vcluster: {
     pluginId: "vcluster",
     displayName: "vCluster",
-    stableVersion: "0.33.0",
-    stableLabel: "v0.33 Stable",
+    stableVersion: "0.34.0",
+    stableLabel: "v0.34 Stable",
   },
   platform: {
     pluginId: "platform",
     displayName: "Platform",
-    stableVersion: "4.8.0",
-    stableLabel: "v4.8 Stable",
+    stableVersion: "4.9.0",
+    stableLabel: "v4.9 Stable",
   },
 };
 

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -8,8 +8,8 @@
  * `versions` and `onlyIncludeVersions` config.
  */
 
-export const vclusterHiddenVersions = ["0.34.0"];
-export const platformHiddenVersions = ["4.9.0"];
+export const vclusterHiddenVersions = [];
+export const platformHiddenVersions = [];
 
 export const vclusterEOLVersions = [
   { to: "https://vcluster.com/docs/v0.29", label: "v0.29 (EOS)" },

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -1,13 +1,13 @@
 {
   "product": "Platform",
-  "lastUpdated": "2026-04-22",
+  "lastUpdated": "2026-04-30",
   "versions": [
     {
       "version": "4.9.0",
-      "releaseDate": "2026-04-27",
+      "releaseDate": "2026-04-29",
       "status": "active",
-      "eosDate": "2026-10-27",
-      "eolDate": "2027-01-27"
+      "eosDate": "2026-10-29",
+      "eolDate": "2027-01-29"
     },
     {
       "version": "4.8.0",
@@ -33,7 +33,7 @@
     {
       "version": "4.5.0",
       "releaseDate": "2025-10-29",
-      "status": "active",
+      "status": "eos",
       "eosDate": "2026-04-29",
       "eolDate": "2026-07-29"
     },

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -1,13 +1,13 @@
 {
   "product": "vCluster",
-  "lastUpdated": "2026-04-22",
+  "lastUpdated": "2026-04-30",
   "versions": [
     {
       "version": "0.34.0",
-      "releaseDate": "2026-04-27",
+      "releaseDate": "2026-04-29",
       "status": "active",
-      "eosDate": "2026-07-27",
-      "eolDate": "2026-10-27"
+      "eosDate": "2026-07-29",
+      "eolDate": "2026-10-29"
     },
     {
       "version": "0.33.0",
@@ -26,14 +26,14 @@
     {
       "version": "0.31.0",
       "releaseDate": "2026-01-29",
-      "status": "active",
+      "status": "eos",
       "eosDate": "2026-04-29",
       "eolDate": "2026-07-29"
     },
     {
       "version": "0.30.0",
       "releaseDate": "2025-10-28",
-      "status": "eos",
+      "status": "eol",
       "eosDate": "2026-01-28",
       "eolDate": "2026-04-28"
     },

--- a/vcluster_versioned_docs/version-0.30.0/_fragments/tenancy-support.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_fragments/tenancy-support.mdx
@@ -9,14 +9,14 @@ Running the control plane as a container and the following worker node types:
 {props.hostNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#host-nodes">Host Nodes</Link>
+      <Link to="/docs/vcluster/0.30.0/configure/tenancy-model#host-nodes">Host Nodes</Link>
     </b>
   </li>
 )}
 {props.privateNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#private-nodes">Private Nodes</Link>
+      <Link to="/docs/vcluster/0.30.0/configure/tenancy-model#private-nodes">Private Nodes</Link>
     </b>
   </li>
 )}

--- a/vcluster_versioned_docs/version-0.31.0/_fragments/tenancy-support.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_fragments/tenancy-support.mdx
@@ -8,14 +8,14 @@ Running the control plane as a container with:
 {props.hostNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#host-nodes">Host Nodes</Link>
+      <Link to="/docs/vcluster/0.31.0/configure/tenancy-model#host-nodes">Host Nodes</Link>
     </b>
   </li>
 )}
 {props.privateNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#private-nodes">Private Nodes</Link>
+      <Link to="/docs/vcluster/0.31.0/configure/tenancy-model#private-nodes">Private Nodes</Link>
     </b>
   </li>
 )}
@@ -23,6 +23,6 @@ Running the control plane as a container with:
 </div>
 )}
 {props.standalone && (
-<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/configure/tenancy-model#private-nodes">private nodes</Link></b>.</div>
+<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/0.31.0/configure/tenancy-model#private-nodes">private nodes</Link></b>.</div>
 )}
 :::

--- a/vcluster_versioned_docs/version-0.32.0/_fragments/tenancy-support.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_fragments/tenancy-support.mdx
@@ -8,14 +8,14 @@ Running the control plane as a container with:
 {props.hostNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#host-nodes">Host Nodes</Link>
+      <Link to="/docs/vcluster/0.32.0/configure/tenancy-model#host-nodes">Host Nodes</Link>
     </b>
   </li>
 )}
 {props.privateNodes && (
   <li>
     <b>
-      <Link to="/docs/vcluster/configure/tenancy-model#private-nodes">Private Nodes</Link>
+      <Link to="/docs/vcluster/0.32.0/configure/tenancy-model#private-nodes">Private Nodes</Link>
     </b>
   </li>
 )}
@@ -23,6 +23,6 @@ Running the control plane as a container with:
 </div>
 )}
 {props.standalone && (
-<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/configure/tenancy-model#private-nodes">private nodes</Link></b>.</div>
+<div>Running the control plane as a binary with <b><Link to="/docs/vcluster/deploy/control-plane/binary">vCluster Standalone</Link></b>. When scaling with additional worker nodes, they are joined as <b><Link to="/docs/vcluster/0.32.0/configure/tenancy-model#private-nodes">private nodes</Link></b>.</div>
 )}
 :::


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Release day config flip for vCluster 0.34 and Platform 4.9. Exposes both versions in the dropdown, promotes them to stable, updates search/announcement bar/netlify redirects. Also fixes a build error in 0.30–0.32 versioned docs caused by an absolute link to a page deleted in 0.34.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2041--vcluster-docs-site.netlify.app/docs

## Internal Reference
Closes DOC-1327, Closes DOC-1329

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs