### PR TITLE
fix(platform-partials): drop removed RancherIntegrationSpec generation

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -45,7 +45,12 @@ func main() {
 	util.GenerateSection(&managementv1.ConfigStatus{}, true, path.Join(util.BasePath, "config/status_reference.mdx"))
 	util.GenerateSection(&managementv1.AuditPolicy{}, true, path.Join(util.BasePath, "config/status/audit/policy.mdx"))
 	util.GenerateSection(&managementv1.Audit{}, true, path.Join(util.BasePath, "config/status/audit.mdx"))
-	util.GenerateSection(&storagev1.RancherIntegrationSpec{}, true, path.Join(util.BasePath, "projects/spec/rancher.mdx"))
+	// RancherIntegrationSpec was removed from loft-sh/api/v4 in v4.9.0 — the
+	// legacy in-tree Rancher integration is replaced by the standalone
+	// vCluster Rancher operator (see /docs/platform/integrations/rancher and
+	// the migration guide). The previously-generated rancher.mdx is only
+	// imported by frozen versioned docs (4.5/4.6/4.7), which ship their own
+	// partial copies; current platform docs do not import it.
 	util.GenerateSection(&storagev1.VaultIntegrationSpec{}, true, path.Join(util.BasePath, "projects/spec/vault.mdx"))
 
 	util.GenerateMetadata(&util.ObjectInformation{


### PR DESCRIPTION
## Summary

`loft-sh/api/v4` v4.9.0 removed `RancherIntegrationSpec` entirely — the legacy in-tree Rancher integration is replaced by the standalone vCluster Rancher operator. The platform partials generator referenced the type at `hack/platform/partials/main.go:48`, so on the first `platform-released` dispatch after v4.9.0 the generator failed to compile (`undefined: storagev1.RancherIntegrationSpec`) and no docs-sync PR opened.

Caught end-to-end by DEVOPS-889's loft-enterprise sender test ([run 25566461086](https://github.com/loft-sh/vcluster-docs/actions/runs/25566461086)).

## Why dropping is safe

The generated `rancher.mdx` partial is only imported by frozen versioned docs:
- `platform_versioned_docs/version-4.7.0/integrations/rancher/rancher-integration.mdx`
- `platform_versioned_docs/version-4.6.0/integrations/rancher/rancher-integration.mdx`
- `platform_versioned_docs/version-4.5.0/integrations/rancher/rancher-integration.mdx`

Versioned docs ship their own frozen partial copies — they do not regenerate. Current `platform/` docs do not reference the partial.

## Local verification

```
go mod edit -require=github.com/loft-sh/api/v4@v4.9.0
go mod edit -require=github.com/loft-sh/agentapi/v4@v4.9.0
go mod tidy && go mod vendor
go build ./hack/platform/partials/   # clean
```

## Broader pattern (follow-up)

This is the second "real-data regen surfaces edge cases not in sample fixtures" finding (after the four #2075/#2077/#2078/#2081/#2082 receiver-side fixes). The platform partials generator compiles against vendored Go types, so any upstream rename/removal silently breaks it on next release. Worth a separate ticket for either:
- weekly drift-detection CI that bumps to `loft-sh/api/v4@main` and runs the generator pre-release, or
- migrating to a JSON-Schema-driven generator like the vcluster partials path uses (only sees field renames, never breaks compile).

For now, fix-on-detection is acceptable — the receiver makes the failure loud, not silent.

## Test plan

- [x] `go build ./hack/platform/partials/` clean against v4.9.0
- [ ] DEVOPS-889 retriggers loft-enterprise sender → expect end-to-end docs-sync PR with bumped go.mod/go.sum/vendor/ + regenerated platform partials

References DEVOPS-888.