### PR TITLE
fix(hack/vcluster-cli): rewrite home directory in pure go, drop ripgrep dep

### DIFF
--- a/hack/vcluster-cli/main.go
+++ b/hack/vcluster-cli/main.go
@@ -114,11 +114,38 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Fix home directory paths
-	exec.Command("sh", "-c",
-		fmt.Sprintf("rg -l '/home/[^/]+/.vcluster/config.json' --glob '*.md' %s | xargs sed -i 's|/home/[^/]\\+/.vcluster/config.json|~/.vcluster/config.json|g'", cliDocsDir)).Run()
+	// Cobra resolves os.UserHomeDir() at flag-registration time, so any
+	// flag whose default is rooted at $HOME bakes the runner's home into
+	// the generated MDX (e.g. /home/runner/.vcluster/config.json). The
+	// docs need to read as ~/. The previous shell version of this step
+	// depended on ripgrep being on PATH; on a vanilla GitHub-hosted
+	// runner it isn't, so the substitution silently no-op'd and the
+	// runner's home leaked through to the published docs. Pure-Go walk
+	// + literal replace removes the toolchain dependency.
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if err := rewriteHome(cliDocsDir, home); err != nil {
+			log.Fatalf("rewrite home in %q: %v", cliDocsDir, err)
+		}
+	}
 
 	fmt.Printf("CLI documentation generated in %s\n", cliDocsDir)
+}
+
+func rewriteHome(root, home string) error {
+	return filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(p) != ".md" {
+			return err
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		updated := strings.ReplaceAll(string(b), home, "~")
+		if updated == string(b) {
+			return nil
+		}
+		return os.WriteFile(p, []byte(updated), 0o644)
+	})
 }
 
 func copyDir(src, dst string) error {


### PR DESCRIPTION
# Content Description

DEVOPS-889's first end-to-end run of the new release-dispatch receiver against the cli generator surfaced a content regression in https://github.com/loft-sh/vcluster-docs/pull/2076:

```
- (default \"~/.vcluster/config.json\")
+ (default \"/home/runner/.vcluster/config.json\")
```

across 90+ files.

**Root cause**: Cobra resolves `os.UserHomeDir()` at flag-registration time, so any flag whose default is rooted at `$HOME` bakes the runner's home into the generated MDX. The legacy fix on line 119 piped `rg` into `sed` — ripgrep isn't on PATH on a vanilla github-hosted runner, so the substitution silently no-op'd as soon as `handle-source-release.yml` started invoking this generator from a stock `ubuntu-latest` image.

**Fix**: pure-Go walk + literal replace, keyed on the generator's own `os.UserHomeDir()`. Removes the ripgrep dependency, covers any future `$HOME`-rooted flag default without per-pattern grep updates, and works identically in local dev (where the runner's home matches the local home and there's nothing to rewrite).

**Verified**: file-level `go build ./main.go` clean (the constraint per the existing factual memory — full module build is intentionally not viable for this generator).

## Preview Link

No content changes in this PR; the receiver's next dry-run will regenerate the cli docs cleanly.

## Internal Reference

References DEVOPS-888 (the receiver work this fixes).
References DEVOPS-889 (whose dry-run surfaced this).

@netlify /docs