### PR TITLE
fix: correct EOS/EOL labels for vCluster and Platform versions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -276,12 +276,12 @@ const config = {
             badge: true,
           },
           "0.31.0": {
-            label: "v0.31",
+            label: "v0.31 (EOS)",
             banner: "none",
             badge: true,
           },
           "0.30.0": {
-            label: "v0.30 (EOS)",
+            label: "v0.30 (EOL)",
             banner: "none",
             badge: true,
           },

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -12,8 +12,8 @@ export const vclusterHiddenVersions = [];
 export const platformHiddenVersions = [];
 
 export const vclusterEOLVersions = [
-  { to: "https://vcluster.com/docs/v0.29", label: "v0.29 (EOS)" },
-  { to: "https://vcluster.com/docs/v0.28", label: "v0.28 (EOS)" },
+  { to: "https://vcluster.com/docs/v0.29", label: "v0.29 (EOL)" },
+  { to: "https://vcluster.com/docs/v0.28", label: "v0.28 (EOL)" },
   { to: "https://vcluster.com/docs/v0.27", label: "v0.27 (EOL)" },
   { to: "https://vcluster.com/docs/v0.26", label: "v0.26 (EOL)" },
   { to: "https://vcluster.com/docs/v0.25", label: "v0.25 (EOL)" },
@@ -27,7 +27,7 @@ export const vclusterEOLVersions = [
 
 export const platformEOLVersions = [
   { to: "https://platform-v4-5--vcluster-docs-site.netlify.app/docs/platform/", label: "v4.5 (EOS)" },
-  { to: "https://platform-v4-4--vcluster-docs-site.netlify.app/docs/platform/", label: "v4.4 (EOL)" },
+  { to: "https://platform-v4-4--vcluster-docs-site.netlify.app/docs/platform/", label: "v4.4 (EOS)" },
   { to: "https://platform-v4-3--vcluster-docs-site.netlify.app/docs/platform/", label: "v4.3 (EOL)" },
   { to: "https://vcluster.com/docs/v4.2", label: "v4.2 (EOL)" },
   { to: "https://loft.sh/docs/getting-started/install", label: "v3.4 (EOL)" },


### PR DESCRIPTION
## Summary

- `docusaurus.config.js`: v0.31.0 label was missing `(EOS)` (EOS date April 29 passed); v0.30.0 label updated from `(EOS)` to `(EOL)` (EOL date April 28 passed)
- `src/config/versionConfig.js`: v0.29 and v0.28 updated from `(EOS)` to `(EOL)` (EOL dates April 1 and March 8 passed); Platform v4.4 corrected from `(EOL)` to `(EOS)` (EOL date June 9 not yet passed)

## Test plan

- [ ] Version selector shows `v0.31 (EOS)` and `v0.30 (EOL)` for vCluster
- [ ] Archived dropdown shows `v0.29 (EOL)` and `v0.28 (EOL)` for vCluster
- [ ] Archived dropdown shows `v4.4 (EOS)` for Platform

Closes DOC-1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)