### PR TITLE
docs(snapshots): add private nodes restore note

### DIFF
--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -23,6 +23,10 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
+:::note
+Restoring snapshots on tenant clusters using private nodes requires additional manual steps. See [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes).
+:::
+
 <ProAdmonition />
 
 # Snapshots

--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -23,10 +23,6 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-:::note
-Restoring snapshots on tenant clusters using private nodes requires additional manual steps. See [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes).
-:::
-
 <ProAdmonition />
 
 # Snapshots
@@ -40,7 +36,7 @@ For on-demand snapshot creation and restore operations, see the [vCluster Snapsh
 This allows administrators to capture and store the vCluster state in scheduled intervals to help protect
 against infrastructure failures, data corruption, and configuration errors. By maintaining consistent
 recovery points, administrators can quickly restore the vCluster to a known good state without relying on manual backup processes.
-For more details on how snapshots work, refer to the documentation in the [Snapshot and Restore](/vcluster/manage/backup-restore/volume-snapshots/setup) section.
+For more details on how snapshots work, refer to the [Snapshot and Restore](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
 
 In the `vcluster.yaml`, it is configured under `snapshots`. Using the UI, you
 can configure the management of snapshots in the config options of a virtual cluster under **Snapshots**. Though
@@ -48,11 +44,9 @@ snapshot configuration is configured on the virtual cluster itself, the capabili
 is in vCluster Platform.
 
 :::note
-Auto Snapshot is supported from platform version 4.4.0 onward and is currently in Beta.
-:::
-
-:::note
-Volume Snapshot is currently in beta. Support is available from vCluster version 0.30 and beyond, and Platform version 4.5 and beyond.
+Auto Snapshot and Volume Snapshot are currently in beta:
+- Auto Snapshot: platform v4.4.0 and later
+- Volume Snapshot: vCluster v0.30 and later, platform v4.5 and later
 :::
 
 ## Configure
@@ -135,12 +129,10 @@ vcluster snapshot create VCLUSTER_NAME --namespace NAMESPACE s3://my-bucket/my-b
 
 This will take a snapshot of the virtual cluster and saves it to a AWS S3 bucket.
 
-:::info
-There might be additional enryption settings necessary for AWS, which can be configured with following flags:
-- --customer-key-encryption-file
-- --kms-key-id
-- --server-side-encryption
-:::
+Configure additional encryption settings for AWS with these flags:
+- `--customer-key-encryption-file`
+- `--kms-key-id`
+- `--server-side-encryption`
 
 ### Create a container filesystem snapshot (Helm driver)
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds a note to the snapshots configure page pointing users to the private nodes restore documentation. Engineering confirmed that snapshots are supported with private nodes but that restoring to a different node set requires manual steps — this note surfaces that caveat at the point of configuration.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2065--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/snapshots

## Internal Reference
Closes DOC-1397

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs