### PR TITLE
docs(doc-1334): update sync/from-host/ terminology to tenant/control plane cluster

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -17,10 +17,10 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the ConfigMaps and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the ConfigMaps and syncing the resources from the control plane cluster to the tenant cluster.
 :::
 
-Enabling sync from host allows you to sync ConfigMaps from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
+Enabling sync from host allows you to sync ConfigMaps from the specified namespaces in the control plane cluster to the specified namespaces in a tenant cluster.
 Here is how the required configuration in `vcluster.yaml` looks like:
 ```yaml title="configure ConfigMap sync from host"
 sync:
@@ -35,14 +35,14 @@ sync:
 ```
 
 Here are a few things to remember when configuring the sync:
-- It is also possible to modify the name of the synced resource in the virtual cluster.
-- There is no option to sync from all namespaces in the host.
-- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
+- It is also possible to modify the name of the synced resource in the tenant cluster.
+- There is no option to sync from all namespaces in the control plane cluster.
+- Sync is one-directional, from the control plane cluster to the tenant cluster. If you modify an object in the control plane cluster, vCluster syncs the change to virtual object.
 - When you delete a virtual object, vCluster re-creates it if the host object still exist.
 - When you delete a host object, vCluster deletes the corresponding virtual object.
 - It is not possible to sync ConfigMaps that were already synced from virtual to host, they are skipped by vCluster.
 
-Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
+Namespaces in the tenant cluster are created automatically during the sync (if they do not exist already).
 
 :::info kube-root-ca ConfigMap is skipped
 ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if they match the mappings specified in `vcluster.yaml`).
@@ -56,7 +56,7 @@ All the specified namespaces have to exist in the host at the vCluster startup.
 
 
 ## Sync all ConfigMaps from host namespace
-To sync all ConfigMaps from a given namespace in the host to the given namespace in the virtual cluster, use “namespace/*” wildcard, e.g.:
+To sync all ConfigMaps from a given namespace in the control plane cluster to the given namespace in the tenant cluster, use “namespace/*” wildcard, e.g.:
 
 ```yaml title="configure ConfigMap sync from host namespace"
 sync:
@@ -85,10 +85,10 @@ sync:
           "foo/cm-name": "bar/cm-name"
 ```
 
-## Sync all ConfigMaps from virtual cluster's host namespace
-There is also a handy syntax to sync all ConfigMaps from virtual cluster’s own host namespace to the virtual namespace. As virtual cluster’s namespace is not always known upfront (e.g. when virtual cluster is created by the platform), `""` (empty string) is treated as “virtual cluster’s own host namespace”.
+## Sync all ConfigMaps from the tenant cluster’s control plane cluster namespace
+There is also a handy syntax to sync all ConfigMaps from the tenant cluster’s own control plane cluster namespace to the tenant namespace. As the tenant cluster’s namespace is not always known upfront (e.g. when the tenant cluster is created by the platform), `””` (empty string) is treated as “tenant cluster’s own control plane cluster namespace”.
 
-```yaml title="configure ConfigMap sync from host for virtual cluster's namespace"
+```yaml title="configure ConfigMap sync from host for tenant cluster's namespace"
 sync:
   fromHost:
     configMaps:
@@ -100,10 +100,10 @@ sync:
           "": "my-virtual"
 ```
 
-## Sync specific ConfigMap from virtual cluster's host namespace
-you can also specify only a few ConfigMaps from virtual cluster’s own host namespace this way:
+## Sync specific ConfigMap from the tenant cluster’s control plane cluster namespace
+you can also specify only a few ConfigMaps from the tenant cluster’s own control plane cluster namespace this way:
 
-```yaml title="configure ConfigMap sync from host for objects in virtual cluster's namespace"
+```yaml title="configure ConfigMap sync from host for objects in tenant cluster's namespace"
 sync:
   fromHost:
     configMaps:
@@ -115,7 +115,7 @@ sync:
           "/my-cm": "my-virtual/my-cm"
 ```
 
-## Modify synced ConfigMap namespace and name in the virtual cluster
+## Modify synced ConfigMap namespace and name in the tenant cluster
 It’s also possible to modify ConfigMap name during the sync:
 
 ```yaml title="configure ConfigMap sync from host and modify name and namespace"
@@ -157,7 +157,7 @@ sync:
 ```
 
 1. Your ConfigMap in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the tenant cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
 
 
 <FromHostConfigMapExample />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/csi-drivers.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/csi-drivers.mdx
@@ -18,13 +18,13 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 */}
 
 
-Sync [CSIDriver](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) resources from the host cluster to the virtual cluster. Use this in conjunction with the virtual scheduler inside of vCluster for more advanced scheduling needs. Syncing the CSIDriver resources from the host helps the virtual scheduler make decisions about which node to schedule pods to.
+Sync [CSIDriver](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) resources from the control plane cluster to the tenant cluster. Use this in conjunction with the virtual scheduler inside of vCluster for more advanced scheduling needs. Syncing the CSIDriver resources from the control plane cluster helps the virtual scheduler make decisions about which node to schedule pods to.
 
 ## Default value
 
 Default: `enabled: auto`.
 
-## Sync CSIDrivers from the host to virtual cluster
+## Sync CSIDrivers from the control plane cluster to the tenant cluster
 
 Configure `enabled: true` if you aren't using the virtual schedular but want to sync CSIDriver resources.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/csi-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/csi-nodes.mdx
@@ -18,13 +18,13 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 */}
 
 
-Sync [CSINode](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1/) resources from the host cluster to the virtual cluster. Use this in conjunction with the [virtual scheduler](../../control-plane/other/advanced/virtual-scheduler.mdx) inside of vCluster for more advanced scheduling needs. Syncing the CSINode resources from the host helps the virtual scheduler make decisions about which node to schedule pods to.
+Sync [CSINode](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/csi-node-v1/) resources from the control plane cluster to the tenant cluster. Use this in conjunction with the [virtual scheduler](../../control-plane/other/advanced/virtual-scheduler.mdx) inside of vCluster for more advanced scheduling needs. Syncing the CSINode resources from the control plane cluster helps the virtual scheduler make decisions about which node to schedule pods to.
 
 ## Default value
 
 Default: `enabled: auto`.
 
-## Sync CSINodes from the host to virtual cluster
+## Sync CSINodes from the control plane cluster to the tenant cluster
 
 Configure `enabled: true` if you aren't using the virtual schedular but want to sync CSINode resources.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx
@@ -18,19 +18,19 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 - in short syncing these from the host helps the virtual cluster scheduler make decisions about which node to schedule pods to.
 */}
 
-Sync [CSIStorageCapacity](https://kubernetes.io/docs/concepts/storage/storage-capacity/) resources from the host cluster to the 
-virtual cluster if the `.nodeTopology` matches a synced node. Use this in conjunction with the virtual scheduler inside of vCluster 
-for more advanced scheduling needs. Syncing the CSIStorageCapacity resources from the host helps the virtual scheduler make decisions about which node to schedule pods to.
+Sync [CSIStorageCapacity](https://kubernetes.io/docs/concepts/storage/storage-capacity/) resources from the control plane cluster to the 
+tenant cluster if the `.nodeTopology` matches a synced node. Use this in conjunction with the virtual scheduler inside of vCluster 
+for more advanced scheduling needs. Syncing the CSIStorageCapacity resources from the control plane cluster helps the virtual scheduler make decisions about which node to schedule pods to.
 
-CSIStorageCapacity is a namespaced resource. When synchronizing from the host cluster to the virtual cluster, all CSIStorageCapacity objects are synced into the `kube-system`
-namespace of the virtual cluster. During this process, the object name is transformed to the format `<objname>-x-<namespace>`, where `<objname>` is the original object name 
-in the host cluster and `<namespace>` is the namespace in which the object originally existed in the host cluster.
+CSIStorageCapacity is a namespaced resource. When synchronizing from the control plane cluster to the tenant cluster, all CSIStorageCapacity objects are synced into the `kube-system`
+namespace of the tenant cluster. During this process, the object name is transformed to the format `<objname>-x-<namespace>`, where `<objname>` is the original object name 
+in the control plane cluster and `<namespace>` is the namespace in which the object originally existed in the control plane cluster.
 
-When synchronizing from the virtual cluster back to the host cluster, a CSIStorageCapacity object is created in the host cluster only if it includes the physical location 
+When synchronizing from the tenant cluster back to the control plane cluster, a CSIStorageCapacity object is created in the control plane cluster only if it includes the physical location 
 annotations normally added by the syncer. Specifically:
-- `vcluster.loft.sh/object-name` specifies the object name in the host cluster.
-- `vcluster.loft.sh/object-namespace` specifies the host cluster namespace.
-If these annotations are not present, the CSIStorageCapacity object will not be created or updated in the host cluster.
+- `vcluster.loft.sh/object-name` specifies the object name in the control plane cluster.
+- `vcluster.loft.sh/object-namespace` specifies the control plane cluster namespace.
+If these annotations are not present, the CSIStorageCapacity object will not be created or updated in the control plane cluster.
 ```yaml title="Physical annotations of CSIStorageCapacity"
 apiVersion: storage.k8s.io/v1
 kind: CSIStorageCapacity
@@ -49,7 +49,7 @@ metadata:
 
 Default: `enabled: auto`.
 
-## Sync CSIStorageCapacities from the host to virtual cluster
+## Sync CSIStorageCapacities from the control plane cluster to the tenant cluster
 
 Configure `enabled: true` if you aren't using the virtual schedular but want to sync CSIStorageCapacity resources.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -19,18 +19,18 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <ProAdmonition/>
 
-# Sync custom resources from host to virtual cluster
+# Sync custom resources from the control plane cluster to the tenant cluster
 
-vCluster allows you to sync custom resources from the host cluster to the virtual cluster. This feature creates read-only copies of custom resources inside your virtual cluster, making them available to applications and users without giving them direct access to the host cluster.
+vCluster allows you to sync custom resources from the control plane cluster to the tenant cluster. This feature creates read-only copies of custom resources inside your tenant cluster, making them available to applications and users without giving them direct access to the control plane cluster.
 
-When you enable custom resource syncing, vCluster first copies the CustomResourceDefinition (CRD) from the host to the virtual cluster, then begins syncing the actual custom resource instances. This is particularly useful for sharing cluster-wide resources like cluster-scoped custom resources or `ClusterStores` from [external-secrets](https://external-secrets.io/latest/) with your virtual cluster workloads.
+When you enable custom resource syncing, vCluster first copies the CustomResourceDefinition (CRD) from the control plane cluster to the tenant cluster, then begins syncing the actual custom resource instances. This is particularly useful for sharing cluster-wide resources like cluster-scoped custom resources or `ClusterStores` from [external-secrets](https://external-secrets.io/latest/) with your tenant cluster workloads.
 
-The synced resources are read-only in the virtual cluster. If you modify them in the host cluster, vCluster automatically updates the virtual cluster copies. However, changes made to these resources within the virtual cluster are not persisted.
+The synced resources are read-only in the tenant cluster. If you modify them in the control plane cluster, vCluster automatically updates the tenant cluster copies. However, changes made to these resources within the tenant cluster are not persisted.
 
-If you need to sync resources from the virtual cluster to the host cluster instead, see [syncing custom resources to the host cluster](../to-host/advanced/custom-resources.mdx).
+If you need to sync resources from the tenant cluster to the control plane cluster instead, see [syncing custom resources to the control plane cluster](../to-host/advanced/custom-resources.mdx).
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the control plane cluster to the tenant cluster.
 :::
 
 <!-- vale off -->
@@ -39,7 +39,7 @@ vCluster automatically adds the required cluster RBAC permissions for retrieving
 
 Cluster-scoped custom resources exist at the cluster level and are not tied to any specific namespace. These are the simplest to sync because they don't require namespace mapping.
 
-To sync cluster-scoped custom resources from the host cluster, configure the resource in your `vcluster.yaml` file:
+To sync cluster-scoped custom resources from the control plane cluster, configure the resource in your `vcluster.yaml` file:
 
 ```yaml title="configure cluster-scoped CRD sync from host"
 sync:
@@ -60,7 +60,7 @@ If you want to sync a specific version of a CRD that is not the storage version,
 
 By default, namespace-scoped custom resource syncing is disabled.
 
-Enabling this feature allows you to sync namespaced custom resources from specific namespaces in the host cluster to corresponding namespaces in the virtual cluster.
+Enabling this feature allows you to sync namespaced custom resources from specific namespaces in the control plane cluster to corresponding namespaces in the tenant cluster.
 
 ```yaml title="Configure namespace-scoped CRD sync from host"
 sync:
@@ -78,36 +78,36 @@ sync:
 
 Key behaviors for namespace scoped syncing:
 
-- You can modify the name of the synced resource in the virtual cluster.
-- You cannot sync from all namespaces in the host cluster.
-- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to the virtual object.
+- You can modify the name of the synced resource in the tenant cluster.
+- You cannot sync from all namespaces in the control plane cluster.
+- Sync is one-directional, from the control plane cluster to the tenant cluster. If you modify an object in the control plane cluster, vCluster syncs the change to the virtual object.
 - When you delete a virtual object, vCluster re-creates it if the host object still exists.
 - When you delete a host object, vCluster deletes the virtual object.
 
-vCluster creates namespaces in the virtual cluster automatically during the sync if they don't already exist.
+vCluster creates namespaces in the tenant cluster automatically during the sync if they don't already exist.
 
 ### Prerequisites
 
 Ensure you have the following:
 
-- All specified namespaces must exist in the host cluster when vCluster starts.
-- The CustomResourceDefinition must exist in the host cluster when vCluster starts.
+- All specified namespaces must exist in the control plane cluster when vCluster starts.
+- The CustomResourceDefinition must exist in the control plane cluster when vCluster starts.
 
 ### Example
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the control plane cluster to the tenant cluster.
 :::
 
-For namespace scoped custom resources, you must specify `mappings.byName` in the config. This tells vCluster which host resources should be synced and where to place them in the virtual cluster.
+For namespace scoped custom resources, you must specify `mappings.byName` in the config. This tells vCluster which control plane cluster resources should be synced and where to place them in the tenant cluster.
 
-vCluster creates namespaces in the virtual cluster automatically during the sync if they don't already exist.
+vCluster creates namespaces in the tenant cluster automatically during the sync if they don't already exist.
 
 vCluster cannot sync custom resources that were already synced from virtual to host. It skips these resources.
 
 The following is an example with a generic custom resource.
 
-To sync all custom resources from a given namespace in the host to a given namespace in the virtual cluster, use the "namespace/*" wildcard:
+To sync all custom resources from a given namespace in the control plane cluster to a given namespace in the tenant cluster, use the "namespace/*" wildcard:
 
 ```yaml title="Configure custom resource sync from host namespace"
 sync:
@@ -139,9 +139,9 @@ sync:
             "foo/my-object": "bar/my-object"
 ```
 
-There is also a syntax to sync all custom resources from the virtual cluster's own host namespace to the virtual namespace. Since the virtual cluster's namespace is not always known upfront (for example, when vCluster is created by the platform), `""` (empty string) is treated as "vCluster's own host namespace":
+There is also a syntax to sync all custom resources from the tenant cluster's own control plane cluster namespace to the tenant namespace. Since the tenant cluster's namespace is not always known upfront (for example, when vCluster is created by the platform), `""` (empty string) is treated as "tenant cluster's own control plane cluster namespace":
 
-```yaml title="configure custom resource sync from host for virtual cluster's namespace"
+```yaml title="configure custom resource sync from host for tenant cluster's namespace"
 sync:
   fromHost:
     customResources:
@@ -155,9 +155,9 @@ sync:
             "": "my-virtual"
 ```
 
-You can also specify only a few custom resources from the virtual cluster's own host namespace:
+You can also specify only a few custom resources from the tenant cluster's own control plane cluster namespace:
 
-```yaml title="configure custom resource sync from host for objects in virtual cluster's namespace"
+```yaml title="configure custom resource sync from host for objects in tenant cluster's namespace"
 sync:
   fromHost:
     customResources:
@@ -189,9 +189,9 @@ sync:
 
 ### Patches
 
-You can use patches to transform data as it syncs from the host to the virtual cluster.
+You can use patches to transform data as it syncs from the control plane cluster to the tenant cluster.
 
-When syncing custom resources from host to virtual, you can use `reverseExpression` to modify the data during the sync process. The host cluster remains unchanged, but the virtual cluster gets the modified data.
+When syncing custom resources from the control plane cluster to the tenant cluster, you can use `reverseExpression` to modify the data during the sync process. The control plane cluster remains unchanged, but the tenant cluster gets the modified data.
 
 :::note
 `expressions` (used for virtual-to-host syncing) have no effect when syncing from host to virtual.
@@ -217,9 +217,9 @@ sync:
 
 In the example:
 
-- The custom resource in the host namespace `default` named `my-object` is synced to the namespace `barfoo2` in virtual and named `object-my`.
+- The custom resource in the host namespace `default` named `my-object` is synced to the namespace `barfoo2` in the tenant cluster and named `object-my`.
 
-- If the `default/my-object` host object has an annotation with a value that starts with `www.` (for example: `my-address: www.loft.sh`), then the synced object in the virtual cluster `barfoo2/object-my` has the annotation `my-address: loft.sh`.
+- If the `default/my-object` host object has an annotation with a value that starts with `www.` (for example: `my-address: www.loft.sh`), then the synced object in the tenant cluster `barfoo2/object-my` has the annotation `my-address: loft.sh`.
 
 <NamespacedCustomResourcesExample/>
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
@@ -22,41 +22,41 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 By default, this is disabled.
 
-DeviceClass syncing allows virtual clusters to use device classes from the host cluster. 
-With DeviceClass syncing enabled, virtual clusters can reference DeviceClass resources from the 
-host cluster in [resourceclaims](../to-host/DRA/resourceclaims.mdx) and [resourceclaimtemplates](../to-host/DRA/resourceclaimtemplates.mdx).
+DeviceClass syncing allows tenant clusters to use device classes from the control plane cluster. 
+With DeviceClass syncing enabled, tenant clusters can reference DeviceClass resources from the 
+control plane cluster in [resourceclaims](../to-host/DRA/resourceclaims.mdx) and [resourceclaimtemplates](../to-host/DRA/resourceclaimtemplates.mdx).
 
-You can enable this feature to sync DeviceClass resources from the host cluster to the virtual cluster.
-Add labels to DeviceClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors.
-When you create a ResourceClaims or ResourceClaimTemplates resource in the virtual cluster that references a synced DeviceClass, the host cluster's resourceclaim controller handles the resource claims allocation.
+You can enable this feature to sync DeviceClass resources from the control plane cluster to the tenant cluster.
+Add labels to DeviceClass resources in your control plane cluster and configure vCluster to sync only those that match specific label selectors.
+When you create a ResourceClaims or ResourceClaimTemplates resource in the tenant cluster that references a synced DeviceClass, the control plane cluster's resourceclaim controller handles the resource claims allocation.
 
-This saves resources since you don't need resourceclaim controllers in every virtual cluster.
+This saves resources since you don't need resourceclaim controllers in every tenant cluster.
 It also gives you centralized control over which DeviceClass teams can access. 
 
 This approach is useful in scenarios where selective access to DeviceClass configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the DeviceClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
 - **Tenant isolation**: Enable teams to use their own DeviceClass resources while sharing a single Control Plane Cluster.
-- **Security**: Restrict the DeviceClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
+- **Security**: Restrict the DeviceClass resources available in the tenant cluster to enforce access control and prevent unintended configurations.
 
 <EnableSyncing resourceClass="DeviceClass" pluralResourceClass="deviceClasses" />
 
 ## How syncing works
 
-When DeviceClass syncing is enabled, vCluster can use a label selector to control which DeviceClass, ResourceClaims and ResourceClaimTemplates resources are synchronized between the host and virtual clusters. 
+When DeviceClass syncing is enabled, vCluster can use a label selector to control which DeviceClass, ResourceClaims and ResourceClaimTemplates resources are synchronized between the control plane cluster and tenant clusters. 
 This affects the resource types with separate unidirectional sync flows:
 
-- **DeviceClass resources (host → virtual)**: vCluster syncs DeviceClass resources from the host cluster to the virtual cluster. You cannot create DeviceClass resources directly in the virtual cluster. If a selector is defined, only DeviceClass resources matching the selector will sync. If no selector is defined, **all** DeviceClass resources are synced.
+- **DeviceClass resources (control plane → tenant)**: vCluster syncs DeviceClass resources from the control plane cluster to the tenant cluster. You cannot create DeviceClass resources directly in the tenant cluster. If a selector is defined, only DeviceClass resources matching the selector will sync. If no selector is defined, **all** DeviceClass resources are synced.
 
-- **ResourceClaims resources (virtual → host)**: vCluster syncs ResourceClaims resources from the virtual cluster to the host cluster only if all the referenced `deviceClassName` exist in the host cluster and any of the following is true:
+- **ResourceClaims resources (tenant → control plane)**: vCluster syncs ResourceClaims resources from the tenant cluster to the control plane cluster only if all the referenced `deviceClassName` exist in the control plane cluster and any of the following is true:
     - No selector is defined for DeviceClass syncing, which allows all ResourceClaims resources to sync regardless of the `deviceClassName`.
-    - Each of the ResourceClaims's `deviceClassName` references a DeviceClass resource that matches the selector and is synced from the host cluster. 
+    - Each of the ResourceClaims's `deviceClassName` references a DeviceClass resource that matches the selector and is synced from the control plane cluster. 
 
-- **ResourceClaimTemplates resources (virtual → host)**: vCluster syncs ResourceClaimTemplates resources from the virtual cluster to the host cluster only if all the referenced `deviceClassName` exist in the host cluster and any of the following is true:
+- **ResourceClaimTemplates resources (tenant → control plane)**: vCluster syncs ResourceClaimTemplates resources from the tenant cluster to the control plane cluster only if all the referenced `deviceClassName` exist in the control plane cluster and any of the following is true:
     - No selector is defined for DeviceClass syncing, which allows all ResourceClaimTemplates resources to sync regardless of the `deviceClassName`.
-    - Each of the ResourceClaimTemplates's `deviceClassName` references a DeviceClass resource that matches the selector and is synced from the host cluster. 
+    - Each of the ResourceClaimTemplates's `deviceClassName` references a DeviceClass resource that matches the selector and is synced from the control plane cluster. 
 
-The same selector controls both sync flows. The selector determines which DeviceClass resources are imported from the host cluster and which ResourceClaims and ResourceClaimTemplates resources can sync to the host cluster based on the referenced DeviceClass resources.
+The same selector controls both sync flows. The selector determines which DeviceClass resources are imported from the control plane cluster and which ResourceClaims and ResourceClaimTemplates resources can sync to the control plane cluster based on the referenced DeviceClass resources.
 
 <UseSelectors showResource="true" resource="ResourceClaims" pluralResource="resourceClaims" resourceClass="DeviceClass" pluralResourceClass="deviceClasses" expressionKey="kubernetes.io/device.class" expressionValue1="nvidia" expressionValue2="amd" />
 
@@ -64,25 +64,25 @@ The same selector controls both sync flows. The selector determines which Device
 
 ### Resource lifecycle
 
-Synced DeviceClass resources function like any other Kubernetes resource in the virtual cluster. You
+Synced DeviceClass resources function like any other Kubernetes resource in the tenant cluster. You
 can view them with <code>kubectl get deviceclass</code> and reference them in your ResourceClaims 
 and ResourceClaimTemplates resources specifications with the <code>DeviceClassName</code> field.
 
-When you modify the DeviceClass resource in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the DeviceClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the DeviceClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+When you modify the DeviceClass resource in the control plane cluster, vCluster re-evaluates whether it still matches the selector criteria. If the DeviceClass continues to match, vCluster updates the corresponding resource in the tenant cluster to reflect the changes. If the DeviceClass no longer matches the selector criteria, vCluster removes it from the tenant cluster.
 
 The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it
 ensures that vCluster creates only DeviceClass resources matching the defined selector criteria.
 The selector also functions as a creation validation mechanism - when you create ResourceClaims and ResourceClaimTemplates
-resources in the virtual cluster, the resources can only reference DeviceClass resources that exist in the virtual cluster.
+resources in the tenant cluster, the resources can only reference DeviceClass resources that exist in the tenant cluster.
 
 ### Orphaned resources
 
-When vCluster removes a synced DeviceClass from the virtual cluster due to selector changes or deletion from the host cluster,
-any ResourceClaims and ResourceClaimTemplates resources that reference it remain in the virtual and host clusters. 
+When vCluster removes a synced DeviceClass from the tenant cluster due to selector changes or deletion from the control plane cluster,
+any ResourceClaims and ResourceClaimTemplates resources that reference it remain in the tenant and control plane clusters. 
 These orphaned ResourceClaims and ResourceClaimTemplates resources stop receiving updates but vCluster does not
 automatically delete them to prevent unintended data loss.
 
-To remove these orphaned resources, you must delete them manually in the virtual and host clusters. 
+To remove these orphaned resources, you must delete them manually in the tenant and control plane clusters. 
 This manual approach ensures that you maintain full control over resource cleanup and can verify that deletions are intentional.
 
 ### Error handling and troubleshooting
@@ -94,8 +94,8 @@ filtered out and why.
 When you create ResourceClaims and ResourceClaimTemplates resources that reference a DeviceClass not matching
 the selector criteria, several things occur to provide clear feedback:
 
-- The ResourceClaims or ResourceClaimTemplates fails to sync to the host cluster
-- vCluster records an event on the ResourceClaims or ResourceClaimTemplates resource in the virtual cluster
+- The ResourceClaims or ResourceClaimTemplates fails to sync to the control plane cluster
+- vCluster records an event on the ResourceClaims or ResourceClaimTemplates resource in the tenant cluster
 - The event indicates that the specified DeviceClass is not available according to the current selector configuration
 
 The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message clearly states that the ResourceClaims or ResourceClaimTemplates resource was not synced because the referenced DeviceClass does not match the defined selector criteria.

--- a/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/device-classes.mdx
@@ -36,7 +36,7 @@ It also gives you centralized control over which DeviceClass teams can access.
 This approach is useful in scenarios where selective access to DeviceClass configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the DeviceClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Tenant isolation**: Enable teams to use their own DeviceClass resources while sharing a single Control Plane Cluster.
+- **Tenant isolation**: Enable teams to use their own DeviceClass resources while sharing a single control plane cluster.
 - **Security**: Restrict the DeviceClass resources available in the tenant cluster to enforce access control and prevent unintended configurations.
 
 <EnableSyncing resourceClass="DeviceClass" pluralResourceClass="deviceClasses" />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/events.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/events.mdx
@@ -19,9 +19,9 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync [Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) from the host cluster to the virtual cluster to be able to view things like pod events from within the virtual cluster. The synced events are associated with virtual cluster resources that are synced to the host cluster and provide visibility for vCluster users.
+Sync [Events](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/) from the control plane cluster to the tenant cluster to be able to view things like pod events from within the tenant cluster. The synced events are associated with tenant cluster resources that are synced to the control plane cluster and provide visibility for vCluster users.
 
-### Disable syncing Events from the host to virtual cluster
+### Disable syncing Events from the control plane cluster to the tenant cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -16,17 +16,17 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-IngressClass syncing allows virtual clusters to use ingress controllers from the host cluster. Typically, each virtual cluster needs its own ingress controller to handle incoming traffic. With IngressClass syncing enabled, virtual clusters can reference IngressClass resources from the host cluster instead.
+IngressClass syncing allows tenant clusters to use ingress controllers from the control plane cluster. Typically, each tenant cluster needs its own ingress controller to handle incoming traffic. With IngressClass syncing enabled, tenant clusters can reference IngressClass resources from the control plane cluster instead.
 
-You can enable this feature to sync IngressClass resources from the host cluster to the virtual cluster. Add labels to IngressClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors. When you create an Ingress resource in the virtual cluster that references a synced IngressClass, the host cluster's ingress controller handles the traffic routing.
+You can enable this feature to sync IngressClass resources from the control plane cluster to the tenant cluster. Add labels to IngressClass resources in your control plane cluster and configure vCluster to sync only those that match specific label selectors. When you create an Ingress resource in the tenant cluster that references a synced IngressClass, the control plane cluster's ingress controller handles the traffic routing.
 
-This saves resources since you don't need separate ingress controllers in every virtual cluster. It also gives you centralized control over which ingress capabilities teams can access. 
+This saves resources since you don't need separate ingress controllers in every tenant cluster. It also gives you centralized control over which ingress capabilities teams can access. 
 
 This approach is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the IngressClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
 - **Tenant isolation**: Enable teams to use their own IngressClass resources while sharing a single Control Plane Cluster.
-- **Security**: Restrict the IngressClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
+- **Security**: Restrict the IngressClass resources available in the tenant cluster to enforce access control and prevent unintended configurations.
 
 <ClassSyncing showResource="true" lowercaseResource="ingress" resource="Ingress" pluralResource="ingresses" lowercaseResourceClass="ingressclass" resourceClass="IngressClass" pluralResourceClass="ingressClasses" resourceClassName="IngressClassName" expressionKey="kubernetes.io/ingress.class" expressionValue1="istio" expressionValue2="traefik" />
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -25,7 +25,7 @@ This saves resources since you don't need separate ingress controllers in every 
 This approach is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the IngressClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Tenant isolation**: Enable teams to use their own IngressClass resources while sharing a single Control Plane Cluster.
+- **Tenant isolation**: Enable teams to use their own IngressClass resources while sharing a single control plane cluster.
 - **Security**: Restrict the IngressClass resources available in the tenant cluster to enforce access control and prevent unintended configurations.
 
 <ClassSyncing showResource="true" lowercaseResource="ingress" resource="Ingress" pluralResource="ingresses" lowercaseResourceClass="ingressclass" resourceClass="IngressClass" pluralResourceClass="ingressClasses" resourceClassName="IngressClassName" expressionKey="kubernetes.io/ingress.class" expressionValue1="istio" expressionValue2="traefik" />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -12,14 +12,14 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-By default, this is disabled by default. vCluster only displays nodes in the virtual cluster if the virtual cluster
-has synced pods to that worker node from the host. If there 
+By default, this is disabled by default. vCluster only displays nodes in the tenant cluster if the tenant cluster
+has synced pods to that worker node from the control plane cluster. If there 
 are no more pods on a node, vCluster deletes the node. Without syncing the nodes, these nodes are considered pseudo
 nodes as the name is the only real value, and the rest of the nod information is randomly generated. 
 
-If you need specific node informatin, enabling to sync nodes from the host will allow the real information
-from the node to be available from the virtual cluster context. In order to access node informatin, a cluster role is deployed
-onto the host cluster. 
+If you need specific node informatin, enabling to sync nodes from the control plane cluster will allow the real information
+from the node to be available from the tenant cluster context. In order to access node informatin, a cluster role is deployed
+onto the control plane cluster. 
 
 :::info Node IP obfuscation
 By default, vCluster obfuscates node IP addresses when syncing real nodes to protect sensitive information. Learn how to [control node IP visibility](../../../../learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility.mdx) for your use case.
@@ -27,18 +27,18 @@ By default, vCluster obfuscates node IP addresses when syncing real nodes to pro
 
 ## Selecting a set of nodes
 
-By default, vCluster is able to schedule pods to *any* of the worker nodes in the host cluster, but you can isolate a virtual cluster to only use 
-a set of specific nodes from the host cluster. There are multiple reasons why you may want to dedicate nodes to a virtual cluster including:
+By default, vCluster is able to schedule pods to *any* of the worker nodes in the control plane cluster, but you can isolate a tenant cluster to only use 
+a set of specific nodes from the control plane cluster. There are multiple reasons why you may want to dedicate nodes to a tenant cluster including:
   - Restricting vCluster to nodes in a specific region.
   - Targeting nodes with a particular architecture.
   - Using only spot or preemptible instances.
   - Preventing vCluster workloads from running on critical infrastructure nodes.
 
-Selecting nodes is based on a node label selector, where the nodes on the host cluster must have the matching labels.
+Selecting nodes is based on a node label selector, where the nodes on the control plane cluster must have the matching labels.
 
 ### Select a set of nodes without syncing node information
 
-If you don't want to sync node information, you can still select to use only a set of nodes from the host cluster. 
+If you don't want to sync node information, you can still select to use only a set of nodes from the control plane cluster. 
 
 ```yaml title="Select dedicated nodes without syncing real node information"
 sync:
@@ -55,7 +55,7 @@ sync:
 
 ### Select a set of nodes and sync node information
 
-You can select a set of nodes from the host cluster while also requesting that the nodes sync with the real information from the host cluster. 
+You can select a set of nodes from the control plane cluster while also requesting that the nodes sync with the real information from the control plane cluster. 
 
 ```yaml title="Select dedicated nodes and syncing real node information"
 sync:
@@ -72,9 +72,9 @@ sync:
 
 ## Sync real nodes
 
-Sync nodes to the virtual cluster in order to view real node information. The virtual cluster will only display
+Sync nodes to the tenant cluster in order to view real node information. The tenant cluster will only display
 the host nodes that have a pod deployed onto it. By enabling this sync, a cluster role is deployed 
-by the vCluster onto the host cluster.
+by the vCluster onto the control plane cluster.
 
 ```yaml title="Sync nodes for real node information"
 sync:
@@ -85,11 +85,11 @@ sync:
 
 ### Sync all real nodes
 
-When syncing nodes, only nodes that have pods deployed on them will show up in the virtual cluster, but you can
-sync all the nodes from the host cluster. When selecting all the nodes, `kubectl get nodes` will display 
-all the host nodes whether or not a pod has been scheduled onto the host cluster. 
+When syncing nodes, only nodes that have pods deployed on them will show up in the tenant cluster, but you can
+sync all the nodes from the control plane cluster. When selecting all the nodes, `kubectl get nodes` will display 
+all the host nodes whether or not a pod has been scheduled onto the control plane cluster. 
 
-```yaml title="Make all nodes visible to the virtual cluster"
+```yaml title="Make all nodes visible to the tenant cluster"
 sync:
   fromHost:
     nodes:
@@ -100,13 +100,13 @@ sync:
 
 ### Sync back labels and taints
 
-By default, when syncing nodes from the host cluster, labels and taints are only synced from the host cluster to the virtual cluster. No changes from the virtual 
+By default, when syncing nodes from the control plane cluster, labels and taints are only synced from the control plane cluster to the tenant cluster. No changes from the tenant 
 cluster context would be reflected on the host nodes. 
 
-Enabling `syncBackChanges` allows labels and taints set from the virtual cluster context to be synced to the host nodes. Additional 
+Enabling `syncBackChanges` allows labels and taints set from the tenant cluster context to be synced to the host nodes. Additional 
  permissions are added to the cluster role in order to edit the host nodes.
 
-```yaml title="Sync labels and taints from the virtual cluster context to the host node"
+```yaml title="Sync labels and taints from the tenant cluster context to the host node"
 sync:
   fromHost:
     nodes:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -72,7 +72,7 @@ sync:
 
 ## Sync real nodes
 
-Sync nodes to the tenant cluster in order to view real node information. The tenant cluster will only display
+Sync nodes to the tenant cluster to view real node information. The tenant cluster will only display
 the host nodes that have a pod deployed onto it. By enabling this sync, a cluster role is deployed 
 by the vCluster onto the control plane cluster.
 
@@ -100,7 +100,7 @@ sync:
 
 ### Sync back labels and taints
 
-By default, when syncing nodes from the control plane cluster, labels and taints are only synced from the control plane cluster to the tenant cluster. No changes from the tenant 
+By default, when syncing nodes from the control plane cluster, labels, and taints are only synced from the control plane cluster to the tenant cluster. No changes from the tenant 
 cluster context would be reflected on the host nodes. 
 
 Enabling `syncBackChanges` allows labels and taints set from the tenant cluster context to be synced to the host nodes. Additional 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/overview.mdx
@@ -13,7 +13,7 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 <TenancySupport hostNodes="true" />
 
 Read more about [how syncing works](../) before deciding which resources to
-sync from the host cluster to the virtual cluster. 
+sync from the control plane cluster to the tenant cluster. 
 
 <SyncFromHostResources/>
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -19,10 +19,10 @@ By default, this is disabled.
 
 PriorityClass resources set which pods get scheduled first when resources are limited. High-priority pods can kick out low-priority pods to get resources.
 
-Typically, each virtual cluster needs its own copy of every PriorityClass. This means creating the same PriorityClass multiple times-once per virtual cluster. If anything changes in your PriorityClass, you must update each copy in each virtual cluster. 
-PriorityClass syncing eliminates this duplication and maintenance by making host cluster PriorityClass resources available to virtual clusters. You define priority classes once in the host cluster, and vCluster automatically makes them accessible to virtual clusters.
+Typically, each tenant cluster needs its own copy of every PriorityClass. This means creating the same PriorityClass multiple times-once per tenant cluster. If anything changes in your PriorityClass, you must update each copy in each tenant cluster. 
+PriorityClass syncing eliminates this duplication and maintenance by making control plane cluster PriorityClass resources available to tenant clusters. You define priority classes once in the control plane cluster, and vCluster automatically makes them accessible to tenant clusters.
 
-You can either sync all PriorityClass resources or configure syncing using label selectors. When a virtual cluster pod references a `priorityClassName`, vCluster validates that the corresponding PriorityClass exists in the virtual cluster through the syncing process. If the referenced PriorityClass is not synced (either because it does not exist in the host cluster or does not match your label selector), the pod is not scheduled on the host cluster.
+You can either sync all PriorityClass resources or configure syncing using label selectors. When a tenant cluster pod references a `priorityClassName`, vCluster validates that the corresponding PriorityClass exists in the tenant cluster through the syncing process. If the referenced PriorityClass is not synced (either because it does not exist in the control plane cluster or does not match your label selector), the pod is not scheduled on the control plane cluster.
 
 <ClassSyncing lowercaseResource="pod" resource="Pod" pluralResource="pods" lowercaseResourceClass="priorityclass" resourceClass="PriorityClass" pluralResourceClass="priorityClasses" resourceClassName="priorityClassName" expressionKey="kubernetes.io/priority.class" expressionValue1="low" expressionValue2="medium" />
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -17,21 +17,21 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-RuntimeClass syncing allows virtual clusters to use runtime classes from the host cluster. RuntimeClass resources define container runtime configurations including security sandboxes, alternative runtimes like gVisor or Kata Containers, and runtime-specific settings.
+RuntimeClass syncing allows tenant clusters to use runtime classes from the control plane cluster. RuntimeClass resources define container runtime configurations including security sandboxes, alternative runtimes like gVisor or Kata Containers, and runtime-specific settings.
 
-Virtual clusters are isolated from each other; a RuntimeClass created in one virtual cluster does not exist in another. For more details on enabling and disabling synced resources, see the [sync configuration documentation](https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources).
+Tenant clusters are isolated from each other; a RuntimeClass created in one tenant cluster does not exist in another. For more details on enabling and disabling synced resources, see the [sync configuration documentation](https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources).
 
-You can enable this feature to sync RuntimeClass resources from the host cluster to the virtual cluster. Add labels to RuntimeClass resources in your host cluster and configure vCluster to sync only those matching specific selectors. When you create a Pod that references a synced RuntimeClass, the host cluster uses that runtime configuration.
+You can enable this feature to sync RuntimeClass resources from the control plane cluster to the tenant cluster. Add labels to RuntimeClass resources in your control plane cluster and configure vCluster to sync only those matching specific selectors. When you create a Pod that references a synced RuntimeClass, the control plane cluster uses that runtime configuration.
 
-This approach provides centralized control over runtime configurations and ensures consistent container runtime behavior across virtual clusters. Common use cases include:
+This approach provides centralized control over runtime configurations and ensures consistent container runtime behavior across tenant clusters. Common use cases include:
 
-- **Security isolation**: Control which security runtimes different teams can access while sharing a single host cluster. Only authorized workloads can use enhanced security runtimes such as gVisor or Kata Containers. This prevents unauthorized access to privileged runtime configurations.
+- **Security isolation**: Control which security runtimes different teams can access while sharing a single control plane cluster. Only authorized workloads can use enhanced security runtimes such as gVisor or Kata Containers. This prevents unauthorized access to privileged runtime configurations.
 
 - **Development environments**: Sync only required RuntimeClasses to reduce noise and avoid unnecessary exposure to production runtime configurations.
 
 - **Tenant isolation**: Enable teams to use specific runtime configurations while preventing access to incompatible or resource-intensive runtimes that could affect other tenants. Each team gets only the runtime classes appropriate for their workloads and security requirements.
 
-- **Compliance**: Maintain strict control over container runtime configurations by defining runtime classes once in the host cluster and making only approved runtime configurations available to virtual clusters. All workloads use compliant runtime settings.
+- **Compliance**: Maintain strict control over container runtime configurations by defining runtime classes once in the control plane cluster and making only approved runtime configurations available to tenant clusters. All workloads use compliant runtime settings.
 
 - **Resource optimization**: Prevent teams from using resource-intensive runtime configurations that could impact cluster performance without proper oversight. Access to high-overhead runtimes is restricted and used only when necessary.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -17,10 +17,10 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the Secrets and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the Secrets and syncing the resources from the control plane cluster to the tenant cluster.
 :::
 
-Enabling sync from host allows you to sync Secrets from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
+Enabling sync from host allows you to sync Secrets from the specified namespaces in the control plane cluster to the specified namespaces in a tenant cluster.
 Here is how the required configuration in `vcluster.yaml` looks like:
 ```yaml title="configure Secret sync from host"
 sync:
@@ -35,14 +35,14 @@ sync:
 ```
 
 Here are a few things to remember when configuring the sync:
-- It is also possible to modify the name of the synced resource in the virtual cluster.
-- There is no option to sync from all namespaces in the host.
-- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
+- It is also possible to modify the name of the synced resource in the tenant cluster.
+- There is no option to sync from all namespaces in the control plane cluster.
+- Sync is one-directional, from the control plane cluster to the tenant cluster. If you modify an object in the control plane cluster, vCluster syncs the change to virtual object.
 - When you delete a virtual object, vCluster re-creates it if the host object still exist.
 - When you delete a host object, vCluster deletes the corresponding virtual object.
 - It is not possible to sync Secrets that were already synced from virtual to host, they are skipped by vCluster.
 
-Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
+Namespaces in the tenant cluster are created automatically during the sync (if they do not exist already).
 
 You can use synced Secrets in your workloads as an environment variables source or a volume.
 
@@ -52,7 +52,7 @@ All the specified namespaces have to exist in the host at the vCluster startup.
 
 
 ## Sync all Secrets from host namespace
-To sync all Secrets from a given namespace in the host to the given namespace in the virtual cluster, use “namespace/*” wildcard, e.g.:
+To sync all Secrets from a given namespace in the control plane cluster to the given namespace in the tenant cluster, use “namespace/*” wildcard, e.g.:
 
 ```yaml title="configure Secret sync from host namespace"
 sync:
@@ -83,10 +83,10 @@ sync:
 ```
 
 
-## Sync all Secrets from virtual cluster's host namespace
-There is also a handy syntax to sync all Secrets from virtual cluster’s own host namespace to the virtual namespace. As virtual cluster’s namespace is not always known upfront (e.g. when virtual cluster is created by the platform), `""` (empty string) is treated as “virtual cluster’s own host namespace”.
+## Sync all Secrets from the tenant cluster’s control plane cluster namespace
+There is also a handy syntax to sync all Secrets from the tenant cluster’s own control plane cluster namespace to the tenant namespace. As the tenant cluster’s namespace is not always known upfront (e.g. when the tenant cluster is created by the platform), `””` (empty string) is treated as “tenant cluster’s own control plane cluster namespace”.
 
-```yaml title="configure Secret sync from host for virtual cluster's namespace"
+```yaml title="configure Secret sync from host for tenant cluster's namespace"
 sync:
   fromHost:
     secrets:
@@ -99,10 +99,10 @@ sync:
 ```
 
 
-## Sync specific Secret from virtual cluster's host namespace
-you can also specify only a few Secrets from virtual cluster’s own host namespace this way:
+## Sync specific Secret from the tenant cluster’s control plane cluster namespace
+you can also specify only a few Secrets from the tenant cluster’s own control plane cluster namespace this way:
 
-```yaml title="configure Secret sync from host for objects in virtual cluster's namespace"
+```yaml title="configure Secret sync from host for objects in tenant cluster's namespace"
 sync:
   fromHost:
     secrets:
@@ -114,7 +114,7 @@ sync:
           "/my-cm": "my-virtual/my-cm"
 ```
 
-## Modify synced Secret namespace and name in the virtual cluster
+## Modify synced Secret namespace and name in the tenant cluster
 It’s also possible to modify Secret name during the sync:
 
 ```yaml title="configure Secret sync from host and modify name and namespace"
@@ -156,7 +156,7 @@ sync:
 ```
 
 1. Your Secret in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the tenant cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
 
 
 <FromHostSecretExample />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -16,16 +16,16 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-StorageClass resources define how virtual clusters provision storage. They specify storage backends such as AWS EBS, Azure Disk, or GCP Persistent Disk, along with parameters such as performance tiers and replication settings.
+StorageClass resources define how tenant clusters provision storage. They specify storage backends such as AWS EBS, Azure Disk, or GCP Persistent Disk, along with parameters such as performance tiers and replication settings.
 
-By default, each virtual cluster needs its own StorageClass resources. StorageClass syncing allows virtual clusters to use StorageClass resources from the host cluster instead.
+By default, each tenant cluster needs its own StorageClass resources. StorageClass syncing allows tenant clusters to use StorageClass resources from the control plane cluster instead.
 
-You can enable this feature to sync StorageClass resources from the host cluster to the virtual cluster. Add labels to StorageClass resources in your host cluster and configure vCluster to sync only those matching specific selectors. When you create a PersistentVolumeClaim that references a synced StorageClass, the host cluster uses that storage configuration. Common use cases include:
+You can enable this feature to sync StorageClass resources from the control plane cluster to the tenant cluster. Add labels to StorageClass resources in your control plane cluster and configure vCluster to sync only those matching specific selectors. When you create a PersistentVolumeClaim that references a synced StorageClass, the control plane cluster uses that storage configuration. Common use cases include:
 
 - **Cost control**: Restrict access to specific storage classes based on cost or performance characteristics.
-- **Compliance**: Control which storage backends and configurations are available to virtual clusters.
+- **Compliance**: Control which storage backends and configurations are available to tenant clusters.
 - **Tenant isolation**: Provide different storage options to different teams while preventing access to restricted storage types.
-- **Simplified management**: Update storage class configurations in the host cluster rather than in each virtual cluster.
+- **Simplified management**: Update storage class configurations in the control plane cluster rather than in each tenant cluster.
 - **Security**: Control access to storage backends and encryption options.
 
 <ClassSyncing lowercaseResource="pvc" resource="PersistentVolume" pluralResource="persistentVolumes" lowercaseResourceClass="storageclass" resourceClass="StorageClass" pluralResourceClass="storageClasses" resourceClassName="storageClassName" expressionKey="kubernetes.io/storage.class" expressionValue1="network-nas" expressionValue2="fast-sad" showExtraResource="true" extraResource="PersistentVolumeClaim" pluralExtraResource="persistentVolumeClaims" />


### PR DESCRIPTION
# Content Description
Replace "virtual cluster" → "tenant cluster" and "host cluster" → "control plane cluster" in all `sync/from-host/` prose (14 files). YAML code block comments and JSX comment blocks left unchanged.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2098--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs