### PR TITLE
fix(gitignore): exclude release-dispatch source checkouts from docs-sync prs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ audits/
 justfile
 # Local Netlify folder
 .netlify
+# Release-dispatch receiver checks out upstream source under source-*/
+# (e.g. source-vcluster/) for the generators to consume. These are
+# transient working dirs, never docs content; keep them out of any
+# auto-generated docs-sync PR.
+source-*/
 # Keep Claude Code config tracked (overrides global gitignore)
 !CLAUDE.md
 !.claude


### PR DESCRIPTION
# Content Description

DEVOPS-889's first end-to-end dry-run of the receiver opened https://github.com/loft-sh/vcluster-docs/pull/2076 with a stray `source-vcluster +1 -0` line — the source tree the receiver checks out for the generator to consume gets caught by `git add -A` and lands as a gitlink/submodule pointer in the auto-generated docs-sync PR.

Harmless on disk (the generators read the directory normally) but every future receiver PR would ship with the same noise until reviewers learned to ignore it. Cheaper to fix once.

Glob the convention (`source-*/`) rather than the specific path so future generators that follow the same `source-<repo>/` layout inherit the exclusion without the receiver workflow growing an `add-paths:` list.

## Preview Link

No content changes — gitignore-only.

## Internal Reference

References DEVOPS-888 (the receiver this fixes).
References DEVOPS-889 (whose dry-run surfaced this).

@netlify /docs