### PR TITLE
docs(doc-1334): update control-plane/ terminology to tenant/control plane cluster

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -3,7 +3,7 @@ title: External database
 sidebar_label: external
 sidebar_position: 2
 sidebar_class_name: pro host-nodes private-nodes
-description: Configure an external database as the virtual cluster's backing store for enhanced performance and scalability.
+description: Configure an external database as the tenant cluster's backing store for enhanced performance and scalability.
 ---
 
 import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/external.mdx";
@@ -23,9 +23,9 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 ## Introduction
 
-This guide explains how to configure an external database as the backing store for a virtual cluster. A backing store is a persistent storage solution that maintains the state and data of the virtual cluster. Using an external database can provide better performance, scalability, and data persistence compared to the default embedded storage.
+This guide explains how to configure an external database as the backing store for a tenant cluster. A backing store is a persistent storage solution that maintains the state and data of the tenant cluster. Using an external database can provide better performance, scalability, and data persistence compared to the default embedded storage.
 
-Configure this feature to use an external database such as MySQL or PostgreSQL for your virtual cluster's backing store.
+Configure this feature to use an external database such as MySQL or PostgreSQL for your tenant cluster's backing store.
 
 ```yaml title="External database configuration"
 controlPlane:
@@ -39,13 +39,13 @@ controlPlane:
 
 ## Prerequisites
 
-Before configuring an external database for your virtual cluster, ensure you have the following prerequisites based on your chosen method:
+Before configuring an external database for your tenant cluster, ensure you have the following prerequisites based on your chosen method:
 
 ### Data source (direct connection)
 
 - A running MySQL or PostgreSQL database server
 - admin credentials and connection string for the database
-- Network connectivity from the virtual cluster to the database server
+- Network connectivity from the tenant cluster to the database server
 
 ### Connector (platform-managed)
 
@@ -55,25 +55,25 @@ The connector method requires the vCluster Platform to be installed and properly
 
 1. [**vCluster Platform installation**](/platform/install/quick-start-guide): The platform must be installed and accessible in your Kubernetes cluster
 2. [**Database connector secret**](/platform/administer/connector/database): A platform administrator must create a database connector secret
-3. [**Platform API key**](/docs/vcluster/configure/vcluster-yaml/platform): Your virtual cluster must be connected to the platform
+3. [**Platform API key**](/docs/vcluster/configure/vcluster-yaml/platform): Your tenant cluster must be connected to the platform
 
 :::info
-The **connector** option provides automatic database provisioning, credential management, and cleanup when the virtual cluster is deleted. The **dataSource** option gives you direct control but requires manual database and user management.
+The **connector** option provides automatic database provisioning, credential management, and cleanup when the tenant cluster is deleted. The **dataSource** option gives you direct control but requires manual database and user management.
 :::
 
 ## Connector and data source
 
 There are two mutually exclusive options for using an external backing store.
 
-`dataSource`: assign a connection string to `dataSource` that the virtual cluster uses for its control plane backing store.
+`dataSource`: assign a connection string to `dataSource` that the tenant cluster uses for its control plane backing store.
 
-`connector`: assign a name of a [connector secret](/platform/administer/connector/database) that exists in an instance of the platform in the installed namespace. The platform uses the secret to automatically provision a separate database within the database server for the virtual cluster. It also creates a non-privileged user that can only interact with the virtual cluster's database. The virtual cluster receives a connection string built from the user and database.
+`connector`: assign a name of a [connector secret](/platform/administer/connector/database) that exists in an instance of the platform in the installed namespace. The platform uses the secret to automatically provision a separate database within the database server for the tenant cluster. It also creates a non-privileged user that can only interact with the tenant cluster's database. The tenant cluster receives a connection string built from the user and database.
 
 |                               | Connector | DataSource |
 | ----------------------------- | --------- | ---------- |
 | MySQL Support                 | Yes       | Yes        |
 | PostgreSQL Support            | Yes       | Yes        |
-| Share Across virtual clusters | Yes       | No         |
+| Share Across tenant clusters  | Yes       | No         |
 | Automatic DB Cleanup          | Yes       | No         |
 | Credential stored in secret   | Yes       | No         |
 
@@ -86,7 +86,7 @@ Replace `CONNECTION_STRING` with the connection string for your database. Exampl
 
 ### Connector configuration
 
-After completing the [prerequisites](#connector-platform-managed), reference the connector secret in your virtual cluster configuration:
+After completing the [prerequisites](#connector-platform-managed), reference the connector secret in your tenant cluster configuration:
 
 ```yaml title="Connector configuration"
 controlPlane:
@@ -98,11 +98,11 @@ controlPlane:
 ```
 
 :::note
-The virtual cluster must be [connected to the platform](/docs/vcluster/configure/vcluster-yaml/platform) to use the connector. This enables centralized management and monitoring of virtual clusters.
+The tenant cluster must be [connected to the platform](/docs/vcluster/configure/vcluster-yaml/platform) to use the connector. This enables centralized management and monitoring of tenant clusters.
 :::
 
 ## Network policies
-If you are using [network policies](../../../../policies/network-policy.mdx), the virtual cluster control plane traffic to the external database must be allowed.
+If you are using [network policies](../../../../policies/network-policy.mdx), the tenant cluster control plane traffic to the external database must be allowed.
 
 ```yaml title="vcluster.yaml"
 policies:

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/overview.mdx
@@ -15,9 +15,9 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 When using a database as the backing store, you can choose between two deployment options:
 
-- [Embedded](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/sqlite): The database is deployed inside the virtual cluster control plane.
+- [Embedded](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/sqlite): The database is deployed inside the tenant cluster control plane.
 
-- [External](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external): The database runs outside the virtual cluster control plane. You can either:
+- [External](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external): The database runs outside the tenant cluster control plane. You can either:
   - Connect to an existing database.
   - Connect to a database server. (This option requires vCluster Platform.)
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/sqlite.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/sqlite.mdx
@@ -2,7 +2,7 @@
 title: Embedded SQLite
 sidebar_label: embedded
 sidebar_position: 1
-description: Configure SQLite as the virtual cluster's backing store.
+description: Configure SQLite as the tenant cluster's backing store.
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
@@ -13,7 +13,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-When using this backing store option, [etcd](https://etcd.io/) is deployed on the control plane cluster in the same namespace as the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane pod. vCluster deploys etcd with a `StatefulSet`, `Service`, and headless `Service`.
+When using this backing store option, [etcd](https://etcd.io/) is deployed on the control plane cluster in the same namespace as the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane pod. vCluster deploys etcd with a StatefulSet, Service, and headless Service.
 
 ```yaml
 controlPlane:

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 title: External etcd
 sidebar_label: deploy
 sidebar_position: 3
-description: Configure an external etcd instance as the virtual cluster's backing store.
+description: Configure an external etcd instance as the tenant cluster's backing store.
 sidebar_class_name: host-nodes private-nodes
 ---
 
@@ -13,7 +13,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-When using this backing store option, [etcd](https://etcd.io/) is deployed on the host cluster in the same namespace as the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane pod. vCluster deploys etcd with a `StatefulSet`, `Service`, and headless `Service`.
+When using this backing store option, [etcd](https://etcd.io/) is deployed on the control plane cluster in the same namespace as the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane pod. vCluster deploys etcd with a `StatefulSet`, `Service`, and headless `Service`.
 
 ```yaml
 controlPlane:

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -3,7 +3,7 @@ title: Embedded etcd
 sidebar_label: embedded
 sidebar_position: 2
 sidebar_class_name: free host-nodes private-nodes standalone
-description: Configure an embedded etcd instance as the virtual cluster's backing store.
+description: Configure an embedded etcd instance as the tenant cluster's backing store.
 ---
 
 import ConfigReference from '../../../../../../_partials/config/controlPlane/backingStore/etcd/embedded.mdx'
@@ -25,7 +25,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 :::warning Upgrade Notice
 
-An issue exists when upgrading etcd (from version 3.5.1 or later, but earlier than 3.5.20) to version 3.6. This upgrade path can lead to a failed upgrade and cause the virtual cluster to break. etcd version 3.5.20 includes a fix that migrates membership data to the v3 data store. This migration prevents the issue when upgrading to version 3.6.
+An issue exists when upgrading etcd (from version 3.5.1 or later, but earlier than 3.5.20) to version 3.6. This upgrade path can lead to a failed upgrade and cause the tenant cluster to break. etcd version 3.5.20 includes a fix that migrates membership data to the v3 data store. This migration prevents the issue when upgrading to version 3.6.
 
 To avoid this issue, vCluster does not upgrade etcd to version 3.6 until vCluster version 0.29.0.
 
@@ -162,16 +162,16 @@ kubectl logs [[GLOBAL:VCLUSTER_NAME]]-0 -n [[GLOBAL:NAMESPACE]] | grep "cluster 
 <TabItem value="first-replica-failing" label="First replica is failing">
 
 :::warning
-Before attempting any recovery procedure, [create a backup](../../../../../../manage/backup-restore/backup.mdx) of your virtual cluster using `vcluster snapshot create --include-volumes`. This ensures both the virtual cluster's etcd data and persistent volumes are backed up.
+Before attempting any recovery procedure, [create a backup](../../../../../../manage/backup-restore/backup.mdx) of your tenant cluster using `vcluster snapshot create --include-volumes`. This ensures both the tenant cluster's etcd data and persistent volumes are backed up.
 
-If the virtual cluster's etcd is in a bad state and the snapshot command fails, you can still back up from the host cluster (which has its own functioning etcd). Use your preferred backup solution (e.g., Velero, Kasten, or cloud-native backup tools) to back up the host cluster namespace containing the vCluster resources. Ensure the backup includes:
+If the tenant cluster's etcd is in a bad state and the snapshot command fails, you can still back up from the control plane cluster (which has its own functioning etcd). Use your preferred backup solution (e.g., Velero, Kasten, or cloud-native backup tools) to back up the control plane cluster namespace containing the vCluster resources. Ensure the backup includes:
 - All Kubernetes resources in the vCluster namespace (StatefulSet, Services, etc.)
-- PersistentVolumeClaims and their associated volume data (contains the virtual cluster's etcd data)
+- PersistentVolumeClaims and their associated volume data (contains the tenant cluster's etcd data)
 - Secrets and ConfigMaps
 
-When restored, the vCluster pods will restart and the virtual cluster will be recreated from the backed-up etcd data.
+When restored, the vCluster pods will restart and the tenant cluster will be recreated from the backed-up etcd data.
 
-If using namespace syncing, back up all synced namespaces on the host cluster as well.
+If using namespace syncing, back up all synced namespaces on the control plane cluster as well.
 :::
 
 The recovery procedure depends on your StatefulSet `podManagementPolicy` configuration. vCluster version 0.20 and later use `Parallel` by default. Earlier versions used `OrderedReady`.
@@ -268,7 +268,7 @@ Delete the StatefulSet without deleting the pods:
 
 <Step title="Update configuration to Parallel">
 
-Update your virtual cluster configuration to use `Parallel` pod management policy.
+Update your tenant cluster configuration to use `Parallel` pod management policy.
 
 If using a VirtualClusterInstance, edit the instance and update the `podManagementPolicy`:
 
@@ -365,7 +365,7 @@ When the majority of etcd member replicas become corrupted or deleted simultaneo
 Before starting recovery, ensure you have:
 - Created a snapshot using `vcluster snapshot create <vcluster-name> --include-volumes <storage-location>`
 - The snapshot location URL (for example, `s3://my-bucket/backup` or `oci://registry/repo:tag`)
-- Access to the host cluster namespace where the vCluster is deployed
+- Access to the control plane cluster namespace where the vCluster is deployed
 
 For detailed snapshot creation instructions, see [Create snapshots](../../../../../../manage/backup-restore/backup.mdx).
 :::

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/overview.mdx
@@ -13,7 +13,7 @@ import DocCardList from '@theme/DocCardList';
 
 If you choose etcd as your backing store, there are two deployment options:
 
-- [Embedded](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded): etcd is deployed as part of the virtual cluster control plane pod.
+- [Embedded](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded): etcd is deployed as part of the tenant cluster control plane pod.
 - [Deploy](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy): etcd is deployed as a separate component.
 
 <br />

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/overview.mdx
@@ -10,14 +10,14 @@ slug: /configure/vcluster-yaml/control-plane/components/backing-store
 
 import BackingStore from '../../../../../_partials/config/controlPlane/backingStore.mdx'
 
-Each virtual cluster requires a backing store and vCluster provides two different types of backing store options:
+Each tenant cluster requires a backing store and vCluster provides two different types of backing store options:
 
 * [etcd](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd)
 * [database](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database)
 
 There are different ways to deploy the type of backing store.
 
-By default, vCluster uses an embedded SQLite database as the backing store. This option is great for smaller sandbox virtual clusters, but for production, it's recommended to use a different backing store option.
+By default, vCluster uses an embedded SQLite database as the backing store. This option is great for smaller sandbox tenant clusters, but for production, it's recommended to use a different backing store option.
 
 :::warning vCluster Standalone 
 vCluster Standalone has limited backing store options. For single control plane nodes setup,

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -23,21 +23,21 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 
 
-Each virtual cluster runs its own DNS service using CoreDNS. This allows pods and services inside the virtual cluster to discover each other using standard Kubernetes DNS names such as `my-service.default.svc.cluster.local`. The syncer syncs the services necessary for DNS to function as expected.
+Each tenant cluster runs its own DNS service using CoreDNS. This allows pods and services inside the tenant cluster to discover each other using standard Kubernetes DNS names such as `my-service.default.svc.cluster.local`. The syncer syncs the services necessary for DNS to function as expected.
 
-This setup means that applications inside the virtual cluster cannot resolve names for services that only exist in the host cluster. Similarly, pods in the host cluster cannot discover services that only exist inside a virtual cluster. DNS resolution works entirely within the boundaries of the virtual cluster unless you configure external mappings explicitly.
+This setup means that applications inside the tenant cluster cannot resolve names for services that only exist in the control plane cluster. Similarly, pods in the control plane cluster cannot discover services that only exist inside a tenant cluster. DNS resolution works entirely within the boundaries of the tenant cluster unless you configure external mappings explicitly.
 
 :::note
-CoreDNS in the virtual cluster listens on port 1053, not the DNS port 53. This avoids privilege issues, especially when multiple virtual clusters run on the same host cluster. Port 53 is a privileged port and typically requires elevated permissions to bind. Blocked access to port 1053 prevents DNS resolution within the virtual cluster.
+CoreDNS in the tenant cluster listens on port 1053, not the DNS port 53. This avoids privilege issues, especially when multiple tenant clusters run on the same control plane cluster. Port 53 is a privileged port and typically requires elevated permissions to bind. Blocked access to port 1053 prevents DNS resolution within the tenant cluster.
 :::
 
 ## Deployment types
 
 CoreDNS can deploy in two methods, either as a separate pod (default) or CoreDNS components can be embedded as part of the vCluster control plane pod. 
-Each deployment type affects how the DNS service operates, how many pods the virtual cluster requires, and whether users can access and customize 
-the CoreDNS configuration from inside the virtual cluster.
+Each deployment type affects how the DNS service operates, how many pods the tenant cluster requires, and whether users can access and customize 
+the CoreDNS configuration from inside the tenant cluster.
 
-| Deployment Type         | Pod count per replica | Editable from virtual cluster | Corefile customization | Notes                              |
+| Deployment Type         | Pod count per replica | Editable from tenant cluster | Corefile customization | Notes                              |
 |-------------------------|-----------------------|-------------------------------|------------------------|------------------------------------|
 | Separate (_Default_)   | 2                     | Yes                           | Yes                    | CoreDNS runs as a Deployment       |
 | Embedded  | 1                     | No                            | No                     | CoreDNS runs inside the syncer container in the vCluster control plane pod |
@@ -45,9 +45,9 @@ the CoreDNS configuration from inside the virtual cluster.
 
 ### Deploy separate CoreDNS
 
-By default, vCluster creates a dedicated CoreDNS pod. The virtual cluster deployment includes two pods: one pod for the API server and syncer, and another for CoreDNS.
+By default, vCluster creates a dedicated CoreDNS pod. The tenant cluster deployment includes two pods: one pod for the API server and syncer, and another for CoreDNS.
 
-CoreDNS is deployed as a standard Kubernetes deployment inside the virtual cluster. Users can view and modify the CoreDNS deployment using standard Kubernetes tools. DNS configuration is accessible, and you can apply changes or troubleshoot without restarting the virtual cluster's control plane.
+CoreDNS is deployed as a standard Kubernetes deployment inside the tenant cluster. Users can view and modify the CoreDNS deployment using standard Kubernetes tools. DNS configuration is accessible, and you can apply changes or troubleshoot without restarting the tenant cluster's control plane.
 
 :::note Configuration Persistence
 Configuration changes applied directly to CoreDNS are not persistent. They get overwritten when the vCluster control plane pod restarts and the original `vcluster.yaml` configuration is re-applied.
@@ -58,7 +58,7 @@ Configuration changes applied directly to CoreDNS are not persistent. They get o
 
 <ProAdmonition/>
 
-The embedded CoreDNS feature allows you to run CoreDNS as part of the syncer, which saves the resources of an external CoreDNS pod. This consolidates all virtual cluster components into a single pod and optimizes resource allocation. It also enables advanced DNS features like custom hostname mapping, cross-vCluster service resolution, and communication with host cluster services.
+The embedded CoreDNS feature allows you to run CoreDNS as part of the syncer, which saves the resources of an external CoreDNS pod. This consolidates all tenant cluster components into a single pod and optimizes resource allocation. It also enables advanced DNS features like custom hostname mapping, cross-vCluster service resolution, and communication with control plane cluster services.
 
 The embedded approach requires consideration of operational trade-offs. Troubleshooting becomes more complex since DNS and sync functions share the same container and process space. Updates and restarts affect both DNS and sync capabilities simultaneously, though all CoreDNS features remain supported.
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -42,7 +42,7 @@ controlPlane:
         tag: v1.32.1                # Default: v1.32.1 (or matches host Kubernetes version)
 ```
 
-The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm>'s Kubernetes version.
+The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">control plane cluster</GlossaryTerm>'s Kubernetes version.
 
 :::note
 The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -2,7 +2,7 @@
 title: Kubernetes distribution
 sidebar_label: K8s
 sidebar_position: 1
-description: Configure Kubernetes as the distro for the virtual cluster.
+description: Configure Kubernetes as the distro for the tenant cluster.
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 
@@ -71,8 +71,8 @@ The [Kubernetes API server](https://kubernetes.io/docs/reference/command-line-to
 - `--max-requests-inflight`: Maximum number of non-mutating requests (GET, LIST) that can be served at the same time. Default is 400.
 - `--max-mutating-requests-inflight`: Maximum number of mutating requests (POST, PUT, PATCH, DELETE) that can be served at the same time. Default is 200.
 
-:::note Impact on host cluster requests
-The `--max-requests-inflight` and `--max-mutating-requests-inflight` flags only indirectly affect the number of requests sent to the host cluster. With the exception of Service creation, vCluster handles all resource creation asynchronously through the syncer, which self-throttles at a default rate of 40 QPS.
+:::note Impact on control plane cluster requests
+The `--max-requests-inflight` and `--max-mutating-requests-inflight` flags only indirectly affect the number of requests sent to the control plane cluster. With the exception of Service creation, vCluster handles all resource creation asynchronously through the syncer, which self-throttles at a default rate of 40 QPS.
 :::
 
 :::info API Priority and Fairness
@@ -84,7 +84,7 @@ Starting with Kubernetes 1.20, the [API Priority and Fairness](https://kubernete
 When setting rate limits, consider:
 
 - **Workload patterns**: Higher limits for read-heavy workloads, balanced limits for mixed workloads
-- **Available resources**: Ensure the host cluster has sufficient CPU and memory to handle the configured limits
+- **Available resources**: Ensure the control plane cluster has sufficient CPU and memory to handle the configured limits
 - **Client behavior**: Applications with many concurrent API calls may need higher limits
 - **Platform limits**: Some managed Kubernetes platforms (like [EKS](https://docs.aws.amazon.com/eks/latest/best-practices/scale-control-plane.html)) may scale these values automatically
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/overview.mdx
@@ -2,7 +2,7 @@
 title: Kubernetes distro
 sidebar_label: Overview
 sidebar_position: 0
-description: Configure the Kubernetes distribution to use for your virtual cluster.
+description: Configure the Kubernetes distribution to use for your tenant cluster.
 slug: /configure/vcluster-yaml/control-plane/components/distro
 ---
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -13,7 +13,7 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-Virtual cluster internal logging uses a separate component called the [HostPath Mapper](/platform/maintenance/monitoring/central-hostpath-mapper). This component matches virtual pod and container names to their real physical names.
+Tenant cluster internal logging uses a separate component called the [HostPath Mapper](/platform/maintenance/monitoring/central-hostpath-mapper). This component matches virtual pod and container names to their real physical names.
 
 If you don't configure host path mapping, log collectors such as Loki, ELK, and Fluentd incorrectly resolve logs for vCluster pods.
 
@@ -63,7 +63,7 @@ After deployment, the HostPath Mapper DaemonSet starts running on every node tha
 <!-- vale on -->
 
 <!-- vale off -->
-The Central HostPath Mapper enables the following in a virtual cluster:
+The Central HostPath Mapper enables the following in a tenant cluster:
 <!-- vale on -->
 
 - Container-based logging used by tools such as fluentd and Logstash.

--- a/vcluster/configure/vcluster-yaml/control-plane/components/proxy.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/proxy.mdx
@@ -8,7 +8,7 @@ sidebar_class_name: host-nodes private-nodes standalone
 
 import ControlPlaneProxy from '../../../../_partials/config/controlPlane/proxy.mdx'
 
-The Proxy feature lets you configure the address and port that the virtual cluster's API server listens on. vCluster uses these fields when generating the certificate for TLS.
+The Proxy feature lets you configure the address and port that the tenant cluster's API server listens on. vCluster uses these fields when generating the certificate for TLS.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/ingress.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/ingress.mdx
@@ -10,9 +10,9 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-Configure this when you want vCluster to deploy an Ingress resource to expose the virtual cluster's API server at a hostname. The cluster must have an ingress controller running and a LoadBalancer Service.
+Configure this when you want vCluster to deploy an Ingress resource to expose the tenant cluster's API server at a hostname. The cluster must have an ingress controller running and a LoadBalancer Service.
 
-This feature is not the same as syncing Ingress resources between the host and virtual clusters. See [sync.fromHost.ingressClasses](../../sync/from-host/ingress-classes.mdx) and [sync.toHost.ingresses](../../sync/to-host/networking/ingresses.mdx).
+This feature is not the same as syncing Ingress resources between the control plane cluster and tenant clusters. See [sync.fromHost.ingressClasses](../../sync/from-host/ingress-classes.mdx) and [sync.toHost.ingresses](../../sync/to-host/networking/ingresses.mdx).
 
 vCluster uses a default rule, which uses the `ingress.host` and `ingress.pathType` configuration.  When configure `ingress.spec.rules`, vCluster ignores `ingress.host` and `ingress.pathType`.
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -25,9 +25,9 @@ Use the `highAvailability` settings to run multiple replicas of the vCluster con
   - `renewDeadline`: Time a pod waits to renew its leadership before it gives up.
   - `retryPeriod`: Interval between retries when attempting to acquire or renew leadership.
 
-## Schedule virtual cluster pods
+## Schedule tenant cluster pods
 
-You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
+You can configure how and where tenant cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
 
 - **`nodeSelector`**  
   Match specific node labels to guide the scheduler toward preferred nodes. Examples include:  
@@ -36,11 +36,11 @@ You can configure how and where virtual cluster pods are scheduled within the Ku
 
 - **`affinity`** 
   Set rules to control how pods are scheduled in relation to other pods.  
-  - Use anti-affinity (repel the pod) to keep virtual cluster pods on separate nodes. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
+  - Use anti-affinity (repel the pod) to keep tenant cluster pods on separate nodes. A common technique is to make tenant cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
   - Use affinity (attract the pod) to group related pods together and reduce network latency for critical services.
 
 - **`tolerations`**  
-  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
+  Allow pods to run on nodes with specific taints. Use this to schedule tenant cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-tenant-cluster workloads and configure tenant cluster pods to tolerate the taint. This keeps tenant clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
 
 - **`priorityClassName`**  
   Set the pod’s priority to control scheduling order and preemption. See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/kube-vip.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/kube-vip.mdx
@@ -2,7 +2,7 @@
 title: Kube-vip
 sidebar_label: kubeVip
 sidebar_position: 4
-description: Configure embedded kube-vip for virtual cluster control plane.
+description: Configure embedded kube-vip for tenant cluster control plane.
 sidebar_class_name: private-nodes
 ---
 
@@ -14,7 +14,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 # Kube-vip
 
-Kube-vip announces the virtual cluster's control plane endpoint IP address on a specified network interface using ARP (layer 2).
+Kube-vip announces the tenant cluster's control plane endpoint IP address on a specified network interface using ARP (layer 2).
 This makes the endpoint available to private nodes on the same layer 2 network, allowing them to connect to the control plane using a stable IP address.
 
 Kube-vip is intended to be used with high-availability (HA) deployments.
@@ -25,7 +25,7 @@ When the control plane has multiple replicas and the active pod is terminated, k
 When kube-vip is enabled:
 
 1. A virtual IP address (VIP) is configured for the vCluster control plane through the `controlPlane.endpoint` field
-2. Kube-vip uses leader election within the virtual cluster to determine which control plane replica manages the VIP
+2. Kube-vip uses leader election within the tenant cluster to determine which control plane replica manages the VIP
 3. The leader adds the VIP on the specified network interface
 4. Worker nodes on the same layer 2 network discover the active control plane instance through ARP
 5. If the control plane pod is rescheduled, the new leader sends gratuitous ARP packets to update peers about the new VIP location
@@ -63,7 +63,7 @@ Multus is a meta CNI plugin that can attach Pods to additional networks.
 It is a good alternative, especially in bare metal deployments, where a load balancer may not be available or be considerable effort to set up.
 
 This example assumes:
-- Multus is installed in the host cluster
+- Multus is installed in the control plane cluster
 - A bridge named `br-private` exists on the host nodes
 - The bridge is connected to an isolated network where the private nodes are also being deployed
 

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx
@@ -15,27 +15,27 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 # Virtual scheduler
 
-By default, vCluster reuses the host cluster scheduler to schedule workloads. This conserves compute resources.
+By default, vCluster reuses the control plane cluster scheduler to schedule workloads. This conserves compute resources.
 
-If you also [sync PersistentVolumeClaim resources](../../../sync/to-host/storage/persistent-volume-claims.mdx), vCluster mirrors the related `CSIDriver`, `CSINode`, and `CSIStorageCapacity` objects into the virtual cluster. This allows the virtual scheduler to make storage-aware scheduling decisions.
+If you also [sync PersistentVolumeClaim resources](../../../sync/to-host/storage/persistent-volume-claims.mdx), vCluster mirrors the related `CSIDriver`, `CSINode`, and `CSIStorageCapacity` objects into the tenant cluster. This allows the virtual scheduler to make storage-aware scheduling decisions.
 
-In some cases, you might want to label or taint nodes inside the virtual cluster to influence scheduling decisions—for example, using [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) or [topology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
+In some cases, you might want to label or taint nodes inside the tenant cluster to influence scheduling decisions—for example, using [node affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) or [topology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
 
-To support these use cases, vCluster allows you to run a scheduler inside the virtual cluster instead of reusing the host cluster’s scheduler.
+To support these use cases, vCluster allows you to run a scheduler inside the tenant cluster instead of reusing the control plane cluster’s scheduler.
 
 ## Enable the virtual scheduler
 
 To use the virtual scheduler, you must enable the following:
 
-- Syncing nodes from the host cluster (`sync.fromHost.nodes.enabled`)
+- Syncing nodes from the control plane cluster (`sync.fromHost.nodes.enabled`)
 - The virtual scheduler (`controlPlane.advanced.virtualScheduler.enabled`)
 
 When the virtual scheduler is enabled:
 
-- vCluster only syncs pods that already have a node assigned in the host cluster.
-- You can label and taint nodes within the virtual cluster without affecting the host cluster.
+- vCluster only syncs pods that already have a node assigned in the control plane cluster.
+- You can label and taint nodes within the tenant cluster without affecting the control plane cluster.
 
-Configure your `vcluster.yaml` to sync nodes from the host cluster and enable the virtual scheduler:
+Configure your `vcluster.yaml` to sync nodes from the control plane cluster and enable the virtual scheduler:
 
 ```yaml
 sync:
@@ -50,11 +50,11 @@ controlPlane:
 
 ```
 
-This setting makes host cluster nodes available inside the virtual cluster. It allows the virtual scheduler to make scheduling decisions based on node labels and taints.
+This setting makes control plane cluster nodes available inside the tenant cluster. It allows the virtual scheduler to make scheduling decisions based on node labels and taints.
 
 ## Automatically enable sync features
 
-When the virtual scheduler is enabled, the following resources are automatically synced from the host cluster:
+When the virtual scheduler is enabled, the following resources are automatically synced from the control plane cluster:
 
 - [CSI drivers](../../../sync/from-host/csi-drivers.mdx)
 - [CSI nodes](../../..//sync/from-host/csi-nodes.mdx)
@@ -62,11 +62,11 @@ When the virtual scheduler is enabled, the following resources are automatically
 
 This automatic syncing only occurs if:
 
-- Syncing for CSI resources from the host is set to auto (the default).
-- `PersistentVolumeClaim` syncing to the host cluster is enabled.
+- Syncing for CSI resources from the control plane cluster is set to auto (the default).
+- `PersistentVolumeClaim` syncing to the control plane cluster is enabled.
 
 :::info
-If you [sync PersistentVolumeClaim resources](../../../sync/to-host/storage/persistent-volume-claims.mdx), vCluster mirrors the related `CSIDriver`, `CSINode`, and `CSIStorageCapacity` objects into the virtual cluster. This allows the virtual scheduler to make storage-aware scheduling decisions.
+If you [sync PersistentVolumeClaim resources](../../../sync/to-host/storage/persistent-volume-claims.mdx), vCluster mirrors the related `CSIDriver`, `CSINode`, and `CSIStorageCapacity` objects into the tenant cluster. This allows the virtual scheduler to make storage-aware scheduling decisions.
 :::
 
 Manually disabling these features might result in incorrect pod scheduling behavior.

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -14,7 +14,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 For private nodes, workload pods run on dedicated nodes and do not sync to the Control Plane Cluster namespace. Configure image pull authentication at the node level using [`privateNodes.joinNode.containerd.registry`](/docs/vcluster/configure/vcluster-yaml/private-nodes/#privateNodes-joinNode-containerd-registry).
 :::
 
-The workloadServiceAccount allows you to enforce the use of a specific ServiceAccount for all vCluster workload pods running in the host cluster.
+The workloadServiceAccount allows you to enforce the use of a specific ServiceAccount for all vCluster workload pods running in the control plane cluster.
 For example, you can attach a shared imagePullSecret to the ServiceAccount so that all synced pods use the same secret when pulling container images.
 ```yaml
 controlPlane:
@@ -32,10 +32,10 @@ This is because imagePullSecrets are only copied from the ServiceAccount to the 
 The referenced imagePullSecrets must also exist in the host namespace where the vCluster’s workload pods are synced.
 
 An easy way to achieve this is by using [Virtual Cluster Templates](/platform/administer/templates/create-templates).
-In addition to allowing you to add arbitrary Kubernetes objects inside the virtual cluster, Virtual Cluster Templates also enable you to create arbitrary Kubernetes objects in the host cluster namespace where the vCluster’s StatefulSet is deployed.
+In addition to allowing you to add arbitrary Kubernetes objects inside the tenant cluster, Virtual Cluster Templates also enable you to create arbitrary Kubernetes objects in the control plane cluster namespace where the vCluster’s StatefulSet is deployed.
 :::
 
-If [syncing ServiceAccount resources from the virtual cluster to the host cluster](../../../sync/to-host/advanced/service-accounts.mdx) is enabled, the `workloadServiceAccount` setting is ignored.
+If [syncing ServiceAccount resources from the tenant cluster to the control plane cluster](../../../sync/to-host/advanced/service-accounts.mdx) is enabled, the `workloadServiceAccount` setting is ignored.
 
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -11,7 +11,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 <TenancySupport hostNodes="true" />
 
 :::note Private Nodes
-For private nodes, workload pods run on dedicated nodes and do not sync to the Control Plane Cluster namespace. Configure image pull authentication at the node level using [`privateNodes.joinNode.containerd.registry`](/docs/vcluster/configure/vcluster-yaml/private-nodes/#privateNodes-joinNode-containerd-registry).
+For private nodes, workload pods run on dedicated nodes and do not sync to the control plane cluster namespace. Configure image pull authentication at the node level using [`privateNodes.joinNode.containerd.registry`](/docs/vcluster/configure/vcluster-yaml/private-nodes/#privateNodes-joinNode-containerd-registry).
 :::
 
 The workloadServiceAccount allows you to enforce the use of a specific ServiceAccount for all vCluster workload pods running in the control plane cluster.


### PR DESCRIPTION
# Content Description
Replace "virtual cluster" → "tenant cluster" and "host cluster" → "control plane cluster" in all `control-plane/` prose (17 files). Code block comments and product names (Virtual Cluster Templates) left unchanged.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2097--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs