### PR TITLE
fix(workflows): authenticate go module fetches for private loft-sh deps

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -104,6 +104,21 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # vcluster's full module graph (pulled in by the cli generator's
+      # imports) and platform's loft-sh/api dependencies both transitively
+      # reference private loft-sh/* modules. Without git auth + GOPRIVATE,
+      # `go run` falls through to the public proxy, hits 404, then tries
+      # an unauthenticated `git ls-remote` and fails. Mirrors the pattern
+      # the legacy sync-config-schema.yaml used.
+      - name: Configure git for private loft-sh modules
+        if: steps.classify.outputs.skip != 'true'
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          set -eo pipefail
+          git config --global url."https://${GH_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+          echo "GOPRIVATE=github.com/loft-sh/*" >>"$GITHUB_ENV"
+
       # vcluster + vcluster-cli generators consume the released vCluster
       # source tree. Platform generator builds against API types pinned in
       # this repo's go.mod, so no source checkout is needed.


### PR DESCRIPTION
# Content Description

Quick fix surfaced by DEVOPS-889's pre-merge dry-run of `handle-source-release.yml`. The receiver runs the generators with a vanilla `go` toolchain on a hosted runner. The cli generator imports vcluster's full package graph, which transitively pulls private `loft-sh/*` modules (the e2e-framework dep pinned in vcluster's go.mod is the first one `go` hits).

Without `GOPRIVATE` + `insteadOf` rewrites, `go` falls through to the public proxy, hits 404, then tries an unauthenticated `git ls-remote` that dies with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

This was exactly how the legacy `sync-config-schema.yaml` in vcluster handled the same problem — copying that auth shape into the new receiver before any `go` invocation.

**Failing dry-run that surfaced it**: https://github.com/loft-sh/vcluster-docs/actions/runs/25560344393

**Why apply unconditionally to all non-skip runs**: vcluster partials and platform partials don't trigger this today (schema JSON / vendored types respectively), but as their dep graphs evolve they're likely to grow private transitive imports too. Auth gating is cheap; auth gaps surface at release time.

`GH_ACCESS_TOKEN` already exists in vcluster-docs — same secret used by `backport-docs.yml`, `sync-next-branch.yml`, `check-annotation-drift.yml`, `forwardport-docs.yml`, `sync-upstream-features.yml`.

## Preview Link

No content changes — workflow-only fix.

## Internal Reference

References DEVOPS-888 (the receiver this patches).
References DEVOPS-889 (whose dry-run surfaced this).

@netlify /docs