### PR TITLE
docs(workflows): make handle-source-release version input description event-aware

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -39,7 +39,7 @@ on:
           - vcluster-cli-released
           - platform-released
       version:
-        description: 'Released version, e.g. v0.34.5'
+        description: 'Released version (vcluster: vX.Y.Z e.g. v0.34.5; platform: vX.Y.Z e.g. v4.6.0). Must match a real released tag.'
         required: true
         type: string
 


### PR DESCRIPTION
# Content Description

DEVOPS-889 noticed the `workflow_dispatch` `version` input description on `handle-source-release.yml` only shows a vcluster-shaped example (`v0.34.5`), which primes the wrong mental model when an operator re-runs the receiver for `platform-released` (current platform major is v4). Under release-day pressure that's the kind of thing that produces a wrong manual rerun.

Cosmetic only — both shapes still validate via the same `vX.Y.Z[-pre]` regex in the resolve step. Only the human-facing hint changes.

## Preview Link

No content changes — workflow input description only.

## Internal Reference

References DEVOPS-888.

@netlify /docs