### PR TITLE
docs(quick-start): link guide names in decision tree to guide pages

### DIFF
--- a/vcluster/quick-start/index.mdx
+++ b/vcluster/quick-start/index.mdx
@@ -27,7 +27,7 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
   <Link to="./quick-start/private-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
     <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>lock</span>
     <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Private Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for bare metal or VM GPU environments and regulated workloads. Requires vCluster Platform (free mode OK).</p>
+    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for hard tenancy: GPU clouds, regulated platforms, and sovereign deployments. Requires vCluster Platform (free mode OK).</p>
   </Link>
   <Link to="./quick-start/docker" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
     <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>laptop</span>

--- a/vcluster/quick-start/index.mdx
+++ b/vcluster/quick-start/index.mdx
@@ -11,21 +11,7 @@ pagination_prev: null
 
 import Link from '@docusaurus/Link';
 
-vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can go on your existing infrastructure, or they can be built from scratch on bare metal and VMs. Each tenant gets a full Kubernetes API experience while the virtualized control plane stays completely invisible to them. Choose the path that fits your environment.
-
-**Do you have a Kubernetes cluster?**
-
-- **Yes** — What are you building? 
-
-  - An internal developer platform or CI environment → Use the [Shared Nodes](./shared-nodes.mdx) guide (tenants share the existing node pool). 
-  - A GPU cloud, AI inference service, or regulated platform that needs dedicated infrastructure per tenant → Use the [Private Nodes](./private-nodes.mdx) guide (each tenant gets its own nodes).
-
-- **No** — What do you need to create?
-
-  - Local development or CI without real infrastructure → Use the [Docker (vind)](./docker.mdx) guide.
-  - A production platform from bare metal or VMs → Use the [Standalone](./standalone.mdx) guide.
-
-## Choose your guide
+vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can go on your existing infrastructure, or they can be built from scratch on bare metal and VMs. Each tenant gets a full Kubernetes API experience while the virtualized control plane stays completely invisible to them.
 
 <style dangerouslySetInnerHTML={{__html: `
   .deploy-card { transition: all 0.2s ease; }
@@ -55,4 +41,11 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
   </Link>
 </div>
 
-Not sure which path fits your environment? Read [What is vCluster?](../introduction/what-are-virtual-clusters.mdx) to understand the deployment models and tradeoffs.
+## Match your situation to a guide
+
+- Build a production Kubernetes platform from bare metal or VMs → [Standalone](./standalone.mdx)
+- Use an existing cluster for a GPU cloud, AI inference service, or regulated platform that needs dedicated infrastructure per tenant → [Private Nodes](./private-nodes.mdx)
+- Use an existing Kubernetes cluster for internal platforms, CI, or high-density production services → [Shared Nodes](./shared-nodes.mdx)
+- Create a Kubernetes cluster on Docker for local development or CI → [Docker (vind)](./docker.mdx)
+
+Still unsure? Read [What is vCluster?](../introduction/what-are-virtual-clusters.mdx) to understand the deployment models and tradeoffs.

--- a/vcluster/quick-start/index.mdx
+++ b/vcluster/quick-start/index.mdx
@@ -22,12 +22,12 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
   <Link to="./quick-start/shared-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
     <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>group</span>
     <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Shared Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You have a Kubernetes cluster and want isolated environments for your team. No extra infrastructure. Works with OSS CLI or Platform.</p>
+    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You have a Kubernetes cluster and want isolated tenant environments. Tenant workloads run on the existing node pool. No extra infrastructure needed. Works with OSS CLI or Platform.</p>
   </Link>
   <Link to="./quick-start/private-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
     <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>lock</span>
     <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Private Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need hardware-level isolation per tenant for GPU workloads or regulated environments. Requires vCluster Platform (free mode OK).</p>
+    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for bare metal or VM GPU environments and regulated workloads. Requires vCluster Platform (free mode OK).</p>
   </Link>
   <Link to="./quick-start/docker" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
     <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>laptop</span>

--- a/vcluster/quick-start/index.mdx
+++ b/vcluster/quick-start/index.mdx
@@ -17,13 +17,13 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
 
 - **Yes** — What are you building? 
 
-  - An internal developer platform or CI environment → Use the **Shared Nodes** guide (tenants share the existing node pool). 
-  - A GPU cloud, AI inference service, or regulated platform that needs dedicated infrastructure per tenant → Use the **Private Nodes** guide (each tenant gets its own nodes).
+  - An internal developer platform or CI environment → Use the [Shared Nodes](./shared-nodes.mdx) guide (tenants share the existing node pool). 
+  - A GPU cloud, AI inference service, or regulated platform that needs dedicated infrastructure per tenant → Use the [Private Nodes](./private-nodes.mdx) guide (each tenant gets its own nodes).
 
 - **No** — What do you need to create?
 
-  - Local development or CI without real infrastructure → Use the **Docker (vind)** guide.
-  - A production platform from bare metal or VMs → Use the **Standalone** guide.
+  - Local development or CI without real infrastructure → Use the [Docker (vind)](./docker.mdx) guide.
+  - A production platform from bare metal or VMs → Use the [Standalone](./standalone.mdx) guide.
 
 ## Choose your guide
 


### PR DESCRIPTION
# Content Description
Link guide names in the quick-start decision tree to their respective guide pages. Removes friction for users whose viewport doesn't show the card grid on first load.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2066--vcluster-docs-site.netlify.app/docs/vcluster/next/

## Internal Reference
Closes DOC-1399


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs