### PR TITLE
feat: add UI permalinks for control-plane service and ingress

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -606,6 +606,24 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   from = "/docs/platform-ui-link/vcluster/control-plane-distro/:version"
   to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/components/distro/"
 
+# Control Plane > Service
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/control-plane-service"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/deployment/service"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/control-plane-service/:version"
+  to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/deployment/service"
+
+# Control Plane > Ingress
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/control-plane-ingress"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/deployment/ingress"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/control-plane-ingress/:version"
+  to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/deployment/ingress"
+
 # Host Path Mapper
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/host-path-mapper"


### PR DESCRIPTION
Adds two Platform UI permalinks so the tenant cluster networking section can link to dedicated docs pages for the API Server Service and Ingress.

Targets:
- `/docs/vcluster/configure/vcluster-yaml/control-plane/deployment/service`
- `/docs/vcluster/configure/vcluster-yaml/control-plane/deployment/ingress`

Slugs:
- `control-plane-service`
- `control-plane-ingress`