### PR TITLE
docs(terminology): update vcluster/manage top-level files to tenant cluster terminology

### DIFF
--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -54,7 +54,7 @@ vcluster connect my-vcluster -n my-vcluster --server my-domain.org
 
 By default, vCluster updates the current kubeconfig to access the vCluster that contains the default admin client certificate and client key to authenticate to the vCluster. This means that all kubeconfig files generated have cluster admin access within the vCluster.
 
-Often this might not be desired. Instead of giving a user admin access to the virtual cluster, you can also use [service account authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens) to the virtual cluster. Say we want to create a kubeconfig file that only has view access in the virtual cluster. Then you would create a new service account inside the vCluster and assign it the cluster role `view` via a cluster role binding. Then we would generate a service account token and use that instead of the client-cert and client-key inside the kubeconfig.
+Often this might not be desired. Instead of giving a user admin access to the tenant cluster, you can also use [service account authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens) to the tenant cluster. Say we want to create a kubeconfig file that only has view access in the tenant cluster. Then you would create a new service account inside the vCluster and assign it the cluster role `view` via a cluster role binding. Then we would generate a service account token and use that instead of the client-cert and client-key inside the kubeconfig.
 
 ```
 vcluster connect my-vcluster -n my-vcluster --service-account kube-system/my-user --cluster-role view
@@ -197,11 +197,11 @@ Exposing vCluster is different, depending on whether the control-plane is deploy
   ]}>
 <TabItem value="as-binary">
 For vCluster Standalone, you can use the method of your choice for exposing API Server endpoint, as described in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/).
-  If you decide to use vCluster Standalone as a host cluster for virtual clusters, then you can set your current kube context to the vCluster Standalone and create and interact with virtual clusters using vCluster CLI.
+  If you decide to use vCluster Standalone as a control plane cluster for tenant clusters, then you can set your current kube context to the vCluster Standalone and create and interact with tenant clusters using vCluster CLI.
 </TabItem>
 
 <TabItem value="as-container">
-By default, vCluster is only reachable via port-forwarding in remote clusters. However, this means that you need access to the host cluster, where the vCluster is running, in order to access it. To directly access vCluster without port-forwarding, you can use one of the following methods.
+By default, vCluster is only reachable via port-forwarding in remote clusters. However, this means that you need access to the control plane cluster, where the vCluster is running, in order to access it. To directly access vCluster without port-forwarding, you can use one of the following methods.
 
 :::info Local Kubernetes Clusters
 If you are using a local Kubernetes cluster, such as docker-desktop, rancher-desktop, kind or minikube, vCluster automatically connects to it without the need of port-forwarding.
@@ -224,7 +224,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   - [Traefik Proxy](https://doc.traefik.io/traefik/routing/routers/#passthrough)
   - [Emissary](https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings#tls-termination)
 
-  Make sure your ingress controller is installed and healthy on the cluster that hosts your virtual clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
+  Make sure your ingress controller is installed and healthy on the cluster that hosts your tenant clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
 
   ```yaml
   apiVersion: networking.k8s.io/v1
@@ -294,7 +294,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       - my-vcluster.example.com
   ```
 
-  Create the virtual cluster with:
+  Create the tenant cluster with:
   ```
   vcluster create my-vcluster -n my-vcluster --connect=false -f values.yaml
   ```
@@ -413,7 +413,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       - x.x.x.x
   ```
 
-  Create the virtual cluster with:
+  Create the tenant cluster with:
   ```
   vcluster create my-vcluster -n my-vcluster --connect=false -f values.yaml
   ```
@@ -481,7 +481,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       - z.z.z.z
   ```
 
-  Create the virtual cluster with:
+  Create the tenant cluster with:
   ```
   vcluster create my-vcluster -n my-vcluster --connect=false -f values.yaml
   ```
@@ -501,12 +501,12 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
 </TabItem>
 <TabItem value="from-host-cluster">
 
-  In order to access the virtual cluster from within the host cluster, you can directly connect to the vCluster service. Make sure you can access that service and then create a kube config in the following form:
+  To access the tenant cluster from within the control plane cluster, you can directly connect to the vCluster service. Make sure you can access that service and then create a kube config in the following form:
   ```
   vcluster connect my-vcluster -n my-vcluster --server=my-vcluster.my-vcluster --insecure --update-current=false
   ```
 
-  Now access the virtual cluster with:
+  Now access the tenant cluster with:
   ```
   export KUBECONFIG=./kubeconfig.yaml
 

--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -12,27 +12,27 @@ import Flow, { Step } from "@site/src/components/Flow";
 Since version 0.31, vCluster automatically rotates client and server leaf certificates before they expire. Manual rotation is only needed if you want to rotate certificates ahead of the automatic schedule, or if you need to rotate the CA certificate.
 :::
 
-vCluster client and server certificates (also called leaf certificates) remain valid for 1 year from the initial virtual cluster creation.
+vCluster client and server certificates (also called leaf certificates) remain valid for 1 year from the initial tenant cluster creation.
 By default, vCluster uses a self-signed Certificate Authority (CA) to sign these certificates. The CA certificate remains valid for 10 years.
 
 vCluster provides commands that allow you to check details about the certificates as well as rotate them.
 
 :::info
-Checking and rotating certificates is only supported for virtual clusters using the k8s distribution.
+Checking and rotating certificates is only supported for tenant clusters using the k8s distribution.
 :::
 
 :::important
-The virtual cluster Pod must be in a
+The tenant cluster Pod must be in a
 [running](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-running)
 state otherwise the cert commands below abort the operation. In case of
-certificate expiration during runtime of a virtual cluster it will still be in
+certificate expiration during runtime of a tenant cluster it will still be in
 a running state (though, non-functional) and the rotation can still be
 performed.
 :::
 
 ## Check certificate information {#check-certificate-information}
 
-The `vcluster certs check` command provides the following information for each certificate of the given virtual cluster:
+The `vcluster certs check` command provides the following information for each certificate of the given tenant cluster:
 
 <br />
 
@@ -78,11 +78,11 @@ The certificate rotation command performs the following operations:
 
 - **Creates PKI backup**: Backs up the existing Public Key Infrastructure (PKI) directory to preserve the current certificate state.
 - **Generates new certificates**: Creates new client and server leaf certificates signed by the existing Certificate Authority.
-- **Restarts virtual cluster**: Restarts the virtual cluster to load the new certificates.
+- **Restarts tenant cluster**: Restarts the tenant cluster to load the new certificates.
 
 Control-plane components (API server, etcd, kubelet) require the restart because they cache certificates in memory during startup. Without a restart, these components continue using the expired or soon-to-expire certificates, which causes authentication failures.
 
-The restart does not affect running application workloads because the underlying cluster nodes and container runtime remain operational during the virtual cluster restart process.
+The restart does not affect running application workloads because the underlying cluster nodes and container runtime remain operational during the tenant cluster restart process.
 
 <br />
 <InterpolatedCodeBlock
@@ -91,7 +91,7 @@ The restart does not affect running application workloads because the underlying
 />
 
 Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificate).
-This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
+This means that connecting to the tenant cluster with previously issued kubeconfigs continues to work.
 
 ## Changing the CA certificate
 
@@ -99,7 +99,7 @@ This means that connecting to the virtual cluster with previously issued kubecon
 CA rotation replaces the Certificate Authority that validates all certificates in the cluster. This breaks existing client connections and requires regenerating all kubeconfigs. Use this command carefully, as it affects all cluster access.
 :::
 
-When working with virtual clusters with private nodes, there are [extra steps](#additional-steps-required-for-private-nodes) that need to happen before doing any changes to the CA certificate and
+When working with tenant clusters with private nodes, there are [extra steps](#additional-steps-required-for-private-nodes) that need to happen before doing any changes to the CA certificate and
 after making the changes to the CA certificate.
 
 
@@ -109,7 +109,7 @@ The CA rotation command performs these operations:
 
 - **Creates PKI backup**: Backs up the existing certificate directory to enable recovery if needed.
 - **Generates new Certificate Authority**: Creates a new CA certificate and uses it to sign fresh certificates for all cluster components.
-- **Restarts virtual cluster**: Restarts the cluster to load the new certificates.
+- **Restarts tenant cluster**: Restarts the cluster to load the new certificates.
 
 If the rotation fails, you can restore the previous PKI from the automatically created backup. For more information, see the documentation on [restoring the previous CA from a backup](#restore-the-previous-ca-from-a-backup) for recovery.
 
@@ -123,7 +123,7 @@ As this replaces the trust anchor completely, everything configured to trust the
 
 ### Restore the previous CA from a backup {#restore-the-previous-ca-from-a-backup}
 
-The rotation creates a backup in the virtual cluster's data directory using the following pattern:
+The rotation creates a backup in the tenant cluster's data directory using the following pattern:
 
 ```bash
 /data/pki.bak/<unixtimestamp>
@@ -135,7 +135,7 @@ Use caution when performing the following operations. Verify each command before
 
 <Flow>
 <Step>
-To restore from the backup, access the virtual cluster syncer container:
+To restore from the backup, access the tenant cluster syncer container:
 
 <InterpolatedCodeBlock
   code={`kubectl -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] exec -ti svc/[[VAR:VCLUSTER NAME:my-vcluster]] -c syncer -- sh`}
@@ -232,11 +232,11 @@ the updated certificate.
 :::
 
 You must delete all previously joined manually provisioned private nodes. After the rotation,
-you must re-join the nodes again to the virtual cluster. Each step must be performed on each manually provisioned private node.
+you must re-join the nodes again to the tenant cluster. Each step must be performed on each manually provisioned private node.
 
 <Flow>
 <Step>
-Connect to your virtual cluster:
+Connect to your tenant cluster:
 
 <InterpolatedCodeBlock
   code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] connect [[VAR:VCLUSTER NAME:my-vcluster]]`}
@@ -249,7 +249,7 @@ Delete each manually provisioned private node:
 
 :::info
 `vcluster node delete` tries to evict any workload before deleting the
-node from the virtual cluster. If there's no other node for the workload to be re-scheduled to, the
+node from the tenant cluster. If there's no other node for the workload to be re-scheduled to, the
 workload stops. If you forgot to delete a node before change the CA cert,
 you must append `--drain=false` to successfully delete the node.
 :::
@@ -264,11 +264,11 @@ you must append `--drain=false` to successfully delete the node.
 
 #### After changing the CA certificate
 
-After a CA rotation or restoration, you need to re-create a token to join the virtual cluster and join each manually provisioned private node back to the virtual cluster.
+After a CA rotation or restoration, you need to re-create a token to join the tenant cluster and join each manually provisioned private node back to the tenant cluster.
 
 <Flow>
   <Step>
-    Connect to your virtual cluster:
+    Connect to your tenant cluster:
 
     <InterpolatedCodeBlock
       code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] connect [[VAR:VCLUSTER NAME:my-vcluster]]`}
@@ -312,7 +312,7 @@ Automatically provisioned nodes that are managed by the vCluster only require ad
 #### After changing the CA certificate
 
 All logic of the nodes that need to be provisioned is stored in vCluster Platform. After a CA rotation or restoration,
-you need to delete all `NodeClaims` related to the virtual cluster, but those `NodeClaims` are in the Kubernetes cluster that
+you need to delete all `NodeClaims` related to the tenant cluster, but those `NodeClaims` are in the Kubernetes cluster that
  has vCluster Platform deployed on.
 
 <Flow>
@@ -332,21 +332,21 @@ you need to delete all `NodeClaims` related to the virtual cluster, but those `N
     ```
   </Step>
   <Step>
-    Find the relevant `NodeClaims` for the virtual cluster.
+    Find the relevant `NodeClaims` for the tenant cluster.
 
-    From the list of `NodeClaims`, identify the ones associated to your virtual cluster that had the CA certificate change.
+    From the list of `NodeClaims`, identify the ones associated to your tenant cluster that had the CA certificate change.
 
-    In this example, if you have rotated the CA certificate of the virtual cluster named `vcluster-2`, then
+    In this example, if you have rotated the CA certificate of the tenant cluster named `vcluster-2`, then
     the associated `NodeClaim` is `vcluster-5xtx3`.
   </Step>
   <Step>
-    Delete the `NodeClaim` of the virtual cluster that had a CA change.
+    Delete the `NodeClaim` of the tenant cluster that had a CA change.
 
-    For the virtual cluster that you had changed the CA certificate, you'll need to delete each `NodeClaim`, which
+    For the tenant cluster that you had changed the CA certificate, you'll need to delete each `NodeClaim`, which
     removes the `NodeClaim` and deletes the underlying `Node`. vCluster Platform recreates the `NodeClaim`
-    and the new nodes re-join the virtual cluster using the new CA certificate.
+    and the new nodes re-join the tenant cluster using the new CA certificate.
 
-    ```bash title="Example of deleting the NodeClaim for a single virtual cluster"
+    ```bash title="Example of deleting the NodeClaim for a single tenant cluster"
     kubectl -n p-default delete nodeclaims.management.loft.sh vcluster-5xtx3
 
     nodeclaim.management.loft.sh "vcluster-5xtx3" deleted

--- a/vcluster/manage/deploy-changes.mdx
+++ b/vcluster/manage/deploy-changes.mdx
@@ -21,7 +21,7 @@ The vCluster control plane pod is going to be re-deployed.
 <p></p>
 
 :::warning Limitations on changing configuration
-You cannot change distros once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s migration guide](/vcluster/manage/upgrade/distro-migration.mdx).
+You cannot change distros once a tenant cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s migration guide](/vcluster/manage/upgrade/distro-migration.mdx).
 :::
 
 <DeployChanges />

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -13,16 +13,16 @@ import TenancySupport from '../_fragments/tenancy-support.mdx';
 
 # Sleep and wakeup vCluster
 
-This page describes how to **manually** put a virtual cluster to sleep and wake it up using CLI commands. This is different from auto sleep, which automatically manages sleep and wake operations based on activity detection or schedules.
+This page describes how to **manually** put a tenant cluster to sleep and wake it up using CLI commands. This is different from auto sleep, which automatically manages sleep and wake operations based on activity detection or schedules.
 
 ## Manual versus auto sleep
 
-There are two ways to manage sleep for virtual clusters:
+There are two ways to manage sleep for tenant clusters:
 
 - **Manual sleep** (this page): Use CLI commands to manually put a vCluster to sleep or wake it up. This is a free feature available to all users.
 - **Auto sleep**: Configure the vCluster to automatically sleep and wake based on inactivity detection, schedules, or ingress activity. This is an enterprise feature. For details, see the [Auto Sleep configuration documentation](../configure/vcluster-yaml/sleep.mdx).
 
-When you manually put a virtual cluster to sleep, it **temporarily scales down** the cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+When you manually put a tenant cluster to sleep, it **temporarily scales down** the cluster and deletes all its created workloads on the control plane cluster. This approach helps **save computing resources** used by tenant cluster workloads in the control plane cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
 
 
 ## Prerequisites
@@ -34,9 +34,9 @@ When you manually put a virtual cluster to sleep, it **temporarily scales down**
 
 ## Put a vCluster to sleep
 
-Put a virtual cluster to sleep manually with the `vCluster` CLI:
+Put a tenant cluster to sleep manually with the `vCluster` CLI:
 
-```bash title="Sleep a virtual cluster"
+```bash title="Sleep a tenant cluster"
 vcluster platform sleep my-vcluster -n my-vcluster-namespace
 ```
 
@@ -49,10 +49,10 @@ Read about using the [vcluster platform sleep](/vcluster/cli/vcluster_platform_s
 ### What happens during manual sleep
 
 This command performs the following actions:
-- Scales down any StatefulSets or Deployments in the virtual cluster
-- Deletes all workloads created by the virtual cluster on the host cluster
+- Scales down any StatefulSets or Deployments in the tenant cluster
+- Deletes all workloads created by the tenant cluster on the control plane cluster
 
-While the command preserves object definitions within the virtual cluster, any standalone pods (those without a controlling replica set or StatefulSet) need to be restarted when the cluster wakes up.
+While the command preserves object definitions within the tenant cluster, any standalone pods (those without a controlling replica set or StatefulSet) need to be restarted when the cluster wakes up.
 
 :::warning Restarting pods
 When pods are restarted:
@@ -73,15 +73,15 @@ For auto sleep with activity detection, scheduling, and other advanced features,
 
 ## Wake up a vCluster
 
-You can wake up a manually sleeping virtual cluster with two different `vCluster` CLI commands.
+You can wake up a manually sleeping tenant cluster with two different `vCluster` CLI commands.
 
-As soon as the virtual cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the host cluster.
+As soon as the tenant cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the control plane cluster.
 
 ### Direct wake up
 
-Wake up the virtual cluster explicitly with a `vCluster` CLI command:
+Wake up the tenant cluster explicitly with a `vCluster` CLI command:
 
-```bash title="Wake up a virtual cluster"
+```bash title="Wake up a tenant cluster"
 vcluster platform wakeup my-vcluster -n my-vcluster-namespace
 ```
 
@@ -93,9 +93,9 @@ Read about using the [vcluster platform wakeup](/vcluster/cli/vcluster_platform_
 
 ### Connect to wake up
 
-Connect to the virtual cluster with a `vCluster` CLI command, which automatically wakes up the virtual cluster if it's sleeping:
+Connect to the tenant cluster with a `vCluster` CLI command, which automatically wakes up the tenant cluster if it's sleeping:
 
-```bash title="Connect to wake up a virtual cluster"
+```bash title="Connect to wake up a tenant cluster"
 vcluster connect my-vcluster -n my-vcluster-namespace
 ```
 


### PR DESCRIPTION
# Content Description
Updates terminology in `vcluster/manage/` top-level files: `certificates.mdx`, `sleep-wakeup.mdx`, `accessing-vcluster.mdx`, and `deploy-changes.mdx`. Replaces "virtual cluster" with "tenant cluster" and "host cluster" with "control plane cluster" throughout prose. Code blocks, YAML keys, CLI commands, and inline code identifiers are unchanged.

## Preview Link
- https://deploy-preview-2103--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/certificates
- https://deploy-preview-2103--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/sleep-wakeup
- https://deploy-preview-2103--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/accessing-vcluster
- https://deploy-preview-2103--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/deploy-changes

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs