### PR TITLE
fix(algolia): include apex pattern for vmetal www-to-apex redirect

### DIFF
--- a/algolia/docsearch.config.js
+++ b/algolia/docsearch.config.js
@@ -27,6 +27,8 @@ new Crawler({
     "https://www.vcluster.com/docs/**",
     "https://www.vnode.com/docs/**",
     "https://www.vmetal.ai/docs/**",
+    // vmetal.ai 301-redirects www to apex; include both so the resolved URL matches.
+    "https://vmetal.ai/docs/**",
   ],
   exclusionPatterns: ["https://www.vcluster.com/docs/v0.19/**"],
   schedule: "at 05:00 on Saturday",
@@ -153,7 +155,11 @@ new Crawler({
     },
     {
       indexName: "vcluster",
-      pathsToMatch: ["https://www.vmetal.ai/docs/**"],
+      // vmetal.ai 301-redirects www to apex; include both so the resolved URL matches.
+      pathsToMatch: [
+        "https://www.vmetal.ai/docs/**",
+        "https://vmetal.ai/docs/**",
+      ],
       recordExtractor: ({ $, helpers }) => {
         $(".hash-link").remove();
         return helpers.docsearch({


### PR DESCRIPTION
# Content Description

Adds `https://vmetal.ai/docs/**` (apex form) alongside the existing `https://www.vmetal.ai/docs/**` (www form) in `discoveryPatterns` and in the vmetal action's `pathsToMatch` in `algolia/docsearch.config.js`. Net change: 7 added lines, 1 removed.

## Why

PR #2056 (merged 2026-05-06) extended the Algolia crawler to vmetal and vnode but used only the **www** form of `vmetal.ai` in `discoveryPatterns` and in the vmetal action's `pathsToMatch`. Empirically:

- `https://www.vmetal.ai/docs/sitemap.xml` returns **301 → 200** (host-level redirect to apex).
- Sitemap entries themselves reference `www.vmetal.ai/docs/...`, but every page resolves to `vmetal.ai/docs/...` after the 301 follow.
- Algolia's DocSearch crawler matches `discoveryPatterns` and `pathsToMatch` against the **resolved** URL, not the requested URL.

Without the apex glob, the crawler discovers vmetal URLs via the sitemap, follows the 301, and then rejects the resolved URL because it doesn't match `https://www.vmetal.ai/docs/**`. Pages are silently dropped from the index. That's the same failure mode that triggered #2056 (zero hits for `product:vmetal` after reindex), and per smoke tests after the most recent reindex, the symptom persisted.

vnode is unaffected: `www.vnode.com/docs/` returns 200 directly, sitemap is www-consistent, no redirect. Its single www glob is correct as-is.

## Verification

- `node -c algolia/docsearch.config.js` → exit 0, parses cleanly.
- `curl -sSI https://www.vmetal.ai/docs/sitemap.xml` → `HTTP/2 301`, `location: https://vmetal.ai/docs/sitemap.xml`.
- `curl -sSL -o /dev/null -w '%{url_effective}' https://www.vmetal.ai/docs/architecture/` → `https://vmetal.ai/docs/architecture/` (confirms page-level redirect).

## Post-merge step (this PR does NOT auto-sync)

Per `algolia/IMPLEMENTATION.md`, this repo's `docsearch.config.js` is a reference document, not a live deploy artifact. The Algolia Crawler is configured by `PATCH https://crawler.algolia.com/api/1/crawlers/$CRAWLER_ID/config` against a JSON payload (IMPLEMENTATION.md Step 5). After merge, the JSON payload needs to be updated to mirror this change, the crawler patched, and a fresh reindex triggered. Then smoke test `product:vmetal` returns hits.

If the apex glob turns out to be unnecessary (e.g., the vmetal site removes the `www → apex` redirect, or the sitemap is regenerated with apex URLs), the apex glob can be dropped and the comment removed.

## Preview Link

N/A — config-only change in `algolia/`, no docs site rendering affected.

## Internal Reference

No Linear issue — direct follow-up to #2056.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs