### PR TITLE
docs(platform): add user-data-template and user-data-template-secret to Metal3 node provider page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ justfile
 # Keep Claude Code config tracked (overrides global gitignore)
 !CLAUDE.md
 !.claude
+.claude/worktrees/
 .playwright-mcp
 slack.md
 TEST_QUICKSTART_PLAN.md

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -482,6 +482,85 @@ References [SSHKey](../../use-platform/machines/ssh-keys.mdx) resources by name.
 
 Custom cloud-init configuration merged with the generated user data. Accepts any valid cloud-config directives (`packages`, `write_files`, `runcmd`, etc.). The platform's provisioning commands are appended after any user-supplied `runcmd` entries.
 
+Takes precedence over `vcluster.com/user-data-template` and `vcluster.com/user-data-template-secret`.
+
+#### `vcluster.com/user-data-template`
+
+**Type:** `string`
+
+A Go template string that renders into a cloud-config YAML document. Evaluated when `vcluster.com/user-data` is not set. The template receives a `Values` object with the following fields:
+
+| Field | Description |
+|-------|-------------|
+| `NodeClaim` | The NodeClaim being provisioned |
+| `Project` | The project the node belongs to |
+| `Properties` | Annotation properties on the node type |
+| `SSHKeys` | SSH public keys to inject |
+
+Provider-specific parameters are also available depending on the node provider in use.
+
+Example:
+
+```yaml
+annotations:
+  vcluster.com/user-data-template: |
+    #cloud-config
+    users:
+      - name: ubuntu
+        ssh_authorized_keys:
+        {{- range .SSHKeys }}
+          - {{ .PublicKey }}
+        {{- end }}
+    runcmd:
+      - echo "Provisioning {{ .NodeClaim.Name }}"
+```
+
+Takes precedence over `vcluster.com/user-data-template-secret`.
+
+#### `vcluster.com/user-data-template-secret`
+
+**Type:** `string`
+
+The name of a Secret containing a Go template for user data. Evaluated when both `vcluster.com/user-data` and `vcluster.com/user-data-template` are unset. The Secret must have the label `vcluster.com/user-data-template-type` set.
+
+Example Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-user-data-template
+  namespace: loft
+  labels:
+    vcluster.com/user-data-template-type: cloud-config
+stringData:
+  template: |
+    #cloud-config
+    users:
+      - name: ubuntu
+        ssh_authorized_keys:
+        {{- range .SSHKeys }}
+          - {{ .PublicKey }}
+        {{- end }}
+```
+
+Reference it by name on the node type:
+
+```yaml
+annotations:
+  vcluster.com/user-data-template-secret: my-user-data-template
+```
+
+:::note Precedence order
+The platform resolves user data using the first property that is set:
+
+1. `vcluster.com/user-data`
+2. `vcluster.com/user-data-template`
+3. `vcluster.com/user-data-template-secret`
+
+In all cases, the platform appends the vCluster join command and SSH keys to the resolved cloud-config.
+:::
+
 ## Try it yourself
 
 The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints — no physical hardware required.


### PR DESCRIPTION
# Content Description
Adds the two missing user data template properties to the Metal3 node provider configuration reference: `vcluster.com/user-data-template` (inline Go template) and `vcluster.com/user-data-template-secret` (Secret-backed Go template). Also adds a precedence note and Go template examples to both new properties.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2051--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/metal3#vclustercomuser-data

## Internal Reference
Closes DOC-1384

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs