### PR TITLE
feat(search): multi-domain algolia crawl and product badges for vnode/vmetal

### DIFF
--- a/algolia/docsearch.config.js
+++ b/algolia/docsearch.config.js
@@ -11,21 +11,24 @@ new Crawler({
   apiKey: "YOUR_API_KEY",
   rateLimit: 8,
   maxDepth: 10,
+  // vnode.com 301-redirects apex → www; vmetal.ai 301-redirects www → apex.
+  // Algolia matches against the resolved URL after redirects, so each domain
+  // must use the form it resolves to, not the form it's requested as.
   startUrls: [
     "https://www.vcluster.com/docs/",
-    "https://vnode.com/docs/",
+    "https://www.vnode.com/docs/",
     "https://vmetal.ai/docs/",
   ],
   sitemaps: [
     "https://www.vcluster.com/docs/sitemap.xml",
-    "https://vnode.com/docs/sitemap.xml",
+    "https://www.vnode.com/docs/sitemap.xml",
     "https://vmetal.ai/docs/sitemap.xml",
   ],
   renderJavaScript: false,
   ignoreCanonicalTo: true,
   discoveryPatterns: [
     "https://www.vcluster.com/docs/**",
-    "https://vnode.com/docs/**",
+    "https://www.vnode.com/docs/**",
     "https://vmetal.ai/docs/**",
   ],
   exclusionPatterns: ["https://www.vcluster.com/docs/v0.19/**"],
@@ -123,7 +126,7 @@ new Crawler({
     },
     {
       indexName: "vcluster",
-      pathsToMatch: ["https://vnode.com/docs/**"],
+      pathsToMatch: ["https://www.vnode.com/docs/**"],
       recordExtractor: ({ $, helpers }) => {
         $(".hash-link").remove();
         return helpers.docsearch({

--- a/algolia/docsearch.config.js
+++ b/algolia/docsearch.config.js
@@ -13,21 +13,19 @@ new Crawler({
   maxDepth: 10,
   startUrls: [
     "https://www.vcluster.com/docs/",
-    "https://www.vnode.com/docs/",
-    "https://www.vmetal.ai/docs/",
+    "https://vnode.com/docs/",
+    "https://vmetal.ai/docs/",
   ],
   sitemaps: [
     "https://www.vcluster.com/docs/sitemap.xml",
-    "https://www.vnode.com/docs/sitemap.xml",
-    "https://www.vmetal.ai/docs/sitemap.xml",
+    "https://vnode.com/docs/sitemap.xml",
+    "https://vmetal.ai/docs/sitemap.xml",
   ],
   renderJavaScript: false,
   ignoreCanonicalTo: true,
   discoveryPatterns: [
     "https://www.vcluster.com/docs/**",
-    "https://www.vnode.com/docs/**",
-    "https://www.vmetal.ai/docs/**",
-    // vmetal.ai 301-redirects www to apex; include both so the resolved URL matches.
+    "https://vnode.com/docs/**",
     "https://vmetal.ai/docs/**",
   ],
   exclusionPatterns: ["https://www.vcluster.com/docs/v0.19/**"],
@@ -68,7 +66,7 @@ new Crawler({
         const pageRank =
           pathname === `/${product}/` || pathname === `/${product}`
             ? 160
-            : pageRankByStatus[versionStatus] ?? 0;
+            : pageRankByStatus[versionStatus] || 0;
 
         // priority order: deepest active sub list header -> navbar active item -> 'Documentation'
         const lvl0 =
@@ -125,7 +123,7 @@ new Crawler({
     },
     {
       indexName: "vcluster",
-      pathsToMatch: ["https://www.vnode.com/docs/**"],
+      pathsToMatch: ["https://vnode.com/docs/**"],
       recordExtractor: ({ $, helpers }) => {
         $(".hash-link").remove();
         return helpers.docsearch({
@@ -155,11 +153,7 @@ new Crawler({
     },
     {
       indexName: "vcluster",
-      // vmetal.ai 301-redirects www to apex; include both so the resolved URL matches.
-      pathsToMatch: [
-        "https://www.vmetal.ai/docs/**",
-        "https://vmetal.ai/docs/**",
-      ],
+      pathsToMatch: ["https://vmetal.ai/docs/**"],
       recordExtractor: ({ $, helpers }) => {
         $(".hash-link").remove();
         return helpers.docsearch({

--- a/src/config/docsearch.js
+++ b/src/config/docsearch.js
@@ -26,6 +26,13 @@ export const DOCSEARCH_PRODUCTS = {
   },
 };
 
+// Brand colors for products that appear in search results from external domains.
+// Used to render product badge pills in the search modal and search page.
+export const PRODUCT_BADGES = {
+  vnode: {label: DOCSEARCH_PRODUCTS.vnode.displayName, color: '#0C00FF'},
+  vmetal: {label: DOCSEARCH_PRODUCTS.vmetal.displayName, color: '#0098B2'},
+};
+
 export function getDocsearchProduct(pluginId) {
   return DOCSEARCH_PRODUCTS[pluginId] ?? null;
 }

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -93,8 +93,25 @@ function useResultsFooterComponent({closeModal}) {
   );
 }
 
+const PRODUCT_BADGES = {
+  vnode: {label: 'vNode', color: '#0C00FF'},
+  vmetal: {label: 'vMetal', color: '#0098B2'},
+};
+
 function Hit({hit, children}) {
-  return <Link to={hit.url}>{children}</Link>;
+  const badge = PRODUCT_BADGES[hit.product];
+  return (
+    <Link to={hit.url}>
+      {badge && (
+        <span
+          className="docsearch-product-badge"
+          style={{backgroundColor: badge.color}}>
+          {badge.label}
+        </span>
+      )}
+      {children}
+    </Link>
+  );
 }
 
 function ResultsFooter({state, onClose}) {

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -18,6 +18,7 @@ import {useActivePluginAndVersion} from '@docusaurus/plugin-content-docs/client'
 import translations from '@theme/SearchTranslations';
 import {
   DOCSEARCH_PRODUCTS,
+  PRODUCT_BADGES,
   getVersionFacetValue,
   getVersionStatus,
 } from '@site/src/config/docsearch';
@@ -92,11 +93,6 @@ function useResultsFooterComponent({closeModal}) {
     [closeModal],
   );
 }
-
-const PRODUCT_BADGES = {
-  vnode: {label: 'vNode', color: '#0C00FF'},
-  vmetal: {label: 'vMetal', color: '#0098B2'},
-};
 
 function Hit({hit, children}) {
   const badge = PRODUCT_BADGES[hit.product];

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -66,6 +66,20 @@
   background: var(--ifm-color-primary-dark);
 }
 
+.docsearch-product-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15em 0.5em;
+  margin-right: 0.5rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
 @media (max-width: 768px) {
   .DocSearch-Dropdown {
     padding-bottom: 56px;

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -22,7 +22,7 @@ import {
 } from '@docusaurus/theme-search-algolia/client';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
-import {getDocsearchProduct} from '@site/src/config/docsearch';
+import {getDocsearchProduct, PRODUCT_BADGES} from '@site/src/config/docsearch';
 import styles from './styles.module.css';
 
 const SEARCH_ALL_VERSIONS = "__all__";
@@ -150,11 +150,6 @@ function getSearchPageTitle(searchQuery) {
         description: 'The search page title for empty query',
       });
 }
-
-const PRODUCT_BADGES = {
-  vnode: {label: 'vNode', color: '#0C00FF'},
-  vmetal: {label: 'vMetal', color: '#0098B2'},
-};
 
 function ProductBadge({product}) {
   const badge = PRODUCT_BADGES[product];

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -151,6 +151,23 @@ function getSearchPageTitle(searchQuery) {
       });
 }
 
+const PRODUCT_BADGES = {
+  vnode: {label: 'vNode', color: '#0C00FF'},
+  vmetal: {label: 'vMetal', color: '#0098B2'},
+};
+
+function ProductBadge({product}) {
+  const badge = PRODUCT_BADGES[product];
+  if (!badge) return null;
+  return (
+    <span
+      className={styles.productBadge}
+      style={{backgroundColor: badge.color}}>
+      {badge.label}
+    </span>
+  );
+}
+
 function SearchPageContent() {
   const {
     i18n: {currentLocale},
@@ -244,6 +261,7 @@ function SearchPageContent() {
       const items = hits.map(
         ({
           url,
+          product,
           _highlightResult: {hierarchy},
           _snippetResult: snippet = {},
         }) => {
@@ -258,6 +276,7 @@ function SearchPageContent() {
               ? `${sanitizeValue(snippet.content.value)}...`
               : '',
             breadcrumbs: titles,
+            product,
           };
         },
       );
@@ -461,10 +480,11 @@ function SearchPageContent() {
         {searchResultState.items.length > 0 ? (
           <main>
             {searchResultState.items.map(
-              ({title, url, summary, breadcrumbs}, i) => (
+              ({title, url, summary, breadcrumbs, product}, i) => (
                 <article key={i} className={styles.searchResultItem}>
                   <Heading as="h2" className={styles.searchResultItemHeading}>
                     <Link to={url} dangerouslySetInnerHTML={{__html: title}} />
+                    <ProductBadge product={product} />
                   </Heading>
 
                   {breadcrumbs.length > 0 && (

--- a/src/theme/SearchPage/styles.module.css
+++ b/src/theme/SearchPage/styles.module.css
@@ -73,6 +73,19 @@
   margin-bottom: 0;
 }
 
+.productBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15em 0.5em;
+  margin-left: 0.6rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  vertical-align: middle;
+}
+
 .searchResultItemPath {
   font-size: 0.8rem;
   color: var(--ifm-color-content-secondary);

--- a/src/theme/SearchPage/styles.module.css
+++ b/src/theme/SearchPage/styles.module.css
@@ -80,7 +80,7 @@
   margin-left: 0.6rem;
   border-radius: 4px;
   color: #fff;
-  font-size: 0.65rem;
+  font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0.03em;
   vertical-align: middle;


### PR DESCRIPTION
## Content Description

Fixes the Algolia crawler config to support indexing vnode.com and vmetal.ai alongside vcluster.com, and adds product badge pills to search results so users can distinguish cross-domain hits at a glance.

## Preview Link

@netlify /docs

## Internal Reference

Closes DOC-1395