### PR TITLE
fix(workflows): bump loft-sh/api pins on platform-released before regen

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -13,10 +13,14 @@
 # interpolated into a `run:` block, and the classifier rejects malformed
 # versions before any side-effect runs.
 #
-# Known gap (tracked separately): platform-released regenerates against
-# the loft-sh/api version pinned in go.mod here, not the just-released
-# one. A "Sync API" workflow is expected to PR a go.mod bump on platform
-# releases — this receiver consumes whatever is on main when it runs.
+# For platform-released the receiver also bumps loft-sh/api +
+# loft-sh/agentapi pins in go.mod to the released version before running
+# the platform partials generator. The generator reflects against
+# vendored Go types, so without the bump the regen would silently
+# produce no diff against the previous release's types and no PR would
+# open. The bumped go.mod + go.sum land in the same docs-sync PR
+# alongside the regenerated partials — both have to ship together to
+# compile on next regen.
 
 name: handle-source-release
 
@@ -119,9 +123,31 @@ jobs:
           git config --global url."https://${GH_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
           echo "GOPRIVATE=github.com/loft-sh/*" >>"$GITHUB_ENV"
 
+      # The platform partials generator reflects against the loft-sh/api +
+      # loft-sh/agentapi types pinned in this repo's go.mod. Without bumping
+      # the pins to the just-released version, the regen sees identical
+      # types to last time and emits no diff — the receiver would silently
+      # produce no PR. The legacy sync-api.yaml `update-docs` job did this
+      # bump before opening the docs PR; with that job removed in DEVOPS-889
+      # PR #4, the bump moves here. Major-version segment is taken from the
+      # released version itself, so a future v5 cutover doesn't need code.
+      - name: Bump loft-sh/api + loft-sh/agentapi pins to released platform version
+        if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+        run: |
+          set -eo pipefail
+          stripped="${VERSION#v}"
+          major="v${stripped%%.*}"
+          echo "Bumping github.com/loft-sh/{api,agentapi}/${major} to ${VERSION}"
+          go mod edit -require "github.com/loft-sh/agentapi/${major}@${VERSION}"
+          go mod edit -require "github.com/loft-sh/api/${major}@${VERSION}"
+          go mod tidy
+
       # vcluster + vcluster-cli generators consume the released vCluster
       # source tree. Platform generator builds against API types pinned in
-      # this repo's go.mod, so no source checkout is needed.
+      # this repo's go.mod (see bump step above), so no source checkout is
+      # needed.
       - name: Checkout vCluster source
         if: steps.classify.outputs.skip != 'true' && (steps.inputs.outputs.event == 'vcluster-released' || steps.inputs.outputs.event == 'vcluster-cli-released')
         uses: actions/checkout@v4


### PR DESCRIPTION
# Content Description

DEVOPS-889 surfaced this during their pre-merge dry-run of the receiver against `platform-released v4.9.0`:

```
classify-version: skip=false, target=platform_versioned_docs/version-4.9.0 ✓
Generate docs: exit 0
Open or update PR: ::notice::No content changes for platform-released v4.9.0
```

**Root cause**: the platform partials generator reflects against vendored Go types. The legacy `sync-api.yaml` `update-docs` job (commit `e2a6c70823` in loft-enterprise) bumped `loft-sh/api` and `loft-sh/agentapi` pins in `go.mod` *before* running the generator, so the regen was always against the just-released types. DEVOPS-889's PR #4 removes that job on the assumption the new dispatch architecture replaces it — but the receiver only ran the generator, never the bump. With v4.8.1 still pinned, regen sees identical types to last time → zero diff → silent no-PR.

**Fix**: move the bump into the receiver, gated on `event == 'platform-released'` so vcluster paths are unaffected. Mirrors the legacy `update-docs` shape:

```yaml
go mod edit -require "github.com/loft-sh/agentapi/${major}@${VERSION}"
go mod edit -require "github.com/loft-sh/api/${major}@${VERSION}"
go mod tidy
```

Major-version segment is extracted from the released tag itself, so a future v5 cutover doesn't need a code change here. The bumped `go.mod` + `go.sum` land in the same `docs-sync/<event>-<version>` PR alongside the regenerated partials — both have to ship together to compile.

`go mod tidy` needs git auth to fetch the private modules; the existing `Configure git for private loft-sh modules` step (PR #2075) runs before this and provides it.

**Validation plan after merge**: `workflow_dispatch` on this workflow with `event_type=platform-released, version=v4.9.0` (or whatever the next platform release tag is). Expect a docs-sync PR with: bumped pins in go.mod/go.sum, regenerated MDX under `platform_versioned_docs/version-4.9.0/api/`.

## Preview Link

No content changes — workflow only.

## Internal Reference

References DEVOPS-888 (the receiver this completes).
References DEVOPS-889 (whose dry-run surfaced this gap).

@netlify /docs