### PR TITLE
docs(terminology): update experimental/proxy.mdx to tenant/control plane cluster terminology

### DIFF
--- a/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
@@ -4,7 +4,7 @@ sidebar_label: proxy
 sidebar_position: 8
 sidebar_class_name: pro host-nodes private-nodes standalone
 toc_max_heading_level: 3
-description: Configure vCluster to proxy custom resources to other virtual clusters.
+description: Configure vCluster to proxy custom resources to other tenant clusters.
 ---
 
 import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
@@ -19,14 +19,14 @@ import ProxyPlatformRbac from '!!raw-loader!@site/vcluster/configure/vcluster-ya
 <ProAdmonition/>
 
 :::note vCluster Platform required
-This feature requires [vCluster Platform][vcluster-platform]. Both the client and target virtual clusters must be managed as [VirtualClusterInstance][virtualclusterinstance-api] within the platform.
+This feature requires [vCluster Platform][vcluster-platform]. Both the client and target tenant clusters must be managed as [VirtualClusterInstance][virtualclusterinstance-api] within the platform.
 :::
 
-The Resource Proxy feature enables vCluster to proxy custom resource (CRD) requests to other virtual clusters. When enabled, the client virtual cluster transparently stores resources in and delegates management to a target virtual cluster. This enables cross-cluster communication patterns, centralized resource management, and multi-tenant architectures.
+The Resource Proxy feature enables vCluster to proxy custom resource (CRD) requests to other tenant clusters. When enabled, the client tenant cluster transparently stores resources in and delegates management to a target tenant cluster. This enables cross-cluster communication patterns, centralized resource management, and multi-tenant architectures.
 
 ## How it works {#how-it-works}
 
-When you configure a client virtual cluster to proxy custom resources, vCluster intercepts API requests for those resources and forwards them to the target virtual cluster through vCluster Platform.
+When you configure a client tenant cluster to proxy custom resources, vCluster intercepts API requests for those resources and forwards them to the target tenant cluster through vCluster Platform.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'edgeLabelBackground':'#F3E8FF','edgeLabelColor':'#111827'}, 'flowchart': {'curve': 'linear', 'htmlLabels': true}}}%%
@@ -77,7 +77,7 @@ The proxy performs several key functions:
 
 ### Multi-client isolation {#multi-client-isolation-overview}
 
-When multiple client virtual clusters proxy to the same target, each client only sees resources it created by default. The proxy achieves this through owner labels and label selector injection.
+When multiple client tenant clusters proxy to the same target, each client only sees resources it created by default. The proxy achieves this through owner labels and label selector injection.
 
 ```mermaid
 %%{init: {'theme': 'base', 'flowchart': {'curve': 'linear', 'htmlLabels': 'true'}}}%%
@@ -114,14 +114,14 @@ flowchart LR
 
 ## Key capabilities {#key-capabilities}
 
-- **Transparent access**: Users interact with custom resources as if they were local to their virtual cluster.
-- **Centralized storage**: A dedicated target virtual cluster stores all resources.
-- **Multi-tenant isolation**: Each client virtual cluster only sees its own resources by default.
-- **RBAC enforcement**: The target virtual cluster enforces its own RBAC policies on proxied requests.
+- **Transparent access**: Users interact with custom resources as if they were local to their tenant cluster.
+- **Centralized storage**: A dedicated target tenant cluster stores all resources.
+- **Multi-tenant isolation**: Each client tenant cluster only sees its own resources by default.
+- **RBAC enforcement**: The target tenant cluster enforces its own RBAC policies on proxied requests.
 
 ## Platform RBAC requirements {#platform-rbac}
 
-For the resource proxy to function, the client virtual cluster must be authorized to access the target virtual cluster through vCluster Platform. This requires RBAC configuration on the platform's management cluster.
+For the resource proxy to function, the client tenant cluster must be authorized to access the target tenant cluster through vCluster Platform. This requires RBAC configuration on the platform's management cluster.
 
 ### Platform RBAC configuration {#platform-rbac-config}
 
@@ -129,7 +129,7 @@ Create a Role and RoleBinding in the project namespace (`p-<project-name>`) on t
 
 <CodeBlock language="yaml" title="platform-proxy-rbac.yaml">{ProxyPlatformRbac}</CodeBlock>
 
-Apply this configuration to the platform's management cluster (not the virtual clusters):
+Apply this configuration to the platform's management cluster (not the tenant clusters):
 
 ```bash title="Apply platform RBAC"
 kubectl apply -f platform-proxy-rbac.yaml --context <platform-context>
@@ -147,8 +147,8 @@ To enable resource proxying, configure the `experimental.proxy.customResources` 
 |-------|------|-------------|
 | `enabled` | boolean | Enable or disable the proxy for this resource. |
 | `targetVirtualCluster` | object | Reference to the target [VirtualClusterInstance][virtualclusterinstance-api] to proxy requests to. |
-| `targetVirtualCluster.name` | string | Name of the target virtual cluster. Required when enabled. |
-| `targetVirtualCluster.project` | string | Project of the target virtual cluster. Defaults to the same project as the client vCluster. |
+| `targetVirtualCluster.name` | string | Name of the target tenant cluster. Required when enabled. |
+| `targetVirtualCluster.project` | string | Project of the target tenant cluster. Defaults to the same project as the client vCluster. |
 | `accessResources` | string | Resource visibility mode: `owned` (default) or `all`. See [Access modes](#access-modes). |
 
 ### Resource key format {#resource-key-format}
@@ -161,17 +161,17 @@ The resource key follows the format `resource.apiGroup/version`:
 
 ## Example: Basic proxy setup {#basic-setup}
 
-This example demonstrates a simple two-cluster setup where a client virtual cluster proxies MyResource resources to a target virtual cluster.
+This example demonstrates a simple two-cluster setup where a client tenant cluster proxies MyResource resources to a target tenant cluster.
 
 <Flow id="basic-proxy-setup">
 
 <Step>
 
-**Create the target virtual cluster**.
+**Create the target tenant cluster**.
 
-Create a virtual cluster to serve as the target. The target doesn't need any proxy configuration - it just stores the resources and enforces RBAC:
+Create a tenant cluster to serve as the target. The target doesn't need any proxy configuration - it just stores the resources and enforces RBAC:
 
-```bash title="Create target virtual cluster"
+```bash title="Create target tenant cluster"
 vcluster create target
 ```
 
@@ -179,9 +179,9 @@ vcluster create target
 
 <Step>
 
-**Install the CustomResourceDefinition in the target virtual cluster**.
+**Install the CustomResourceDefinition in the target tenant cluster**.
 
-The CustomResourceDefinition must exist in the target virtual cluster:
+The CustomResourceDefinition must exist in the target tenant cluster:
 
 ```yaml title="myresource-crd.yaml"
 apiVersion: apiextensions.k8s.io/v1
@@ -213,7 +213,7 @@ spec:
                   type: string
 ```
 
-Apply the CustomResourceDefinition to the target virtual cluster:
+Apply the CustomResourceDefinition to the target tenant cluster:
 
 ```bash title="Apply CustomResourceDefinition to target"
 vcluster connect target -- kubectl apply -f myresource-crd.yaml
@@ -223,9 +223,9 @@ vcluster connect target -- kubectl apply -f myresource-crd.yaml
 
 <Step>
 
-**Configure RBAC in the target virtual cluster**.
+**Configure RBAC in the target tenant cluster**.
 
-Create RBAC rules to allow the client virtual cluster to access resources. The client virtual cluster authenticates using its vCluster Platform identity in the format `loft:vcluster:p-<project>:<name>`:
+Create RBAC rules to allow the client tenant cluster to access resources. The client tenant cluster authenticates using its vCluster Platform identity in the format `loft:vcluster:p-<project>:<name>`:
 
 ```yaml title="target-rbac.yaml"
 apiVersion: rbac.authorization.k8s.io/v1
@@ -258,7 +258,7 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
 ```
 
-Apply RBAC to the target virtual cluster:
+Apply RBAC to the target tenant cluster:
 
 ```bash title="Apply RBAC to target"
 vcluster connect target -- kubectl apply -f target-rbac.yaml
@@ -270,7 +270,7 @@ vcluster connect target -- kubectl apply -f target-rbac.yaml
 
 **Configure platform RBAC**.
 
-Grant the client virtual cluster permission to access the target through vCluster Platform. Apply this to the platform's management cluster:
+Grant the client tenant cluster permission to access the target through vCluster Platform. Apply this to the platform's management cluster:
 
 <CodeBlock language="yaml" title="platform-rbac.yaml">{ProxyPlatformRbac}</CodeBlock>
 
@@ -284,9 +284,9 @@ kubectl apply -f platform-rbac.yaml --context <platform-context>
 
 <Step>
 
-**Create the client virtual cluster with proxy configuration**.
+**Create the client tenant cluster with proxy configuration**.
 
-Configure the client virtual cluster to proxy MyResource resources to the target:
+Configure the client tenant cluster to proxy MyResource resources to the target:
 
 ```yaml title="client-vcluster.yaml"
 experimental:
@@ -298,9 +298,9 @@ experimental:
           name: "target"
 ```
 
-Deploy the client virtual cluster:
+Deploy the client tenant cluster:
 
-```bash title="Deploy client virtual cluster"
+```bash title="Deploy client tenant cluster"
 vcluster create client -f client-vcluster.yaml
 ```
 
@@ -310,7 +310,7 @@ vcluster create client -f client-vcluster.yaml
 
 **Test the proxy**.
 
-Create a MyResource in the client virtual cluster:
+Create a MyResource in the client tenant cluster:
 
 ```bash title="Create MyResource in client"
 vcluster connect client -- kubectl apply -f - <<EOF
@@ -325,7 +325,7 @@ spec:
 EOF
 ```
 
-Verify the resource exists in both virtual clusters:
+Verify the resource exists in both tenant clusters:
 
 ```bash title="Verify resource in both clusters"
 # Check in client via proxy
@@ -341,7 +341,7 @@ vcluster connect target -- kubectl get myresources
 
 ## Example: Multi-target proxy {#multi-target}
 
-A single virtual cluster can proxy different resources to different target virtual clusters based on API group and version.
+A single tenant cluster can proxy different resources to different target tenant clusters based on API group and version.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'edgeLabelBackground':'#F3E8FF','edgeLabelColor':'#111827'}, 'flowchart': {'curve': 'linear', 'htmlLabels': true}}}%%
@@ -389,7 +389,7 @@ In this configuration:
 
 ## Example: Cross-project proxy {#cross-project}
 
-By default, the target virtual cluster is assumed to be in the same project as the client. You can proxy to a virtual cluster in a different project by specifying the `project` field. This works across different host clusters connected to the same vCluster Platform.
+By default, the target tenant cluster is assumed to be in the same project as the client. You can proxy to a tenant cluster in a different project by specifying the `project` field. This works across different control plane clusters connected to the same vCluster Platform.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'edgeLabelBackground':'#F3E8FF','edgeLabelColor':'#111827'}, 'flowchart': {'curve': 'linear'}}}%%
@@ -430,38 +430,38 @@ flowchart TB
 This is useful for scenarios where:
 - A shared resource storage cluster exists in a centralized project
 - Teams in different projects need to access common resources
-- Virtual clusters across different host clusters need to share CRDs
+- Tenant clusters across different control plane clusters need to share CRDs
 - CI/CD environments need access to centralized resource management
 
 ## Access modes {#access-modes}
 
-The `accessResources` field controls which resources a client virtual cluster can see in the target:
+The `accessResources` field controls which resources a client tenant cluster can see in the target:
 
 <CodeBlock language="yaml" title="Access modes configuration">{ProxyAccessModesConfig}</CodeBlock>
 
 ### `owned` mode - default {#owned-mode}
 
-Each client virtual cluster only sees resources it created. This enables multi-tenant isolation where multiple client virtual clusters can share a target without seeing each other's resources.
+Each client tenant cluster only sees resources it created. This enables tenant isolation where multiple client tenant clusters can share a target without seeing each other's resources.
 
 ### `all` mode {#all-mode}
 
-The client virtual cluster can see all resources in the target, regardless of who created them. This is useful for read-only observers, centralized dashboards, or admin access.
+The client tenant cluster can see all resources in the target, regardless of who created them. This is useful for read-only observers, centralized dashboards, or admin access.
 
 :::tip Combine access modes with RBAC
-The `accessResources` mode controls **visibility** - what resources a virtual cluster can see. RBAC in the target virtual cluster controls **permissions** - what operations the virtual cluster can perform.
+The `accessResources` mode controls **visibility** - what resources a tenant cluster can see. RBAC in the target tenant cluster controls **permissions** - what operations the tenant cluster can perform.
 
-For example, a virtual cluster with `accessResources: all` but read-only RBAC can see all resources but can't modify any.
+For example, a tenant cluster with `accessResources: all` but read-only RBAC can see all resources but can't modify any.
 :::
 
 ## Example: Multi-client isolation {#multi-client}
 
-This example demonstrates how multiple client virtual clusters can share a target while maintaining isolation.
+This example demonstrates how multiple client tenant clusters can share a target while maintaining isolation.
 
 <Flow id="multi-client-setup">
 
 <Step>
 
-**Configure client virtual clusters**.
+**Configure client tenant clusters**.
 
 Both clients proxy to the same target:
 
@@ -540,7 +540,7 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
 ```
 
-Apply to the target virtual cluster:
+Apply to the target tenant cluster:
 
 ```bash title="Apply target RBAC"
 vcluster connect orchestrator -- kubectl apply -f multi-client-target-rbac.yaml
@@ -552,7 +552,7 @@ vcluster connect orchestrator -- kubectl apply -f multi-client-target-rbac.yaml
 
 **Configure platform RBAC for multiple clients**.
 
-Grant both client virtual clusters permission to access the target through vCluster Platform:
+Grant both client tenant clusters permission to access the target through vCluster Platform:
 
 ```yaml title="multi-client-platform-rbac.yaml"
 apiVersion: rbac.authorization.k8s.io/v1
@@ -651,7 +651,7 @@ vcluster connect orchestrator -- kubectl get myresources
 
 ## Limitations {#limitations}
 
-- All `CustomResources` within the same API `GroupVersion` must use the same target virtual cluster.
+- All `CustomResources` within the same API `GroupVersion` must use the same target tenant cluster.
 - When configuring RBAC for status updates, include permissions for the status subresource.
 
 ## Troubleshoot {#troubleshoot}
@@ -660,7 +660,7 @@ vcluster connect orchestrator -- kubectl get myresources
 
 If resources don't appear after creation:
 
-1. **Check RBAC configuration**: Ensure the client virtual cluster's identity has correct permissions in the target.
+1. **Check RBAC configuration**: Ensure the client tenant cluster's identity has correct permissions in the target.
 
 2. **Verify the CustomResourceDefinition exists in target**:
 
@@ -668,15 +668,15 @@ If resources don't appear after creation:
 vcluster connect <target> -- kubectl get crd <resource>.<group>
 ```
 
-3. **Check virtual cluster logs** for errors:
+3. **Check tenant cluster logs** for errors:
 
-```bash title="Check virtual cluster logs"
+```bash title="Check tenant cluster logs"
 kubectl logs -n vcluster-<name> -l app=vcluster --tail=100
 ```
 
 ### Permission denied errors {#permission-denied}
 
-Permission errors can occur at two levels: the platform level and the target virtual cluster level.
+Permission errors can occur at two levels: the platform level and the target tenant cluster level.
 
 1. **Check platform RBAC**: Ensure the client has "use" permission on the target VirtualClusterInstance:
 
@@ -687,7 +687,7 @@ kubectl auth can-i use virtualclusterinstances/target \
   --context <platform-context>
 ```
 
-2. **Verify the virtual cluster identity format**: The identity follows `loft:vcluster:p-<project>:<name>`.
+2. **Verify the tenant cluster identity format**: The identity follows `loft:vcluster:p-<project>:<name>`.
 
 3. **Test target RBAC directly**:
 
@@ -698,7 +698,7 @@ vcluster connect <target> -- kubectl auth can-i create myresources.example.com \
 
 ### Target unavailable errors {#target-unavailable}
 
-Ensure the target virtual cluster is running and healthy. vCluster automatically attempts to reconnect when the target becomes available.
+Ensure the target tenant cluster is running and healthy. vCluster automatically attempts to reconnect when the target becomes available.
 
 ## Config reference {#config-reference}
 
@@ -713,15 +713,15 @@ Ensure the target virtual cluster is running and healthy. vCluster automatically
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Enable the proxy for this resource. |
-| `targetVirtualCluster` | `VirtualClusterRef` | - | Reference to the target virtual cluster. Required when enabled. |
+| `targetVirtualCluster` | `VirtualClusterRef` | - | Reference to the target tenant cluster. Required when enabled. |
 | `accessResources` | `string` | `"owned"` | Resource visibility mode: `owned` or `all`. |
 
 ### `VirtualClusterRef` {#virtual-cluster-ref}
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | `string` | - | Name of the target virtual cluster. Required. |
-| `project` | `string` | Same as source | Project of the target virtual cluster. |
+| `name` | `string` | - | Name of the target tenant cluster. Required. |
+| `project` | `string` | Same as source | Project of the target tenant cluster. |
 
 {/* Links */}
 [vcluster-platform]: /platform/


### PR DESCRIPTION
# Content Description
Updates `experimental/proxy.mdx` to replace deprecated "virtual cluster" and "host cluster" terminology with "tenant cluster" and "control plane cluster" throughout prose. Code blocks, YAML keys, CLI commands, and inline code identifiers are unchanged.

## Preview Link
https://deploy-preview-2101--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/experimental/proxy

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs