### PR TITLE
docs(doc-1334): update sync/to-host terminology (part 4)

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx
@@ -22,16 +22,16 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 By default, this is disabled.
 
-When enabled, sync all [ResourceClaims](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates) resources from the virtual cluster to the host cluster.
+When enabled, sync all [ResourceClaims](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates) resources from the tenant cluster to the control plane cluster.
 Use this option to create resource claims that can be referenced in workloads created in the vCluster.
 
-When enabled, vCluster automatically tries to detect the presence of api-resource `resource.k8s.io/v1` on the host cluster and fails to start up if the api-resource is missing.
+When enabled, vCluster automatically tries to detect the presence of api-resource `resource.k8s.io/v1` on the control plane cluster and fails to start up if the api-resource is missing.
 
 :::warning Referenced Device Class
 The resource claims must reference **[device classes](../../from-host/device-classes.mdx)** synced from the host.
 :::
 
-### Sync ResourceClaims from the virtual to host cluster
+### Sync ResourceClaims from the tenant to control plane cluster
 
 ```yaml
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaimtemplates.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaimtemplates.mdx
@@ -22,16 +22,16 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 By default, this is disabled.
 
-When enabled, sync all [ResourceClaimTemplates](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates) resources from the virtual cluster to the host cluster.
+When enabled, sync all [ResourceClaimTemplates](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#resourceclaims-templates) resources from the tenant cluster to the control plane cluster.
 Use this option to create resource claim templates that can be referenced in workloads created in the vCluster.
 
-When enabled, vCluster automatically tries to detect the presence of api-resource `resource.k8s.io/v1` on the host cluster and fails to start up if the api-resource is missing.
+When enabled, vCluster automatically tries to detect the presence of api-resource `resource.k8s.io/v1` on the control plane cluster and fails to start up if the api-resource is missing.
 
 :::warning Referenced Device Class
 The resource claim templates must reference **[device classes](../../from-host/device-classes.mdx)** synced from the host.
 :::
 
-### Sync ResourceClaimTemplates from the virtual to host cluster
+### Sync ResourceClaimTemplates from the tenant to control plane cluster
 
 ```yaml
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -16,11 +16,11 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-vCluster allows you to sync custom resources from the virtual cluster to the host cluster. This is useful for syncing resources that are not included in the default sync behavior.
+vCluster allows you to sync custom resources from the tenant cluster to the control plane cluster. This is useful for syncing resources that are not included in the default sync behavior.
 
-This feature only works for resources that have a corresponding CustomResourceDefinition (CRD) installed in the host cluster.
+This feature only works for resources that have a corresponding CustomResourceDefinition (CRD) installed in the control plane cluster.
 
-If a synced custom resource creates additional resources in the host cluster, vCluster attempts to detect and sync those resources back to the virtual cluster. For example, a custom resource that creates a `Secret` has that `Secret` automatically synced into the virtual cluster.
+If a synced custom resource creates additional resources in the control plane cluster, vCluster attempts to detect and sync those resources back to the tenant cluster. For example, a custom resource that creates a `Secret` has that `Secret` automatically synced into the tenant cluster.
 
 vCluster also adds the necessary cluster and namespace-level RBAC permissions to retrieve the CRD and sync the corresponding resources.
 
@@ -36,9 +36,9 @@ If you want to sync many custom resources, consider using [namespace syncing](..
 
 ## Enable custom resource syncing {#enable-custom-resource-syncing}
 
-To enable custom resource syncing from the virtual cluster to the host cluster, first identify which CustomResourceDefinitions (CRDs) you want to sync by running `kubectl get crds`. Then, add the name of each CRD to the `customResources` section under `sync` in your `vcluster.yaml` configuration file.
+To enable custom resource syncing from the tenant cluster to the control plane cluster, first identify which CustomResourceDefinitions (CRDs) you want to sync by running `kubectl get crds`. Then, add the name of each CRD to the `customResources` section under `sync` in your `vcluster.yaml` configuration file.
 
-Although the custom resources themselves are synced from the virtual cluster to the host cluster, vCluster also copies the corresponding CRDs from the host cluster into the virtual cluster. This ensures the virtual cluster can understand and manage those custom resources correctly.
+Although the custom resources themselves are synced from the tenant cluster to the control plane cluster, vCluster also copies the corresponding CRDs from the control plane cluster into the tenant cluster. This ensures the tenant cluster can understand and manage those custom resources correctly.
 
 By default, you do not need to specify an API version when syncing a custom resource. If the CRD defines multiple versions and no version is explicitly set, vCluster uses the storage version. To sync a specific version, such as when the storage version is not suitable, you can define that version directly in the `vcluster.yaml`.
 
@@ -62,7 +62,7 @@ You can use `*` in paths to select all entries of an array or object, for exampl
 
 ### Reference patches
 
-You can use a reference patch to make a specific field in one resource point to another resource that vCluster should rewrite. If the referenced resource exists in the host cluster, vCluster automatically imports it into the virtual cluster.
+You can use a reference patch to make a specific field in one resource point to another resource that vCluster should rewrite. If the referenced resource exists in the control plane cluster, vCluster automatically imports it into the tenant cluster.
 
 This is useful when working with resources that reference other resources like `Secrets`:
 
@@ -79,13 +79,13 @@ sync:
             kind: Secret
 ```
 
-vCluster translates the path `spec.secretName` as it points to a Secret. If the Secret is created in the host cluster, vCluster automatically imports it into the virtual cluster.
+vCluster translates the path `spec.secretName` as it points to a Secret. If the Secret is created in the control plane cluster, vCluster automatically imports it into the tenant cluster.
 
 <!-- vale off -->
 ### JavaScript expression patches {#javascript-expression-patches}
 <!-- vale on -->
 
-These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a prefix to field values you can:
+These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the tenant cluster into the control plane cluster or when syncing from the control plane cluster into the tenant cluster. To add a prefix to field values you can:
 
 ```yaml
 sync:
@@ -102,9 +102,9 @@ sync:
 ```
 
 There is also a variable called `context` besides `value` that can be used to access vCluster specific data:
-- `context.vcluster.name`: Name of the virtual cluster
-- `context.vcluster.namespace`: Namespace of the virtual cluster
-- `context.vcluster.config`: Config of the virtual cluster, basically `vcluster.yaml` merged with the defaults
+- `context.vcluster.name`: Name of the tenant cluster
+- `context.vcluster.namespace`: Namespace of the tenant cluster
+- `context.vcluster.config`: Config of the tenant cluster, basically `vcluster.yaml` merged with the defaults
 - `context.hostObject`: Host object (can be null if not available)
 - `context.virtualObject`: Virtual object (can be null if not available)
 - `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
@@ -137,7 +137,7 @@ spec:
     - server.example.com
 ```
 
-vCluster syncs the host cluster and applies your patch, creating this modified resource:
+vCluster syncs the control plane cluster and applies your patch, creating this modified resource:
 
 ```yaml
 apiVersion: example.io/v1
@@ -149,7 +149,7 @@ spec:
     - prod-server.example.com # the patch added prod- prefix to this field
 ```
 
-If you directly edit the resource in the host cluster and change the value:
+If you directly edit the resource in the control plane cluster and change the value:
 
 ```yaml
 apiVersion: example.io/v1
@@ -161,7 +161,7 @@ spec:
     - prod-other-server.example.com # changed from prod-server.example.com
 ```
 
-vCluster detects the change, applies the reverse patch, and updates the resource in your virtual cluster:
+vCluster detects the change, applies the reverse patch, and updates the resource in your tenant cluster:
 
 ```yaml
 apiVersion: example.io/v1
@@ -175,11 +175,11 @@ spec:
 
 ## Configure Kubernetes Gateway API sync
 
-To use the Kubernetes Gateway API with custom resources, install the Gateway API CRDs in the host cluster and then create the waypoint gateway.
+To use the Kubernetes Gateway API with custom resources, install the Gateway API CRDs in the control plane cluster and then create the waypoint gateway.
 
 ### Install Gateway CRD in the host
 
-To create gateway resources, install the Gateway API CustomResourceDefinition in the host cluster if it's not already present:
+To create gateway resources, install the Gateway API CustomResourceDefinition in the control plane cluster if it's not already present:
 
 ```bash title="Install Gateway CRD"
 kubectl --context="${HOST_CTX}" get crd gateways.gateway.networking.k8s.io &> /dev/null || \
@@ -205,13 +205,13 @@ spec:
     protocol: HBONE
 ```
 
-Apply it to your host cluster:
+Apply it to your control plane cluster:
 
 ```bash title="Create Waypoint Gateway"
 kubectl --context="${HOST_CTX}" create -f waypoint-gateway.yaml --namespace="${VCLUSTER_HOST_NAMESPACE}"
 ```
 
-After it is configured, you can configure your custom resources to sync Gateway API resources between the virtual and host clusters.
+After it is configured, you can configure your custom resources to sync Gateway API resources between the tenant and control plane clusters.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -20,7 +20,7 @@ vCluster allows you to sync custom resources from the tenant cluster to the cont
 
 This feature only works for resources that have a corresponding CustomResourceDefinition (CRD) installed in the control plane cluster.
 
-If a synced custom resource creates additional resources in the control plane cluster, vCluster attempts to detect and sync those resources back to the tenant cluster. For example, a custom resource that creates a `Secret` has that `Secret` automatically synced into the tenant cluster.
+If a synced custom resource creates additional resources in the control plane cluster, vCluster attempts to detect and sync those resources back to the tenant cluster. For example, a custom resource that creates a Secret has that Secret automatically synced into the tenant cluster.
 
 vCluster also adds the necessary cluster and namespace-level RBAC permissions to retrieve the CRD and sync the corresponding resources.
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/namespaces.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/namespaces.mdx
@@ -3,7 +3,7 @@ title: Namespaces
 sidebar_label: namespaces
 sidebar_position: 6
 sidebar_class_name: free host-nodes
-description: Configure namespace synchronization between vCluster and host cluster.
+description: Configure namespace synchronization between vCluster and the control plane cluster.
 ---
 
 import HiddenCodeBlock from '@site/src/components/HiddenCodeBlock';
@@ -21,7 +21,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 ## Overview
 
-Namespace syncing is an advanced vCluster feature that creates dedicated namespaces on the host cluster corresponding to namespaces in the virtual cluster. This feature preserves original resource names and enables complex integrations with cloud providers and custom schedulers.
+Namespace syncing is an advanced vCluster feature that creates dedicated namespaces on the control plane cluster corresponding to namespaces in the tenant cluster. This feature preserves original resource names and enables complex integrations with cloud providers and custom schedulers.
 
 ### Why use namespace syncing?
 
@@ -65,7 +65,7 @@ sync:
           example-virtual-namespace: example-host-namespace
 ```
 
-When enabled, vCluster creates corresponding namespaces on the host cluster for each namespace created in the vCluster, based on the defined mapping rules.
+When enabled, vCluster creates corresponding namespaces on the control plane cluster for each namespace created in the vCluster, based on the defined mapping rules.
 
 
 ## Import existing namespaces
@@ -76,7 +76,7 @@ Any host namespace matching a defined mapping (exact or pattern) is automaticall
 
 When a host namespace matches your mapping rules:
 1. vCluster automatically imports the namespace
-2. Existing pods and resources appear in the virtual cluster
+2. Existing pods and resources appear in the tenant cluster
 3. Resources created in either direction sync bidirectionally
 
 ## Configure mapping rule types
@@ -149,7 +149,7 @@ sync:
 
 ## Delete a vCluster
 
-When you delete a vCluster, namespaces and resources created by the vCluster on the host are removed. Resources that originated from the host cluster and were imported remain unchanged - vCluster only cleans up what it created.
+When you delete a vCluster, namespaces and resources created by the vCluster on the host are removed. Resources that originated from the control plane cluster and were imported remain unchanged - vCluster only cleans up what it created.
 
 You can test this behavior by deploying vCluster with the following configuration:
 
@@ -167,11 +167,11 @@ sync:
 
 ## Examples
 
-The following end-to-end examples demonstrate namespace syncing behavior in both virtual and host clusters.
+The following end-to-end examples demonstrate namespace syncing behavior in both tenant and control plane clusters.
 
 ### Example: Enable namespace mappings
 
-This example demonstrates how different namespace mapping rules affect resource creation and placement on the host cluster.
+This example demonstrates how different namespace mapping rules affect resource creation and placement on the control plane cluster.
 
 <Flow>
 <Step>
@@ -207,7 +207,7 @@ kubectl create namespace some-other-namespace
 </Step>
 
 <Step>
-Verify the namespaces on the host cluster:
+Verify the namespaces on the control plane cluster:
 
 ```bash
 kubectl --context kind-vcluster get namespace
@@ -227,7 +227,7 @@ local-path-storage                Active   45h
 vcluster-mapping-demo             Active   2m11s
 ```
 
-Only namespaces matched by mappings sync directly to the host cluster.
+Only namespaces matched by mappings sync directly to the control plane cluster.
 </Step>
 
 <Step>
@@ -264,7 +264,7 @@ team-a-ns1             nginx-from-team-a            1/1     Running   0         
 </Step>
 
 <Step>
-Verify pods running on the host cluster:
+Verify pods running on the control plane cluster:
 
 ```bash
 kubectl --context kind-vcluster get pods -A
@@ -308,7 +308,7 @@ kubectl --context kind-vcluster create namespace  h-team-a-namespace-synced-from
 ```
 </Step>
 <Step>
-Start a pod inside this namespace on host cluster:
+Start a pod inside this namespace on the control plane cluster:
 
 ```bash
 kubectl --context kind-vcluster -n h-team-a-namespace-synced-from-host run nginx-from-host --image nginx
@@ -395,19 +395,19 @@ This example demonstrates the cleanup behavior when deleting a vCluster, showing
 <Flow>
 
 <Step>
-Create a namespace on your host cluster that matches host-side mappings in the configuration and start a pod inside of it:
+Create a namespace on your control plane cluster that matches host-side mappings in the configuration and start a pod inside of it:
 
 ```bash
 kubectl --context kind-vcluster create namespace host-namespace-from-host
 kubectl --context kind-vcluster -n host-namespace-from-host run nginx-from-host --image nginx
 ```
 
-The commands run an NGINX pod directly in the host cluster namespace. This pod gets imported into vCluster when the vCluster starts.
+The commands run an NGINX pod directly in the control plane cluster namespace. This pod gets imported into vCluster when the vCluster starts.
 
 </Step>
 
 <Step>
-Verify that the pod started in host cluster:
+Verify that the pod started in the control plane cluster:
 
 ```bash
 kubectl --context kind-vcluster -n host-namespace-from-host get pods
@@ -439,12 +439,12 @@ kubectl create namespace sync-namespace-from-vcluster
 kubectl -n sync-namespace-from-vcluster run nginx-from-vcluster --image nginx
 ```
 
-This runs an NGINX pod inside the vCluster namespace. This gets synced to the host cluster.
+This runs an NGINX pod inside the tenant cluster namespace. This gets synced to the control plane cluster.
 
 </Step>
 
 <Step>
-Verify both namespaces are available in both host cluster and vCluster:
+Verify both namespaces are available in both the control plane cluster and the tenant cluster:
 
 ```bash
 kubectl get ns
@@ -462,7 +462,7 @@ sync-namespace-from-host       Active   2m21s
 sync-namespace-from-vcluster   Active   5s
 ```
 
-List namespaces as they exist on the host cluster (show both original host namespaces and synced vCluster namespaces):
+List namespaces as they exist on the control plane cluster (show both original control plane cluster namespaces and synced vCluster namespaces):
 
 ```bash
 kubectl --context kind-vcluster get ns
@@ -482,7 +482,7 @@ local-path-storage             Active   6d23h
 vcluster-test-cleanup          Active   4m43s
 ```
 
-Show all `nginx` pods as seen from inside the vCluster. The following command displays the virtual cluster's view of resources:
+Show all `nginx` pods as seen from inside the vCluster. The following command displays the tenant cluster's view of resources:
 
 ```bash title="View pods from vCluster perspective"
 kubectl get po -A | grep nginx
@@ -495,9 +495,9 @@ sync-namespace-from-host       nginx-from-host          1/1     Running   0     
 sync-namespace-from-vcluster   nginx-from-vcluster      1/1     Running   0          114s
 ```
 
-Shows all `nginx` pods as seen from the host cluster. The following command displays how the same resources appear on the physical cluster:
+Shows all `nginx` pods as seen from the control plane cluster. The following command displays how the same resources appear on the physical cluster:
 
-```bash title="View pods from host cluster perspective"
+```bash title="View pods from control plane cluster perspective"
 kubectl --context kind-vcluster get po -A | grep nginx
 ```
 
@@ -563,7 +563,7 @@ NAME              READY   STATUS    RESTARTS   AGE
 nginx-from-host   1/1     Running   0          6m48s
 ```
 
-Resources synced from vCluster are gone while all resources created on host cluster remained untouched.
+Resources synced from vCluster are gone while all resources created on the control plane cluster remained untouched.
 
 </Step>
 </Flow>
@@ -576,7 +576,7 @@ If you enable `sync.toHost.namespaces`, you must NOT use `genericSync`. Instead,
 for resource synchronization.
 
 ### Automatic syncing of all secrets and ConfigMaps
-When namespace syncing is enabled, all `Secrets` and `ConfigMaps` automatically sync to host namespaces (equivalent to `sync.toHost.secrets.all: true` and `sync.toHost.configMaps.all: true`). This cannot be disabled and makes these resources visible on the host cluster.
+When namespace syncing is enabled, all `Secrets` and `ConfigMaps` automatically sync to host namespaces (equivalent to `sync.toHost.secrets.all: true` and `sync.toHost.configMaps.all: true`). This cannot be disabled and makes these resources visible on the control plane cluster.
 
 ### NetworkPolicy syncing is disabled
 The `sync.toHost.networkPolicies` feature is not supported with namespace syncing. NetworkPolicy objects created in the vCluster won't sync to the host and have no effect on network traffic.

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
@@ -15,14 +15,14 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) resources from the virtual cluster to the host cluster.
+Sync [PodDisruptionBudget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) resources from the tenant cluster to the control plane cluster.
 
 {/*
 `podDistruptionBudgets.enabled`:
 - covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
 */}
 
-### Sync PodDisruptionBudgets from the virtual to host cluster
+### Sync PodDisruptionBudgets from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/priority-classes.mdx
@@ -2,7 +2,7 @@
 title: Priority classes
 sidebar_label: priorityClasses
 sidebar_position: 3
-description: Configure the host scheduler to use a PriorityClass when scheduling your virtual cluster workloads.
+description: Configure the host scheduler to use a PriorityClass when scheduling your tenant cluster workloads.
 sidebar_class_name: host-nodes
 ---
 
@@ -18,13 +18,13 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled. 
 
-Sync [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) resources from the virtual cluster to the host cluster.
+Sync [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) resources from the tenant cluster to the control plane cluster.
 
-Enable this feature if you need to configure the host scheduler to use a certain PriorityClass that is created within the virtual cluster when scheduling the virtual cluster workloads.
+Enable this feature if you need to configure the host scheduler to use a certain PriorityClass that is created within the tenant cluster when scheduling the tenant cluster workloads.
 
 When enabled, will update the vCluster control plane's ClusterRole to include the necessary permissions.
 
-### Sync PriorityClasses from the virtual to host cluster
+### Sync PriorityClasses from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/service-accounts.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/service-accounts.mdx
@@ -20,11 +20,11 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled. 
 
-Sync [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) resources from the virtual cluster to the host cluster. 
+Sync [ServiceAccount](https://kubernetes.io/docs/concepts/security/service-accounts/) resources from the tenant cluster to the control plane cluster. 
 
-This is useful for using [AWS IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) with the virtual cluster. In this scenario, the host cluster is defined as the identity provider to access your OIDC-compatible system, which means you don't have to configure each virtual cluster as a provider. vCluster creates a host cluster ServiceAccount token for your synchronized ServiceAccount from the virtual cluster. 
+This is useful for using [AWS IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) with the tenant cluster. In this scenario, the control plane cluster is defined as the identity provider to access your OIDC-compatible system, which means you don't have to configure each tenant cluster as a provider. vCluster creates a control plane cluster ServiceAccount token for your synchronized ServiceAccount from the tenant cluster. 
 
-### Sync ServiceAccounts from the virtual to host cluster
+### Sync ServiceAccounts from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
@@ -22,12 +22,12 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) resources that are used by pods from the virtual cluster to the host cluster. Apps frequently need configuration data to function.
+Sync [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) resources that are used by pods from the tenant cluster to the control plane cluster. Apps frequently need configuration data to function.
 
 
-### Sync only used ConfigMaps from the virtual to host cluster
+### Sync only used ConfigMaps from the tenant to control plane cluster
 
-Sync any ConfigMap that is used by a Pod synced from the virtual to host cluster.
+Sync any ConfigMap that is used by a Pod synced from the tenant to control plane cluster.
 
 ```YAML
 sync:
@@ -36,9 +36,9 @@ sync:
       enabled: true
 ```
 
-### Sync all ConfigMaps from the virtual to host cluster
+### Sync all ConfigMaps from the tenant to control plane cluster
 
-If you have a resource in the host cluster monitoring ConfigMap objects that aren't required by a Pod to run, then you can enable the `all` option.
+If you have a resource in the control plane cluster monitoring ConfigMap objects that aren't required by a Pod to run, then you can enable the `all` option.
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -2,7 +2,7 @@
 title: Hybrid scheduling
 sidebar_label: hybridScheduling
 sidebar_class_name: pro host-nodes
-description: Configure hybrid scheduling to use both host and virtual cluster schedulers for workload placement.
+description: Configure hybrid scheduling to use both control plane and tenant cluster schedulers for workload placement.
 ---
 
 import ProAdmonition from '../../../../../../_partials/admonitions/pro-admonition.mdx'
@@ -18,7 +18,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <ProAdmonition/>
 
-Hybrid scheduling enables virtual clusters to use multiple schedulers simultaneously - both from the host cluster and virtual cluster. Pods within the virtual cluster can use different schedulers based on their individual configuration.
+Hybrid scheduling enables tenant clusters to use multiple schedulers simultaneously - both from the control plane cluster and tenant cluster. Pods within the tenant cluster can use different schedulers based on their individual configuration.
 
 You can enable hybrid scheduling using the following:
 
@@ -35,9 +35,9 @@ sync:
       enabled: true
 ```
 
-You must also enable syncing of real nodes from the host to the virtual cluster. If you don’t, the virtual cluster displays an error.
+You must also enable syncing of real nodes from the control plane cluster to the tenant cluster. If you don’t, the tenant cluster displays an error.
 
-By default, all nodes from the host cluster are synced to the virtual cluster. To sync only specific nodes, you can define a label selector as shown in the following example:
+By default, all nodes from the control plane cluster are synced to the tenant cluster. To sync only specific nodes, you can define a label selector as shown in the following example:
 
 ```yaml
 sync:
@@ -64,15 +64,15 @@ custom host and virtual schedulers and use them with Hybrid scheduling.
 
 ## Use host schedulers
 
-`sync.toHost.pods.hybridScheduling.hostSchedulers` specifies a list of schedulers available on the host cluster that virtual cluster pods can use.
+`sync.toHost.pods.hybridScheduling.hostSchedulers` specifies a list of schedulers available on the control plane cluster that tenant cluster pods can use.
 
-The default Kubernetes scheduler on the host cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.
+The default Kubernetes scheduler on the control plane cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.
 
-A default scheduler can be used in two ways: by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`. In both cases, the default Kubernetes scheduler running on the host cluster schedules the pod.
+A default scheduler can be used in two ways: by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`. In both cases, the default Kubernetes scheduler running on the control plane cluster schedules the pod.
 
 ### Use custom host schedulers
 
-The following hybrid scheduling configuration allows virtual cluster pods to use the host cluster's custom schedulers my-custom-scheduler and my-gpu-scheduler.
+The following hybrid scheduling configuration allows tenant cluster pods to use the control plane cluster's custom schedulers my-custom-scheduler and my-gpu-scheduler.
 
 :::note
 This example omits the full vCluster configuration to highlight the relevant hybrid scheduling settings.
@@ -89,7 +89,7 @@ sync:
         - my-gpu-scheduler
 ```
 
-You can now deploy pods in the virtual cluster that use the host cluster’s custom schedulers `my-custom-scheduler` and `my-gpu-scheduler`. For example:
+You can now deploy pods in the tenant cluster that use the control plane cluster’s custom schedulers `my-custom-scheduler` and `my-gpu-scheduler`. For example:
 
 ```yaml
 apiVersion: v1
@@ -115,10 +115,10 @@ spec:
 
 ## Use custom virtual schedulers
 
-Virtual cluster pods can use a custom scheduler that runs inside the virtual cluster.
+Tenant cluster pods can use a custom scheduler that runs inside the tenant cluster.
 To ensure these pods are scheduled correctly, **do not** include virtual schedulers in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list in your vCluster configuration.
 
-The following example shows the hybrid scheduling configuration and a pod that uses the `my-virtual-ai-scheduler` running in the virtual cluster.
+The following example shows the hybrid scheduling configuration and a pod that uses the `my-virtual-ai-scheduler` running in the tenant cluster.
 
 **Hybrid scheduling configuration**:
 ```yaml
@@ -144,21 +144,21 @@ spec:
 
 ## Other related configurations and cluster permissions
 
-When hybrid scheduling is enabled and PersistentVolumeClaims are synced from the virtual cluster to the host cluster, additional resources must also be present in the virtual cluster for scheduling to function correctly.
+When hybrid scheduling is enabled and PersistentVolumeClaims are synced from the tenant cluster to the control plane cluster, additional resources must also be present in the tenant cluster for scheduling to function correctly.
 
-By default, vCluster automatically syncs the following resources from the host to the virtual cluster, unless this behavior is explicitly disabled in the configuration:
+By default, vCluster automatically syncs the following resources from the control plane cluster to the tenant cluster, unless this behavior is explicitly disabled in the configuration:
 
 - `CSINodes`,
 - `CSIStorageCapacities`
 - `CSIDrivers`
 
 
-When `PersistentVolumeClaims` are synced to the host cluster, vCluster also enables syncing of `StorageClasses` from the host to the virtual cluster.
-However, this only happens if syncing `StorageClasses` from the virtual cluster to the host is disabled in the configuration.
+When `PersistentVolumeClaims` are synced to the control plane cluster, vCluster also enables syncing of `StorageClasses` from the control plane cluster to the tenant cluster.
+However, this only happens if syncing `StorageClasses` from the tenant cluster to the control plane cluster is disabled in the configuration.
 
 :::warning
 Manually disabling `CSINodes`, `CSIStorageCapacities`, `CSIDrivers` and `StorageClasses` sync
-in the above cases can cause pod scheduling to fail in your virtual cluster.
+in the above cases can cause pod scheduling to fail in your tenant cluster.
 :::
 
 vCluster automatically adds the required `ClusterRole` rules to ensure syncing works correctly for automatically enabled `CSINodes`, `CSIStorageCapacities`, `CSIDrivers`, and `StorageClasses`.

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/overview.mdx
@@ -15,7 +15,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync all [Pod](https://kubernetes.io/docs/concepts/workloads/pods/) resources, including ephemeral containers, from the virtual cluster to the host cluster.
+Sync all [Pod](https://kubernetes.io/docs/concepts/workloads/pods/) resources, including ephemeral containers, from the tenant cluster to the control plane cluster.
 
 {/*
 `pods.enabled`:
@@ -67,7 +67,7 @@ vCluster does not support setting the `tolerationSeconds` field of a toleration.
 
 ### Replace container images when pods are synced
 
-If certain images used within the virtual cluster are not accessible in the host cluster due to registry restrictions or security policies, `translateImage` can map these to equivalent, permitted images in the host cluster's registry.
+If certain images used within the tenant cluster are not accessible in the control plane cluster due to registry restrictions or security policies, `translateImage` can map these to equivalent, permitted images in the control plane cluster's registry.
 
 ```YAML
 sync:
@@ -84,13 +84,13 @@ sync:
 
 ## Use secrets for ServiceAccount tokens
 
-A host Pod requires a ServiceAccount token to communicate with the virtual clusters API. If you don't want to create these secrets in the host cluster, disable this option. vCluster then adds annotations to the pods.
+A host Pod requires a ServiceAccount token to communicate with the tenant cluster's API. If you don't want to create these secrets in the control plane cluster, disable this option. vCluster then adds annotations to the pods.
 
 ## Rewrite hosts
 
 Applies only to Pods that have the field `spec.subdomain` set.
-In such Pods, the fqdn hostname (`hostname -f`) is constructed based on the host cluster namespace the vCluster runs in.
-This is usually not what applications expect as they are unaware of the host cluster.
+In such Pods, the fqdn hostname (`hostname -f`) is constructed based on the control plane cluster namespace the vCluster runs in.
+This is usually not what applications expect as they are unaware of the control plane cluster.
 
 If this option is enabled, vCluster injects an initContainer to override the Pod's `/etc/hosts` file to change the fqdn hostname to match the expected domain.
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
@@ -21,9 +21,9 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 */}
 By default, this is enabled.
 
-Sync [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) resources used by pods from the virtual cluster to the host cluster. Apps frequently need secret data to function.
+Sync [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) resources used by pods from the tenant cluster to the control plane cluster. Apps frequently need secret data to function.
 
-### Sync only utilized secrets from virtual to host cluster (Default)
+### Sync only utilized secrets from tenant to control plane cluster (Default)
 
 ```YAML
 sync:
@@ -32,9 +32,9 @@ sync:
       enabled: true
 ```
 
-### Sync all secrets from virtual to host cluster
+### Sync all secrets from tenant to control plane cluster
 
-vCluster only knows about a couple of virtual cluster resources that actually use secrets and tries to sync only those into the host cluster. You can enable syncing all virtual cluster secrets to avoid the problem that needed secrets are not synced to the host cluster.
+vCluster only knows about a couple of tenant cluster resources that actually use secrets and tries to sync only those into the control plane cluster. You can enable syncing all tenant cluster secrets to avoid the problem that needed secrets are not synced to the control plane cluster.
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
@@ -19,9 +19,9 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync all [Endpoint](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) resources from the virtual cluster to the host cluster. Service resources are also enabled by default and require Endpoint resources.
+Sync all [Endpoint](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) resources from the tenant cluster to the control plane cluster. Service resources are also enabled by default and require Endpoint resources.
 
-### Disable syncing Endpoints from the virtual to host cluster
+### Disable syncing Endpoints from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpointslices.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpointslices.mdx
@@ -19,11 +19,11 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync all [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) resources from the virtual cluster to the host cluster. Service resources are also enabled by default and require EndpointSlice resources.
+Sync all [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/) resources from the tenant cluster to the control plane cluster. Service resources are also enabled by default and require EndpointSlice resources.
 
 EndpointSlices provide a more scalable alternative to Endpoints for tracking network endpoints in Kubernetes clusters with many services or endpoints.
 
-### Disable syncing EndpointSlices from the virtual to host cluster
+### Disable syncing EndpointSlices from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
@@ -20,11 +20,11 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-When enabled, sync all [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources from the virtual cluster to the host cluster. Use this option to make a virtual cluster service available via a hostname/domain without having to configure DNS for each virtual cluster. You do, however, need to install a separate Ingress controller for each vCluster instance.
+When enabled, sync all [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources from the tenant cluster to the control plane cluster. Use this option to make a tenant cluster service available via a hostname/domain without having to configure DNS for each tenant cluster. You do, however, need to install a separate Ingress controller for each vCluster instance.
 
 When enabled, vCluster automatically tries to detect the supported ingress version (`networking.k8s.io/v1` or `networking.k8s.io/v1beta1`).
 
-### Sync Ingresses from the virtual to host cluster
+### Sync Ingresses from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
@@ -20,9 +20,9 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resources from the virtual cluster to the host cluster. This ensures correct policies are created in the host cluster to achieve the desired traffic behavior between pods.
+Sync [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) resources from the tenant cluster to the control plane cluster. This ensures correct policies are created in the control plane cluster to achieve the desired traffic behavior between pods.
 
-### Sync NetworkPolicies from the virtual to host cluster
+### Sync NetworkPolicies from the tenant to control plane cluster
 
 ```YAML
 sync:
@@ -32,7 +32,7 @@ sync:
 ```
 
 :::info
-NetworkPolicy resources inside virtual clusters rely on the host cluster's support for this feature. Make sure that your host cluster satisfies the [Network Policy prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites).
+NetworkPolicy resources inside tenant clusters rely on the control plane cluster's support for this feature. Make sure that your control plane cluster satisfies the [Network Policy prerequisites](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites).
 :::
 
 ## Patches

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
@@ -20,7 +20,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync all [Service](https://kubernetes.io/docs/concepts/services-networking/service/) resources from the virtual cluster to the host cluster.
+Sync all [Service](https://kubernetes.io/docs/concepts/services-networking/service/) resources from the tenant cluster to the control plane cluster.
 
 
 ## Patches

--- a/vcluster/configure/vcluster-yaml/sync/to-host/overview.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/overview.mdx
@@ -13,7 +13,7 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 <TenancySupport hostNodes="true" />
 
 Read more about [how syncing works](../) before deciding which resources to
-sync from the virtual cluster to the host cluster. 
+sync from the tenant cluster to the control plane cluster. 
 
 <SyncToHostResources/>
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
@@ -20,9 +20,9 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is enabled.
 
-Sync [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the virtual cluster to the host cluster.
+Sync [PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the tenant cluster to the control plane cluster.
 
-### Disable syncing PersistentVolumeClaims from the virtual to host cluster
+### Disable syncing PersistentVolumeClaims from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
@@ -20,11 +20,11 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the virtual cluster to the host cluster. When disabled, vCluster creates pseudo PersistentVolume resources instead. Enabling PersistentVolume syncing is not necessary in order to use PersistentVolumeClaim syncing.
+Sync [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the tenant cluster to the control plane cluster. When disabled, vCluster creates pseudo PersistentVolume resources instead. Enabling PersistentVolume syncing is not necessary in order to use PersistentVolumeClaim syncing.
 
-Enable this feature if you have a scenario that require details about the PersistentVolume and its IDs, you want to create PersistentVolume's directly in the virtual cluster, such as when you want to use Velero or specific CSI drivers.
+Enable this feature if you have a scenario that require details about the PersistentVolume and its IDs, you want to create PersistentVolume's directly in the tenant cluster, such as when you want to use Velero or specific CSI drivers.
 
-### Sync PersistentVolumes from the virtual to host cluster
+### Sync PersistentVolumes from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
@@ -20,7 +20,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the tenant cluster to the control plane cluster. When disabled, vCluster creates pseudo PersistentVolume resources instead. Enabling PersistentVolume syncing is not necessary in order to use PersistentVolumeClaim syncing.
+Sync [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) resources from the tenant cluster to the control plane cluster. When disabled, vCluster creates pseudo PersistentVolume resources instead. Enabling PersistentVolume syncing is not necessary to use PersistentVolumeClaim syncing.
 
 Enable this feature if you have a scenario that require details about the PersistentVolume and its IDs, you want to create PersistentVolume's directly in the tenant cluster, such as when you want to use Velero or specific CSI drivers.
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
@@ -20,9 +20,9 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) resources from the virtual cluster to the host cluster. When enabled and when the necessary CSI driver is installed within the host cluster, vCluster updates certain parameters for the CSI driver through synced StorageClass resources.
+Sync [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) resources from the tenant cluster to the control plane cluster. When enabled and when the necessary CSI driver is installed within the control plane cluster, vCluster updates certain parameters for the CSI driver through synced StorageClass resources.
 
-### Sync StorageClasses from the virtual to host cluster
+### Sync StorageClasses from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
@@ -21,15 +21,15 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/), `VolumeSnapshotContent` and `VolumeSnapshotClass` resources from the virtual cluster to the host cluster.
+Sync [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/), `VolumeSnapshotContent` and `VolumeSnapshotClass` resources from the tenant cluster to the control plane cluster.
 
-Until enabled, creating a VolumeSnapshot custom resource in the virtual cluster has no effect on the host cluster.
+Until enabled, creating a VolumeSnapshot custom resource in the tenant cluster has no effect on the control plane cluster.
 
 ### Host prerequisites
 
 <Prereqs/>
 
-### Sync VolumeSnapshots from the virtual to host cluster
+### Sync VolumeSnapshots from the tenant to control plane cluster
 
 ```YAML
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
@@ -21,7 +21,7 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 By default, this is disabled.
 
-Sync [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/), `VolumeSnapshotContent` and `VolumeSnapshotClass` resources from the tenant cluster to the control plane cluster.
+Sync [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/), VolumeSnapshotContent and VolumeSnapshotClass resources from the tenant cluster to the control plane cluster.
 
 Until enabled, creating a VolumeSnapshot custom resource in the tenant cluster has no effect on the control plane cluster.
 


### PR DESCRIPTION
# Content Description
Terminology update for the `sync/to-host` section as part of the vCluster docs repositioning. Replaces "virtual cluster" with "tenant cluster" and "host cluster" with "control plane cluster" in prose across all 21 pages. Code blocks, YAML comments, JSX comment blocks, and CLI output are unchanged.

## Preview Link 
https://deploy-preview-2099--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs