### PR TITLE
docs(doc-1334): update sleep/deletion/snapshots terminology (part 5)

### DIFF
--- a/vcluster/configure/vcluster-yaml/deletion.mdx
+++ b/vcluster/configure/vcluster-yaml/deletion.mdx
@@ -2,7 +2,7 @@
 title: Deletion
 sidebar_label: deletion
 sidebar_position: 6
-description: Configure virtual cluster deletion
+description: Configure tenant cluster deletion
 sidebar_class_name: pro host-nodes
 ---
 
@@ -21,18 +21,18 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <ProAdmonition />
 
-Accidental deletion of virtual clusters is something that can not be reverted. In order to prevent deletion of virtual clusters you can either set `deletion.prevent` or the `loft.sh/non-deletable` annotation to true.
+Accidental deletion of tenant clusters is something that can not be reverted. In order to prevent deletion of tenant clusters you can either set `deletion.prevent` or the `loft.sh/non-deletable` annotation to true.
 
 :::note
-If you want to delete this virtual cluster in the future, you need to either toggle `deletion.prevent` to false, remove the annotation in the YAML manifest or through the toggle in the UI.
-Once you have done this, you can delete the virtual cluster as usual.
+If you want to delete this tenant cluster in the future, you need to either toggle `deletion.prevent` to false, remove the annotation in the YAML manifest or through the toggle in the UI.
+Once you have done this, you can delete the tenant cluster as usual.
 :::
 
-There are scenarios where it is desirable that virtual clusters are automatically deleted after a certain inactivity duration. This could be after firing up single-shot batch jobs or more generally not having to remember cleaning things up afterwards.
+There are scenarios where it is desirable that tenant clusters are automatically deleted after a certain inactivity duration. This could be after firing up single-shot batch jobs or more generally not having to remember cleaning things up afterwards.
 You can enable automatic deletion by configuring `deletion.auto` accordingly.
 
 :::important
-In order for auto deletion to work it requires an agent to be installed on the host cluster of the virtual cluster.
+In order for auto deletion to work it requires an agent to be installed on the control plane cluster of the tenant cluster.
 :::
 
 ## Configure
@@ -48,7 +48,7 @@ In order for auto deletion to work it requires an agent to be installed on the h
 <TabItem value="yaml">
 ### Prevent deletion
 
-To prevent a virtual cluster from being deleted, add the following configuration to your `vcluster.yaml`:
+To prevent a tenant cluster from being deleted, add the following configuration to your `vcluster.yaml`:
 
 ```yaml title="Prevent Deletion"
 deletion:
@@ -71,13 +71,13 @@ deletion:
 <Flow id="vcluster-prevent-deletion-ui">
   <Step>
     From the project drop-down menu (top left corner), select the project you'd like to create the
-    virtual cluster in.
+    tenant cluster in.
   </Step>
   <Step>
     Click on <NavStep>Virtual Clusters</NavStep>.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
+    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
   </Step>
   <Step>
     Select the <Expander>Auto-Sleep and Auto-Deletion</Expander> expander and toggle the <Label>Prevent Deletion</Label> slider accordingly or configure an inactivity duration (<Label>Sleep After Inactivity</Label>) for auto deletion.
@@ -91,7 +91,7 @@ deletion:
 </TabItem>
 
 <TabItem value="crds">
-  You can prevent virtual cluster deletion, by setting the annotation `loft.sh/non-deletable: "true"` in the YAML manifest of the virtual cluster instance.
+  You can prevent tenant cluster deletion, by setting the annotation `loft.sh/non-deletable: "true"` in the YAML manifest of the tenant cluster instance.
 
 ```yaml {6}
 apiVersion: management.loft.sh/v1

--- a/vcluster/configure/vcluster-yaml/sleep.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep.mdx
@@ -3,7 +3,7 @@ title: Auto Sleep
 sidebar_label: sleep
 sidebar_position: 7
 sidebar_class_name: pro host-nodes
-description: Learn how to configure and manage auto sleep feature in virtual clusters, with or without a platform agent.
+description: Learn how to configure and manage auto sleep feature in tenant clusters, with or without a platform agent.
 ---
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 import Sleep from '../../_partials/config/sleep.mdx'
@@ -32,7 +32,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 Not all workloads need to run continuously. Scaling them down reduces costs. With auto sleep, you can scale workloads based on a set schedule or user activity and ingress.
 
 :::warning
-Auto sleep is intended for pre-production use cases only, and has limitations when used on a virtual cluster instance not connected to the platform.
+Auto sleep is intended for pre-production use cases only, and has limitations when used on a tenant cluster instance not connected to the platform.
 :::
 
 ## Configure
@@ -61,10 +61,10 @@ sleep:
 ### Deployment example
 
 A deployment resource in Kubernetes manages a set of identical pods. Configuring auto sleep for a deployment scales down the pods while keeping the control plane active.
-This setup allows the virtual cluster to reduce resource usage while still being able to monitor activity and trigger wake-up actions when needed.
+This setup allows the tenant cluster to reduce resource usage while still being able to monitor activity and trigger wake-up actions when needed.
 
 :::note Control plane behavior
-- **Without agent**: The control plane remains active, allowing the virtual cluster instance to monitor activity and wake up automatically.
+- **Without agent**: The control plane remains active, allowing the tenant cluster instance to monitor activity and wake up automatically.
 - **With agent**: The platform agent can shut down the control plane completely for maximum resource savings.
 :::
 
@@ -76,7 +76,7 @@ This setup allows the virtual cluster to reduce resource usage while still being
 ### Ingress controller example
 
 An ingress controller, such as NGINX, manages external HTTP/S traffic to services in a Kubernetes cluster.
-To configure auto sleep for the ingress controller, make sure it stays responsive to incoming traffic and can wake up the cluster if needed. This setup keeps the ingress controller active, even when the virtual cluster instance is in auto sleep and allows the controller to handle requests that trigger the virtual cluster to wake up.
+To configure auto sleep for the ingress controller, make sure it stays responsive to incoming traffic and can wake up the cluster if needed. This setup keeps the ingress controller active, even when the tenant cluster instance is in auto sleep and allows the controller to handle requests that trigger the tenant cluster to wake up.
 
 <details>
 <summary>Configure auto sleep with an ingress resource</summary>
@@ -89,9 +89,9 @@ To configure auto sleep for the ingress controller, make sure it stays responsiv
 Enable Istio integration for auto sleep to work with Istio resources.
 :::
 
-When Istio is installed on the host cluster and the [Istio integration](./integrations/istio.mdx) is enabled, the virtual cluster instance syncs [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) and [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources to the host cluster.
+When Istio is installed on the control plane cluster and the [Istio integration](./integrations/istio.mdx) is enabled, the tenant cluster instance syncs [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) and [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources to the control plane cluster.
 
-With auto sleep enabled, any traffic routed to a Service in the virtual cluster instance is tracked as activity and keeps the virtual cluster instance awake. If the vCluster is asleep, incoming traffic wakes it up.
+With auto sleep enabled, any traffic routed to a Service in the tenant cluster instance is tracked as activity and keeps the tenant cluster instance awake. If the vCluster is asleep, incoming traffic wakes it up.
 
 <details>
   <summary>Configure an ingress gateway for cluster external access</summary>
@@ -134,41 +134,41 @@ sleep:
 
 <Flow id="sleep-manual-ui">
   <Step>
-    Click on <NavStep>Virtual Clusters</NavStep> to find the virtual cluster that you want to put to sleep.
+    Click on <NavStep>Virtual Clusters</NavStep> to find the tenant cluster that you want to put to sleep.
   </Step>
   <Step>
-    Hover over the row of the virtual cluster that you want to put to sleep.
+    Hover over the row of the tenant cluster that you want to put to sleep.
   </Step>
   <Step>
-    Click on the vertical ellipsis button and select <Label>Sleep</Label> to put the virtual cluster to sleep.
+    Click on the vertical ellipsis button and select <Label>Sleep</Label> to put the tenant cluster to sleep.
   </Step>
   <Step>
-    Notice how the <Label>Status</Label> column shows that the virtual cluster is now sleeping.
+    Notice how the <Label>Status</Label> column shows that the tenant cluster is now sleeping.
   </Step>
 </Flow>
 
 :::info Automatic Wakeup
-Note that the virtual cluster will automatically wake up again, once you run a kubectl command or send a Kubernetes request via another tool to the virtual cluster.
+Note that the tenant cluster will automatically wake up again, once you run a kubectl command or send a Kubernetes request via another tool to the tenant cluster.
 :::
 
 ### Configure auto sleep
 
 :::info Manual Support only
-This only works for virtual clusters without a template, if you want to change the auto sleep configuration for a virtual cluster created by a template, it must be configured in the template.
+This only works for tenant clusters without a template, if you want to change the auto sleep configuration for a tenant cluster created by a template, it must be configured in the template.
 :::
 
 <Flow id="sleep-automatic-ui">
   <Step>
-    Click on <NavStep>Virtual Clusters</NavStep> to find the virtual cluster that you want to configure auto sleep for.
+    Click on <NavStep>Virtual Clusters</NavStep> to find the tenant cluster that you want to configure auto sleep for.
   </Step>
   <Step>
-    Hover over the row of the virtual cluster that you want to configure.
+    Hover over the row of the tenant cluster that you want to configure.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
+    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
   </Step>
   <Step>
-    Use the <Label>Sleep After Inactivity (minutes)</Label> field to specify the time to wait before putting the virtual cluster to sleep if there is no more user activity in this virtual cluster.
+    Use the <Label>Sleep After Inactivity (minutes)</Label> field to specify the time to wait before putting the tenant cluster to sleep if there is no more user activity in this tenant cluster.
   </Step>
   <Step>
     Click on the <Button>Save</Button> button to save the changes.
@@ -178,18 +178,18 @@ This only works for virtual clusters without a template, if you want to change t
 ### Configure scheduled auto sleep and wake-up
 
 :::info Manual Support only
-This only works for virtual clusters without a template, if you want to change the auto sleep configuration for a virtual cluster created by a template, it must be configured in the template.
+This only works for tenant clusters without a template, if you want to change the auto sleep configuration for a tenant cluster created by a template, it must be configured in the template.
 :::
 
 <Flow id="sleep-automatic-constraint-schedule-ui">
   <Step>
-    In the <NavStep>Virtual Clusters</NavStep> view, hover over the virtual cluster that you want to configure auto sleep for.
+    In the <NavStep>Virtual Clusters</NavStep> view, hover over the tenant cluster that you want to configure auto sleep for.
   </Step>
   <Step>
     Click on the <Button>Edit</Button> button.
   </Step>
   <Step>
-    In the <Label>Definition</Label> section, under the <Label>Sleep Mode</Label> section, use the <Label>Sleep Schedule</Label> field and/or the <Label>Wake-Up Schedule</Label> field to specify the <Input>Cronjob Times</Input> when the respective virtual cluster should be put to sleep or woken up.
+    In the <Label>Definition</Label> section, under the <Label>Sleep Mode</Label> section, use the <Label>Sleep Schedule</Label> field and/or the <Label>Wake-Up Schedule</Label> field to specify the <Input>Cronjob Times</Input> when the respective tenant cluster should be put to sleep or woken up.
   </Step>
   <Step>
     <b>[Optional]</b> Input a <Label>Schedule Timezone</Label> for the timezone to apply the schedule.
@@ -199,37 +199,37 @@ This only works for virtual clusters without a template, if you want to change t
   </Step>
 </Flow>
 
-### Wake up virtual cluster
+### Wake up tenant cluster
 
 <Flow id="wakeup-manual-ui">
   <Step>
-    In the <NavStep>Virtual Clusters</NavStep> view, hover over the virtual cluster that you want to wake up.
+    In the <NavStep>Virtual Clusters</NavStep> view, hover over the tenant cluster that you want to wake up.
   </Step>
   <Step>
-    Click on the vertical ellipsis button and select <Label>Wake Up</Label> to wake up the virtual cluster.
+    Click on the vertical ellipsis button and select <Label>Wake Up</Label> to wake up the tenant cluster.
   </Step>
   <Step>
-    Notice how the <Label>Status</Label> column shows that the virtual cluster is now running again after a <Label>Pending</Label> state.
+    Notice how the <Label>Status</Label> column shows that the tenant cluster is now running again after a <Label>Pending</Label> state.
   </Step>
 </Flow>
 
 ### Configure auto-delete
 
-The platform lets you configure auto-delete for virtual clusters that have not been used for a certain period of time.
+The platform lets you configure auto-delete for tenant clusters that have not been used for a certain period of time.
 
 :::tip Manual Support only
-This only works for virtual clusters without a template, if you want to change the auto sleep configuration for a virtual cluster created by a template, it must be configured in the template.
+This only works for tenant clusters without a template, if you want to change the auto sleep configuration for a tenant cluster created by a template, it must be configured in the template.
 :::
 
 <Flow id="auto-delete-ui">
   <Step>
-    In the <NavStep>Virtual Clusters</NavStep> view, hover over the virtual cluster that you want to configure auto-delete for.
+    In the <NavStep>Virtual Clusters</NavStep> view, hover over the tenant cluster that you want to configure auto-delete for.
   </Step>
   <Step>
     Click on the <Button>Edit</Button> button.
   </Step>
   <Step>
-    Under the <Label>Sleep Mode</Label> section, use the <Label>Delete After Inactivity (minutes)</Label> field to specify the time to wait before deleting the virtual cluster if there was no more user activity within this virtual cluster.
+    Under the <Label>Sleep Mode</Label> section, use the <Label>Delete After Inactivity (minutes)</Label> field to specify the time to wait before deleting the tenant cluster if there was no more user activity within this tenant cluster.
   </Step>
   <Step>
     Click on the <Button>Save</Button> button to save the changes.
@@ -240,7 +240,7 @@ This only works for virtual clusters without a template, if you want to change t
 
 <TabItem value="crds">
 
-You can configure auto sleep for a virtual cluster by setting the sleep configuration in the VirtualClusterInstance manifest.
+You can configure auto sleep for a tenant cluster by setting the sleep configuration in the VirtualClusterInstance manifest.
 
 ```yaml {8-11}
 apiVersion: management.loft.sh/v1
@@ -282,46 +282,46 @@ spec:
 
 <TabItem value="cli">
 
-### Pause a virtual cluster (Helm driver)
+### Pause a tenant cluster (Helm driver)
 
-For virtual clusters deployed with the Helm driver (without platform):
+For tenant clusters deployed with the Helm driver (without platform):
 
 ```bash
 vcluster pause VCLUSTER_NAME --namespace NAMESPACE
 ```
 
-This will scale down the virtual cluster and delete all workloads created through the virtual cluster. Upon resume, all workloads will be recreated. Other resources such as persistent volume claims, services etc. will not be affected.
+This will scale down the tenant cluster and delete all workloads created through the tenant cluster. Upon resume, all workloads will be recreated. Other resources such as persistent volume claims, services etc. will not be affected.
 
-### Resume a paused virtual cluster
+### Resume a paused tenant cluster
 
 ```bash
 vcluster resume VCLUSTER_NAME --namespace NAMESPACE
 ```
 
-### Sleep a virtual cluster (Platform)
+### Sleep a tenant cluster (Platform)
 
-For virtual clusters managed by the vCluster Platform:
+For tenant clusters managed by the vCluster Platform:
 
 ```bash
 vcluster platform sleep vcluster VCLUSTER_NAME --project PROJECT_NAME
 ```
 
-You can optionally prevent the virtual cluster from waking up for a certain period:
+You can optionally prevent the tenant cluster from waking up for a certain period:
 
 ```bash
 vcluster platform sleep vcluster VCLUSTER_NAME --project PROJECT_NAME --prevent-wakeup 3600
 ```
 
-The `--prevent-wakeup` flag specifies the number of seconds the virtual cluster should remain asleep (use 0 for infinite sleeping).
+The `--prevent-wakeup` flag specifies the number of seconds the tenant cluster should remain asleep (use 0 for infinite sleeping).
 
-### Wake up a sleeping virtual cluster (Platform)
+### Wake up a sleeping tenant cluster (Platform)
 
 ```bash
 vcluster platform wakeup vcluster VCLUSTER_NAME --project PROJECT_NAME
 ```
 
 :::info Automatic Wakeup
-Note that the virtual cluster will automatically wake up again, once you run a kubectl command or send a Kubernetes request via another tool to the virtual cluster.
+Note that the tenant cluster will automatically wake up again, once you run a kubectl command or send a Kubernetes request via another tool to the tenant cluster.
 :::
 
 </TabItem>

--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -39,8 +39,8 @@ recovery points, administrators can quickly restore the vCluster to a known good
 For more details on how snapshots work, refer to the [Snapshot and Restore](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
 
 In the `vcluster.yaml`, it is configured under `snapshots`. Using the UI, you
-can configure the management of snapshots in the config options of a virtual cluster under **Snapshots**. Though
-snapshot configuration is configured on the virtual cluster itself, the capability and logic of scheduling snapshots
+can configure the management of snapshots in the config options of a tenant cluster under **Snapshots**. Though
+snapshot configuration is configured on the tenant cluster itself, the capability and logic of scheduling snapshots
 is in vCluster Platform.
 
 :::note
@@ -86,7 +86,7 @@ snapshots:
 ```
 
 :::warning
-In order to create volume snapshots, several installation and configuration steps have to be done in your host or virtual cluster.
+In order to create volume snapshots, several installation and configuration steps have to be done in your control plane cluster or tenant cluster.
 Check the [Volume Snapshot](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation page to learn more about getting your cluster ready for snapshotting volumes
 :::
 
@@ -111,23 +111,23 @@ Snapshots can be stored in an AWS S3 bucket.
 
 ### Create an OCI snapshot (Helm driver)
 
-For virtual clusters deployed with the Helm driver (without platform):
+For tenant clusters deployed with the Helm driver (without platform):
 
 ```bash
 vcluster snapshot create VCLUSTER_NAME --namespace NAMESPACE oci://ghcr.io/my-user/my-repo:my-tag
 ```
 
-This will take a snapshot of the virtual cluster and saves it as an OCI image.
+This will take a snapshot of the tenant cluster and saves it as an OCI image.
 
 ### Create an AWS S3 snapshot (Helm driver)
 
-For virtual clusters deployed with the Helm driver (without platform):
+For tenant clusters deployed with the Helm driver (without platform):
 
 ```bash
 vcluster snapshot create VCLUSTER_NAME --namespace NAMESPACE s3://my-bucket/my-bucket-key
 ```
 
-This will take a snapshot of the virtual cluster and saves it to a AWS S3 bucket.
+This will take a snapshot of the tenant cluster and saves it to a AWS S3 bucket.
 
 Configure additional encryption settings for AWS with these flags:
 - `--customer-key-encryption-file`
@@ -136,13 +136,13 @@ Configure additional encryption settings for AWS with these flags:
 
 ### Create a container filesystem snapshot (Helm driver)
 
-For virtual clusters deployed with the Helm driver (without platform):
+For tenant clusters deployed with the Helm driver (without platform):
 
 ```bash
 vcluster snapshot create VCLUSTER_NAME --namespace NAMESPACE container:///data/my-local-snapshot.tar.gz
 ```
 
-This will take a snapshot of the virtual cluster to the vCluster container filesystem.
+This will take a snapshot of the tenant cluster to the vCluster container filesystem.
 
 </TabItem>
 
@@ -151,13 +151,13 @@ This will take a snapshot of the virtual cluster to the vCluster container files
 <Flow id="vcluster-prevent-deletion-ui">
   <Step>
     From the project drop-down menu (top left corner), select the project you'd like to create the
-    virtual cluster in.
+    tenant cluster in.
   </Step>
   <Step>
     Click on <NavStep>Virtual Clusters</NavStep>.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
+    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
   </Step>
   <Step>
     Select the <Expander>Snapshots</Expander> expander, toggle the <Label>Enable Snapshots</Label> slider to enable auto snapshots and configure accordingly.


### PR DESCRIPTION
# Content Description
Terminology update for `sleep.mdx`, `deletion.mdx`, and `snapshots.mdx` as part of the vCluster docs repositioning. Replaces "virtual cluster" with "tenant cluster" and "host cluster" with "control plane cluster" in prose. UI nav labels (`<NavStep>Virtual Clusters</NavStep>`) are preserved. Code blocks are unchanged.

## Preview Link 
- https://deploy-preview-2100--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/sleep
- https://deploy-preview-2100--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/deletion
- https://deploy-preview-2100--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/snapshots

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs