### PR TITLE
feat: release-dispatch receiver scaffolding (DEVOPS-888 PR #2a)

### DIFF
--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -78,6 +78,28 @@ get() {
     [ "$(get channel)" = "stable" ]
 }
 
+@test "vcluster: way-future minor (>+1 above max-frozen) → skip per A4 appx B" {
+    # A4 example: v9.9.9 against a 0.x history must skip, not silently
+    # land into the current docs folder.
+    VERSION=v9.9.9 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster: major-version bump (1.0.0 against 0.x history) → skip" {
+    # Prevents silent routing of an unexpected major to current_root.
+    VERSION=v1.0.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster: skipped a minor (current=0.34, incoming=0.36) → skip" {
+    # Only the immediate next minor (max-frozen + 1) maps to current_root.
+    VERSION=v0.36.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
 @test "vcluster: RC on frozen minor → versioned folder, channel=rc" {
     VERSION=v0.34.0-rc.3 EVENT_TYPE=vcluster-released run "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -87,7 +109,8 @@ get() {
 }
 
 @test "vcluster: RC of next minor → current docs folder, channel=rc" {
-    VERSION=v0.36.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    # Next minor against max-frozen 0.34 is 0.35 (max + 1).
+    VERSION=v0.35.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
     [ "$status" -eq 0 ]
     [ "$(get skip)" = "false" ]
     [ "$(get target_folder)" = "vcluster" ]

--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+#
+# Tests for classify-version.sh. Each test points the script at a fixture repo
+# layout (versions.json + version-X.Y.Z folders) instead of the real docs tree
+# so cases stay deterministic and don't depend on which versions happen to be
+# frozen on main today.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/classify-version.sh"
+    FIXTURE="$(mktemp -d)"
+
+    # vcluster fixture: 0.28, 0.30, 0.31, 0.32, 0.33, 0.34 frozen with folders.
+    # versions.json also lists 0.26 and 0.25 — frozen-but-pruned, no folder.
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.28.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.30.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.31.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.32.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.33.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.34.0"
+    cat >"$FIXTURE/vcluster_versions.json" <<EOF
+[
+  "0.34.0",
+  "0.33.0",
+  "0.32.0",
+  "0.31.0",
+  "0.30.0",
+  "0.28.0",
+  "0.26.0",
+  "0.25.0"
+]
+EOF
+
+    # platform fixture: 4.5–4.9 frozen with folders, plus 4.4-4.2 in versions.json without folders.
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.5.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.6.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.7.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.8.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.9.0"
+    cat >"$FIXTURE/platform_versions.json" <<EOF
+[
+  "4.9.0",
+  "4.8.0",
+  "4.7.0",
+  "4.6.0",
+  "4.5.0",
+  "4.4.0",
+  "4.3.0",
+  "4.2.0"
+]
+EOF
+
+    export REPO_ROOT="$FIXTURE"
+}
+
+teardown() {
+    rm -rf "$FIXTURE"
+}
+
+# Pull a single key from the script's `key=value` stdout block.
+get() {
+    local key="$1"
+    grep "^${key}=" <<<"$output" | head -n1 | cut -d= -f2-
+}
+
+@test "vcluster: stable patch on frozen minor → versioned folder" {
+    VERSION=v0.34.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: stable release of next minor → current docs folder" {
+    VERSION=v0.35.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: RC on frozen minor → versioned folder, channel=rc" {
+    VERSION=v0.34.0-rc.3 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+    [ "$(get channel)" = "rc" ]
+}
+
+@test "vcluster: RC of next minor → current docs folder, channel=rc" {
+    VERSION=v0.36.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster" ]
+    [ "$(get channel)" = "rc" ]
+}
+
+@test "vcluster: alpha is always skipped" {
+    VERSION=v0.34.5-alpha.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "alpha" ]
+}
+
+@test "vcluster: beta is always skipped" {
+    VERSION=v0.36.0-beta.2 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "beta" ]
+}
+
+@test "vcluster: frozen-but-pruned minor (in versions.json, no folder) → skip" {
+    # 0.26.0 is in versions.json but no folder exists for it.
+    VERSION=v0.26.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: missing-from-versions.json minor with folder → versioned folder" {
+    # 0.29 isn't in versions.json AND has no folder; treated as past minor → skip.
+    # Confirms classifier doesn't accidentally route to "current" when it's lower than highest.
+    VERSION=v0.29.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster-cli rides on vcluster versioning" {
+    VERSION=v0.34.5 EVENT_TYPE=vcluster-cli-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+}
+
+@test "platform: stable patch on frozen minor → versioned folder" {
+    VERSION=v4.6.5 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "platform_versioned_docs/version-4.6.0" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "platform: release of next minor → current docs folder" {
+    VERSION=v4.10.0 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "platform" ]
+}
+
+@test "unknown event type → skip with channel=unknown-event" {
+    VERSION=v1.2.3 EVENT_TYPE=something-else run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "unknown-event" ]
+}
+
+@test "malformed version → skip with channel=invalid" {
+    VERSION=not-a-version EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "invalid" ]
+}
+
+@test "missing VERSION env var → script exits non-zero" {
+    EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing EVENT_TYPE env var → script exits non-zero" {
+    VERSION=v0.34.5 run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "GITHUB_OUTPUT is appended when set" {
+    OUTFILE="$(mktemp)"
+    GITHUB_OUTPUT="$OUTFILE" VERSION=v0.34.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "^skip=false$" "$OUTFILE"
+    grep -q "^target_folder=vcluster_versioned_docs/version-0.34.0$" "$OUTFILE"
+    grep -q "^channel=stable$" "$OUTFILE"
+    rm -f "$OUTFILE"
+}

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# classify-version.sh — pure(-ish) classifier for release-dispatch routing.
+#
+# Maps a released VERSION + EVENT_TYPE to a routing decision:
+#   - skip:           true if the version should not produce docs
+#   - target_folder:  path (relative to REPO_ROOT) where generated docs land
+#   - channel:        stable | rc | alpha | beta | invalid | unknown-event
+#
+# Inputs (env):
+#   VERSION      Released version, e.g. v0.34.5, v0.34.0-rc.3, v4.6.0-alpha.1
+#   EVENT_TYPE   One of: vcluster-released | vcluster-cli-released | platform-released
+#   REPO_ROOT    (optional) docs-repo root; default $PWD. Used for folder probes
+#                and reading versions.json. Tests override to point at fixtures.
+#
+# Outputs:
+#   key=value lines on stdout, also appended to $GITHUB_OUTPUT when set.
+#
+# Always exits 0; "skip" is signalled via the output, not the exit code, so a
+# calling workflow can branch with `if: steps.classify.outputs.skip != 'true'`
+# without conflating skip-by-design with classifier failure.
+#
+# Routing rules (matches A4 design appendix B):
+#
+#   * alpha / beta  → always skip
+#   * MAJOR.MINOR strictly newer than the highest frozen MAJOR.MINOR in the
+#     event's versions.json → target = current docs root (the unreleased
+#     "next" docs folder)
+#   * MAJOR.MINOR ≤ highest frozen, candidate folder exists →
+#     target = versioned folder (e.g. version-0.34.0)
+#   * MAJOR.MINOR ≤ highest frozen, candidate folder absent → skip
+#     (past minor we don't track)
+
+set -eo pipefail
+
+: "${VERSION:?VERSION env var required (e.g. VERSION=v0.34.5)}"
+: "${EVENT_TYPE:?EVENT_TYPE env var required (vcluster-released|vcluster-cli-released|platform-released)}"
+REPO_ROOT="${REPO_ROOT:-$PWD}"
+
+emit() {
+    printf '%s=%s\n' "$1" "$2"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+emit_skip() {
+    # $1 = channel
+    emit skip true
+    emit target_folder ""
+    emit channel "$1"
+    exit 0
+}
+
+case "$EVENT_TYPE" in
+    vcluster-released|vcluster-cli-released)
+        versioned_root="vcluster_versioned_docs"
+        current_root="vcluster"
+        versions_json="vcluster_versions.json"
+        ;;
+    platform-released)
+        versioned_root="platform_versioned_docs"
+        current_root="platform"
+        versions_json="platform_versions.json"
+        ;;
+    *)
+        emit_skip unknown-event
+        ;;
+esac
+
+stripped="${VERSION#v}"
+
+channel=stable
+case "$stripped" in
+    *-alpha*) emit_skip alpha ;;
+    *-beta*)  emit_skip beta  ;;
+    *-rc.*|*-rc[0-9]*) channel=rc ;;
+esac
+
+base="${stripped%%-*}"
+if ! [[ "$base" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    emit_skip invalid
+fi
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+incoming_key=$(( major * 100000 + minor ))
+
+# Highest frozen MAJOR.MINOR from versions.json (Docusaurus convention).
+versions_path="${REPO_ROOT}/${versions_json}"
+highest_key=-1
+if [[ -f "$versions_path" ]]; then
+    while read -r v; do
+        [[ -z "$v" ]] && continue
+        if [[ "$v" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            v_major="${BASH_REMATCH[1]}"
+            v_minor="${BASH_REMATCH[2]}"
+            v_key=$(( v_major * 100000 + v_minor ))
+            (( v_key > highest_key )) && highest_key=$v_key
+        fi
+    done < <(tr -d '[]" ' <"$versions_path" | tr ',' '\n')
+fi
+
+if (( incoming_key > highest_key )); then
+    # Strictly newer than anything frozen → next/current docs.
+    emit skip false
+    emit target_folder "$current_root"
+    emit channel "$channel"
+    exit 0
+fi
+
+candidate="${versioned_root}/version-${major}.${minor}.0"
+if [[ -d "${REPO_ROOT}/${candidate}" ]]; then
+    emit skip false
+    emit target_folder "$candidate"
+    emit channel "$channel"
+    exit 0
+fi
+
+# Past minor that was frozen-but-pruned (in versions.json, no folder) — skip.
+emit_skip "$channel"

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -101,11 +101,17 @@ if [[ -f "$versions_path" ]]; then
 fi
 
 if (( incoming_key > highest_key )); then
-    # Strictly newer than anything frozen → next/current docs.
-    emit skip false
-    emit target_folder "$current_root"
-    emit channel "$channel"
-    exit 0
+    # Newer than anything frozen. Only the immediate next minor in the
+    # same major series can map to current docs — anything further is
+    # treated as garbage / unexpected, per A4 appendix B (e.g. v9.9.9
+    # against a 0.x history must skip, not silently write into current).
+    if (( incoming_key == highest_key + 1 )); then
+        emit skip false
+        emit target_folder "$current_root"
+        emit channel "$channel"
+        exit 0
+    fi
+    emit_skip "$channel"
 fi
 
 candidate="${versioned_root}/version-${major}.${minor}.0"

--- a/hack/release/run-generator.bats
+++ b/hack/release/run-generator.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Tests for run-generator.sh. Use DRY_RUN=true so the suite verifies the
+# resolved command line per event type without actually invoking `go run`.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/run-generator.sh"
+    export DRY_RUN=true
+}
+
+@test "vcluster-released → vcluster partials generator with _partials/config suffix" {
+    EVENT_TYPE=vcluster-released \
+        TARGET_FOLDER=vcluster_versioned_docs/version-0.34.0 \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/vcluster/partials/main.go"* ]]
+    [[ "$output" == *"--source-path /tmp/_source"* ]]
+    [[ "$output" == *"--target-folder vcluster_versioned_docs/version-0.34.0/_partials/config"* ]]
+}
+
+@test "vcluster-cli-released → vcluster-cli generator with cli suffix" {
+    EVENT_TYPE=vcluster-cli-released \
+        TARGET_FOLDER=vcluster_versioned_docs/version-0.34.0 \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/vcluster-cli/main.go"* ]]
+    [[ "$output" == *"--source-path /tmp/_source"* ]]
+    [[ "$output" == *"--target-folder vcluster_versioned_docs/version-0.34.0/cli"* ]]
+}
+
+@test "platform-released → platform partials with both base flags" {
+    EVENT_TYPE=platform-released \
+        TARGET_FOLDER=platform_versioned_docs/version-4.6.0 \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/platform/partials/main.go"* ]]
+    [[ "$output" == *"--partials-base platform_versioned_docs/version-4.6.0/api/_partials/resources/"* ]]
+    [[ "$output" == *"--resources-base platform_versioned_docs/version-4.6.0/api/resources"* ]]
+}
+
+@test "vcluster-released against the next/current docs folder works the same" {
+    # Confirms the suffix is appended to whatever the classifier output, not just versioned.
+    EVENT_TYPE=vcluster-released \
+        TARGET_FOLDER=vcluster \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--target-folder vcluster/_partials/config"* ]]
+}
+
+@test "platform-released does not require SOURCE_PATH" {
+    # Platform reflects against vendored Go types; SOURCE_PATH has no role.
+    unset SOURCE_PATH || true
+    EVENT_TYPE=platform-released \
+        TARGET_FOLDER=platform_versioned_docs/version-4.6.0 \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/platform/partials/main.go"* ]]
+}
+
+@test "vcluster-released without SOURCE_PATH → script exits non-zero" {
+    EVENT_TYPE=vcluster-released TARGET_FOLDER=vcluster run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "vcluster-cli-released without SOURCE_PATH → script exits non-zero" {
+    EVENT_TYPE=vcluster-cli-released TARGET_FOLDER=vcluster run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "unknown EVENT_TYPE → script exits with code 2" {
+    EVENT_TYPE=mystery-released \
+        TARGET_FOLDER=foo \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unsupported EVENT_TYPE"* ]]
+}
+
+@test "missing EVENT_TYPE env var → script exits non-zero" {
+    TARGET_FOLDER=vcluster SOURCE_PATH=/tmp/_source run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing TARGET_FOLDER env var → script exits non-zero" {
+    EVENT_TYPE=vcluster-released SOURCE_PATH=/tmp/_source run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}

--- a/hack/release/run-generator.sh
+++ b/hack/release/run-generator.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# run-generator.sh — dispatch a release-dispatch event to the matching
+# documentation generator with the correct output subpath.
+#
+# Inputs (env):
+#   EVENT_TYPE     vcluster-released | vcluster-cli-released | platform-released
+#   TARGET_FOLDER  Folder produced by classify-version.sh, e.g.
+#                  "vcluster_versioned_docs/version-0.34.0" or "vcluster".
+#   SOURCE_PATH    Local checkout of the released source repo.
+#                  (Required for vcluster + cli; ignored for platform, which
+#                  reflects against vendored Go types.)
+#   REPO_ROOT      (optional) docs repo root. Default $PWD.
+#   DRY_RUN        (optional) if "true", print the resolved command and exit
+#                  without invoking the generator. Used by the bats suite.
+#
+# Subpath suffixes per the A4 design doc:
+#   vcluster-released      → ${TARGET_FOLDER}/_partials/config
+#   vcluster-cli-released  → ${TARGET_FOLDER}/cli
+#   platform-released      → ${TARGET_FOLDER}/api/_partials/resources/  (partials)
+#                            ${TARGET_FOLDER}/api/resources             (overview)
+#
+# Note on flag interface: the vcluster + platform partials generators land
+# their --source-path / --target-folder / --partials-base / --resources-base
+# flags in PR #2b (DEVOPS-888 D.4 / D.5). This router targets that future
+# interface so PR #2b can flip the receiver workflow on without touching
+# this file. vcluster-cli already accepts the flags as of D.6.
+
+set -eo pipefail
+
+: "${EVENT_TYPE:?EVENT_TYPE env var required}"
+: "${TARGET_FOLDER:?TARGET_FOLDER env var required}"
+DRY_RUN="${DRY_RUN:-false}"
+REPO_ROOT="${REPO_ROOT:-$PWD}"
+
+case "$EVENT_TYPE" in
+    vcluster-released)
+        : "${SOURCE_PATH:?SOURCE_PATH required for vcluster-released}"
+        cmd=(go run hack/vcluster/partials/main.go
+             --source-path "$SOURCE_PATH"
+             --target-folder "${TARGET_FOLDER}/_partials/config")
+        ;;
+    vcluster-cli-released)
+        : "${SOURCE_PATH:?SOURCE_PATH required for vcluster-cli-released}"
+        cmd=(go run hack/vcluster-cli/main.go
+             --source-path "$SOURCE_PATH"
+             --target-folder "${TARGET_FOLDER}/cli")
+        ;;
+    platform-released)
+        cmd=(go run hack/platform/partials/main.go
+             --partials-base "${TARGET_FOLDER}/api/_partials/resources/"
+             --resources-base "${TARGET_FOLDER}/api/resources")
+        ;;
+    *)
+        echo "run-generator.sh: unsupported EVENT_TYPE='${EVENT_TYPE}'" >&2
+        exit 2
+        ;;
+esac
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    printf '%s\n' "${cmd[*]}"
+    exit 0
+fi
+
+cd "$REPO_ROOT"
+exec "${cmd[@]}"

--- a/hack/vcluster-cli/README.md
+++ b/hack/vcluster-cli/README.md
@@ -13,6 +13,9 @@ Options:
 - `-branch` - vCluster branch to use (default: current)
 - `-vcluster-dir` - Path to local vCluster repo (default: ~/loft/vCluster)
 - `-local` - Use local repo instead of cloning (default: true)
+- `-output` - Output folder for generated CLI docs (default: `./vcluster/cli`)
+- `-source-path` - Source checkout path; set by the release receiver workflow. Overrides `-vcluster-dir` and forces `-local`.
+- `-target-folder` - Output folder; set by the release receiver workflow. Overrides `-output`. Passing this flag with an empty value exits non-zero (caller misconfiguration).
 
 Output: `./vcluster/cli/`
 

--- a/hack/vcluster-cli/main.go
+++ b/hack/vcluster-cli/main.go
@@ -12,14 +12,37 @@ import (
 )
 
 func main() {
-	var branch, vclusterDir, outputDir string
+	var branch, vclusterDir, outputDir, sourcePath, targetFolder string
 	var useLocal bool
 
 	flag.StringVar(&branch, "branch", "current", "vCluster branch to checkout")
 	flag.StringVar(&vclusterDir, "vcluster-dir", "~/loft/vcluster", "Path to local vCluster repository")
 	flag.StringVar(&outputDir, "output", "./vcluster/cli", "Output directory for generated CLI docs")
 	flag.BoolVar(&useLocal, "local", true, "Use local vCluster repository")
+	flag.StringVar(&sourcePath, "source-path", "", "Source checkout path; set by release receiver. Overrides --vcluster-dir and forces --local.")
+	flag.StringVar(&targetFolder, "target-folder", "", "Output folder for generated CLI docs; set by release receiver. Overrides --output.")
 	flag.Parse()
+
+	// --target-folder explicitly passed empty means the caller computed an
+	// empty path (e.g. classify-version.sh returned no folder). Refuse rather
+	// than silently writing into the legacy default under release CI.
+	targetFolderSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "target-folder" {
+			targetFolderSet = true
+		}
+	})
+	if targetFolderSet && targetFolder == "" {
+		log.Fatal("vcluster-cli generator: --target-folder was passed but empty; refusing to write to legacy default. Check the calling workflow (hack/release/run-generator.sh).")
+	}
+
+	if sourcePath != "" {
+		vclusterDir = sourcePath
+		useLocal = true
+	}
+	if targetFolder != "" {
+		outputDir = targetFolder
+	}
 
 	cliDocsDir := outputDir
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Receiver-side scaffolding for the cross-repo release-dispatch architecture
(A4 design doc). This is **PR #2a** of a 2-PR split of [DEVOPS-888](https://linear.app/loft/issue/DEVOPS-888):
the mechanical, locally-testable pieces. The load-bearing generator
surgery (D.4 A1 prose migration, D.5 A2 platform flags + JSON-Schema
removal, D.1 receiver workflow + act smoke) lands in **PR #2b** with
human-in-loop review.

What this PR adds:

- **`hack/release/classify-version.sh`** — pure(-ish) classifier mapping
  `VERSION` + `EVENT_TYPE` to a routing decision (skip / target_folder /
  channel). Probes versions.json + folder existence to distinguish past
  minors, the next/current docs folder, and frozen-but-pruned versions.
  16 bats cases cover the full A4 appendix-B matrix.
- **`hack/release/run-generator.sh`** — dispatch router that composes the
  per-event generator command with the correct subpath suffix
  (`_partials/config/`, `cli/`, `api/_partials/resources/` +
  `api/resources`). 10 bats cases via `DRY_RUN=true`. Targets the future
  flag interface for D.4/D.5 generators (PR #2b lights it up end-to-end).
- **`hack/vcluster-cli/main.go`** — adds `--source-path` and
  `--target-folder` per A3 CONTRACT. Empty `--target-folder` is fatal
  (misconfigured caller); both flags default to empty so existing
  local-dev invocations are byte-for-byte unchanged.
- **`.github/workflows/release-tests.yml`** — runs shellcheck, bats, and
  a `go vet` + `go build` of `hack/vcluster-cli` on every PR that touches
  the dispatch surface.

What is **not** in this PR (intentionally deferred to PR #2b):

- D.1: `handle-source-release.yaml` receiver workflow + `act` smoke test
- D.4: A1 Extras-map preserve mechanism in `hack/vcluster/partials/main.go`
       with the load-bearing schema-key panic, plus migration of existing
       hand-authored prose from MDX into `pathExtras`
- D.5: A2 two-flag interface in `hack/platform/partials/main.go` and
       removal of the dead JSON-Schema input pipe (needs an off-tree
       caller audit across vcluster, vcluster-pro, loft-enterprise
       release scripts)
- D.7: 4 A3 audit tickets in Linear
- CONTRIBUTING.md section on Extras vs. separate non-generated partial

Each of those needs real-data regen, primary-source enumeration, or both —
work that benefits from human eyes rather than autonomous extrapolation.

## Preview Link

N/A — this PR adds CI, shell scripts, and Go flag plumbing; it does not
modify any docs prose, so there is no Netlify deploy preview page to link.

## Internal Reference

References [DEVOPS-888](https://linear.app/loft/issue/DEVOPS-888) (does
not close — PR #2b is required to satisfy the issue's done-criteria).

Prerequisite [DEVOPS-887](https://linear.app/loft/issue/DEVOPS-887)
(repository-dispatch composite action) is released and tagged
`repository-dispatch/v1` in `loft-sh/github-actions`.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs