### PR TITLE
fix(platform): create dockerconfigjson secret with proper init value

### DIFF
--- a/platform/use-platform/secrets/secret-sync.mdx
+++ b/platform/use-platform/secrets/secret-sync.mdx
@@ -7,8 +7,8 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="secrets" />
 
 
-Creating project secrets with data or synchronized from a global secret is great and all, but we still need a 
-Kubernetes native secret to make use of the secret data from a Pod. vCluster Platform makes this possible 
+Creating project secrets with data or synchronized from a global secret is great and all, but we still need a
+Kubernetes native secret to make use of the secret data from a Pod. vCluster Platform makes this possible
 by reading a special label from Kubernetes native secrets and updating it with the project secret data.
 
 ## Create an Opaque Secret
@@ -26,14 +26,14 @@ metadata:
 type: Opaque
 ```
 
-Replace `<PROJECT_SECRET_NAME>` with the name of the project secret. 
+Replace `<PROJECT_SECRET_NAME>` with the name of the project secret.
 
-The secret will be synchronized with the project secret momentarily. Secrets may be synchronized in any namespace or virtual cluster that belong to the project.
+The secret will be synchronized with the project secret momentarily. Secrets may be synchronized in any namespace or tenant cluster that belong to the project.
 
 ## Syncing Secrets in Intervals
 
-Secrets inside virtual clusters will be synchronized whenever the project secret is created or modified. However, since it would be inefficient to watch all secrets in all virtual clusters, 
-vCluster Platform synchronizes the virtual cluster secrets on an interval. This means there's a small delay before a virtual cluster secret is synchronized once it's created.
+Secrets inside tenant clusters will be synchronized whenever the project secret is created or modified. However, since it would be inefficient to watch all secrets in all tenant clusters,
+vCluster Platform synchronizes the tenant cluster secrets on an interval. This means there's a small delay before a tenant cluster secret is synchronized once it's created.
 
 
 ## Create other Secret Types

--- a/platform/use-platform/secrets/secret-sync.mdx
+++ b/platform/use-platform/secrets/secret-sync.mdx
@@ -38,8 +38,10 @@ vCluster Platform synchronizes the virtual cluster secrets on an interval. This 
 
 ## Create other Secret Types
 
-There are other types of secrets that can be created because any type of native Kubernetes secret is allowed. In this case example, the secret `type` will remain unchanged 
-by vCluster Platform, and the data will be populated as-is from the project secret. The project secret data must match the expected format of the chosen secret type.
+There are other types of secrets that can be created because any type of native Kubernetes secret is allowed. In this case example, the secret `type` will remain unchanged
+by vCluster Platform, and the data will be populated as-is from the project secret. The project secret data must conform to the format required by the Kubernetes secret type.
+All mandatory keys must be present with a valid value and cannot be omitted, even when using a placeholder.
+For example, `kubernetes.io/dockerconfigjson` requires the `.dockerconfigjson` key; an empty JSON object (`{}`) is the minimum valid value.
 
 
 ```yaml
@@ -50,9 +52,9 @@ metadata:
   namespace: my-space
   labels:
     loft.sh/project-secret-name: <PROJECT_SECRET_NAME>
-type: kubernetes.io/dockercfg
+data:
+  .dockerconfigjson: e30K  # base64("{}")
+type: kubernetes.io/dockerconfigjson
 ```
 
-Replace `<PROJECT_SECRET_NAME>` with the name of the project secret. 
-
-
+Replace `<PROJECT_SECRET_NAME>` with the name of the project secret.

--- a/platform/use-platform/secrets/secret-sync.mdx
+++ b/platform/use-platform/secrets/secret-sync.mdx
@@ -41,7 +41,7 @@ vCluster Platform synchronizes the tenant cluster secrets on an interval. This m
 There are other types of secrets that can be created because any type of native Kubernetes secret is allowed. In this case example, the secret `type` will remain unchanged
 by vCluster Platform, and the data will be populated as-is from the project secret. The project secret data must conform to the format required by the Kubernetes secret type.
 All mandatory keys must be present with a valid value and cannot be omitted, even when using a placeholder.
-For example, `kubernetes.io/dockerconfigjson` requires the `.dockerconfigjson` key; an empty JSON object (`{}`) is the minimum valid value.
+The type `kubernetes.io/dockerconfigjson` requires the `.dockerconfigjson` key, an empty JSON object `{}` is the minimum valid value.
 
 
 ```yaml


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

The code block in the secret sync docs used the deprecated `kubernetes.io/dockercfg` type. Today, `kubernetes.io/dockerconfigjson`is more common, but requires the `.data.\.dockerconfigjson` field. This
  caused any user who copied the template to create an invalid secret that Kubernetes would reject.

Changes                                                                                                                                    
- Corrects secret type to kubernetes.io/dockerconfigjson
- Adds data[.dockerconfigjson]: e30K (base64 of {}) as a valid initialization value required by the type   

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Part of ENGPLAT-124

<!-- Do not change the line below -->
@netlify /docs

