### PR TITLE
docs(terminology): update vcluster/manage subdirectory files to tenant cluster terminology

### DIFF
--- a/vcluster/manage/backup-restore/velero.mdx
+++ b/vcluster/manage/backup-restore/velero.mdx
@@ -7,9 +7,9 @@ sidebar_class_name: host-nodes private-nodes standalone
 
 ## Use Velero
 
-You can use [Velero](https://velero.io/) to back up virtual clusters.
+You can use [Velero](https://velero.io/) to back up tenant clusters.
 
-Ensure your cluster supports [volume snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to allow Velero to backup persistent volumes and persistent volume claims that save the virtual cluster state. Alternatively, you can use [Velero's file system backup](https://velero.io/docs/main/file-system-backup/) with the Node Agent to back up the virtual cluster state.
+Ensure your cluster supports [volume snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to allow Velero to backup persistent volumes and persistent volume claims that save the tenant cluster state. Alternatively, you can use [Velero's file system backup](https://velero.io/docs/main/file-system-backup/) with the Node Agent to back up the tenant cluster state.
 
 ### Back up a vCluster
 
@@ -66,7 +66,7 @@ Verify the restore process using the following command:
   velero restore logs <restore-name>
   ```
 
-This restores the vCluster workloads, configuration, and state in the virtual cluster namespace.
+This restores the vCluster workloads, configuration, and state in the tenant cluster namespace.
 
 :::warning Moving vCluster
 Moving a vCluster from one namespace to another can be challenging because some objects, such as cluster role bindings and persistent volumes, contain namespace references. Velero supports namespace mapping, which works in most cases, but use caution—this may not be compatible with all vCluster setups.
@@ -78,9 +78,9 @@ You can use Velero inside vCluster to protect your workloads and data. To use Ve
 
 1. Enable the [hostpath-mapper](/docs/vcluster/configure/vcluster-yaml/control-plane/components/host-path-mapper) component in vCluster.
 
-2. After enabling `hostpath-mapper`, install the Velero CLI (as described above), connect to your vCluster, and install Velero inside the virtual cluster:
+2. After enabling `hostpath-mapper`, install the Velero CLI (as described above), connect to your vCluster, and install Velero inside the tenant cluster:
 
-      ```bash title="Velero inside the virtual cluster"
+      ```bash title="Velero inside the tenant cluster"
       velero install --provider <provider> --bucket <bucket_name> --secret-file <your_secret_file> --plugins velero/velero-plugin-for-<provider>:<semver> --use-node-agent
       ```
 

--- a/vcluster/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
+++ b/vcluster/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
@@ -16,7 +16,7 @@ Volume Snapshots are point-in-time copies of storage volumes that capture the co
 - Content sharing – duplicate or distribute consistent datasets without disruption.
 - Testing and development – create isolated environments for safe experimentation.
 
-This guide walks you through creating volume snapshots for a virtual cluster with persistent data and restoring that data from the snapshot. You'll deploy a sample application that writes data to a persistent volume, creates a snapshot, simulates data loss, and restores from the snapshot using AWS EBS as the storage provider.
+This guide walks you through creating volume snapshots for a tenant cluster with persistent data and restoring that data from the snapshot. You'll deploy a sample application that writes data to a persistent volume, creates a snapshot, simulates data loss, and restores from the snapshot using AWS EBS as the storage provider.
 :::info Supported CSI Drivers
 vCluster officially supports volume snapshots with **AWS EBS CSI Driver** and **OpenEBS**. This walkthrough demonstrates the complete end-to-end process using AWS as an example. Similar steps can be adapted for other supported CSI drivers.
 :::
@@ -41,15 +41,15 @@ Choose the deployment option based on your worker node type. See [worker nodes](
   groupId="tenancy-model"
   defaultValue="host-nodes"
   values={[
-    { label: "vCluster with shared host cluster nodes", value: "host-nodes" },
+    { label: "vCluster with shared control plane cluster nodes", value: "host-nodes" },
     { label: "vCluster with private nodes", value: "private-nodes" },
   ]
 }>
 <TabItem value="host-nodes">
 
-Here, we define a virtual cluster using default settings. You can also create a virtual cluster from your custom configuration file by running `vcluster create myvcluster --values vcluster.yaml`.
+Here, we define a tenant cluster using default settings. You can also create a tenant cluster from your custom configuration file by running `vcluster create myvcluster --values vcluster.yaml`.
 
-In this page, the `myvcluster` is the name of the virtual cluster. Replace it with your own name if necessary.
+In this page, the `myvcluster` is the name of the tenant cluster. Replace it with your own name if necessary.
 
 ```bash title="Create vCluster"
 vcluster create myvcluster
@@ -58,10 +58,10 @@ vcluster create myvcluster
 </TabItem>
 <TabItem value="private-nodes">
 
-For private nodes, you'll need to create an EC2 instance and join it to the virtual cluster. Follow the [private nodes documentation](../../../deploy/worker-nodes/private-nodes/join.mdx) to join the instance as a node in the virtual cluster.
-Create the virtual cluster with volume snapshot support enabled using the following `vcluster.yaml`. In this page, the `myvcluster` is the name of the virtual cluster. Replace it with your own name if necessary.
+For private nodes, you'll need to create an EC2 instance and join it to the tenant cluster. Follow the [private nodes documentation](../../../deploy/worker-nodes/private-nodes/join.mdx) to join the instance as a node in the tenant cluster.
+Create the tenant cluster with volume snapshot support enabled using the following `vcluster.yaml`. In this page, the `myvcluster` is the name of the tenant cluster. Replace it with your own name if necessary.
 
-```bash title="Create a virtual cluster with private nodes"
+```bash title="Create a tenant cluster with private nodes"
 vcluster create myvcluster --values vcluster.yaml
 ```
 
@@ -163,8 +163,8 @@ Tue Oct 28 13:38:51 UTC 2025
 
 ## Create snapshot with volumes
 
-Now create a vCluster snapshot with volume snapshots included by using the `--include-volumes` parameter. The vCluster CLI creates a snapshot request in the host cluster, which is then processed in the background by the vCluster snapshot controller.
-First, disconnect from the virtual cluster:
+Now create a vCluster snapshot with volume snapshots included by using the `--include-volumes` parameter. The vCluster CLI creates a snapshot request in the control plane cluster, which is then processed in the background by the vCluster snapshot controller.
+First, disconnect from the tenant cluster:
 
 ```bash title="Disconnect from myvcluster"
 vcluster disconnect
@@ -204,9 +204,9 @@ Wait until the status shows `Completed` and `SAVED` shows `Yes` before proceedin
 
 ## Simulate data loss
 
-To demonstrate the restore capability of the created volume snapshot just now, we first delete the application and its data from the virtual cluster. 
+To demonstrate the restore capability of the created volume snapshot just now, we first delete the application and its data from the tenant cluster.
 
-First, connect to the virtual cluster:
+First, connect to the tenant cluster:
 ```bash title="Connect to vCluster"
 vcluster connect myvcluster
 ```
@@ -248,7 +248,7 @@ EOF
 
 ## Restore from snapshot
 
-After the PVC is deleted, we now restore the virtual cluster from the snapshot,  including the volume data. 
+After the PVC is deleted, we now restore the tenant cluster from the snapshot, including the volume data. 
 
 First, disconnect from `myvcluster`:
 ```bash title="Disconnect from myvcluster"
@@ -272,7 +272,7 @@ The expected output would be:
 
 ### Verify the restore
 
-Once the virtual cluster is running again, connect to it and verify that the pod and PVC have been restored.
+Once the tenant cluster is running again, connect to it and verify that the pod and PVC have been restored.
 
 First, connect to `myvcluster`:
 ```bash title="Connect to myvcluster"
@@ -323,7 +323,7 @@ This confirms that the data was successfully recovered from the snapshot, and th
 ## Cleanup
 
 You can now free up the created resources in this tutorial.
-First, delete the created virtual cluster:
+First, delete the created tenant cluster:
 
 ```bash title="Delete myvcluster"
 vcluster delete myvcluster

--- a/vcluster/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
+++ b/vcluster/manage/backup-restore/volume-snapshots/aws-ebs-guide.mdx
@@ -41,7 +41,7 @@ Choose the deployment option based on your worker node type. See [worker nodes](
   groupId="tenancy-model"
   defaultValue="host-nodes"
   values={[
-    { label: "vCluster with shared control plane cluster nodes", value: "host-nodes" },
+    { label: "vCluster with shared nodes", value: "host-nodes" },
     { label: "vCluster with private nodes", value: "private-nodes" },
   ]
 }>

--- a/vcluster/manage/backup-restore/volume-snapshots/setup.mdx
+++ b/vcluster/manage/backup-restore/volume-snapshots/setup.mdx
@@ -16,7 +16,7 @@ This feature is currently in Beta.
 See vCluster [Lifecycle Policy](../../upgrade/supported_versions.mdx#feature-versioning) for more information.
 :::
 
-vCluster snapshots enable you to create volume snapshots for PersistentVolumeClaims that are provisioned by CSI drivers. This allows you to protect not only your virtual cluster resources and config, but also your application data.
+vCluster snapshots enable you to create volume snapshots for PersistentVolumeClaims that are provisioned by CSI drivers. This allows you to protect not only your tenant cluster resources and config, but also your application data.
 
 See [how volume snapshots are created](../../../understand/volume-snapshots.mdx) if you would like to learn more about volume snapshots and how vCluster creates them.
 
@@ -28,17 +28,17 @@ Volume snapshots can be created only for PVCs that are provisioned by CSI driver
 
 ## Setup
 
-In order to create volume snapshots, several installation and configuration steps have to be done in your host or virtual cluster.
+Several installation and configuration steps have to be done in your control plane cluster or tenant cluster to create volume snapshots.
 
 ### Host nodes
 
-The following setup has to be done in the host cluster:
+The following setup has to be done in the control plane cluster:
 1. Install the [Kubernetes CSI snapshotter](https://github.com/kubernetes-csi/external-snapshotter) and VolumeSnapshot, VolumeSnapshotContent, and VolumeSnapshotClass CRDs. You can find further instructions in the upstream repo.
 2. Install a CSI driver that supports volume snapshots, and storage classes for that CSI driver.
-3. Configure the default VolumeSnapshotClass for each CSI driver in the host cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
+3. Configure the default VolumeSnapshotClass for each CSI driver in the control plane cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
 
 :::note OCI and S3 credentials secret location
-When using `autoSnapshot` with OCI registries or S3 buckets, the credentials secret must exist on the **host cluster** where the vCluster control plane pod is deployed, not just the Platform management cluster. Create the secret in either:
+When using `autoSnapshot` with OCI registries or S3 buckets, the credentials secret must exist on the **control plane cluster** where the vCluster control plane pod is deployed, not just the Platform management cluster. Create the secret in either:
 - The vCluster namespace (e.g., `loft-<project>-<vcluster-name>`)
 - Another namespace that the vCluster control plane can access
 
@@ -47,11 +47,11 @@ If the vCluster is deployed externally, ensure the vCluster ClusterRole (`vc-<vC
 
 ### Private nodes
 
-Create virtual cluster with `deploy.volumeSnapshotController.enabled` config set to `true`. With this config, vCluster installs the common snapshot-controller, and VolumeSnapshot, VolumeSnapshotContent and VolumeSnapshotClass CRDs in your virtual cluster.
+Create a tenant cluster with `deploy.volumeSnapshotController.enabled` config set to `true`. With this config, vCluster installs the common snapshot-controller, and VolumeSnapshot, VolumeSnapshotContent and VolumeSnapshotClass CRDs in your tenant cluster.
 
-The following setup has to be done in the virtual cluster:
+The following setup has to be done in the tenant cluster:
 1. Install a CSI driver that supports volume snapshots, and storage classes for that CSI driver.
-2. Configure the default VolumeSnapshotClass for each CSI driver in the host cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
+2. Configure the default VolumeSnapshotClass for each CSI driver in the control plane cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
 
 <!-- vale off -->
 ### Use non-default VolumeSnapshotClasses
@@ -78,7 +78,7 @@ spec:
 
 ## Create snapshot with volumes
 
-You can create a vCluster snapshot, with volume snapshots included, by using the `--include-volumes` param. vCluster CLI creates a snapshot request in the host cluster, which is then processed in the background by the vCluster snapshot controller, which will create volume snapshots.
+You can create a vCluster snapshot, with volume snapshots included, by using the `--include-volumes` param. vCluster CLI creates a snapshot request in the control plane cluster, which is then processed in the background by the vCluster snapshot controller, which will create volume snapshots.
 
 Here is an example:
 
@@ -107,8 +107,8 @@ When taking volume snapshots, there are limitations:
   - Currently volume snapshots are created only for PersistentVolumeClaims that are synced to the vCluster host namespace. This means that, when the [Namespace sync](../../../configure/vcluster-yaml/sync/to-host/advanced/namespaces.mdx) is enabled, volume snapshots are not created for the PersistentVolumeClaims that are synced to namespaces different than the vCluster host namespace.
 - When using private nodes:
   - vCluster has to be deployed with `deploy.volumeSnapshotController.enabled` config set to `true`.
-  - CSI driver that supports volume snapshots has to be installed in the virtual cluster.
-  - The default VolumeSnapshotClass has to be configured for each CSI driver in the virtual cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
+  - CSI driver that supports volume snapshots has to be installed in the tenant cluster.
+  - The default VolumeSnapshotClass has to be configured for each CSI driver in the tenant cluster. See [Kubernetes Volume Snapshot Classes docs](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/) for more details.
 - Volume snapshots are currently not supported for [vCluster standalone](../../../deploy/control-plane/binary/overview.mdx).
 - Volume snapshots to OCI storage are currently not supported.
 

--- a/vcluster/manage/upgrade/distro-migration.mdx
+++ b/vcluster/manage/upgrade/distro-migration.mdx
@@ -2,7 +2,7 @@
 title: Migrate from K3s to Kubernetes
 sidebar_label: K3s to K8s Migration
 sidebar_position: 2.2
-description: Learn how to migrate virtual clusters from the K3s distribution to Kubernetes (K8s)
+description: Learn how to migrate tenant clusters from the K3s distribution to Kubernetes (K8s)
 sidebar_class_name: host-nodes
 ---
 
@@ -12,10 +12,10 @@ import TenancySupport from '../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-Starting in vCluster 0.25.0, you can migrate virtual clusters from the K3s distribution to the standard Kubernetes (K8s) distribution. This migration gives you access to the full Kubernetes feature set while preserving your existing workloads and configuration.
+Starting in vCluster 0.25.0, you can migrate tenant clusters from the K3s distribution to the standard Kubernetes (K8s) distribution. This migration gives you access to the full Kubernetes feature set while preserving your existing workloads and configuration.
 
 :::caution K3s removal in v0.33
-vCluster v0.33 removes support for the K3s distribution entirely. If your virtual clusters currently use K3s, migrate them to K8s on your current vCluster version before upgrading to v0.33.
+vCluster v0.33 removes support for the K3s distribution entirely. If your tenant clusters currently use K3s, migrate them to K8s on your current vCluster version before upgrading to v0.33.
 :::
 
 ## Prerequisites {#prerequisites}
@@ -24,7 +24,7 @@ vCluster v0.33 removes support for the K3s distribution entirely. If your virtua
 
 Additionally, you need:
 - `vCluster` CLI version 0.25.0 or higher
-- An existing virtual cluster using K3s distro
+- An existing tenant cluster using K3s distro
 
 ## Migration process {#migration-process}
 
@@ -59,14 +59,14 @@ All your existing workloads, services, and resources remain available after migr
 The automated migration process only supports moving from the K3s distro to the K8s distro. Migration between other distro types is not supported. This is a one-way process—migrating back from the K8s distro to K3s is not possible.
 :::
 
-## Migrate a virtual cluster {#migrate-a-virtual-cluster}
+## Migrate a tenant cluster {#migrate-a-virtual-cluster}
 
 <!-- vale off -->
 ### Use a vcluster.yaml file {#use-vcluster-yaml}
 <!-- vale on -->
 
 <!-- vale off -->
-If you're managing your virtual cluster with a vcluster.yaml file, modify it to use K8s distro:
+If you're managing your tenant cluster with a vcluster.yaml file, modify it to use K8s distro:
 <!-- vale on -->
 
 Original configuration:

--- a/vcluster/manage/upgrade/supported_versions.mdx
+++ b/vcluster/manage/upgrade/supported_versions.mdx
@@ -18,7 +18,7 @@ vCluster follows a regular release cadence and adheres to [semantic versioning](
 
 ## Kubernetes compatibility matrix
 
-The matrix below shows compatibility between host and virtual clusters running vanilla Kubernetes. It specifies which versions of vanilla Kubernetes on the host cluster support which versions on the virtual cluster.
+The matrix below shows compatibility between control plane clusters and tenant clusters running vanilla Kubernetes. It specifies which versions of vanilla Kubernetes on the control plane cluster support which versions on the tenant cluster.
 
 When a new Kubernetes version is released, conformance tests are conducted on the latest vCluster version within 30 days.
 

--- a/vcluster/manage/upgrade/upgrade-version.mdx
+++ b/vcluster/manage/upgrade/upgrade-version.mdx
@@ -25,15 +25,15 @@ Optionally, you can update your `vcluster.yaml` to change your configuration opt
 
 <p></p>
 :::warning Limitations on changing configuration
-You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s Migration](./distro-migration.mdx).
+You cannot change distros or backing store once a tenant cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s Migration](./distro-migration.mdx).
 :::
 
 ## Upgrade vCluster version
 
 These steps assume that you have been a `vcluster.yaml`, but there are variables in the code blocks for you to replace for:
 
-- Name of the virtual cluster
-- Namespace of where the virtual cluster is deployed
+- Name of the tenant cluster
+- Namespace of where the tenant cluster is deployed
 - Version to upgrade to
 
 <UpgradeVersion />


### PR DESCRIPTION
# Content Description
Updates terminology in `vcluster/manage/` subdirectories: `backup-restore/velero.mdx`, `backup-restore/volume-snapshots/setup.mdx`, `backup-restore/volume-snapshots/aws-ebs-guide.mdx`, `upgrade/distro-migration.mdx`, `upgrade/upgrade-version.mdx`, and `upgrade/supported_versions.mdx`. Replaces "virtual cluster" with "tenant cluster" and "host cluster" with "control plane cluster" throughout prose. Code blocks, YAML keys, CLI commands, and inline code identifiers are unchanged.

## Preview Link
https://github.com/loft-sh/vcluster-docs/pull/2104#issue-4433038855

(And other files in the subdirectories of the manage section.)

## Internal Reference
Part of DOC-1334

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs