### PR TITLE
Update supported navBarButtons positions

### DIFF
--- a/platform_versioned_docs/version-4.9.0/configure/platform-configs/custom-branding.mdx
+++ b/platform_versioned_docs/version-4.9.0/configure/platform-configs/custom-branding.mdx
@@ -45,7 +45,7 @@ navBarButtons:
   - text: "My Link"
     icon: "https://acme.com/static/my-icon.svg"
     link: "https://acme.com/my-link"
-    position: TopEnd # Options: TopStart, TopEnd, BottomStart, BottomEnd (default: BottomEnd)
+    position: Top # Options: Top, Bottom (default: Bottom)
 ```
 
 <!-- vale off -->


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
From version 4.9, the platform sidebar (_side navigation_) supports only two `navBarButtons` positions, Top & Bottom.

<!-- Do not change the line below -->
@netlify /docs

