### PR TITLE
docs(doc-1334): terminology — vcluster-yaml networking, policies, top-level pages

### DIFF
--- a/vcluster/configure/vcluster-yaml/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/deploy.mdx
@@ -12,7 +12,7 @@ import DeployConfig from '../../_partials/config/deploy.mdx';
 
 ## Configure addons
 
-vCluster supports addons that extend the functionality of your tenant cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
+vCluster supports addons that extend the capabilities of your tenant cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
 
 ### [Deprecated]: Ingress Nginx
 <TenancySupport privateNodes="true" hostNodes="true" />

--- a/vcluster/configure/vcluster-yaml/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/deploy.mdx
@@ -12,7 +12,7 @@ import DeployConfig from '../../_partials/config/deploy.mdx';
 
 ## Configure addons
 
-vCluster supports addons that extend the functionality of your virtual cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
+vCluster supports addons that extend the functionality of your tenant cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
 
 ### [Deprecated]: Ingress Nginx
 <TenancySupport privateNodes="true" hostNodes="true" />

--- a/vcluster/configure/vcluster-yaml/experimental/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/deploy.mdx
@@ -15,7 +15,7 @@ import ExperimentalAdmonition from '@site/docs/_partials/vcluster/experimental-a
 
 ## Apply manifests on initialization in vCluster
 
-Apply Kubernetes manifests when the virtual cluster starts. This is useful for configuring internal vCluster resources. For example:
+Apply Kubernetes manifests when the tenant cluster starts. This is useful for configuring internal vCluster resources. For example:
 
 ```yaml
 experimental:
@@ -95,7 +95,7 @@ Replace _`COMPRESSED_STRING`_ with a compressed base64 string that has the chart
 
 ## Apply manifests on initialization in host
 
-Apply Kubernetes manifests when the virtual cluster starts into the host namespace. This is useful for configuring external vCluster resources. For example:
+Apply Kubernetes manifests when the tenant cluster starts into the host namespace. This is useful for configuring external vCluster resources. For example:
 
 ```yaml
 experimental:

--- a/vcluster/configure/vcluster-yaml/experimental/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/overview.mdx
@@ -26,8 +26,8 @@ vCluster provides several experimental features that extend its capabilities:
 
 - **[Deploy](./deploy.mdx)** - Configure deployment settings for experimental features
 - **[Sync settings](./sync-settings.mdx)** - Advanced synchronization configuration
-- **[Deny proxy requests](./deny-proxy-requests.mdx)** - Block proxy requests to the host cluster
-- **[Resource proxy](./proxy.mdx)** - Proxy custom resources to other virtual clusters
+- **[Deny proxy requests](./deny-proxy-requests.mdx)** - Block proxy requests to the control plane cluster
+- **[Resource proxy](./proxy.mdx)** - Proxy custom resources to other tenant clusters
 
 ### Configure experimental features
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -43,11 +43,11 @@ In addition to the default secret, you can also [export additional kubeconfig se
 
 ## Customize the default secret
 
-The following example configures a virtual cluster to use a specific kubeconfig context and server endpoint for the default
+The following example configures a tenant cluster to use a specific kubeconfig context and server endpoint for the default
 kubeconfig secret `vc-NAME`:
 
 - Set the kubeconfig context name to `my-domain-context`.
-- Configure the kubeconfig to use `https://my-domain.org:443` as the endpoint for the exposed virtual cluster.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the endpoint for the exposed tenant cluster.
 
 ```yaml
 exportKubeConfig:
@@ -73,12 +73,12 @@ You can export additional kubeconfig secrets by specifying `exportKubeConfig.add
 
 ### Using the default namespace for the additional secret
 
-The following example configures a virtual cluster to export an additional secret `vc-my-domain`, which is created in
+The following example configures a tenant cluster to export an additional secret `vc-my-domain`, which is created in
 the namespace where vCluster is deployed.
 
 In this example, the additional secret `vc-my-domain` is customized in the following way:
 - Set the kubeconfig context name to `my-domain-context`.
-- Configure the kubeconfig to use `https://my-domain.org:443` as the server endpoint for the exposed virtual cluster.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the server endpoint for the exposed tenant cluster.
 
 ```yaml
 exportKubeConfig:
@@ -95,11 +95,11 @@ additional secret that you may have configured.
 
 ### Using a new namespace for the additional secret
 
-The following example configures a virtual cluster to store the kubeconfig secret in a separate namespace while maintaining
+The following example configures a tenant cluster to store the kubeconfig secret in a separate namespace while maintaining
 proper access control:
 
 - Set the kubeconfig context name to `my-domain-context`.
-- Configure the kubeconfig to use `https://my-domain.org:443` as the virtual cluster endpoint.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the tenant cluster endpoint.
 - Create a namespace called `kubeconfig-secret-namespace` to store the secret.
 - Name the secret `vc-my-domain` instead of using the default "vc-NAME" (where `NAME` is the vCluster name).
 - Additionally, grant access to the new namespace by creating a `Role` and `RoleBinding` for the vCluster service account:

--- a/vcluster/configure/vcluster-yaml/logging.mdx
+++ b/vcluster/configure/vcluster-yaml/logging.mdx
@@ -11,7 +11,7 @@ import Logging from '../../_partials/config/logging.mdx'
 
 By default, vCluster writes logs to the control plane pod using a human-readable console format. This format is easy to scan and works well when reviewing logs manually with tools such as `kubectl logs`. 
 
-You can alternatively configure the control plane to output logs in JSON format, which provides structured data compatible with external log aggregation tools (such as Elasticsearch). JSON logs simplify log collection, parsing, and analysis across multiple virtual clusters.
+You can alternatively configure the control plane to output logs in JSON format, which provides structured data compatible with external log aggregation tools (such as Elasticsearch). JSON logs simplify log collection, parsing, and analysis across multiple tenant clusters.
 
 ## Log encoding formats
 
@@ -22,10 +22,10 @@ vCluster supports two log encoding formats for the vCluster control plane pod.
 
 ### Console format
 
-The console format provides human-readable logs with timestamps, log levels, source locations, and contextual information. This format works well for use cases where users are troubleshooting a single virtual cluster. Choose this format in environments where human readability is more important than structured log parsing. Example use cases include:
+The console format provides human-readable logs with timestamps, log levels, source locations, and contextual information. This format works well for use cases where users are troubleshooting a single tenant cluster. Choose this format in environments where human readability is more important than structured log parsing. Example use cases include:
 
 - Local development and testing, where developers benefit from quick, readable output.
-- Single virtual cluster analysis, where users manually review logs and debug in a terminal.
+- Single tenant cluster analysis, where users manually review logs and debug in a terminal.
 
 ```text
 2025-06-16 04:43:25	INFO	license	loader/inject.go:52	initializing license...	{"component": "vcluster"}
@@ -37,9 +37,9 @@ The console format provides human-readable logs with timestamps, log levels, sou
 <!-- vale off -->
 ### JSON format
 
-The JSON format structures log data for programmatic processing and integration with log management systems. This format is works well for use cases where external tools monitor and analyze logs for multiple virtual clusters. Log aggregation tools (such as Elasticsearch or Splunk) can import these logs to support automated analysis, alerting, and integration with monitoring platforms (for example, Prometheus and Grafana). Example use cases include:
+The JSON format structures log data for programmatic processing and integration with log management systems. This format is works well for use cases where external tools monitor and analyze logs for multiple tenant clusters. Log aggregation tools (such as Elasticsearch or Splunk) can import these logs to support automated analysis, alerting, and integration with monitoring platforms (for example, Prometheus and Grafana). Example use cases include:
 
-- Production environments where you monitor multiple virtual clusters and require automatic parsing and processing of logs.
+- Production environments where you monitor multiple tenant clusters and require automatic parsing and processing of logs.
 
 ```json
 {"level":"info","ts":1750160027.442782,"logger":"license","caller":"loader/inject.go:52","msg":"initializing license...","component":"vcluster"}

--- a/vcluster/configure/vcluster-yaml/networking/advanced.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/advanced.mdx
@@ -11,13 +11,13 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-Each vCluster has its own DNS service, which is CoreDNS by default. DNS allows pods in the virtual cluster to get the IP addresses of services that are also running in the virtual cluster. The syncer ensures that the intuitive naming logic of Kubernetes DNS names for services applies, and that users can connect to these DNS names, which map to the IP address of the synchronized services that are present in the host cluster.
+Each vCluster has its own DNS service, which is CoreDNS by default. DNS allows pods in the tenant cluster to get the IP addresses of services that are also running in the tenant cluster. The syncer ensures that the intuitive naming logic of Kubernetes DNS names for services applies, and that users can connect to these DNS names, which map to the IP address of the synchronized services that are present in the control plane cluster.
 
-However, this also means that you cannot directly access host services inside the virtual cluster via DNS. Host pods can only access virtual cluster services by their synced name. vCluster offers a feature to map services from the virtual cluster to the host cluster and vice versa.
+However, this also means that you cannot directly access host services inside the tenant cluster via DNS. Host pods can only access tenant cluster services by their synced name. vCluster offers a feature to map services from the tenant cluster to the control plane cluster and vice versa.
 
 **Fallback to Host DNS**
 
-When you enable `fallbackHostCluster`, vCluster falls back to the host cluster's DNS for resolving domains. This is useful if the host cluster is using Istio or Dapr and the sidecar containers cannot connect to the central instance. It is also useful if you want to access the host cluster services from within the virtual cluster.
+When you enable `fallbackHostCluster`, vCluster falls back to the control plane cluster's DNS for resolving domains. This is useful if the control plane cluster is using Istio or Dapr and the sidecar containers cannot connect to the central instance. It is also useful if you want to access the control plane cluster services from within the tenant cluster.
 
 **`proxyKubelets`**
 

--- a/vcluster/configure/vcluster-yaml/networking/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/overview.mdx
@@ -34,21 +34,21 @@ To allow pods to communicate with services, vCluster also synchronizes Service o
 
 No additional configuration is required for Pod to Service networking in the same tenant cluster.
 
-### Pod in the tenant cluster to Service in the Control Plane Cluster
+### Pod in the tenant cluster to Service in the control plane cluster
 
-See [Control Plane Cluster to tenant cluster](./replicate-services.mdx).
+See [Control plane cluster to tenant cluster](./replicate-services.mdx).
 
 ### Pod in the tenant cluster to Service in a different tenant cluster
 
 See [Mapping services across vCluster instances](./resolve-dns.mdx).
 
-## From the Control Plane Cluster
+## From the control plane cluster
 
 <TenancySupport hostNodes="true" />
 
-### Pod in the Control Plane Cluster to Service in the tenant cluster
+### Pod in the control plane cluster to Service in the tenant cluster
 
-See [Tenant cluster to Control Plane Cluster](./replicate-services.mdx)
+See [Tenant cluster to control plane cluster](./replicate-services.mdx)
 
 ## Service CIDR and Pod CIDR 
 

--- a/vcluster/configure/vcluster-yaml/networking/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/overview.mdx
@@ -16,39 +16,39 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 ### Ingress to Service
 
-The vCluster has the option to enable Ingress resources synchronization. That means that you can create an ingress in a vCluster to make a service in this vCluster available via a hostname/domain. However, instead of having to run a separate ingress controller in each vCluster, the ingress resource synchronizes to the underlying cluster (when enabled) which means that the vCluster can use a shared ingress controller that is running in the host cluster. This helps to share resources across different virtual clusters and is easier for users of virtual clusters because otherwise, they would need to install an ingress controller and manually configure DNS for each vCluster.
+The vCluster has the option to enable Ingress resources synchronization. That means that you can create an ingress in a vCluster to make a service in this vCluster available via a hostname/domain. However, instead of having to run a separate ingress controller in each vCluster, the ingress resource synchronizes to the underlying cluster (when enabled) which means that the vCluster can use a shared ingress controller that is running in the control plane cluster. This helps to share resources across different tenant clusters and is easier for users of tenant clusters because otherwise, they would need to install an ingress controller and manually configure DNS for each vCluster.
 
-## From inside a virtual cluster
+## From inside a tenant cluster
 
 <TenancySupport hostNodes="true" />
 
-### Pod in the virtual cluster to Pod in the same virtual cluster
+### Pod in the tenant cluster to Pod in the same tenant cluster
 
-Pods run inside the underlying host cluster. vCluster's syncer component syncs Pods between host and virtual cluster. These synced Pods have cluster-internal IP addresses and can communicate with each other via IP-based networking.
+Pods run inside the underlying control plane cluster. vCluster's syncer component syncs Pods between control plane cluster and tenant cluster. These synced Pods have cluster-internal IP addresses and can communicate with each other via IP-based networking.
 
-No additional configuration is required for Pod to Pod networking in the same virtual cluster.
+No additional configuration is required for Pod to Pod networking in the same tenant cluster.
 
-### Pod in the virtual cluster to Service in the same virtual cluster
+### Pod in the tenant cluster to Service in the same tenant cluster
 
-To allow pods to communicate with services, vCluster also synchronizes Service objects, while stripping away unnecessary information from the resource. However, instead of using the DNS names of the Services inside the host cluster, vCluster has its own DNS service which allows virtual cluster pods to use much more intuitive DNS mappings, just as in a regular cluster.
+To allow pods to communicate with services, vCluster also synchronizes Service objects, while stripping away unnecessary information from the resource. However, instead of using the DNS names of the Services inside the control plane cluster, vCluster has its own DNS service which allows tenant cluster pods to use much more intuitive DNS mappings, just as in a regular cluster.
 
-No additional configuration is required for Pod to Service networking in the same virtual cluster.
+No additional configuration is required for Pod to Service networking in the same tenant cluster.
 
-### Pod in the virtual cluster to Service in the host cluster
+### Pod in the tenant cluster to Service in the Control Plane Cluster
 
-See [Host cluster to virtual cluster](./replicate-services.mdx).
+See [Control Plane Cluster to tenant cluster](./replicate-services.mdx).
 
-### Pod in the virtual cluster to Service in a different virtual cluster
+### Pod in the tenant cluster to Service in a different tenant cluster
 
 See [Mapping services across vCluster instances](./resolve-dns.mdx).
 
-## From the host cluster
+## From the Control Plane Cluster
 
 <TenancySupport hostNodes="true" />
 
-### Pod in the host cluster to Service in the virtual cluster
+### Pod in the Control Plane Cluster to Service in the tenant cluster
 
-See [Virtual cluster to host cluster](./replicate-services.mdx)
+See [Tenant cluster to Control Plane Cluster](./replicate-services.mdx)
 
 ## Service CIDR and Pod CIDR 
 

--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -12,7 +12,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 With open source vCluster, you need to replicate services between the control plane cluster and tenant cluster.
 
-## Control Plane Cluster to tenant cluster
+## Control plane cluster to tenant cluster
 
 In this example, you map a service `my-host-service` in the namespace `my-host-namespace` to the tenant cluster service `my-virtual-service` in the tenant cluster namespace `my-virtual-namespace`.
 
@@ -29,7 +29,7 @@ vCluster replicates the service in the tenant cluster, with the tenant cluster s
 In the above example, when you remove the `my-host-namespace/my-host-service` service replication config from `networking.replicateServices.fromHost`,
 the tenant cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the tenant cluster.
 
-## Tenant cluster to Control Plane Cluster
+## Tenant cluster to control plane cluster
 
 You can also map a tenant cluster service to a control plane cluster service. This is especially useful if you want to expose an application that runs inside the tenant cluster to other workloads running in the control plane cluster, which makes it easier to share services across vCluster instances.
 

--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -10,11 +10,11 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-With open source vCluster, you need to replicate services between the host cluster and virtual cluster.
+With open source vCluster, you need to replicate services between the control plane cluster and tenant cluster.
 
-## Host cluster to virtual cluster
+## Control Plane Cluster to tenant cluster
 
-In this example, you map a service `my-host-service` in the namespace `my-host-namespace` to the virtual cluster service `my-virtual-service` in the virtual cluster namespace `my-virtual-namespace`.
+In this example, you map a service `my-host-service` in the namespace `my-host-namespace` to the tenant cluster service `my-virtual-service` in the tenant cluster namespace `my-virtual-namespace`.
 
 ```yaml
 networking:
@@ -24,14 +24,14 @@ networking:
       to: my-virtual-namespace/my-virtual-service
 ```
 
-vCluster replicates the service in the virtual cluster, with the virtual cluster service pointing to the service running in the host cluster. Pods inside the virtual cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
+vCluster replicates the service in the tenant cluster, with the tenant cluster service pointing to the service running in the control plane cluster. Pods inside the tenant cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
 
 In the above example, when you remove the `my-host-namespace/my-host-service` service replication config from `networking.replicateServices.fromHost`,
-the virtual cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the virtual cluster.
+the tenant cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the tenant cluster.
 
-## Virtual cluster to host cluster
+## Tenant cluster to Control Plane Cluster
 
-You can also map a virtual cluster service to a host cluster service. This is especially useful if you want to expose an application that runs inside the virtual cluster to other workloads running in the host cluster, which makes it easier to share services across vCluster instances.
+You can also map a tenant cluster service to a control plane cluster service. This is especially useful if you want to expose an application that runs inside the tenant cluster to other workloads running in the control plane cluster, which makes it easier to share services across vCluster instances.
 
 In this example, you map the virtual service `my-virtual-service` in the namespace `my-virtual-namespace` to the host namespace service `my-host-service`
 
@@ -43,11 +43,11 @@ networking:
       to: my-host-service
 ```
 
-With this configuration, vCluster manages a service called `my-host-service` inside the namespace where the vCluster workloads are synced, which points to the virtual service `my-virtual-service` in namespace `my-virtual-namespace` inside the virtual cluster. Pods in the host cluster are able to access the virtual service by calling the host service. If you use cURL, the command based on the preceding example is `curl http://my-host-service`.
+With this configuration, vCluster manages a service called `my-host-service` inside the namespace where the vCluster workloads are synced, which points to the virtual service `my-virtual-service` in namespace `my-virtual-namespace` inside the tenant cluster. Pods in the control plane cluster are able to access the virtual service by calling the host service. If you use cURL, the command based on the preceding example is `curl http://my-host-service`.
 
 In the above example, when you remove the `my-virtual-namespace/my-virtual-service` service replication config from
-`networking.replicateServices.toHost`, the host cluster service `my-host-service` is not automatically deleted from
-the host cluster, so you need to delete it manually, if you don't want to keep it in the host cluster.
+`networking.replicateServices.toHost`, the control plane cluster service `my-host-service` is not automatically deleted from
+the control plane cluster, so you need to delete it manually, if you don't want to keep it in the control plane cluster.
 
 ## Network policies
 

--- a/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -12,7 +12,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-This feature enables adding custom DNS rules to the virtual cluster to allow communication with services deployed in the host cluster and across services in separate vCluster instances.
+This feature enables adding custom DNS rules to the tenant cluster to allow communication with services deployed in the control plane cluster and across services in separate vCluster instances.
 
 ## Examples
 
@@ -30,7 +30,7 @@ controlplane:
 
 ### Map a hostname
 
-This is a URL-based mapping of one virtual cluster hostname to another hostname. A `wikipedia.com` DNS lookup would return a DNS response with answer as `en.wikipedia.org`.
+This is a URL-based mapping of one tenant cluster hostname to another hostname. A `wikipedia.com` DNS lookup would return a DNS response with answer as `en.wikipedia.org`.
 
 ```yaml
 controlplane:
@@ -46,7 +46,7 @@ networking:
 
 ### Map a hostname wildcard
 
-This is a URL-based mapping of one virtual cluster hostname to another hostname. A `test.svc.kubernetes` DNS lookup would return a DNS response with answer as `test.svc.cluster.local`.
+This is a URL-based mapping of one tenant cluster hostname to another hostname. A `test.svc.kubernetes` DNS lookup would return a DNS response with answer as `test.svc.cluster.local`.
 
 ```yaml
 controlplane:
@@ -60,9 +60,9 @@ networking:
         hostname: *.svc.cluster.local
 ```
 
-### Map a virtual cluster service to a host cluster service
+### Map a tenant cluster service to a control plane cluster service
 
-This example maps the virtual cluster's `my-namespace/my-svc` resource to the host cluster's `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
+This example maps the tenant cluster's `my-namespace/my-svc` resource to the control plane cluster's `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
 
 ```yaml
 controlplane:
@@ -78,7 +78,7 @@ networking:
 
 ### Map services across vCluster instances
 
-This example maps a virtual cluster Service to another Service in a separate virtual cluster.
+This example maps a tenant cluster Service to another Service in a separate tenant cluster.
 `my-ns-in-vcluster/my-svc-vcluster` maps to  `dns-test-in-vcluster-ns/test-in-vcluster-service` in a vCluster instance named `test-cluster` deployed in the host namespace `test-vcluster-ns`.
 
 ```yaml
@@ -95,7 +95,7 @@ networking:
 
 ### Map namespaces
 
-Map all services under a virtual cluster namespace to a host namespace. This host namespace could also contain another vCluster instance, thereby mapping all vCluster services to another vCluster instance.
+Map all services under a tenant cluster namespace to a host namespace. This host namespace could also contain another vCluster instance, thereby mapping all vCluster services to another vCluster instance.
 ```yaml
 controlplane:
   coredns:
@@ -108,7 +108,7 @@ networking:
         hostNamespace: external-vc-ns
 ```
 
-All services in the `test-vcluster` virtual cluster's target namespace `test-in-vcluster-ns`  map to namespace `external-vc-ns`.
+All services in the `test-vcluster` tenant cluster's target namespace `test-in-vcluster-ns`  map to namespace `external-vc-ns`.
 
 ```
     ┌──────────────────────┐┌──────────────────────────────┐

--- a/vcluster/configure/vcluster-yaml/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/overview.mdx
@@ -29,15 +29,15 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <!-- vale off -->
 
-The `vcluster.yaml` configuration file defines how your virtual cluster operates and integrates with the host cluster. Use the `vcluster.yaml` file to configure vCluster. It allows you to override default settings by specifying resource sync rules, networking behavior, storage options, and authentication methods.
+The `vcluster.yaml` configuration file defines how your tenant cluster operates and integrates with the control plane cluster. Use the `vcluster.yaml` file to configure vCluster. It allows you to override default settings by specifying resource sync rules, networking behavior, storage options, and authentication methods.
 
 If you're familiar with [Helm](https://helm.sh/), you can use `vcluster.yaml` in the same way as a [`values.yaml`](https://helm.sh/docs/chart_template_guide/values_files/) file. All vCluster deployment methods are based on Helm, which ensures consistent behavior across environments.
 
-The configuration file controls resource synchronization between the host cluster and the virtual cluster, network access methods, storage persistence, authentication settings, and external service integrations. You can apply most configurations during deployment or upgrades, though some settings like the data store must be configured during initial deployment.
+The configuration file controls resource synchronization between the control plane cluster and the tenant cluster, network access methods, storage persistence, authentication settings, and external service integrations. You can apply most configurations during deployment or upgrades, though some settings like the data store must be configured during initial deployment.
 
 To explore configuration options, review the [vCluster chart values file](https://github.com/loft-sh/vcluster/blob/main/chart/values.yaml) for default settings and available parameters. The [vCluster Helm chart](https://github.com/loft-sh/vcluster/blob/main/chart/values.schema.json) also includes a JSON schema for validating `vcluster.yaml`. For more information on configuration structure, see [What is vcluster.yaml?](/vcluster/configure/what-is-vcluster-yaml).
 
-## Deploy a virtual cluster
+## Deploy a tenant cluster
 
 Before you deploy, review the [worker node deployment options](../../introduction/architecture.mdx#worker-nodes) to determine how the infrastructure of the tenant cluster will be configured.
 

--- a/vcluster/configure/vcluster-yaml/platform.mdx
+++ b/vcluster/configure/vcluster-yaml/platform.mdx
@@ -10,7 +10,7 @@ import Platform from '../../_partials/config/platform.mdx'
 
 <!-- vale off -->
 You can connect to [vCluster Platform](/platform/) through the `vcluster.yaml` and configure different
-vCluster Platform settings that work with the virtual cluster.
+vCluster Platform settings that work with the tenant cluster.
 <!-- vale on -->
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -24,27 +24,27 @@ import FeatureTable from '@site/src/components/FeatureTable';
 You must enable `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers to use the Central Admission Control feature. For more information, see the Kubernetes [admission controllers reference](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
 :::
 
-Centralized admission control is an advanced feature for cluster admins that have custom rules that they need to apply to the virtual cluster. Cluster admins can enforce [Kubernetes admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that reference the host cluster or external policy services from within the virtual cluster. Examples of validating and mutating webhook based policy engines include OPA, Kyverno, and jsPolicy.
+Centralized admission control is an advanced feature for cluster admins that have custom rules that they need to apply to the tenant cluster. Cluster admins can enforce [Kubernetes admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that reference the control plane cluster or external policy services from within the tenant cluster. Examples of validating and mutating webhook based policy engines include OPA, Kyverno, and jsPolicy.
 
 :::warning
-- Central admission control is read-only after virtual cluster creation. Admins cannot bypass or alter hooks after vCluster deployment.
-- If you need to modify or delete webhook configurations, do not use central admission control. Instead, manually map the host policy service into the virtual cluster.
+- Central admission control is read-only after tenant cluster creation. Admins cannot bypass or alter hooks after vCluster deployment.
+- If you need to modify or delete webhook configurations, do not use central admission control. Instead, manually map the host policy service into the tenant cluster.
 :::
 
 Central admission webhooks are different from the other policies:
 
-- LimitRange and ResourceQuota resources are created and enforced on the host cluster. They do not appear as resources in the virtual cluster.
-- A user could define LimitRange and ResourceQuota resources inside the virtual cluster, but they have full control over them and can delete them when needed.
-- Webhooks are different because they need to be configured inside the virtual cluster in order for them to be called by the vCluster's API server.
-- vCluster rewrites these definitions to point to a proxy for a host cluster service that handles webhook requests. The host might also have webhook configurations that use this service.
-- A user can still install a webhook service or webhook configuration into the virtual cluster outside of this config, but it would run inside the virtual cluster like any other workload.
+- LimitRange and ResourceQuota resources are created and enforced on the control plane cluster. They do not appear as resources in the tenant cluster.
+- A user could define LimitRange and ResourceQuota resources inside the tenant cluster, but they have full control over them and can delete them when needed.
+- Webhooks are different because they need to be configured inside the tenant cluster in order for them to be called by the vCluster's API server.
+- vCluster rewrites these definitions to point to a proxy for a control plane cluster service that handles webhook requests. The host might also have webhook configurations that use this service.
+- A user can still install a webhook service or webhook configuration into the tenant cluster outside of this config, but it would run inside the tenant cluster like any other workload.
 
 :::info Namespace rewriting
 vCluster rewrites the namespace of the object (if the object is namespace scoped) to the host namespace where vCluster is running in. This is not visible to the end-user, but the admission controller is able to use things like namespace selector like usual. Some admission controllers like gatekeeper wouldn't work otherwise as they rely on the namespace to always be there in the underlying cluster. To access the virtual namespace in a webhook, you can access the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request) that holds the full virtual namespace object.
 :::
 
 :::info Translated name of pods
-In some circumstances it might be necessary to have the translated name of a pod, which is used when this pod is created on the host cluster, available in a webhook running inside a virtual cluster.
+In some circumstances it might be necessary to have the translated name of a pod, which is used when this pod is created on the control plane cluster, available in a webhook running inside a tenant cluster.
 Therefore, vCluster puts the translated pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
 As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for pods.
 :::
@@ -64,7 +64,7 @@ Missing `caBundle` with `failurePolicy: Fail` can make vCluster unrecoverable. T
 
 ## Kyverno example
 
-This example ensures that all new ConfigMap resources are sent to a mutating webhook on the host cluster.
+This example ensures that all new ConfigMap resources are sent to a mutating webhook on the control plane cluster.
 
 ```yaml
 centralAdmission:
@@ -103,13 +103,13 @@ centralAdmission:
         timeoutSeconds: 10
 ```
 
-Any time a ConfigMap is created, the vCluster API server forwards the admission request to a proxy, which in turn calls the actual admission hook running in the host cluster in the `kyverno` namespace.
+Any time a ConfigMap is created, the vCluster API server forwards the admission request to a proxy, which in turn calls the actual admission hook running in the control plane cluster in the `kyverno` namespace.
 
-The service providing the webhooks should not rely on the real names of the objects if they are synced on the host cluster (for example, pods). The requests that reach the host admission service holds the objects from the virtual cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined below).
+The service providing the webhooks should not rely on the real names of the objects if they are synced on the control plane cluster (for example, pods). The requests that reach the host admission service holds the objects from the tenant cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined below).
 
 The hook services do not require authentication as the proxy does not have access to the `AdmissionConfiguration` object or the files it references. Most policy engines (such as jsPolicy, Kyverno, or Gatekeeper) do not set authentication by default, so it should work with most installations.
 
-If a user inside the virtual cluster (admin or not) tries to delete one of your admission hooks, that uses is prompted with the following error message:
+If a user inside the tenant cluster (admin or not) tries to delete one of your admission hooks, that uses is prompted with the following error message:
 
 ```bash
 kubectl delete kyverno-webhook

--- a/vcluster/configure/vcluster-yaml/policies/limit-range.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/limit-range.mdx
@@ -12,7 +12,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-You can create a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) policy to constrain virtual cluster resource allocation. vCluster creates the LimitRange on the host in the same namespace as vCluster itself. LimitRange only applies to synced resources, such as pods.
+You can create a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) policy to constrain tenant cluster resource allocation. vCluster creates the LimitRange on the host in the same namespace as vCluster itself. LimitRange only applies to synced resources, such as pods.
 
 ## Example
 

--- a/vcluster/configure/vcluster-yaml/policies/network-policy.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/network-policy.mdx
@@ -2,7 +2,7 @@
 title: Network policy
 sidebar_label: networkPolicy
 sidebar_position: 1
-description: Configure network policies to isolate virtual cluster workloads and implement project-scoped network boundaries.
+description: Configure network policies to isolate tenant cluster workloads and implement project-scoped network boundaries.
 sidebar_class_name: host-nodes
 ---
 
@@ -18,9 +18,9 @@ import Column from '@site/src/components/Column';
 This feature is disabled by default.
 :::
 
-By default, workloads created by vCluster are able to communicate with other workloads in the host cluster through their cluster IPs. Configure network policies when you want to isolate namespaces and do not want the pods running inside the virtual cluster to have access to other workloads in the host cluster.
+By default, workloads created by vCluster are able to communicate with other workloads in the control plane cluster through their cluster IPs. Configure network policies when you want to isolate namespaces and do not want the pods running inside the tenant cluster to have access to other workloads in the control plane cluster.
 
-Enabling this creates Kubernetes [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resources in the host namespace that control how vCluster pods (both control plane and workloads) communicate with each other and with other pods on the host cluster.
+Enabling this creates Kubernetes [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resources in the host namespace that control how vCluster pods (both control plane and workloads) communicate with each other and with other pods on the control plane cluster.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Enabling this creates Kubernetes [NetworkPolicy](https://kubernetes.io/docs/conc
 
 ## Enable network isolation {#enable-isolation}
 
-Set `policies.networkPolicy.enabled` to create NetworkPolicies that isolate the virtual cluster:
+Set `policies.networkPolicy.enabled` to create NetworkPolicies that isolate the tenant cluster:
 
 ```yaml title="vcluster.yaml"
 policies:
@@ -37,7 +37,7 @@ policies:
 ```
 
 This creates Kubernetes NetworkPolicies resources in the host namespace that:
-- Allow traffic between pods within the virtual cluster
+- Allow traffic between pods within the tenant cluster
 - Block traffic from other namespaces
 - Permit DNS and API server communication
 
@@ -284,7 +284,7 @@ spec:
 ```
 
 This automatically:
-- Isolates virtual clusters by project
+- Isolates tenant clusters by project
 - Allows communication within the same project
 - Enforces network boundaries for CI/CD pipelines
 

--- a/vcluster/configure/vcluster-yaml/policies/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/overview.mdx
@@ -22,8 +22,8 @@ Policies cover several different topics:
 - [Network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) like network isolation.
 - [Admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks)
   - [Central Admission Control](./admission-control.mdx)
-  - The admission controller is typically running on the host cluster, where the policies enforced by the webhook cannot be changed by the virtual cluster.
-  - Users could deploy their own admission webhooks to the virtual cluster, but there's little value in doing so, and this configuration is not concerned with that use case.
+  - The admission controller is typically running on the control plane cluster, where the policies enforced by the webhook cannot be changed by the tenant cluster.
+  - Users could deploy their own admission webhooks to the tenant cluster, but there's little value in doing so, and this configuration is not concerned with that use case.
   - Some examples of admission controller projects:
     - [OPA](https://www.openpolicyagent.org/docs/latest/)
     - [Kyverno](https://kyverno.io/)

--- a/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
@@ -19,7 +19,7 @@ This feature is disabled by default.
 
 [Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) prevent Pods from starting if they request permissions beyond what's allowed. These standards check settings like `spec.securityContext`, host ports, volume types, and AppArmor annotations.
 
-Enable this feature to block privileged Pods from escaping the virtual cluster.
+Enable this feature to block privileged Pods from escaping the tenant cluster.
 
 ```yaml
 policies:

--- a/vcluster/configure/vcluster-yaml/policies/resource-quota.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/resource-quota.mdx
@@ -2,7 +2,7 @@
 title: Resource quota
 sidebar_label: resourceQuota
 sidebar_position: 3
-description: Configure ResourceQuota for your virtual cluster.
+description: Configure ResourceQuota for your tenant cluster.
 sidebar_class_name: host-nodes
 ---
 
@@ -13,7 +13,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-You can control vCluster resource consumption by configuring a ResourceQuota. vCluster creates the ResourceQuota in the same namespace as vCluster itself. Resource quotas apply to all resources synced to the host cluster.
+You can control vCluster resource consumption by configuring a ResourceQuota. vCluster creates the ResourceQuota in the same namespace as vCluster itself. Resource quotas apply to all resources synced to the control plane cluster.
 
 ## Example
 

--- a/vcluster/configure/vcluster-yaml/telemetry.mdx
+++ b/vcluster/configure/vcluster-yaml/telemetry.mdx
@@ -19,7 +19,7 @@ To advance the project and ensure long-term maintainability, decisions are made 
 
 LoftLabs is not interested in collecting data about individuals that are using vCluster. Rather, LoftLabs collects data about how vCluster is being used. This entails information about the configuration of vCluster, and the environment where it is deployed (e.g. Kubernetes version, CPU architecture, etc.).
 
-Each vCluster is deployed with a syncer component, which contains all controllers that make a virtual cluster function. This component collects the data and uploads it to LoftLabs at regular intervals (once every 1-5 minutes). LoftLabs provides a documented example of the telemetry payload. The source code responsible for this is fully available in the vCluster [repo](https://github.com/loft-sh/vcluster). The telemetry backend is hosted at "https://admin.loft.sh/analytics/v1/vcluster/". The ingestion service is written and maintained by the vCluster maintainers. The data is saved into a relational database with strict access control.
+Each vCluster is deployed with a syncer component, which contains all controllers that make a tenant cluster function. This component collects the data and uploads it to LoftLabs at regular intervals (once every 1-5 minutes). LoftLabs provides a documented example of the telemetry payload. The source code responsible for this is fully available in the vCluster [repo](https://github.com/loft-sh/vcluster). The telemetry backend is hosted at "https://admin.loft.sh/analytics/v1/vcluster/". The ingestion service is written and maintained by the vCluster maintainers. The data is saved into a relational database with strict access control.
 
 ### Telemetry payload example
 


### PR DESCRIPTION
## Content Description

- Replaces `virtual cluster(s)` → `tenant cluster(s)` and `host cluster(s)` → `Control Plane Cluster(s)` in prose across 18 files in `vcluster/configure/vcluster-yaml/`
- Covers: `networking/`, `policies/`, `experimental/overview.mdx`, `experimental/deploy.mdx`, `overview.mdx`, `export-kube-config.mdx`, `logging.mdx`, `deploy.mdx`, `platform.mdx`, `telemetry.mdx`
- Code blocks, CLI commands, YAML keys, file paths, and JSX comments are unchanged
- First batch of DOC-1334 phase 3; subsequent PRs will cover `control-plane/`, `sync/from-host/`, `sync/to-host/`, and `experimental/proxy.mdx`

## Preview Link
<!-- The preview link or links to the documents-->
- https://deploy-preview-2096--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/networking
- https://deploy-preview-2096--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/policies

## Test plan

- [ ] Review diff for any accidental changes to code blocks or YAML keys
- [ ] Verify rendered headings in networking pages read coherently (e.g. "Control Plane Cluster to tenant cluster")
- [ ] Build passes (`npm run build`)

## Internal Reference

Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs