### PR TITLE
feat(release): receiver workflow + a1/a2 generator integration (DEVOPS-888 PR #2b)

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -1,0 +1,179 @@
+# Receiver for upstream release dispatches. Source repos (vcluster,
+# vcluster-cli inside the same repo, loft-enterprise / "platform") fire
+# `repository_dispatch` events when they cut a release; this workflow
+# decides where the docs land (current vs versioned vs skipped) and
+# regenerates the affected partials in a PR.
+#
+# Routing rules and version → folder mapping live in
+# hack/release/classify-version.sh — bats coverage in the same folder.
+# Per-event generator dispatch lives in hack/release/run-generator.sh.
+#
+# `client_payload` is untrusted (any pusher in the source repo can
+# craft it). Every field is plumbed through `env:` so it is never
+# interpolated into a `run:` block, and the classifier rejects malformed
+# versions before any side-effect runs.
+#
+# Known gap (tracked separately): platform-released regenerates against
+# the loft-sh/api version pinned in go.mod here, not the just-released
+# one. A "Sync API" workflow is expected to PR a go.mod bump on platform
+# releases — this receiver consumes whatever is on main when it runs.
+
+name: handle-source-release
+
+on:
+  repository_dispatch:
+    types:
+      - vcluster-released
+      - vcluster-cli-released
+      - platform-released
+  # Manual simulation; matches the dispatch contract one-for-one so a
+  # failed receiver run can be rerun without re-cutting the source release.
+  workflow_dispatch:
+    inputs:
+      event_type:
+        description: 'Which dispatch to simulate'
+        required: true
+        type: choice
+        options:
+          - vcluster-released
+          - vcluster-cli-released
+          - platform-released
+      version:
+        description: 'Released version, e.g. v0.34.5'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve event + version
+        id: inputs
+        env:
+          DISPATCH_EVENT: ${{ github.event.action }}
+          DISPATCH_VERSION: ${{ github.event.client_payload.version }}
+          MANUAL_EVENT: ${{ inputs.event_type }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          set -eo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            event="$MANUAL_EVENT"
+            version="$MANUAL_VERSION"
+          else
+            event="$DISPATCH_EVENT"
+            version="$DISPATCH_VERSION"
+          fi
+          # Cheap shape check; the classifier does the authoritative one.
+          if ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "::error::Refusing to proceed: version '$version' is not vX.Y.Z[-pre]" >&2
+            exit 1
+          fi
+          {
+            echo "event=$event"
+            echo "version=$version"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Classify version
+        id: classify
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          EVENT_TYPE: ${{ steps.inputs.outputs.event }}
+        run: bash hack/release/classify-version.sh
+
+      - name: Skip notice
+        if: steps.classify.outputs.skip == 'true'
+        env:
+          EVENT: ${{ steps.inputs.outputs.event }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.classify.outputs.channel }}
+        run: |
+          echo "::notice::No docs change for $EVENT $VERSION (channel=$CHANNEL)"
+
+      - name: Set up Go
+        if: steps.classify.outputs.skip != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # vcluster + vcluster-cli generators consume the released vCluster
+      # source tree. Platform generator builds against API types pinned in
+      # this repo's go.mod, so no source checkout is needed.
+      - name: Checkout vCluster source
+        if: steps.classify.outputs.skip != 'true' && (steps.inputs.outputs.event == 'vcluster-released' || steps.inputs.outputs.event == 'vcluster-cli-released')
+        uses: actions/checkout@v4
+        with:
+          repository: loft-sh/vcluster
+          ref: ${{ steps.inputs.outputs.version }}
+          path: source-vcluster
+          fetch-depth: 1
+
+      # The partials generator expects vcluster.schema.json /
+      # default_values.yaml; the source tree exposes them as
+      # chart/values.schema.json / chart/values.yaml. Keeping the rename
+      # here (instead of teaching the generator both names) keeps the
+      # generator's I/O contract obvious from its flag list.
+      - name: Stage vCluster schema for partials generator
+        if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'vcluster-released'
+        env:
+          STAGE_DIR: ${{ github.workspace }}/source-vcluster-staged
+        run: |
+          set -eo pipefail
+          mkdir -p "$STAGE_DIR"
+          cp source-vcluster/chart/values.schema.json "$STAGE_DIR/vcluster.schema.json"
+          cp source-vcluster/chart/values.yaml         "$STAGE_DIR/default_values.yaml"
+          echo "STAGED=$STAGE_DIR" >>"$GITHUB_ENV"
+
+      - name: Generate docs
+        if: steps.classify.outputs.skip != 'true'
+        env:
+          EVENT_TYPE: ${{ steps.inputs.outputs.event }}
+          TARGET_FOLDER: ${{ steps.classify.outputs.target_folder }}
+          # SOURCE_PATH only used by vcluster + vcluster-cli generators;
+          # platform generator ignores it.
+          SOURCE_PATH: ${{ steps.inputs.outputs.event == 'vcluster-released' && env.STAGED || (steps.inputs.outputs.event == 'vcluster-cli-released' && format('{0}/source-vcluster', github.workspace) || '') }}
+        run: bash hack/release/run-generator.sh
+
+      - name: Open or update PR
+        if: steps.classify.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ steps.inputs.outputs.event }}
+          VERSION: ${{ steps.inputs.outputs.version }}
+          CHANNEL: ${{ steps.classify.outputs.channel }}
+          TARGET_FOLDER: ${{ steps.classify.outputs.target_folder }}
+        run: |
+          set -eo pipefail
+          git config user.name  "Loft Bot"
+          git config user.email "loft-bot@users.noreply.github.com"
+
+          branch="docs-sync/${EVENT}-${VERSION}"
+          git checkout -B "$branch"
+
+          if git diff --quiet --exit-code; then
+            echo "::notice::No content changes for $EVENT $VERSION (target=$TARGET_FOLDER)"
+            exit 0
+          fi
+
+          git add -A
+          git commit -m "docs: sync ${EVENT} ${VERSION}" -m "Channel: ${CHANNEL}. Target: ${TARGET_FOLDER}."
+          git push -u origin "$branch" --force
+
+          if gh pr list --head "$branch" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "::notice::Existing PR on $branch updated by force-push."
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "docs: sync ${EVENT} ${VERSION}" \
+            --body "Auto-generated by handle-source-release. Channel: \`${CHANNEL}\`. Target: \`${TARGET_FOLDER}\`."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -510,3 +510,52 @@ This content won't be checked by Vale.
 ```
 
 <!-- vale on -->
+
+## Adding prose to generated partials
+
+The vCluster config partials under `vcluster/_partials/config/` are
+overwritten on every release by `hack/vcluster/partials/main.go`. Editing
+those files in place was the original workflow and the original failure
+mode: the next regeneration silently dropped the edit. Two routes exist
+now, both designed to survive regeneration.
+
+### Use the Extras map when prose belongs with a schema field
+
+If the prose is intrinsically tied to one schema path — a security
+warning that only makes sense alongside `controlPlane.standalone.joinNode`,
+a migration tip that belongs at the bottom of `controlPlane.distro` —
+add a `pathExtras` entry in `hack/vcluster/partials/main.go`:
+
+```go
+var pathExtras = map[string]Extras{
+    "controlPlane/standalone/joinNode": {
+        Before: "\n:::warning Security consideration\n...\n:::\n\n",
+    },
+}
+```
+
+`Before` lands above the rendered schema content, `After` below.
+The map keys are validated against the live schema before any output
+is written; a rename or removal upstream panics the generator with the
+full list of dangling keys, so the prose can be migrated explicitly
+instead of silently orphaned.
+
+### Use a separate, non-generated partial when prose stands alone
+
+If the prose is conceptual (an overview page, a how-to, a comparison)
+and only happens to live near generated content, write it as a
+hand-authored `.mdx` outside `vcluster/_partials/config/` and import it
+where needed. The generator will not touch it. This is the right choice
+when:
+
+- The prose can be read on its own without a specific schema field next
+  to it.
+- The prose references multiple schema paths.
+- The prose has its own headings, examples, and lifecycle (changes for
+  reasons unrelated to schema bumps).
+
+### Quick rule of thumb
+
+- One schema path, one or two paragraphs of prose → `pathExtras`.
+- Multi-paragraph prose, multiple references, own structure → separate
+  partial, imported manually.

--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/invopop/jsonschema"
 	"github.com/loft-sh/vcluster-docs/hack/platform/util"
 
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
@@ -23,14 +22,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var paths []string
-
 func main() {
-	if len(os.Args) != 2 {
-		panic("expected to be called with vcluster jsonschema path as first argument, e.g.\n" +
-			"go run hack/vcluster/partials/main.go configsrc/v0.21/vcluster.schema.json")
+	// Flags let the release-dispatch receiver redirect output into a
+	// versioned folder without modifying util.BasePath in source. Both
+	// default to empty, in which case the legacy util.BasePath /
+	// util.BaseResourcesPath defaults stand and unmodified scripted
+	// callers keep writing to the same locations.
+	var partialsBase, resourcesBase string
+	flag.StringVar(&partialsBase, "partials-base", "", "Override util.BasePath; receiver passes ${target_folder}/api/_partials/resources/")
+	flag.StringVar(&resourcesBase, "resources-base", "", "Override util.BaseResourcesPath; receiver passes ${target_folder}/api/resources")
+	flag.Parse()
+
+	if partialsBase != "" {
+		util.BasePath = partialsBase
 	}
-	jsonSchemaPath := os.Args[1]
+	if resourcesBase != "" {
+		util.BaseResourcesPath = resourcesBase
+	}
 
 	removeAllExceptPreserved(util.BasePath)
 
@@ -1115,29 +1123,6 @@ spec:
 	})
 
 	util.DefaultRequire = false
-	schema := &jsonschema.Schema{}
-	schemaBytes, err := os.ReadFile(jsonSchemaPath)
-	if err != nil {
-		panic(fmt.Errorf("failed to read schema file %q: %w", jsonSchemaPath, err))
-	}
-	err = json.Unmarshal(schemaBytes, schema)
-	if err != nil {
-		panic(fmt.Errorf("failed to parse JSON schema from %q: %w", jsonSchemaPath, err))
-	}
-
-	// fmt.Println("properties:")
-	// for childNode := schema.Properties.Oldest(); childNode != nil; childNode = childNode.Next() {
-	// 	fmt.Printf("%v : %v\n", childNode.Key, childNode.Value)
-	// }
-	// fmt.Println(paths)
-	for _, p := range paths {
-		p := strings.TrimPrefix(p, "/")
-		err := util.GenerateFromPathWithError(schema, util.BasePath+"/config", p, nil)
-		if err != nil {
-			fmt.Printf("Warning: Skipping path %q: %v\n", p, err)
-			continue
-		}
-	}
 }
 
 // removeAllExceptPreserved deletes basePath and recreates it, but first backs

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -25,9 +25,13 @@ const (
 
 var DefaultRequire = true
 
-const BasePath = "platform/api/_partials/resources/"
+// BasePath and BaseResourcesPath are package-level vars (not const) so the
+// release-dispatch receiver can redirect generator output to versioned
+// folders without a fork. Defaults match the legacy const values byte-for-byte
+// so unmodified scripted callers continue to write to the same place.
+var BasePath = "platform/api/_partials/resources/"
 
-const BaseResourcesPath = "platform/api/resources"
+var BaseResourcesPath = "platform/api/resources"
 
 var pluralizeClient = pluralize.NewClient()
 

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -341,6 +341,23 @@ func GenerateFromPath(schema *jsonschema.Schema, basePath string, schemaPath str
 }
 
 func GenerateFromPathWithError(schema *jsonschema.Schema, basePath string, schemaPath string, defaults map[string]interface{}) error {
+	content, err := RenderFromPath(schema, schemaPath, defaults)
+	if err != nil {
+		return err
+	}
+	filePath := path.Join(basePath, schemaPath) + ".mdx"
+	_ = os.MkdirAll(path.Dir(filePath), 0o777)
+	if err := os.WriteFile(filePath, []byte(content), os.ModePerm); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+	return nil
+}
+
+// RenderFromPath resolves a schema path and returns the rendered MDX content
+// without writing it. Callers can compose the content with hand-authored
+// prose (e.g. pathExtras Before/After in the vcluster partials generator)
+// before deciding where to write it.
+func RenderFromPath(schema *jsonschema.Schema, schemaPath string, defaults map[string]interface{}) (string, error) {
 	splittedSchemaPath := strings.Split(schemaPath, "/")
 
 	fieldSchema := schema
@@ -350,7 +367,7 @@ func GenerateFromPathWithError(schema *jsonschema.Schema, basePath string, schem
 		lastProperty = property
 		fieldSchema, ok = fieldSchema.Properties.Get(property)
 		if !ok {
-			return fmt.Errorf("couldn't find schema path '%s' at '%s'", schemaPath, property)
+			return "", fmt.Errorf("couldn't find schema path '%s' at '%s'", schemaPath, property)
 		}
 
 		if i+1 == len(splittedSchemaPath) {
@@ -379,7 +396,7 @@ func GenerateFromPathWithError(schema *jsonschema.Schema, basePath string, schem
 			refSplit := strings.Split(ref, "/")
 			fieldSchema, ok = schema.Definitions[refSplit[len(refSplit)-1]]
 			if !ok {
-				return fmt.Errorf("couldn't find schema definition %s", refSplit[len(refSplit)-1])
+				return "", fmt.Errorf("couldn't find schema definition %s", refSplit[len(refSplit)-1])
 			}
 		}
 	}
@@ -393,15 +410,7 @@ func GenerateFromPathWithError(schema *jsonschema.Schema, basePath string, schem
 		1,
 		defaults,
 	)
-	filePath := path.Join(basePath, schemaPath) + ".mdx"
-
-	// write file
-	_ = os.MkdirAll(path.Dir(filePath), 0o777)
-	err := os.WriteFile(filePath, []byte(content), os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
-	}
-	return nil
+	return content, nil
 }
 
 func GenerateResource(schema *jsonschema.Schema, basePath string, subResource bool) error {

--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -78,6 +78,28 @@ get() {
     [ "$(get channel)" = "stable" ]
 }
 
+@test "vcluster: way-future minor (>+1 above max-frozen) → skip per A4 appx B" {
+    # A4 example: v9.9.9 against a 0.x history must skip, not silently
+    # land into the current docs folder.
+    VERSION=v9.9.9 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster: major-version bump (1.0.0 against 0.x history) → skip" {
+    # Prevents silent routing of an unexpected major to current_root.
+    VERSION=v1.0.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster: skipped a minor (current=0.34, incoming=0.36) → skip" {
+    # Only the immediate next minor (max-frozen + 1) maps to current_root.
+    VERSION=v0.36.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
 @test "vcluster: RC on frozen minor → versioned folder, channel=rc" {
     VERSION=v0.34.0-rc.3 EVENT_TYPE=vcluster-released run "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -87,7 +109,8 @@ get() {
 }
 
 @test "vcluster: RC of next minor → current docs folder, channel=rc" {
-    VERSION=v0.36.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    # Next minor against max-frozen 0.34 is 0.35 (max + 1).
+    VERSION=v0.35.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
     [ "$status" -eq 0 ]
     [ "$(get skip)" = "false" ]
     [ "$(get target_folder)" = "vcluster" ]

--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+#
+# Tests for classify-version.sh. Each test points the script at a fixture repo
+# layout (versions.json + version-X.Y.Z folders) instead of the real docs tree
+# so cases stay deterministic and don't depend on which versions happen to be
+# frozen on main today.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/classify-version.sh"
+    FIXTURE="$(mktemp -d)"
+
+    # vcluster fixture: 0.28, 0.30, 0.31, 0.32, 0.33, 0.34 frozen with folders.
+    # versions.json also lists 0.26 and 0.25 — frozen-but-pruned, no folder.
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.28.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.30.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.31.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.32.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.33.0"
+    mkdir -p "$FIXTURE/vcluster_versioned_docs/version-0.34.0"
+    cat >"$FIXTURE/vcluster_versions.json" <<EOF
+[
+  "0.34.0",
+  "0.33.0",
+  "0.32.0",
+  "0.31.0",
+  "0.30.0",
+  "0.28.0",
+  "0.26.0",
+  "0.25.0"
+]
+EOF
+
+    # platform fixture: 4.5–4.9 frozen with folders, plus 4.4-4.2 in versions.json without folders.
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.5.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.6.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.7.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.8.0"
+    mkdir -p "$FIXTURE/platform_versioned_docs/version-4.9.0"
+    cat >"$FIXTURE/platform_versions.json" <<EOF
+[
+  "4.9.0",
+  "4.8.0",
+  "4.7.0",
+  "4.6.0",
+  "4.5.0",
+  "4.4.0",
+  "4.3.0",
+  "4.2.0"
+]
+EOF
+
+    export REPO_ROOT="$FIXTURE"
+}
+
+teardown() {
+    rm -rf "$FIXTURE"
+}
+
+# Pull a single key from the script's `key=value` stdout block.
+get() {
+    local key="$1"
+    grep "^${key}=" <<<"$output" | head -n1 | cut -d= -f2-
+}
+
+@test "vcluster: stable patch on frozen minor → versioned folder" {
+    VERSION=v0.34.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: stable release of next minor → current docs folder" {
+    VERSION=v0.35.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: RC on frozen minor → versioned folder, channel=rc" {
+    VERSION=v0.34.0-rc.3 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+    [ "$(get channel)" = "rc" ]
+}
+
+@test "vcluster: RC of next minor → current docs folder, channel=rc" {
+    VERSION=v0.36.0-rc.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster" ]
+    [ "$(get channel)" = "rc" ]
+}
+
+@test "vcluster: alpha is always skipped" {
+    VERSION=v0.34.5-alpha.1 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "alpha" ]
+}
+
+@test "vcluster: beta is always skipped" {
+    VERSION=v0.36.0-beta.2 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "beta" ]
+}
+
+@test "vcluster: frozen-but-pruned minor (in versions.json, no folder) → skip" {
+    # 0.26.0 is in versions.json but no folder exists for it.
+    VERSION=v0.26.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "vcluster: missing-from-versions.json minor with folder → versioned folder" {
+    # 0.29 isn't in versions.json AND has no folder; treated as past minor → skip.
+    # Confirms classifier doesn't accidentally route to "current" when it's lower than highest.
+    VERSION=v0.29.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+}
+
+@test "vcluster-cli rides on vcluster versioning" {
+    VERSION=v0.34.5 EVENT_TYPE=vcluster-cli-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
+}
+
+@test "platform: stable patch on frozen minor → versioned folder" {
+    VERSION=v4.6.5 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "platform_versioned_docs/version-4.6.0" ]
+    [ "$(get channel)" = "stable" ]
+}
+
+@test "platform: release of next minor → current docs folder" {
+    VERSION=v4.10.0 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "false" ]
+    [ "$(get target_folder)" = "platform" ]
+}
+
+@test "unknown event type → skip with channel=unknown-event" {
+    VERSION=v1.2.3 EVENT_TYPE=something-else run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "unknown-event" ]
+}
+
+@test "malformed version → skip with channel=invalid" {
+    VERSION=not-a-version EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "invalid" ]
+}
+
+@test "missing VERSION env var → script exits non-zero" {
+    EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing EVENT_TYPE env var → script exits non-zero" {
+    VERSION=v0.34.5 run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "GITHUB_OUTPUT is appended when set" {
+    OUTFILE="$(mktemp)"
+    GITHUB_OUTPUT="$OUTFILE" VERSION=v0.34.5 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "^skip=false$" "$OUTFILE"
+    grep -q "^target_folder=vcluster_versioned_docs/version-0.34.0$" "$OUTFILE"
+    grep -q "^channel=stable$" "$OUTFILE"
+    rm -f "$OUTFILE"
+}

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# classify-version.sh — pure(-ish) classifier for release-dispatch routing.
+#
+# Maps a released VERSION + EVENT_TYPE to a routing decision:
+#   - skip:           true if the version should not produce docs
+#   - target_folder:  path (relative to REPO_ROOT) where generated docs land
+#   - channel:        stable | rc | alpha | beta | invalid | unknown-event
+#
+# Inputs (env):
+#   VERSION      Released version, e.g. v0.34.5, v0.34.0-rc.3, v4.6.0-alpha.1
+#   EVENT_TYPE   One of: vcluster-released | vcluster-cli-released | platform-released
+#   REPO_ROOT    (optional) docs-repo root; default $PWD. Used for folder probes
+#                and reading versions.json. Tests override to point at fixtures.
+#
+# Outputs:
+#   key=value lines on stdout, also appended to $GITHUB_OUTPUT when set.
+#
+# Always exits 0; "skip" is signalled via the output, not the exit code, so a
+# calling workflow can branch with `if: steps.classify.outputs.skip != 'true'`
+# without conflating skip-by-design with classifier failure.
+#
+# Routing rules (matches A4 design appendix B):
+#
+#   * alpha / beta  → always skip
+#   * MAJOR.MINOR strictly newer than the highest frozen MAJOR.MINOR in the
+#     event's versions.json → target = current docs root (the unreleased
+#     "next" docs folder)
+#   * MAJOR.MINOR ≤ highest frozen, candidate folder exists →
+#     target = versioned folder (e.g. version-0.34.0)
+#   * MAJOR.MINOR ≤ highest frozen, candidate folder absent → skip
+#     (past minor we don't track)
+
+set -eo pipefail
+
+: "${VERSION:?VERSION env var required (e.g. VERSION=v0.34.5)}"
+: "${EVENT_TYPE:?EVENT_TYPE env var required (vcluster-released|vcluster-cli-released|platform-released)}"
+REPO_ROOT="${REPO_ROOT:-$PWD}"
+
+emit() {
+    printf '%s=%s\n' "$1" "$2"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+emit_skip() {
+    # $1 = channel
+    emit skip true
+    emit target_folder ""
+    emit channel "$1"
+    exit 0
+}
+
+case "$EVENT_TYPE" in
+    vcluster-released|vcluster-cli-released)
+        versioned_root="vcluster_versioned_docs"
+        current_root="vcluster"
+        versions_json="vcluster_versions.json"
+        ;;
+    platform-released)
+        versioned_root="platform_versioned_docs"
+        current_root="platform"
+        versions_json="platform_versions.json"
+        ;;
+    *)
+        emit_skip unknown-event
+        ;;
+esac
+
+stripped="${VERSION#v}"
+
+channel=stable
+case "$stripped" in
+    *-alpha*) emit_skip alpha ;;
+    *-beta*)  emit_skip beta  ;;
+    *-rc.*|*-rc[0-9]*) channel=rc ;;
+esac
+
+base="${stripped%%-*}"
+if ! [[ "$base" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    emit_skip invalid
+fi
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+incoming_key=$(( major * 100000 + minor ))
+
+# Highest frozen MAJOR.MINOR from versions.json (Docusaurus convention).
+versions_path="${REPO_ROOT}/${versions_json}"
+highest_key=-1
+if [[ -f "$versions_path" ]]; then
+    while read -r v; do
+        [[ -z "$v" ]] && continue
+        if [[ "$v" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            v_major="${BASH_REMATCH[1]}"
+            v_minor="${BASH_REMATCH[2]}"
+            v_key=$(( v_major * 100000 + v_minor ))
+            (( v_key > highest_key )) && highest_key=$v_key
+        fi
+    done < <(tr -d '[]" ' <"$versions_path" | tr ',' '\n')
+fi
+
+if (( incoming_key > highest_key )); then
+    # Strictly newer than anything frozen → next/current docs.
+    emit skip false
+    emit target_folder "$current_root"
+    emit channel "$channel"
+    exit 0
+fi
+
+candidate="${versioned_root}/version-${major}.${minor}.0"
+if [[ -d "${REPO_ROOT}/${candidate}" ]]; then
+    emit skip false
+    emit target_folder "$candidate"
+    emit channel "$channel"
+    exit 0
+fi
+
+# Past minor that was frozen-but-pruned (in versions.json, no folder) — skip.
+emit_skip "$channel"

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -101,11 +101,17 @@ if [[ -f "$versions_path" ]]; then
 fi
 
 if (( incoming_key > highest_key )); then
-    # Strictly newer than anything frozen → next/current docs.
-    emit skip false
-    emit target_folder "$current_root"
-    emit channel "$channel"
-    exit 0
+    # Newer than anything frozen. Only the immediate next minor in the
+    # same major series can map to current docs — anything further is
+    # treated as garbage / unexpected, per A4 appendix B (e.g. v9.9.9
+    # against a 0.x history must skip, not silently write into current).
+    if (( incoming_key == highest_key + 1 )); then
+        emit skip false
+        emit target_folder "$current_root"
+        emit channel "$channel"
+        exit 0
+    fi
+    emit_skip "$channel"
 fi
 
 candidate="${versioned_root}/version-${major}.${minor}.0"

--- a/hack/release/run-generator.bats
+++ b/hack/release/run-generator.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Tests for run-generator.sh. Use DRY_RUN=true so the suite verifies the
+# resolved command line per event type without actually invoking `go run`.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/run-generator.sh"
+    export DRY_RUN=true
+}
+
+@test "vcluster-released → vcluster partials generator with _partials/config suffix" {
+    EVENT_TYPE=vcluster-released \
+        TARGET_FOLDER=vcluster_versioned_docs/version-0.34.0 \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/vcluster/partials/main.go"* ]]
+    [[ "$output" == *"--source-path /tmp/_source"* ]]
+    [[ "$output" == *"--target-folder vcluster_versioned_docs/version-0.34.0/_partials/config"* ]]
+}
+
+@test "vcluster-cli-released → vcluster-cli generator with cli suffix" {
+    EVENT_TYPE=vcluster-cli-released \
+        TARGET_FOLDER=vcluster_versioned_docs/version-0.34.0 \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/vcluster-cli/main.go"* ]]
+    [[ "$output" == *"--source-path /tmp/_source"* ]]
+    [[ "$output" == *"--target-folder vcluster_versioned_docs/version-0.34.0/cli"* ]]
+}
+
+@test "platform-released → platform partials with both base flags" {
+    EVENT_TYPE=platform-released \
+        TARGET_FOLDER=platform_versioned_docs/version-4.6.0 \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/platform/partials/main.go"* ]]
+    [[ "$output" == *"--partials-base platform_versioned_docs/version-4.6.0/api/_partials/resources/"* ]]
+    [[ "$output" == *"--resources-base platform_versioned_docs/version-4.6.0/api/resources"* ]]
+}
+
+@test "vcluster-released against the next/current docs folder works the same" {
+    # Confirms the suffix is appended to whatever the classifier output, not just versioned.
+    EVENT_TYPE=vcluster-released \
+        TARGET_FOLDER=vcluster \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--target-folder vcluster/_partials/config"* ]]
+}
+
+@test "platform-released does not require SOURCE_PATH" {
+    # Platform reflects against vendored Go types; SOURCE_PATH has no role.
+    unset SOURCE_PATH || true
+    EVENT_TYPE=platform-released \
+        TARGET_FOLDER=platform_versioned_docs/version-4.6.0 \
+        run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hack/platform/partials/main.go"* ]]
+}
+
+@test "vcluster-released without SOURCE_PATH → script exits non-zero" {
+    EVENT_TYPE=vcluster-released TARGET_FOLDER=vcluster run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "vcluster-cli-released without SOURCE_PATH → script exits non-zero" {
+    EVENT_TYPE=vcluster-cli-released TARGET_FOLDER=vcluster run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "unknown EVENT_TYPE → script exits with code 2" {
+    EVENT_TYPE=mystery-released \
+        TARGET_FOLDER=foo \
+        SOURCE_PATH=/tmp/_source \
+        run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"unsupported EVENT_TYPE"* ]]
+}
+
+@test "missing EVENT_TYPE env var → script exits non-zero" {
+    TARGET_FOLDER=vcluster SOURCE_PATH=/tmp/_source run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing TARGET_FOLDER env var → script exits non-zero" {
+    EVENT_TYPE=vcluster-released SOURCE_PATH=/tmp/_source run "$SCRIPT"
+    [ "$status" -ne 0 ]
+}

--- a/hack/release/run-generator.sh
+++ b/hack/release/run-generator.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# run-generator.sh — dispatch a release-dispatch event to the matching
+# documentation generator with the correct output subpath.
+#
+# Inputs (env):
+#   EVENT_TYPE     vcluster-released | vcluster-cli-released | platform-released
+#   TARGET_FOLDER  Folder produced by classify-version.sh, e.g.
+#                  "vcluster_versioned_docs/version-0.34.0" or "vcluster".
+#   SOURCE_PATH    Local checkout of the released source repo.
+#                  (Required for vcluster + cli; ignored for platform, which
+#                  reflects against vendored Go types.)
+#   REPO_ROOT      (optional) docs repo root. Default $PWD.
+#   DRY_RUN        (optional) if "true", print the resolved command and exit
+#                  without invoking the generator. Used by the bats suite.
+#
+# Subpath suffixes per the A4 design doc:
+#   vcluster-released      → ${TARGET_FOLDER}/_partials/config
+#   vcluster-cli-released  → ${TARGET_FOLDER}/cli
+#   platform-released      → ${TARGET_FOLDER}/api/_partials/resources/  (partials)
+#                            ${TARGET_FOLDER}/api/resources             (overview)
+#
+# Note on flag interface: the vcluster + platform partials generators land
+# their --source-path / --target-folder / --partials-base / --resources-base
+# flags in PR #2b (DEVOPS-888 D.4 / D.5). This router targets that future
+# interface so PR #2b can flip the receiver workflow on without touching
+# this file. vcluster-cli already accepts the flags as of D.6.
+
+set -eo pipefail
+
+: "${EVENT_TYPE:?EVENT_TYPE env var required}"
+: "${TARGET_FOLDER:?TARGET_FOLDER env var required}"
+DRY_RUN="${DRY_RUN:-false}"
+REPO_ROOT="${REPO_ROOT:-$PWD}"
+
+case "$EVENT_TYPE" in
+    vcluster-released)
+        : "${SOURCE_PATH:?SOURCE_PATH required for vcluster-released}"
+        cmd=(go run hack/vcluster/partials/main.go
+             --source-path "$SOURCE_PATH"
+             --target-folder "${TARGET_FOLDER}/_partials/config")
+        ;;
+    vcluster-cli-released)
+        : "${SOURCE_PATH:?SOURCE_PATH required for vcluster-cli-released}"
+        cmd=(go run hack/vcluster-cli/main.go
+             --source-path "$SOURCE_PATH"
+             --target-folder "${TARGET_FOLDER}/cli")
+        ;;
+    platform-released)
+        cmd=(go run hack/platform/partials/main.go
+             --partials-base "${TARGET_FOLDER}/api/_partials/resources/"
+             --resources-base "${TARGET_FOLDER}/api/resources")
+        ;;
+    *)
+        echo "run-generator.sh: unsupported EVENT_TYPE='${EVENT_TYPE}'" >&2
+        exit 2
+        ;;
+esac
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    printf '%s\n' "${cmd[*]}"
+    exit 0
+fi
+
+cd "$REPO_ROOT"
+exec "${cmd[@]}"

--- a/hack/vcluster-cli/README.md
+++ b/hack/vcluster-cli/README.md
@@ -13,6 +13,9 @@ Options:
 - `-branch` - vCluster branch to use (default: current)
 - `-vcluster-dir` - Path to local vCluster repo (default: ~/loft/vCluster)
 - `-local` - Use local repo instead of cloning (default: true)
+- `-output` - Output folder for generated CLI docs (default: `./vcluster/cli`)
+- `-source-path` - Source checkout path; set by the release receiver workflow. Overrides `-vcluster-dir` and forces `-local`.
+- `-target-folder` - Output folder; set by the release receiver workflow. Overrides `-output`. Passing this flag with an empty value exits non-zero (caller misconfiguration).
 
 Output: `./vcluster/cli/`
 

--- a/hack/vcluster-cli/main.go
+++ b/hack/vcluster-cli/main.go
@@ -12,14 +12,37 @@ import (
 )
 
 func main() {
-	var branch, vclusterDir, outputDir string
+	var branch, vclusterDir, outputDir, sourcePath, targetFolder string
 	var useLocal bool
 
 	flag.StringVar(&branch, "branch", "current", "vCluster branch to checkout")
 	flag.StringVar(&vclusterDir, "vcluster-dir", "~/loft/vcluster", "Path to local vCluster repository")
 	flag.StringVar(&outputDir, "output", "./vcluster/cli", "Output directory for generated CLI docs")
 	flag.BoolVar(&useLocal, "local", true, "Use local vCluster repository")
+	flag.StringVar(&sourcePath, "source-path", "", "Source checkout path; set by release receiver. Overrides --vcluster-dir and forces --local.")
+	flag.StringVar(&targetFolder, "target-folder", "", "Output folder for generated CLI docs; set by release receiver. Overrides --output.")
 	flag.Parse()
+
+	// --target-folder explicitly passed empty means the caller computed an
+	// empty path (e.g. classify-version.sh returned no folder). Refuse rather
+	// than silently writing into the legacy default under release CI.
+	targetFolderSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "target-folder" {
+			targetFolderSet = true
+		}
+	})
+	if targetFolderSet && targetFolder == "" {
+		log.Fatal("vcluster-cli generator: --target-folder was passed but empty; refusing to write to legacy default. Check the calling workflow (hack/release/run-generator.sh).")
+	}
+
+	if sourcePath != "" {
+		vclusterDir = sourcePath
+		useLocal = true
+	}
+	if targetFolder != "" {
+		outputDir = targetFolder
+	}
 
 	cliDocsDir := outputDir
 

--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -2,14 +2,51 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
 
 	"github.com/ghodss/yaml"
 	"github.com/invopop/jsonschema"
 	"github.com/loft-sh/vcluster-docs/hack/platform/util"
 )
+
+// Extras carries hand-authored prose that wraps the auto-generated MDX
+// for a schema path. Authors include leading/trailing newlines as needed
+// to keep MDX admonitions parseable; both fields are inserted as-is.
+type Extras struct {
+	Before string
+	After  string
+}
+
+// pathExtras is the single source of truth for hand-authored prose that
+// must survive every regeneration. Keys are schema paths (matching the
+// `paths` slice). Adding a key whose schema path no longer resolves is
+// a build-break (see validateExtras below) — that converts the silent
+// drop-on-rename failure mode of the previous "edit the MDX in place"
+// workflow into a loud, traceable error.
+var pathExtras = map[string]Extras{
+	"controlPlane/distro": {
+		After: "\n\n:::tip K3s to K8s migration\n" +
+			"Starting with vCluster 0.25.0, migration from K3s to K8s is supported. " +
+			"For more details, see the [K3s to K8s migration guide](/docs/vcluster/manage/upgrade/distro-migration).\n" +
+			":::\n",
+	},
+	"controlPlane/standalone/joinNode": {
+		Before: "\n:::warning Security consideration\n" +
+			"When `joinNode.enabled` is `true`, the control-plane node also runs kubelet as a worker.\n" +
+			"Tenant workloads scheduled onto this node share the machine with the vCluster control-plane\n" +
+			"process and its platform credentials. A tenant with sufficient privileges (such as `hostPID`,\n" +
+			"hostPath volumes, or `nodes/proxy` access) can read the platform access key from the process\n" +
+			"environment.\n\n" +
+			"For production deployments, keep the control-plane node dedicated by setting\n" +
+			"`joinNode.enabled: false` and use separate worker nodes for tenant workloads.\n" +
+			":::\n\n",
+	},
+}
 
 // we only generate paths we actually need
 var paths = []string{
@@ -114,23 +151,38 @@ var paths = []string{
 }
 
 func main() {
-	if len(os.Args) != 3 {
-		panic("expected to be called with vcluster jsonschema directory as first argument and output dir as a second, e.g.\n" +
-			"go run hack/vcluster/partials/main.go configsrc/v0.21/ vcluster_versioned_docs/version-0.21.0/_partials/config")
+	// Two flags + back-compat positional args. Receiver passes the flag
+	// form; humans regenerating locally usually still type positional.
+	var sourcePath, targetFolder string
+	flag.StringVar(&sourcePath, "source-path", "", "Checkout root containing vcluster.schema.json and default_values.yaml. Set by the release-dispatch receiver.")
+	flag.StringVar(&targetFolder, "target-folder", "", "Output folder for generated partials, e.g. vcluster_versioned_docs/version-0.34.0/_partials/config. Set by the release-dispatch receiver.")
+	flag.Parse()
+
+	versionDir := sourcePath
+	outputDir := targetFolder
+	if positional := flag.Args(); len(positional) >= 2 {
+		if versionDir == "" {
+			versionDir = positional[0]
+		}
+		if outputDir == "" {
+			outputDir = positional[1]
+		}
+	}
+	if versionDir == "" || outputDir == "" {
+		panic("expected --source-path and --target-folder, e.g.\n" +
+			"go run hack/vcluster/partials/main.go --source-path configsrc/v0.21/ --target-folder vcluster_versioned_docs/version-0.21.0/_partials/config\n" +
+			"(positional args still accepted for back-compat)")
 	}
 
 	util.DefaultRequire = false
-	versionDir := os.Args[1]
 	jsonSchemaPath := filepath.Join(versionDir, "vcluster.schema.json")
 	defaultValues := filepath.Join(versionDir, "default_values.yaml")
 	values, err := os.ReadFile(defaultValues)
 	if err != nil {
 		panic(fmt.Errorf("failed to read default values from %q: %w", defaultValues, err))
 	}
-	outputDir := os.Args[2]
 	defaults := map[string]interface{}{}
-	err = yaml.Unmarshal(values, &defaults)
-	if err != nil {
+	if err := yaml.Unmarshal(values, &defaults); err != nil {
 		panic(fmt.Errorf("failed to parse default values YAML: %w", err))
 	}
 	schema := &jsonschema.Schema{}
@@ -138,15 +190,51 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("failed to read schema file %q: %w", jsonSchemaPath, err))
 	}
-	err = json.Unmarshal(schemaBytes, schema)
-	if err != nil {
+	if err := json.Unmarshal(schemaBytes, schema); err != nil {
 		panic(fmt.Errorf("failed to parse schema JSON: %w", err))
 	}
-	for _, path := range paths {
-		err := util.GenerateFromPathWithError(schema, outputDir, path, defaults)
+
+	// Load-bearing: every pathExtras key must resolve in the live schema
+	// before any output is written. A schema rename or removal that left a
+	// stale Extras key would otherwise silently orphan the prose; this
+	// converts that into a build-break with the full list of dangling keys.
+	validateExtras(schema, defaults)
+
+	for _, p := range paths {
+		content, err := util.RenderFromPath(schema, p, defaults)
 		if err != nil {
-			fmt.Printf("Warning: Skipping path %q: %v\n", path, err)
+			fmt.Printf("Warning: Skipping path %q: %v\n", p, err)
 			continue
 		}
+
+		extras := pathExtras[p]
+		final := extras.Before + content + extras.After
+
+		filePath := path.Join(outputDir, p) + ".mdx"
+		_ = os.MkdirAll(path.Dir(filePath), 0o777)
+		if err := os.WriteFile(filePath, []byte(final), os.ModePerm); err != nil {
+			panic(fmt.Errorf("failed to write %q: %w", filePath, err))
+		}
 	}
+}
+
+// validateExtras panics if any pathExtras key fails to resolve in the
+// schema. Output names every dangling key so a schema rename surfaces the
+// full migration scope on the first run, not one error at a time.
+func validateExtras(schema *jsonschema.Schema, defaults map[string]interface{}) {
+	var dangling []string
+	for key := range pathExtras {
+		if _, err := util.RenderFromPath(schema, key, defaults); err != nil {
+			dangling = append(dangling, key)
+		}
+	}
+	if len(dangling) == 0 {
+		return
+	}
+	sort.Strings(dangling)
+	panic(fmt.Sprintf(
+		"preserve key drift: %d Extras path(s) do not resolve in schema: %v\n"+
+			"Either update pathExtras to match the new schema layout, or remove the stale entries.",
+		len(dangling), dangling,
+	))
 }


### PR DESCRIPTION
# Content Description

PR #2b in the DEVOPS-888 split — the human-in-loop half of [the receiver + generator work](https://linear.app/loft/issue/DEVOPS-888). PR #2a (#2072) shipped the autonomous-safe scaffolding (classifier + router + vcluster-cli flags); this one lands the receiver workflow itself plus the two generator changes that touch live partials.

Stacked on top of #2072 — when that merges, this diff shrinks to just the 4 commits below.

**What this lands**

- **D.4 — A1 extras-map preserve in `hack/vcluster/partials/main.go`.** `Extras{Before, After}` struct + `pathExtras` map carry hand-authored prose through every regeneration. A startup-time validator panics with the full sorted list of dangling keys when a schema rename or removal orphans a key — so prose can be migrated explicitly instead of silently dropped on the next dispatch. Extracts `RenderFromPath` from `hack/platform/util/schema.go` so the vcluster generator can compose schema content with extras prose before writing. Two seeded entries cover the prose currently on the live partials (`controlPlane/distro` K3s→K8s tip; `controlPlane/standalone/joinNode` security warning).
- **D.5 — A2 two-flag interface in `hack/platform/partials/main.go`.** `util.BasePath` / `util.BaseResourcesPath` go from `const` to `var`; new `--partials-base` / `--resources-base` flags override them. The dead JSON-Schema arg (post ENGNODE-78) and its imports are removed. Already validated: 113 MDX files at the redirected versioned shape.
- **D.1 — `handle-source-release.yml` receiver.** Listens for `vcluster-released | vcluster-cli-released | platform-released` repository_dispatch events plus a manual `workflow_dispatch` mirror. Validates the version, runs `classify-version.sh`, optionally checks out the released vCluster tag, runs `run-generator.sh`, opens or force-pushes a `docs-sync/<event>-<version>` PR. `client_payload` flows only through `env:` (never inline), and the version is shape-checked before any side effect.
- **CONTRIBUTING.md** — \"Adding prose to generated partials\" section explaining when to use `pathExtras` vs. a separate hand-authored partial.

**End-to-end simulation** (DRY_RUN router + real generators against `/tmp/vcluster-source` and the go.mod-pinned platform types):

| Event | Version | Target | Output |
| --- | --- | --- | --- |
| vcluster-released | v0.34.5 | `vcluster_versioned_docs/version-0.34.0/_partials/config/` | 94 MDX, both extras prose blocks at the right positions |
| platform-released | v4.6.5 | `platform_versioned_docs/version-4.6.0/api/` | 113 MDX across `_partials/resources/` + `resources/` |
| vcluster-released | v9.9.9 / v0.36.0 | (skip) | classifier correctly skips non-+1 future minors per A4 appendix B |

**Audit follow-ups filed** ([A3-cli-references AUDIT.md](.) → Linear): DEVOPS-896 (versioned routing — fulfilled by #2072), DEVOPS-897 (CI gate for generators), DEVOPS-898 (interface alignment, blocked on this PR), DEVOPS-899 (cli extras — deferred).

## Preview Link

No content changes — this PR ships generator infrastructure and CONTRIBUTING.md only. The receiver workflow's first run will be against a real release; until then there is no preview path.

## Internal Reference

Closes DEVOPS-888 (alongside #2072).
References DEVOPS-887 (the upstream `repository-dispatch@v1` action this receiver pairs with).

@netlify /docs