### PR TITLE
fix(doc-1404): resolve all broken anchor and HTML warnings in versioned docs

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -401,7 +401,8 @@ export const InlineSearch = () => {
     margin: 0 0 0.4rem 0;
     font-size: 1.05rem;
   }
-  .audience-card p {
+  .audience-card .card-desc {
+    display: block;
     margin: 0;
     font-size: 0.9rem;
     color: var(--ifm-color-content-secondary);
@@ -424,17 +425,17 @@ export const InlineSearch = () => {
   <Link to="/vcluster/quick-start/standalone" className="audience-card">
     <span className="audience-label">AI Cloud &amp; GPU Platforms</span>
     <h3>Build a managed Kubernetes platform</h3>
-    <p>Deliver dedicated tenant clusters over GPU infrastructure. Full isolation, no cluster-per-tenant overhead.</p>
+    <span className="card-desc">Deliver dedicated tenant clusters over GPU infrastructure. Full isolation, no cluster-per-tenant overhead.</span>
   </Link>
   <Link to="/platform/" className="audience-card">
     <span className="audience-label">Enterprise Platform Teams</span>
     <h3>Manage tenant isolation at scale</h3>
-    <p>Central management, access control, and lifecycle operations across all tenant clusters and environments.</p>
+    <span className="card-desc">Central management, access control, and lifecycle operations across all tenant clusters and environments.</span>
   </Link>
   <Link to="/vcluster/" className="audience-card">
     <span className="audience-label">Developers &amp; CI</span>
     <h3>Spin up isolated clusters fast</h3>
-    <p>Isolated Kubernetes environments for testing, development, and CI pipelines. Runs on Kubernetes or Docker.</p>
+    <span className="card-desc">Isolated Kubernetes environments for testing, development, and CI pipelines. Runs on Kubernetes or Docker.</span>
   </Link>
 </div>
 
@@ -453,15 +454,15 @@ export const InlineSearch = () => {
     <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.25rem'}}>
       <Link to="/vcluster/introduction/what-are-virtual-clusters/" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>What is vCluster</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Tenant isolation, tenancy models, and features.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Tenant isolation, tenancy models, and features.</span>
       </Link>
       <Link to="/vcluster/introduction/architecture/" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Architecture</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Control plane, tenancy models, and syncer internals.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Control plane, tenancy models, and syncer internals.</span>
       </Link>
       <Link to="/vcluster/deploy/control-plane/kubernetes-pod/basics" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Deploy</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Deploy tenant clusters with Helm, CLI, Terraform, or ArgoCD.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Deploy tenant clusters with Helm, CLI, Terraform, or ArgoCD.</span>
       </Link>
     </div>
   </div>
@@ -476,15 +477,15 @@ export const InlineSearch = () => {
     <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.25rem'}}>
       <Link to="/platform/" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Get Started</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vCluster Platform.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vCluster Platform.</span>
       </Link>
       <Link to="/platform/configure/introduction" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Configure</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure Platform settings and options.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure Platform settings and options.</span>
       </Link>
       <Link to="/platform/administer/users-permissions/overview/" className="card feature-card" style={{padding: '0.75rem 1rem'}}>
         <h4 style={{margin: 0, fontSize: '1rem'}}>Administer</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Manage users, teams, and platform operations.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Manage users, teams, and platform operations.</span>
       </Link>
     </div>
   </div>
@@ -499,15 +500,15 @@ export const InlineSearch = () => {
     <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.25rem'}}>
       <a href="https://www.vnode.com/docs/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Get Started</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vNode.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vNode.</span>
       </a>
       <a href="https://www.vnode.com/docs/configuration/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Configure</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure vNode Helm chart values and runtime settings.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure vNode Helm chart values and runtime settings.</span>
       </a>
       <a href="https://www.vnode.com/docs/architecture/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Architecture</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>vNode sandboxes pods with Linux user namespaces.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>vNode sandboxes pods with Linux user namespaces.</span>
       </a>
     </div>
   </div>
@@ -522,15 +523,15 @@ export const InlineSearch = () => {
     <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.25rem'}}>
       <a href="https://www.vmetal.ai/docs/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Get Started</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vMetal.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Quick start guide for vMetal.</span>
       </a>
       <a href="https://www.vmetal.ai/docs/configuration/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Configure</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure vMetal settings and deployment options.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>Configure vMetal settings and deployment options.</span>
       </a>
       <a href="https://www.vmetal.ai/docs/architecture/" className="card feature-card" style={{padding: '0.75rem 1rem'}} target="_blank" rel="noopener noreferrer">
         <h4 style={{margin: 0, fontSize: '1rem'}}>Architecture</h4>
-        <p style={{margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>vMetal bare-metal provisioning architecture.</p>
+        <span style={{display: 'block', margin: '0.25rem 0 0 0', fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>vMetal bare-metal provisioning architecture.</span>
       </a>
     </div>
   </div>
@@ -539,9 +540,7 @@ export const InlineSearch = () => {
 <div style={{marginTop: '2rem', marginBottom: '3rem'}}>
   <h2 style={{marginBottom: '2rem'}}>Try vCluster Platform</h2>
   <div className="intro-card">
-    <p style={{fontSize: '1.1rem', marginBottom: '1.5rem', color: 'var(--ifm-color-content-secondary)'}}>
-      Create your own platform instance, connect a cluster, and deploy tenant clusters. The platform provides centralized management, access control, and operational features across all your environments.
-    </p>
+    <p style={{fontSize: '1.1rem', marginBottom: '1.5rem', color: 'var(--ifm-color-content-secondary)'}}>Create your own platform instance, connect a cluster, and deploy tenant clusters. The platform provides centralized management, access control, and operational features across all your environments.</p>
     <a href="https://vcluster.cloud" className="button button--primary" style={{textDecoration: 'none', padding: '0.75rem 1.25rem', fontSize: '1.05rem'}}>Get Started →</a>
   </div>
 </div>

--- a/platform_versioned_docs/version-4.6.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.6.0/administer/node-providers/kubevirt.mdx
@@ -461,7 +461,9 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
+<!-- vale Vale.Terms = NO -->
 ### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
+<!-- vale Vale.Terms = YES -->
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.6.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.6.0/administer/node-providers/kubevirt.mdx
@@ -461,7 +461,7 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
-### `kubevirt.vcluster.com/network-attachment-definition`
+### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.6.0/configure/agent-settings/security-context.mdx
+++ b/platform_versioned_docs/version-4.6.0/configure/agent-settings/security-context.mdx
@@ -80,7 +80,7 @@ agentValues:
 #### Cluster-specific security context
 As mentioned [here](customization.mdx), you can customize the agent in each connected host cluster independently. 
 
-To achieve cluster-specific security context, you can override security contexts for specific clusters using the [`loft.sh/agent-values` annotation](overview#loftsh-annotations):
+To achieve cluster-specific security context, you can override security contexts for specific clusters using the [`loft.sh/agent-values` annotation](customization#loftsh-annotations):
 
 ```yaml title="Example of cluster-specific-agent-values.yaml"
 # Applied via loft.sh/agent-values annotation on the Cluster resource
@@ -102,4 +102,4 @@ podSecurityContext:
   - 5000
 ```
 
-Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](overview#override-values) and add your security context configuration in the Extra Agent Values text area.
+Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](customization#override-values) and add your security context configuration in the Extra Agent Values text area.

--- a/platform_versioned_docs/version-4.7.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.7.0/administer/node-providers/kubevirt.mdx
@@ -461,7 +461,9 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
+<!-- vale Vale.Terms = NO -->
 ### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
+<!-- vale Vale.Terms = YES -->
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.7.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.7.0/administer/node-providers/kubevirt.mdx
@@ -461,7 +461,7 @@ DNS nameservers to configure in the VM. Example: `8.8.8.8,8.8.4.4`
 Allows providing a complete custom network configuration for cloud-init.
 When set, this overrides automatic network configuration.
 
-### `kubevirt.vcluster.com/network-attachment-definition`
+### `kubevirt.vcluster.com/network-attachment-definition` {#kubevirt-vcluster-com-network-attachment-definition}
 
 **Type:** `string` (format: `[<namespace>/]<name>`)
 

--- a/platform_versioned_docs/version-4.7.0/configure/agent-settings/security-context.mdx
+++ b/platform_versioned_docs/version-4.7.0/configure/agent-settings/security-context.mdx
@@ -80,7 +80,7 @@ agentValues:
 #### Cluster-specific security context
 As mentioned [here](customization.mdx), you can customize the agent in each connected host cluster independently. 
 
-To achieve cluster-specific security context, you can override security contexts for specific clusters using the [`loft.sh/agent-values` annotation](overview#loftsh-annotations):
+To achieve cluster-specific security context, you can override security contexts for specific clusters using the [`loft.sh/agent-values` annotation](customization#loftsh-annotations):
 
 ```yaml title="Example of cluster-specific-agent-values.yaml"
 # Applied via loft.sh/agent-values annotation on the Cluster resource
@@ -102,4 +102,4 @@ podSecurityContext:
   - 5000
 ```
 
-Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](overview#override-values) and add your security context configuration in the Extra Agent Values text area.
+Or you can apply cluster-specific security context through the UI by following the steps in [Setting Agent Values via UI](customization#override-values) and add your security context configuration in the Extra Agent Values text area.

--- a/vcluster_versioned_docs/version-0.30.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_fragments/integrations/cert-manager.mdx
@@ -43,7 +43,7 @@ This configuration enables the integration and configures automatic resource syn
 
 ## Set up cluster contexts
 
-Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/#deploy-vcluster).
+Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/).
 Configure cluster contexts to simplify switching between host and virtual clusters:
 
 ```bash

--- a/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-configmap-example.mdx
@@ -51,7 +51,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync ConfigMap to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -102,7 +102,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync namespaced CustomResource to virtual cluster

--- a/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_fragments/sync-from-host-secret-example.mdx
@@ -53,7 +53,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync Secret to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.30.0/_partials/quick-start-guide/key-concepts.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/_partials/quick-start-guide/key-concepts.mdx
@@ -3,6 +3,6 @@ a certain level of tenancy for your virtual cluster.
 
 - [**Architecture of Tenancy Models**](../../introduction/architecture.mdx): Different tenancy models can be achieved based on how the vCluster is built, but the main two
 components that will dictate your tenancy models are the vCluster control plane and worker nodes.
-- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane): Contains a Kubernetes API server, a controller manager and a data store mount. 
+- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane-as-a-container): Contains a Kubernetes API server, a controller manager and a data store mount. 
 - [**Worker Nodes**](../../configure/tenancy-model.mdx): Worker nodes can be either from the host cluster that the vCluster control plane is deployed on.
 

--- a/vcluster_versioned_docs/version-0.30.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -77,7 +77,7 @@ Normal pod restarts or terminations do not require manual recovery. These events
 Recovery procedures depend on whether the first replica (the pod ending with `-0`) is among the failing replicas.
 
 :::note
-The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the [first replica recovery section](#migrate-to-parallel) for details on migrating between policies if needed.
+The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the first replica recovery section below for details on migrating between policies if needed.
 :::
 
 :::info Find your vCluster namespace
@@ -174,7 +174,7 @@ If using namespace syncing, back up all synced namespaces on the host cluster as
 The recovery procedure depends on your StatefulSet `podManagementPolicy` configuration. vCluster version 0.20 and later use `Parallel` by default. Earlier versions used `OrderedReady`.
 
 :::info
-If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first [migrate to `Parallel`](#migrate-to-parallel) before attempting recovery.
+If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first migrate to `Parallel` (see below) before attempting recovery.
 :::
 
 Check your configuration:
@@ -262,7 +262,6 @@ Delete the StatefulSet without deleting the pods:
 </Step>
 
 <Step title="Update configuration to Parallel">
-<a id="migrate-to-parallel"></a>
 
 Update your virtual cluster configuration to use `Parallel` pod management policy.
 

--- a/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
@@ -288,7 +288,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 The `--force-join` flag leads to running containers being killed via the
 container runtime and being restarted by the kubelet. If you have a
 stateful application running that requires graceful termination, please ensure
-that you have performed the necessary steps beforehand (vcluster node delete,
+that you have performed the necessary steps beforehand (`vcluster node delete`,
 backups etc.).
 :::
 

--- a/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
@@ -86,7 +86,7 @@ The restart does not affect running application workloads because the underlying
   language="bash"
 />
 
-Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-the-ca-certificate).
+Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificate).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
 ## Changing the CA certificate

--- a/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
@@ -284,6 +284,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
+<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
     :::warning
     The `--force-join` flag leads to running containers being killed via the
     container runtime and being restarted by the kubelet. If you have a
@@ -291,6 +292,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
     that you have performed the necessary steps beforehand (vcluster node delete,
     backups etc.).
     :::
+<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.30.0/manage/certificates.mdx
@@ -284,15 +284,13 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
-<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
-    :::warning
-    The `--force-join` flag leads to running containers being killed via the
-    container runtime and being restarted by the kubelet. If you have a
-    stateful application running that requires graceful termination, please ensure
-    that you have performed the necessary steps beforehand (vcluster node delete,
-    backups etc.).
-    :::
-<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
+:::warning
+The `--force-join` flag leads to running containers being killed via the
+container runtime and being restarted by the kubelet. If you have a
+stateful application running that requires graceful termination, please ensure
+that you have performed the necessary steps beforehand (vcluster node delete,
+backups etc.).
+:::
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.31.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_fragments/integrations/cert-manager.mdx
@@ -43,7 +43,7 @@ This configuration enables the integration and configures automatic resource syn
 
 ## Set up cluster contexts
 
-Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/#deploy-vcluster).
+Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/).
 Configure cluster contexts to simplify switching between host and virtual clusters:
 
 ```bash

--- a/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-configmap-example.mdx
@@ -51,7 +51,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync ConfigMap to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -102,7 +102,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync namespaced CustomResource to virtual cluster

--- a/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_fragments/sync-from-host-secret-example.mdx
@@ -53,7 +53,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync Secret to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.31.0/_partials/quick-start-guide/key-concepts.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/_partials/quick-start-guide/key-concepts.mdx
@@ -3,6 +3,6 @@ a certain level of tenancy for your virtual cluster.
 
 - [**Architecture of Tenancy Models**](../../introduction/architecture.mdx): Different tenancy models can be achieved based on how the vCluster is built, but the main two
 components that will dictate your tenancy models are the vCluster control plane and worker nodes.
-- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane): Contains a Kubernetes API server, a controller manager and a data store mount. 
+- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane-as-a-container): Contains a Kubernetes API server, a controller manager and a data store mount. 
 - [**Worker Nodes**](../../configure/tenancy-model.mdx): Worker nodes can be either from the host cluster that the vCluster control plane is deployed on.
 

--- a/vcluster_versioned_docs/version-0.31.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -80,7 +80,7 @@ Normal pod restarts or terminations do not require manual recovery. These events
 Recovery procedures depend on whether the first replica (the pod ending with `-0`) is among the failing replicas.
 
 :::note
-The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the [first replica recovery section](#migrate-to-parallel) for details on migrating between policies if needed.
+The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the first replica recovery section below for details on migrating between policies if needed.
 :::
 
 :::info Find your vCluster namespace
@@ -177,7 +177,7 @@ If using namespace syncing, back up all synced namespaces on the host cluster as
 The recovery procedure depends on your StatefulSet `podManagementPolicy` configuration. vCluster version 0.20 and later use `Parallel` by default. Earlier versions used `OrderedReady`.
 
 :::info
-If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first [migrate to `Parallel`](#migrate-to-parallel) before attempting recovery.
+If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first migrate to `Parallel` (see below) before attempting recovery.
 :::
 
 Check your configuration:
@@ -265,7 +265,6 @@ Delete the StatefulSet without deleting the pods:
 </Step>
 
 <Step title="Update configuration to Parallel">
-<a id="migrate-to-parallel"></a>
 
 Update your virtual cluster configuration to use `Parallel` pod management policy.
 

--- a/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
@@ -288,7 +288,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 The `--force-join` flag leads to running containers being killed via the
 container runtime and being restarted by the kubelet. If you have a
 stateful application running that requires graceful termination, please ensure
-that you have performed the necessary steps beforehand (vcluster node delete,
+that you have performed the necessary steps beforehand (`vcluster node delete`,
 backups etc.).
 :::
 

--- a/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
@@ -86,7 +86,7 @@ The restart does not affect running application workloads because the underlying
   language="bash"
 />
 
-Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-the-ca-certificate).
+Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificate).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
 ## Changing the CA certificate

--- a/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
@@ -284,6 +284,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
+<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
     :::warning
     The `--force-join` flag leads to running containers being killed via the
     container runtime and being restarted by the kubelet. If you have a
@@ -291,6 +292,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
     that you have performed the necessary steps beforehand (vcluster node delete,
     backups etc.).
     :::
+<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.31.0/manage/certificates.mdx
@@ -284,15 +284,13 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
-<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
-    :::warning
-    The `--force-join` flag leads to running containers being killed via the
-    container runtime and being restarted by the kubelet. If you have a
-    stateful application running that requires graceful termination, please ensure
-    that you have performed the necessary steps beforehand (vcluster node delete,
-    backups etc.).
-    :::
-<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
+:::warning
+The `--force-join` flag leads to running containers being killed via the
+container runtime and being restarted by the kubelet. If you have a
+stateful application running that requires graceful termination, please ensure
+that you have performed the necessary steps beforehand (vcluster node delete,
+backups etc.).
+:::
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.32.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_fragments/integrations/cert-manager.mdx
@@ -43,7 +43,7 @@ This configuration enables the integration and configures automatic resource syn
 
 ## Set up cluster contexts
 
-Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/#deploy-vcluster).
+Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/).
 Configure cluster contexts to simplify switching between host and virtual clusters:
 
 ```bash

--- a/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-configmap-example.mdx
@@ -51,7 +51,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync ConfigMap to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -102,7 +102,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync namespaced CustomResource to virtual cluster

--- a/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_fragments/sync-from-host-secret-example.mdx
@@ -53,7 +53,7 @@ This configuration:
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
+guide](/vcluster/).
 :::
 
 ### Sync Secret to virtual cluster and use it in pod

--- a/vcluster_versioned_docs/version-0.32.0/_partials/quick-start-guide/key-concepts.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/_partials/quick-start-guide/key-concepts.mdx
@@ -3,6 +3,6 @@ a certain level of tenancy for your virtual cluster.
 
 - [**Architecture of Tenancy Models**](../../introduction/architecture.mdx): Different tenancy models can be achieved based on how the vCluster is built, but the main two
 components that will dictate your tenancy models are the vCluster control plane and worker nodes.
-- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane): Contains a Kubernetes API server, a controller manager and a data store mount. 
+- [**vCluster Control Plane**](../../introduction/architecture.mdx#virtual-control-plane-as-a-container): Contains a Kubernetes API server, a controller manager and a data store mount. 
 - [**Worker Nodes**](../../configure/tenancy-model.mdx): Worker nodes can be either from the host cluster that the vCluster control plane is deployed on.
 

--- a/vcluster_versioned_docs/version-0.32.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -80,7 +80,7 @@ Normal pod restarts or terminations do not require manual recovery. These events
 Recovery procedures depend on whether the first replica (the pod ending with `-0`) is among the failing replicas.
 
 :::note
-The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the [first replica recovery section](#migrate-to-parallel) for details on migrating between policies if needed.
+The recovery procedure for the first replica also depends on your StatefulSet's `podManagementPolicy` configuration (`Parallel` or `OrderedReady`). See the first replica recovery section below for details on migrating between policies if needed.
 :::
 
 :::info Find your vCluster namespace
@@ -177,7 +177,7 @@ If using namespace syncing, back up all synced namespaces on the host cluster as
 The recovery procedure depends on your StatefulSet `podManagementPolicy` configuration. vCluster version 0.20 and later use `Parallel` by default. Earlier versions used `OrderedReady`.
 
 :::info
-If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first [migrate to `Parallel`](#migrate-to-parallel) before attempting recovery.
+If more than one pod is down with `podManagementPolicy: OrderedReady`, you must first migrate to `Parallel` (see below) before attempting recovery.
 :::
 
 Check your configuration:
@@ -265,7 +265,6 @@ Delete the StatefulSet without deleting the pods:
 </Step>
 
 <Step title="Update configuration to Parallel">
-<a id="migrate-to-parallel"></a>
 
 Update your virtual cluster configuration to use `Parallel` pod management policy.
 

--- a/vcluster_versioned_docs/version-0.32.0/deploy/control-plane/binary/manage.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/deploy/control-plane/binary/manage.mdx
@@ -39,7 +39,7 @@ When a standalone cluster is connected to <Link to="/docs/platform">vCluster Pla
   </Step>
 </Flow>
 
-For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone). Review the [standalone limitations](./README.mdx#other-vcluster-feature-limitations) before changing settings.
+For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone). Review the [standalone limitations](./README.mdx) before changing settings.
 
 ### Add and remove nodes
 

--- a/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
@@ -288,7 +288,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 The `--force-join` flag leads to running containers being killed via the
 container runtime and being restarted by the kubelet. If you have a
 stateful application running that requires graceful termination, please ensure
-that you have performed the necessary steps beforehand (vcluster node delete,
+that you have performed the necessary steps beforehand (`vcluster node delete`,
 backups etc.).
 :::
 

--- a/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
@@ -86,7 +86,7 @@ The restart does not affect running application workloads because the underlying
   language="bash"
 />
 
-Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-the-ca-certificate).
+Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificate).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
 ## Changing the CA certificate

--- a/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
@@ -284,6 +284,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
+<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
     :::warning
     The `--force-join` flag leads to running containers being killed via the
     container runtime and being restarted by the kubelet. If you have a
@@ -291,6 +292,7 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
     that you have performed the necessary steps beforehand (vcluster node delete,
     backups etc.).
     :::
+<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
+++ b/vcluster_versioned_docs/version-0.32.0/manage/certificates.mdx
@@ -284,15 +284,13 @@ After a CA rotation or restoration, you need to re-create a token to join the vi
 
     Copy the command and append the `--force-join` flag. Run the updated command on every private node.
 
-<!-- vale Loft.no-indented-admonitions-in-steps = NO -->
-    :::warning
-    The `--force-join` flag leads to running containers being killed via the
-    container runtime and being restarted by the kubelet. If you have a
-    stateful application running that requires graceful termination, please ensure
-    that you have performed the necessary steps beforehand (vcluster node delete,
-    backups etc.).
-    :::
-<!-- vale Loft.no-indented-admonitions-in-steps = YES -->
+:::warning
+The `--force-join` flag leads to running containers being killed via the
+container runtime and being restarted by the kubelet. If you have a
+stateful application running that requires graceful termination, please ensure
+that you have performed the necessary steps beforehand (vcluster node delete,
+backups etc.).
+:::
 
     ```bash
     curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join

--- a/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/manage.mdx
+++ b/vcluster_versioned_docs/version-0.33.0/deploy/control-plane/binary/manage.mdx
@@ -39,7 +39,7 @@ When a standalone cluster is connected to <Link to="/docs/platform">vCluster Pla
   </Step>
 </Flow>
 
-For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone.mdx). Review the [standalone limitations](./README.mdx#other-vcluster-feature-limitations) before changing settings.
+For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone.mdx). Review the [standalone limitations](./README.mdx) before changing settings.
 
 ### Add and remove nodes
 

--- a/vcluster_versioned_docs/version-0.34.0/deploy/control-plane/binary/manage.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/deploy/control-plane/binary/manage.mdx
@@ -39,7 +39,7 @@ When a standalone cluster is connected to <Link to="/docs/platform">vCluster Pla
   </Step>
 </Flow>
 
-For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone.mdx). Review the [standalone limitations](./overview.mdx#other-vcluster-feature-limitations) before changing settings.
+For the full configuration reference, see `config.yaml` in the [standalone configuration reference](../../../configure/vcluster-yaml/control-plane/components/standalone.mdx). Review the [standalone limitations](./overview.mdx) before changing settings.
 
 ### Add and remove nodes
 


### PR DESCRIPTION
# Content Description

Fixes all broken anchor warnings emitted during `npm run build` across versioned vcluster docs (0.30–0.34) and platform docs (4.6–4.7), and resolves an HTML minifier warning on the `/docs/` home page.

**Anchor fixes (7 categories, 29 files):**
- Removed non-existent `#other-vcluster-feature-limitations` fragment from standalone `manage.mdx` links (0.32–0.34)
- Corrected `#virtual-control-plane` → `#virtual-control-plane-as-a-container` in quick-start key-concepts (0.30–0.32)
- Removed `<a id="migrate-to-parallel">` (Docusaurus 3 ignores `<a id>` anchors) and converted two internal links to plain text in `embedded.mdx` (0.30–0.32)
- Removed non-existent `#deploy-vcluster` fragment from quick-start links in 12 fragment files (0.30–0.32)
- Fixed `#rotate-the-ca-certificate` → `#rotate-ca-certificate` in `certificates.mdx` (0.30–0.32)
- Added explicit `{#kubevirt-vcluster-com-network-attachment-definition}` to heading (github-slugger drops dots/slashes) in `kubevirt.mdx` (platform 4.6–4.7)
- Fixed `overview#loftsh-annotations` → `customization#loftsh-annotations` and `overview#override-values` → `customization#override-values` in `security-context.mdx` (platform 4.6–4.7)

**HTML minifier fix (`docs/index.mdx`):**
- MDX wraps multiline JSX `<p>` content in an implicit `<p>`, creating `<p><p>text</p></p>`. The outer `<p>` auto-closes on the inner `<p>` open, leaving an orphaned `</p>`. Fixed by inlining the text on the same line as the opening tag.

## Preview Link
<!-- The preview link or links to the documents-->

## Internal Reference

Closes DOC-1404

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs