### PR TITLE
fix(receiver): re-vendor after platform pin bump

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -131,6 +131,14 @@ jobs:
       # bump before opening the docs PR; with that job removed in DEVOPS-889
       # PR #4, the bump moves here. Major-version segment is taken from the
       # released version itself, so a future v5 cutover doesn't need code.
+      #
+      # `go mod vendor` is load-bearing: this repo carries a `vendor/` tree
+      # and `go run` resolves with vendor semantics. Without re-vendoring,
+      # `vendor/modules.txt` still records the previous version while go.mod
+      # claims the new one and the generator fails with "inconsistent
+      # vendoring". The bumped vendor tree ships in the same docs-sync PR
+      # alongside go.mod/go.sum + regenerated partials — they have to ship
+      # together to compile on next regen.
       - name: Bump loft-sh/api + loft-sh/agentapi pins to released platform version
         if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
         env:
@@ -143,6 +151,7 @@ jobs:
           go mod edit -require "github.com/loft-sh/agentapi/${major}@${VERSION}"
           go mod edit -require "github.com/loft-sh/api/${major}@${VERSION}"
           go mod tidy
+          go mod vendor
 
       # vcluster + vcluster-cli generators consume the released vCluster
       # source tree. Platform generator builds against API types pinned in


### PR DESCRIPTION
## Summary

PR #2081 added the platform pin bump (`go mod edit -require` + `go mod tidy`) to the release-dispatch receiver, but stopped short of `go mod vendor`. This repo carries a `vendor/` tree, so `go run` resolves with vendor semantics; `go mod tidy` updated go.mod/go.sum but `vendor/modules.txt` still recorded the previous platform version, and the platform partials generator failed with `inconsistent vendoring` before producing any output. No docs-sync PR opened.

DEVOPS-889 caught this with the platform-released v4.9.0 dispatch ([run 25565980645](https://github.com/loft-sh/vcluster-docs/actions/runs/25565980645)).

## Fix

Add `go mod vendor` after `go mod tidy` in the bump step. The bumped vendor tree now ships in the same docs-sync PR alongside go.mod/go.sum + regenerated partials — they have to ship together to compile on next regen.

Local repro confirmed:
```
go mod edit -require=github.com/loft-sh/api/v4@v4.9.0
go mod edit -require=github.com/loft-sh/agentapi/v4@v4.9.0
go mod tidy && go mod vendor
grep -E '^# github.com/loft-sh/(api|agentapi)/v4 ' vendor/modules.txt
# github.com/loft-sh/agentapi/v4 v4.9.0
# github.com/loft-sh/api/v4 v4.9.0
```

## Test plan

- [x] Local repro of the failing case + fix
- [ ] DEVOPS-889 re-runs platform-released v4.9.0 dispatch after merge → expect a real docs-sync PR with bumped go.mod, go.sum, vendor/, and regenerated platform partials in one commit

References DEVOPS-888.