### PR TITLE
feat: extend DocSearch crawler and config to cover vNode and vMetal (DOC-1392)

### DIFF
--- a/algolia/IMPLEMENTATION.md
+++ b/algolia/IMPLEMENTATION.md
@@ -276,6 +276,37 @@ Check:
 - older docs still show up when explicitly filtered
 - unreleased docs don’t dominate results unless intentionally targeted
 
+## External Site Reindex (vNode and vMetal)
+
+The crawler now covers three domains: `vcluster.com`, `vnode.com`, and `vmetal.ai`. The Saturday schedule crawls all three automatically. However, vnode-docs and vmetal-docs deploy independently and have no per-deploy crawler hook — a manual reindex is required after either external site ships significant content changes.
+
+### When to trigger a manual reindex
+
+Trigger after any deploy to `vnode-docs` or `vmetal-docs` that adds or substantially changes pages. Small edits don't warrant a reindex — the Saturday crawl will pick them up.
+
+### Before triggering the reindex
+
+Verify the external site is live with the correct meta tags. Check page source on any doc page and confirm:
+
+```
+<meta name="docsearch:product" content="vnode">   <!-- or vmetal -->
+<meta name="docsearch:page_category" content="docs">
+```
+
+If the tags are missing (e.g. the `DocItem/Layout` swizzle wasn't deployed), the crawler falls back to the `defaultValue` fields in `docsearch.config.js`. Results will still be faceted correctly, but confirm this before proceeding.
+
+### Trigger the reindex
+
+```bash
+curl --request POST \
+  --url "https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID/reindex" \
+  --header "Authorization: Basic $CRAWLER_BASIC_AUTH"
+```
+
+### Verify
+
+After the crawl completes, open the Algolia index browser and filter by `product:vnode` and `product:vmetal` to confirm records are present with correct `version_label` and `is_latest` values.
+
 ## After Each Stable Release
 
 When a new stable version ships for either product:

--- a/algolia/docsearch.config.js
+++ b/algolia/docsearch.config.js
@@ -11,11 +11,23 @@ new Crawler({
   apiKey: "YOUR_API_KEY",
   rateLimit: 8,
   maxDepth: 10,
-  startUrls: ["https://www.vcluster.com/docs/"],
-  sitemaps: ["https://www.vcluster.com/docs/sitemap.xml"],
+  startUrls: [
+    "https://www.vcluster.com/docs/",
+    "https://www.vnode.com/docs/",
+    "https://www.vmetal.ai/docs/",
+  ],
+  sitemaps: [
+    "https://www.vcluster.com/docs/sitemap.xml",
+    "https://www.vnode.com/docs/sitemap.xml",
+    "https://www.vmetal.ai/docs/sitemap.xml",
+  ],
   renderJavaScript: false,
   ignoreCanonicalTo: true,
-  discoveryPatterns: ["https://www.vcluster.com/docs/**"],
+  discoveryPatterns: [
+    "https://www.vcluster.com/docs/**",
+    "https://www.vnode.com/docs/**",
+    "https://www.vmetal.ai/docs/**",
+  ],
   exclusionPatterns: ["https://www.vcluster.com/docs/v0.19/**"],
   schedule: "at 05:00 on Saturday",
   actions: [
@@ -102,6 +114,66 @@ new Crawler({
               defaultValue: pageCategory,
             },
             pageRank,
+          },
+          indexHeadings: true,
+          aggregateContent: true,
+          recordVersion: "v3",
+        });
+      },
+    },
+    {
+      indexName: "vcluster",
+      pathsToMatch: ["https://www.vnode.com/docs/**"],
+      recordExtractor: ({ $, helpers }) => {
+        $(".hash-link").remove();
+        return helpers.docsearch({
+          recordProps: {
+            lvl0: { selectors: "", defaultValue: "vNode Documentation" },
+            lvl1: ["header h1", "article h1"],
+            lvl2: "article h2",
+            lvl3: "article h3",
+            lvl4: "article h4",
+            lvl5: "article h5, article td:first-child",
+            lvl6: "article h6",
+            content: "article p, article li, article td:last-child",
+            product: { defaultValue: "vnode" },
+            version: { defaultValue: "latest" },
+            version_label: { defaultValue: "Latest" },
+            version_status: { defaultValue: "stable" },
+            is_stable: { defaultValue: "true" },
+            is_latest: { defaultValue: "true" },
+            page_category: { defaultValue: "docs" },
+            pageRank: 120,
+          },
+          indexHeadings: true,
+          aggregateContent: true,
+          recordVersion: "v3",
+        });
+      },
+    },
+    {
+      indexName: "vcluster",
+      pathsToMatch: ["https://www.vmetal.ai/docs/**"],
+      recordExtractor: ({ $, helpers }) => {
+        $(".hash-link").remove();
+        return helpers.docsearch({
+          recordProps: {
+            lvl0: { selectors: "", defaultValue: "vMetal Documentation" },
+            lvl1: ["header h1", "article h1"],
+            lvl2: "article h2",
+            lvl3: "article h3",
+            lvl4: "article h4",
+            lvl5: "article h5, article td:first-child",
+            lvl6: "article h6",
+            content: "article p, article li, article td:last-child",
+            product: { defaultValue: "vmetal" },
+            version: { defaultValue: "latest" },
+            version_label: { defaultValue: "Latest" },
+            version_status: { defaultValue: "stable" },
+            is_stable: { defaultValue: "true" },
+            is_latest: { defaultValue: "true" },
+            page_category: { defaultValue: "docs" },
+            pageRank: 120,
           },
           indexHeadings: true,
           aggregateContent: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -449,7 +449,7 @@ const config = {
         contextualSearch: true,
         searchPagePath: "search",
         externalUrlRegex:
-          "(?:loft\\.sh|platform-v4-[0-9]--vcluster-docs-site\\.netlify\\.app)",
+          "(?:loft\\.sh|platform-v4-[0-9]--vcluster-docs-site\\.netlify\\.app|vnode\\.com|vmetal\\.ai)",
       },
       footer: {
         style: "light",

--- a/src/config/docsearch.js
+++ b/src/config/docsearch.js
@@ -14,6 +14,16 @@ export const DOCSEARCH_PRODUCTS = {
     stableVersion: "4.9.0",
     stableLabel: "v4.9 Stable",
   },
+  vnode: {
+    pluginId: "vnode",
+    displayName: "vNode",
+    versioned: false,
+  },
+  vmetal: {
+    pluginId: "vmetal",
+    displayName: "vMetal",
+    versioned: false,
+  },
 };
 
 export function getDocsearchProduct(pluginId) {

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -150,9 +150,11 @@ function useSearchParameters({contextualSearch, ...props}) {
     }
   } else {
     Object.values(DOCSEARCH_PRODUCTS).forEach((product) => {
-      optionalFilters.push(
-        `docusaurus_tag:docs-${product.pluginId}-${product.stableVersion}<score=2>`,
-      );
+      if (product.stableVersion) {
+        optionalFilters.push(
+          `docusaurus_tag:docs-${product.pluginId}-${product.stableVersion}<score=2>`,
+        );
+      }
     });
   }
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Extends the Algolia DocSearch setup in `vcluster-docs` to cover `vnode.com/docs` and `vmetal.ai/docs` as external products in the shared index. This is the `vcluster-docs`-side work for the universal search epic (DOC-1346).

Changes:
- **Crawler config** — adds vNode and vMetal action blocks to `algolia/docsearch.config.js` with static product/version facets; extends `startUrls`, `sitemaps`, and `discoveryPatterns` for both domains
- **Product config** — adds `vnode` and `vmetal` entries to `DOCSEARCH_PRODUCTS` with `versioned: false`
- **External URL routing** — extends `externalUrlRegex` so modal clicks to `vnode.com` and `vmetal.ai` trigger a full page load instead of an SPA push
- **SearchBar fix** — guards the `optionalFilters` boost loop against products without a `stableVersion` to prevent malformed filter values
- **Runbook** — adds an "External Site Reindex" section to `algolia/IMPLEMENTATION.md`

## Merge sequence

This PR can merge independently. The Algolia crawler config references sitemaps on `vnode.com` and `vmetal.ai` that don't exist until DOC-1393 and DOC-1394 are deployed — but the crawler falls back to link discovery in the meantime, so merging this first is safe. The reindex (DOC-1395) must wait until all three PRs are deployed to production.

Companion PRs (not yet opened):
- DOC-1393 — add DocSearch to `vmetal-docs`
- DOC-1394 — add DocSearch to `vnode-docs`
- DOC-1395 — post-deploy reindex and smoke-test

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
Closes DOC-1392

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs