### PR TITLE
docs(doc-1334): update deploy/control-plane/ terminology

### DIFF
--- a/vcluster/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster/deploy/control-plane/docker-container/basics.mdx
@@ -19,7 +19,7 @@ When deploying vCluster as Docker containers:
 - **Worker nodes**: Simulated as additional Docker containers
 - **Networking**: Uses Docker networking for inter-container communication
 - **Storage**: Uses Docker volumes for persistent data
-- **No host cluster required**: Complete independence from existing Kubernetes infrastructure
+- **No control plane cluster required**: Complete independence from existing Kubernetes infrastructure
 
 ## Prerequisites
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/aks.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/aks.mdx
@@ -81,7 +81,7 @@ After the cluster is created, get credentials to access the cluster:
 az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME
 ```
 
-### Verify the host cluster creation
+### Verify the control plane cluster creation
 
 Verify the cluster by listing the nodes:
 
@@ -114,7 +114,7 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 ## Next steps
 
-Now that you have vCluster running on AKS, consider exploring the [platform UI](/platform/install/quick-start-guide) to manage your virtual clusters.
+Now that you have vCluster running on AKS, consider exploring the [platform UI](/platform/install/quick-start-guide) to manage your tenant clusters.
 
 ## Cleanup
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/eks.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/eks.mdx
@@ -92,7 +92,7 @@ eksctl create cluster -f cluster.yaml
 
 This process typically takes about 15-20 minutes.
 
-### Verify the host cluster creation
+### Verify the control plane cluster creation
 
 Verify the installation by checking if the CSI driver pods are running:
 
@@ -153,15 +153,15 @@ However, some settings — such as what type of worker nodes or the backing stor
 <Deploy />
 
 This configuration ensures that:
-- Service accounts are properly synced between virtual and host clusters
+- Service accounts are properly synced between tenant and control plane clusters
 - Persistent volume claims are handled correctly
 - The `gp3` storage class created earlier is used
 
 ### Allow internal DNS resolution
 
-By default, vCluster runs a CoreDNS component inside the virtual cluster. This component listens on port `1053` instead of the standard DNS port `53` to avoid conflicts with the host cluster DNS.
+By default, vCluster runs a CoreDNS component inside the tenant cluster. This component listens on port `1053` instead of the standard DNS port `53` to avoid conflicts with the control plane cluster DNS.
 
-On EKS, if the CoreDNS pod and other virtual cluster pods are scheduled on different nodes, DNS resolution may fail. This happens because AWS creates separate security groups for the EKS control plane and worker nodes, and the default node security group does not allow inbound traffic on port `1053`.
+On EKS, if the CoreDNS pod and other tenant cluster pods are scheduled on different nodes, DNS resolution may fail. This happens because AWS creates separate security groups for the EKS control plane and worker nodes, and the default node security group does not allow inbound traffic on port `1053`.
 
 To resolve this, manually update the EKS node security group to allow inbound TCP and UDP traffic on port `1053` between nodes.
 
@@ -173,7 +173,7 @@ This step is especially important for EKS clusters created using Terraform or ot
 
 Now that you have vCluster running on EKS, consider:
 
-- Setting up the [platform UI](/platform/install/quick-start-guide) to mange your virtual clusters.
+- Setting up the [platform UI](/platform/install/quick-start-guide) to manage your tenant clusters.
 - Integrating with [Karpenter](/platform/integrations/karpenter) for autoscaling.
 
 ### Pod identity

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/gke.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/gke.mdx
@@ -79,7 +79,7 @@ zone with two nodes of type e2-standard-4.
 
 <KubeconfigUpdate />
 
-### Verify the host cluster creation
+### Verify the control plane cluster creation
 
 Verify the cluster by listing the nodes:
 
@@ -112,7 +112,7 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 ## Next steps
 
-Now that you have vCluster running on GKE, consider setting up the [platform UI](/platform/install/quick-start-guide) to mange your virtual clusters.
+Now that you have vCluster running on GKE, consider setting up the [platform UI](/platform/install/quick-start-guide) to manage your tenant clusters.
 
 ## Workload Identity
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/netris.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/netris.mdx
@@ -7,19 +7,19 @@ sidebar_class_name: private-nodes
 ---
 
 One deployment model for vCluster is through private nodes.
-It allows for stronger isolation between the virtual clusters, since the Pods in a virtual cluster don't share the same Nodes.
+It allows for stronger isolation between the tenant clusters, since the Pods in a tenant cluster don't share the same Nodes.
 
 Unlike cloud providers that offer stable network abstractions for automation, bare metal infrastructure lacks these built-in capabilities, making network configuration and management significantly more complex.
 This guide shows how vCluster with [Netris](https://netris.ai/) delivers an equally seamless integration for bare metal environments.
-It enables you to isolate virtual clusters spanning mixed bare metal and VM private nodes that share the same underlying hardware with an exclusive network.
+It enables you to isolate tenant clusters spanning mixed bare metal and VM private nodes that share the same underlying hardware with an exclusive network.
 
 Netris server clusters provide network abstractions that can be configured in different ways depending on your hardware setup—including access ports, trunk ports, or other network configurations.
 
 ![Architecture](/img/netris_architecture.svg)
 
-The goal of this guide is to have a virtual cluster on an isolated network:
+The goal of this guide is to have a tenant cluster on an isolated network:
 
-- Virtual cluster managed by vCluster platform
+- Tenant cluster managed by vCluster platform
 - Control plane is reachable on the network behind a stable address
 - BCM server provisioned and joined as a private node
 - KubeVirt VM provisioned and joined as a private node
@@ -27,11 +27,11 @@ The goal of this guide is to have a virtual cluster on an isolated network:
 - Hosts on other networks cannot reach the Nodes or workloads (unless explicitly peered)
 
 Like in traditional Kubernetes clusters, Nodes share the same network domain.
-Instead of control plane _nodes_, the vCluster control plane runs as (multihomed) Pods in the host cluster.
-This is transparent to the virtual cluster; however, the host cluster remains inaccessible.
+Instead of control plane _nodes_, the vCluster control plane runs as (multihomed) Pods in the control plane cluster.
+This is transparent to the tenant cluster; however, the control plane cluster remains inaccessible.
 
 This can be repeated for any number of clusters.
-The VPCs of each virtual cluster may also be peered to access shared services across clusters.
+The VPCs of each tenant cluster may also be peered to access shared services across clusters.
 
 ## Netris
 
@@ -49,23 +49,23 @@ We assume the following:
 - Netris controller & agent installed & configured
 - Networks configured in Netris (VPC and Server cluster) and BCM (See [below](#prepare-networks))
     - Default network with BCM head node
-    - Host-cluster network
+    - Control plane cluster network
     - vCluster tenant network
-- Netris controller API is reachable from the host cluster network
-- BCM head node (API) is reachable from the host cluster network
-- "Host" Kubernetes cluster set up (See [below](#prepare-host-cluster))
+- Netris controller API is reachable from the control plane cluster network
+- BCM head node (API) is reachable from the control plane cluster network
+- Control plane cluster set up (See [below](#prepare-control-plane-cluster))
 - BCM head node must be able to run commands on servers with plain `ssh` when they are on a different BCM network
 - At least one unused server in BCM is available
 
 ## Prepare networks
 
-We must prepare the networks for the host cluster and a vCluster tenant in Netris & BCM.
+We must prepare the networks for the control plane cluster and a vCluster tenant in Netris & BCM.
 
 ### Netris server clusters
 
 1. Create ServerClusterTemplates
 
-    Create a template for the host cluster nodes:
+    Create a template for the control plane cluster nodes:
 
     ```json title="serverClusterTemplate.json"
     [
@@ -90,14 +90,14 @@ We must prepare the networks for the host cluster and a vCluster tenant in Netri
 
     Create a ServerCluster for each of the networks using the respective templates.
 
-    For the host cluster, add the shared servers as endpoints.
+    For the control plane cluster, add the shared servers as endpoints.
 
     This configures the connected ports as access ports within the server cluster V-net, and it's not necessary to make any adjustments in the host OS.
 
     ![ServerCluster](/img/netris_create_host_cluster_servercluster.png)
 
     The one for the tenant network doesn't have any endpoints with untagged ports until later.
-    However, we add the host cluster servers as _shared_ endpoints.
+    However, we add the control plane cluster servers as _shared_ endpoints.
 
     This configures the ports on the shared servers as trunk ports (additionally) carrying tagged VLAN traffic.
     These frames then ingress on a vlan interface that is a port on the bridge for the tenant we'll configure later.
@@ -117,7 +117,7 @@ We must prepare the networks for the host cluster and a vCluster tenant in Netri
 
     ![BCM Network](/img/bcm_create_network.png)
 
-## Prepare host cluster
+## Prepare control plane cluster {#prepare-control-plane-cluster}
 
 :::info
 It is advisable to install Kubernetes after first configuring the network.
@@ -131,7 +131,7 @@ There must be a default StorageClass available.
 
 ### Install compatible CNI plugin
 
-Since the host cluster Nodes handle VLAN traffic, some CNI plugin configurations are not compatible.
+Since the control plane cluster Nodes handle VLAN traffic, some CNI plugin configurations are not compatible.
 
 We have tested the following plugins:
 
@@ -141,9 +141,9 @@ We have tested the following plugins:
     - Must set `cni.exclusive: false`
     - Must set `bpf.vlanBypass: '{0}'`
 
-### Create bridge for tenant network on host cluster nodes
+### Create bridge for tenant network on control plane cluster nodes
 
-We create an unfiltered bridge on all host cluster nodes that is an extension of the Netris fabric for the tenant server cluster.
+We create an unfiltered bridge on all control plane cluster nodes that is an extension of the Netris fabric for the tenant server cluster.
 
 The bridge has a vlan interface with the VLAN id that we looked up earlier as one of its ports.
 
@@ -179,19 +179,19 @@ spec:
 
 ### Install tooling
 
-The following tools are required in the host cluster to manage interfaces that allow adding Pods and VMs to the virtual cluster network.
+The following tools are required in the control plane cluster to manage interfaces that allow adding Pods and VMs to the tenant cluster network.
 
 #### Multus
 
 See install instructions in [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni).
 
-Multus adds additional interfaces to the vCluster control plane Pods and KubeVirt VMs to attach them to the virtual cluster VLAN.
+Multus adds additional interfaces to the vCluster control plane Pods and KubeVirt VMs to attach them to the tenant cluster VLAN.
 
 #### KubeVirt
 
 See install instructions in [KubeVirt](https://kubevirt.io/user-guide/docs/latest/administration/intro.html).
 
-KubeVirt works together with Multus and manages the VMs in the host cluster.
+KubeVirt works together with Multus and manages the VMs in the control plane cluster.
 
 The example below also uses the [containerized data importer](https://kubevirt.io/user-guide/storage/containerized_data_importer/) to create a large enough disk to install and run Kubernetes on top of Ubuntu 24.04.
 
@@ -327,10 +327,10 @@ For more details on kube-vip configuration, see [Kube-vip](/vcluster/configure/v
 
 4. Verify node provisioning
 
-    The BCM node provider will automatically provision the bare metal server as a node in the virtual cluster.
+    The BCM node provider will automatically provision the bare metal server as a node in the tenant cluster.
     You can monitor the node claim status.
 
-    Run in the host cluster:
+    Run in the control plane cluster:
 
     ```text
     kubectl get nodeclaims -A
@@ -338,7 +338,7 @@ For more details on kube-vip configuration, see [Kube-vip](/vcluster/configure/v
     p-default   netris-8gnqh   Available   netris     bcm-netris.dgx-node   2025-10-27T19:39:45Z
     ```
 
-    Once the node joins the cluster, the claim transitions from `Pending` to `Available` and the node will appear in the virtual cluster:
+    Once the node joins the cluster, the claim transitions from `Pending` to `Available` and the node will appear in the tenant cluster:
 
     ```text
     kubectl get nodes
@@ -346,7 +346,7 @@ For more details on kube-vip configuration, see [Kube-vip](/vcluster/configure/v
     dgx-01   Ready    <none>   68s   v1.34.1
     ```
 
-## Join VM running in host cluster infrastructure
+## Join VM running in control plane cluster infrastructure
 
 ### Configure KubeVirt node provider
 
@@ -422,10 +422,10 @@ For more details on kube-vip configuration, see [Kube-vip](/vcluster/configure/v
 
 3. Verify VM provisioning
 
-    The KubeVirt node provider will automatically create VMs that join the virtual cluster.
+    The KubeVirt node provider will automatically create VMs that join the tenant cluster.
     You can monitor the node claims.
 
-    Run in the host cluster:
+    Run in the control plane cluster:
 
     ```text
     kubectl get nodeclaims -A
@@ -434,7 +434,7 @@ For more details on kube-vip configuration, see [Kube-vip](/vcluster/configure/v
     p-default   netris-8gnqh   Available   netris     kubevirt-netris.netris-vm   2025-10-27T19:39:45Z
     ```
 
-    Once the VM joins the cluster, the node claim transitions from `Pending` to `Available` and the VM will appear in the virtual cluster:
+    Once the VM joins the cluster, the node claim transitions from `Pending` to `Available` and the VM will appear in the tenant cluster:
 
     ```bash
     kubectl get nodes

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/openshift.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/openshift.mdx
@@ -55,5 +55,5 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 ## Next steps
 
-Now that you have vCluster running on OpenShift, consider setting up the [platform UI](/platform/install/quick-start-guide) to mange your virtual clusters.
+Now that you have vCluster running on OpenShift, consider setting up the [platform UI](/platform/install/quick-start-guide) to manage your tenant clusters.
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/high-availability.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/high-availability.mdx
@@ -15,8 +15,7 @@ import Deploy from '../../../_partials/deploy/deploy.mdx'
 
 
 By default, vCluster runs one instance of each of its components. This deployment method is recommended for any uses cases that are very ephemeral (e.g. dev environments, CI/CD, etc.), but for production
-use cases, it's recommended to run vCluster with more redundancy. We recommend deploying vCluster in high availability (HA) in order 
-to run multiple copies of the vCluster components so that the virtual cluster is more resistant to failures.
+use cases, it's recommended to run vCluster with more redundancy. We recommend deploying vCluster in high availability (HA) to run multiple copies of the vCluster components so that the tenant cluster is more resistant to failures.
 
 ## Enabling high availability 
 
@@ -73,16 +72,16 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 <Deploy />
 
-## Check the pods of the vCluster on the host cluster
+## Check the pods of the vCluster on the control plane cluster
 
-Ensure that your kubecontext is set to the host cluster. 
+Ensure that your kubecontext is set to the control plane cluster. 
 
 :::warning 
-If you've used the vCluster CLI, your kubecontext automatically switches and connects to the virtual cluster. 
+If you've used the vCluster CLI, your kubecontext automatically switches and connects to the tenant cluster. 
 :::
 
-You can get the pods in the namespace of the virtual cluster. The namespace is 
-called `vcluster-my-vcluster` in the host cluster, and contains the components of the vCluster. 
+You can get the pods in the namespace of the tenant cluster. The namespace is 
+called `vcluster-my-vcluster` in the control plane cluster, and contains the components of the vCluster. 
 
 ```
 kubectl get pods -n vcluster-my-vcluster
@@ -102,7 +101,7 @@ my-vcluster-etcd-2                        0/1     Running   0          20s
 
 There are three replicas running of each component (control plane and etcd) of the vCluster. If one API server pod goes down, the vCluster continues working.
 
-In order to see which nodes in the host cluster that these pods were scheduled on, add the `-o wide` flag to the `kubectl get pods` command:
+To see which nodes in the control plane cluster that these pods were scheduled on, add the `-o wide` flag to the `kubectl get pods` command:
 
 ```
 kubectl get pods -n vcluster-my-vcluster -o wide

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped.mdx
@@ -39,11 +39,11 @@ When deploying vCluster, there are artifacts that are typically accessed using a
 - **vCluster Helm chart**—Typically retrieved from the [LoftLabs Helm chart repository](https://charts.loft.sh/).
 - **Container images referenced in the Helm chart**—Usually pulled from various public container registries.
 
-After uploading the required artifacts to your private registry, create the `vcluster.yaml` configuration file and prepare the host cluster for deployment.
+After uploading the required artifacts to your private registry, create the `vcluster.yaml` configuration file and prepare the control plane cluster for deployment.
 
 :::warning
-When using virtual clusters in air-gapped environments, the
-`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
+When using tenant clusters in air-gapped environments, the
+`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for tenant cluster deployments.
 :::
 
 ## Prerequisites {#prerequisites}
@@ -54,7 +54,7 @@ You must have the vCluster Platform deployed in your air-gapped environment to u
 
 ### Registry requirements
 
-- OCI-compliant private registry with a `/charts` folder - A private registry accessible to both the Kubernetes host cluster and a separate, internet-connected machine.
+- OCI-compliant private registry with a `/charts` folder - A private registry accessible to both the control plane cluster and a separate, internet-connected machine.
 - Ability to push images and Helm charts to your private registry.
 
 ### Deployment requirements
@@ -292,17 +292,17 @@ Before deploying, it's recommended to review the set of configuration options th
 
 ## Create a platform access key {#create-platform-access-key}
 
-Before deploying vCluster, you must [create an access key](../../../../configure/vcluster-yaml/platform.mdx) to authenticate your virtual cluster. This step is essential for connecting your air-gapped vCluster to the platform.
+Before deploying vCluster, you must [create an access key](../../../../configure/vcluster-yaml/platform.mdx) to authenticate your tenant cluster. This step is essential for connecting your air-gapped vCluster to the platform.
 
 ## Deploy vCluster {#deploy-vcluster}
 
 After the platform is deployed, the access key is created, and your private registry is populated with the required images and charts, you can proceed with deploying the vCluster.
 
-### Set up the host cluster and deploy
+### Set up the control plane cluster and deploy
 
 <Flow>
   <Step>
-  On the host cluster, create the namespace for the vCluster, where the secrets and vCluster control plane pod are to be deployed in:
+  On the control plane cluster, create the namespace for the vCluster, where the secrets and vCluster control plane pod are to be deployed in:
 
   ```bash title="Create vCluster namespace"
   export VCLUSTER_NAMESPACE=vcluster-my-vcluster  # Replace with the name of the namespace you want to deploy your vCluster into

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/corporate-proxy.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/corporate-proxy.mdx
@@ -382,7 +382,7 @@ controlPlane:
 
 ### Proxy settings for vCluster workloads
 
-The proxy configuration shown previously applies only to the vCluster control plane. If you need proxy settings for workloads running inside the virtual cluster, configure them separately through:
+The proxy configuration shown previously applies only to the vCluster control plane. If you need proxy settings for workloads running inside the tenant cluster, configure them separately through:
 
 - Pod environment variables in your workload manifests
 - ConfigMaps or Secrets mounted to your workloads

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/fips.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/fips.mdx
@@ -89,7 +89,7 @@ vcluster create my-fips-vcluster -f vcluster.yaml
 
 :::info
 
-To use a different Kubernetes version in your virtual cluster than the host cluster, set the `controlPlane.distro.k8s.image.tag` field in your configuration:
+To use a different Kubernetes version in your tenant cluster than the control plane cluster, set the `controlPlane.distro.k8s.image.tag` field in your configuration:
 
 ```yaml
 controlPlane:

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/1-control-plane-components.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/1-control-plane-components.mdx
@@ -82,13 +82,13 @@ vCluster does not rely on static pod manifests stored on the host such as `/etc/
 
 **Result:** NOT APPLICABLE
 
-vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the host (parent) cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying host cluster as it is not applicable in vCluster environments.
+vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the control plane cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying control plane cluster as it is not applicable in vCluster environments.
 
 ### 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
 
 **Result:** NOT APPLICABLE
 
-vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the host (parent) cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying host cluster as it is not applicable in vCluster environments.
+vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the control plane cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying control plane cluster as it is not applicable in vCluster environments.
 
 ### 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
 
@@ -526,13 +526,13 @@ Verify that the `DenyServiceExternalIPs` argument exists as a string value in --
 
 **Result:** NOT APPLICABLE
 
-The control recommends setting up certificate-based kubelet authentication to ensure that the apiserver authenticates itself to kubelets when submitting requests. However, since vCluster does not interact directly with kubelets running on the host cluster, these client certificates are not required. The check defined in this control is not applicable in the context of vCluster.
+The control recommends setting up certificate-based kubelet authentication to ensure that the apiserver authenticates itself to kubelets when submitting requests. However, since vCluster does not interact directly with kubelets running on the control plane cluster, these client certificates are not required. The check defined in this control is not applicable in the context of vCluster.
 
 ### 1.2.5 Ensure that the --kubelet-certificate-authority argument is set as appropriate
 
 **Result:** NOT APPLICABLE
 
-The control recommends ensuring that the kubelet certificate authority is set appropriately. However, since vCluster does not interact directly with kubelets running on the host cluster, verifying certificates using certificate authority is not required. The check defined in this control is not applicable in the context of vCluster.
+The control recommends ensuring that the kubelet certificate authority is set appropriately. However, since vCluster does not interact directly with kubelets running on the control plane cluster, verifying certificates using certificate authority is not required. The check defined in this control is not applicable in the context of vCluster.
 
 ### 1.2.6 Ensure that the --authorization-mode argument is not set to AlwaysAllow
 
@@ -1823,7 +1823,7 @@ Verify that the `--root-ca-file` argument exists and is set to a certificate bun
 
 **Result:** NOT APPLICABLE
 
-The control recommends enabling the `RotateKubeletServerCertificate` feature-gate which ensures that kubelet server certificates are automatically rotated by the Kubernetes control plane. However, vCluster does not run real kubelets and operates entirely within the host cluster, abstracting away node-level operations. Since vCluster has no control over kubelet configuration or certificate rotation, enforcing this setting must be done at the host cluster level, where the actual kubelets are running. The check defined in this control is not applicable in the context of vCluster.
+The control recommends enabling the `RotateKubeletServerCertificate` feature-gate which ensures that kubelet server certificates are automatically rotated by the Kubernetes control plane. However, vCluster does not run real kubelets and operates entirely within the control plane cluster, abstracting away node-level operations. Since vCluster has no control over kubelet configuration or certificate rotation, enforcing this setting must be done at the control plane cluster level, where the actual kubelets are running. The check defined in this control is not applicable in the context of vCluster.
 
 ### 1.3.7 Ensure that the --bind-address argument is set to 127.0.0.1
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/4-worker-node.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/4-worker-node.mdx
@@ -16,7 +16,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 The following section provides security recommendations for components running on Kubernetes worker nodes. The assessment focuses on Kubelet configuration and security and file system permissions.
 
-Assessment focus for vCluster involves understanding that since vCluster uses the host cluster's nodes, these section requirements are primarily inherited from the host cluster's configuration. Verification should focus on ensuring the host cluster meets these requirements. Most controls in this section are marked as NOT APPLICABLE for vCluster deployments since the underlying node security is managed by the host cluster administrators.
+Assessment focus for vCluster involves understanding that since vCluster uses the control plane cluster's nodes, these section requirements are primarily inherited from the control plane cluster's configuration. Verification should focus on ensuring the control plane cluster meets these requirements. Most controls in this section are marked as NOT APPLICABLE for vCluster deployments since the underlying node security is managed by the control plane cluster administrators.
 
 :::note Control numbering
 The control numbers used throughout this guide (4.1.1, 4.2.1, etc.) correlate directly to the official CIS Kubernetes Benchmark control numbers. This allows you to cross-reference with the official CIS documentation and maintain consistency with standard security frameworks.
@@ -28,7 +28,7 @@ The control numbers used throughout this guide (4.1.1, 4.2.1, etc.) correlate di
 
 **Result:** NOT APPLICABLE
 
-vCluster runs as pods within the host cluster and does not manage kubelet service files directly. The host cluster administrator is responsible for securing kubelet service files. Run the following command based on the file location on your system on each worker node:
+vCluster runs as pods within the control plane cluster and does not manage kubelet service files directly. The control plane cluster administrator is responsible for securing kubelet service files. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chmod 600 /etc/systemd/system/kubelet.service.d/kubeadm.conf
@@ -38,7 +38,7 @@ chmod 600 /etc/systemd/system/kubelet.service.d/kubeadm.conf
 
 **Result:** NOT APPLICABLE
 
-vCluster runs as pods within the host cluster and does not manage kubelet service file ownership. The host cluster administrator is responsible for securing kubelet service file ownership. Run the following command based on the file location on your system on each worker node:
+vCluster runs as pods within the control plane cluster and does not manage kubelet service file ownership. The control plane cluster administrator is responsible for securing kubelet service file ownership. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chown root:root /etc/systemd/system/kubelet.service.d/kubeadm.conf
@@ -48,7 +48,7 @@ chown root:root /etc/systemd/system/kubelet.service.d/kubeadm.conf
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage proxy kubeconfig files as these are part of the host cluster configuration. The host cluster administrator should ensure appropriate permissions. Run the following command based on the file location on your system on each worker node:
+vCluster does not manage proxy kubeconfig files as these are part of the control plane cluster configuration. The control plane cluster administrator should ensure appropriate permissions. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chmod 600 <proxy kubeconfig file>
@@ -58,7 +58,7 @@ chmod 600 <proxy kubeconfig file>
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage proxy kubeconfig file ownership as these are part of the host cluster configuration. The host cluster administrator should ensure appropriate ownership. Run the following command based on the file location on your system on each worker node:
+vCluster does not manage proxy kubeconfig file ownership as these are part of the control plane cluster configuration. The control plane cluster administrator should ensure appropriate ownership. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chown root:root <proxy kubeconfig file>
@@ -68,7 +68,7 @@ chown root:root <proxy kubeconfig file>
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage kubelet configuration files as these are part of the host cluster. The host cluster administrator is responsible for securing kubelet configuration file permissions. Run the following command based on the file location on your system on each worker node:
+vCluster does not manage kubelet configuration files as these are part of the control plane cluster. The control plane cluster administrator is responsible for securing kubelet configuration file permissions. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chmod 600 /etc/kubernetes/kubelet.conf
@@ -78,7 +78,7 @@ chmod 600 /etc/kubernetes/kubelet.conf
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage kubelet configuration file ownership as these are part of the host cluster. The host cluster administrator is responsible for securing kubelet configuration file ownership. Run the following command based on the file location on your system on each worker node:
+vCluster does not manage kubelet configuration file ownership as these are part of the control plane cluster. The control plane cluster administrator is responsible for securing kubelet configuration file ownership. Run the following command based on the file location on your system on each worker node:
 
 ```bash
 chown root:root /etc/kubernetes/kubelet.conf
@@ -88,7 +88,7 @@ chown root:root /etc/kubernetes/kubelet.conf
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage certificate authority files on worker nodes as these are part of the host cluster infrastructure. The host cluster administrator should ensure appropriate file permissions for certificate authorities. Run the following command to modify the file permissions of the `--client-ca-file`:
+vCluster does not manage certificate authority files on worker nodes as these are part of the control plane cluster infrastructure. The control plane cluster administrator should ensure appropriate file permissions for certificate authorities. Run the following command to modify the file permissions of the `--client-ca-file`:
 
 ```bash
 chmod 600 <filename>
@@ -98,7 +98,7 @@ chmod 600 <filename>
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage certificate authority file ownership on worker nodes as these are part of the host cluster infrastructure. The host cluster administrator should ensure appropriate file ownership. Run the following command to modify the ownership of the `--client-ca-file`:
+vCluster does not manage certificate authority file ownership on worker nodes as these are part of the control plane cluster infrastructure. The control plane cluster administrator should ensure appropriate file ownership. Run the following command to modify the ownership of the `--client-ca-file`:
 
 ```bash
 chown root:root <filename>
@@ -108,7 +108,7 @@ chown root:root <filename>
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage kubelet configuration files as these are controlled by the host cluster. The host cluster administrator is responsible for securing kubelet configuration file permissions. Run the following command using the config file location identified in the Audit step:
+vCluster does not manage kubelet configuration files as these are controlled by the control plane cluster. The control plane cluster administrator is responsible for securing kubelet configuration file permissions. Run the following command using the config file location identified in the Audit step:
 
 ```bash
 chmod 600 /var/lib/kubelet/config.yaml
@@ -118,7 +118,7 @@ chmod 600 /var/lib/kubelet/config.yaml
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage kubelet configuration file ownership as these are controlled by the host cluster. The host cluster administrator is responsible for securing kubelet configuration file ownership. Run the following command using the config file location identified in the Audit step:
+vCluster does not manage kubelet configuration file ownership as these are controlled by the control plane cluster. The control plane cluster administrator is responsible for securing kubelet configuration file ownership. Run the following command using the config file location identified in the Audit step:
 
 ```bash
 chown root:root /etc/kubernetes/kubelet.conf
@@ -130,7 +130,7 @@ chown root:root /etc/kubernetes/kubelet.conf
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet configuration parameters as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for disabling anonymous authentication on kubelets. If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to `false`. If using executable arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
+vCluster does not control kubelet configuration parameters as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for disabling anonymous authentication on kubelets. If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to `false`. If using executable arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
 
 ```bash
 --anonymous-auth=false
@@ -147,7 +147,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet authorization modes as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring appropriate authorization modes. If using a Kubelet config file, edit the file to set `authorization: mode` to `Webhook`. If using executable arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_AUTHZ_ARGS` variable:
+vCluster does not control kubelet authorization modes as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring appropriate authorization modes. If using a Kubelet config file, edit the file to set `authorization: mode` to `Webhook`. If using executable arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_AUTHZ_ARGS` variable:
 
 ```bash
 --authorization-mode=Webhook
@@ -164,7 +164,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not manage kubelet client CA configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring client CA files appropriately. If using a Kubelet config file, edit the file to set `authentication: x509: clientCAFile` to the location of the client CA file. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_AUTHZ_ARGS` variable:
+vCluster does not manage kubelet client CA configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring client CA files appropriately. If using a Kubelet config file, edit the file to set `authentication: x509: clientCAFile` to the location of the client CA file. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_AUTHZ_ARGS` variable:
 
 ```bash
 --client-ca-file=<path/to/client-ca-file>
@@ -181,7 +181,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet read-only port configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for disabling the read-only port. If using a Kubelet config file, edit the file to set `readOnlyPort` to `0`. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
+vCluster does not control kubelet read-only port configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for disabling the read-only port. If using a Kubelet config file, edit the file to set `readOnlyPort` to `0`. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
 
 ```bash
 --read-only-port=0
@@ -198,7 +198,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet streaming connection timeout configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring appropriate timeout values. If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a value other than 0. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
+vCluster does not control kubelet streaming connection timeout configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring appropriate timeout values. If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a value other than 0. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_SYSTEM_PODS_ARGS` variable:
 
 ```bash
 --streaming-connection-idle-timeout=5m
@@ -215,7 +215,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet iptables configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring iptables utility chains. If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains: true`. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and remove the `--make-iptables-util-chains` argument from the `KUBELET_SYSTEM_PODS_ARGS` variable.
+vCluster does not control kubelet iptables configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring iptables utility chains. If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains: true`. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and remove the `--make-iptables-util-chains` argument from the `KUBELET_SYSTEM_PODS_ARGS` variable.
 
 Based on your system, restart the `kubelet` service:
 
@@ -228,7 +228,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet hostname configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for hostname configuration. Edit the kubelet service file `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` on each worker node and remove the `--hostname-override` argument from the `KUBELET_SYSTEM_PODS_ARGS` variable.
+vCluster does not control kubelet hostname configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for hostname configuration. Edit the kubelet service file `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` on each worker node and remove the `--hostname-override` argument from the `KUBELET_SYSTEM_PODS_ARGS` variable.
 
 Based on your system, restart the `kubelet` service:
 
@@ -241,7 +241,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet event recording configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring appropriate event recording rates. If using a Kubelet config file, edit the file to set `eventRecordQPS:` to an appropriate level. If using command line arguments, edit the kubelet service file `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` on each worker node and set the following parameter in `KUBELET_ARGS` variable.
+vCluster does not control kubelet event recording configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring appropriate event recording rates. If using a Kubelet config file, edit the file to set `eventRecordQPS:` to an appropriate level. If using command line arguments, edit the kubelet service file `/etc/systemd/system/kubelet.service.d/10-kubeadm.conf` on each worker node and set the following parameter in `KUBELET_ARGS` variable.
 
 Based on your system, restart the `kubelet` service:
 
@@ -254,7 +254,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet TLS configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring TLS certificates appropriately. If using a Kubelet config file, edit the file to set `tlsCertFile` to the location of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile` to the location of the corresponding private key file. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameters in `KUBELET_CERTIFICATE_ARGS` variable:
+vCluster does not control kubelet TLS configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring TLS certificates appropriately. If using a Kubelet config file, edit the file to set `tlsCertFile` to the location of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile` to the location of the corresponding private key file. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameters in `KUBELET_CERTIFICATE_ARGS` variable:
 
 ```bash
 --tls-cert-file=<path/to/tls-certificate-file> --tls-private-key-file=<path/to/tls-key-file>
@@ -271,7 +271,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet certificate rotation configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for enabling certificate rotation. If using a Kubelet config file, edit the file to add the line `rotateCertificates: true` or remove it altogether to use the default value. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and remove `--rotate-certificates=false` argument from the `KUBELET_CERTIFICATE_ARGS` variable or set `--rotate-certificates=true`.
+vCluster does not control kubelet certificate rotation configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for enabling certificate rotation. If using a Kubelet config file, edit the file to add the line `rotateCertificates: true` or remove it altogether to use the default value. If using command line arguments, edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and remove `--rotate-certificates=false` argument from the `KUBELET_CERTIFICATE_ARGS` variable or set `--rotate-certificates=true`.
 
 Based on your system, restart the `kubelet` service:
 
@@ -284,7 +284,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet server certificate rotation as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for enabling server certificate rotation. Edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_CERTIFICATE_ARGS` variable:
+vCluster does not control kubelet server certificate rotation as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for enabling server certificate rotation. Edit the kubelet service file `/etc/kubernetes/kubelet.conf` on each worker node and set the following parameter in `KUBELET_CERTIFICATE_ARGS` variable:
 
 ```bash
 --feature-gates=RotateKubeletServerCertificate=true
@@ -301,7 +301,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet TLS cipher configuration as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for configuring strong cryptographic ciphers. If using a Kubelet config file, edit the file to set `TLSCipherSuites:` to:
+vCluster does not control kubelet TLS cipher configuration as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for configuring strong cryptographic ciphers. If using a Kubelet config file, edit the file to set `TLSCipherSuites:` to:
 
 ```
 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
@@ -324,7 +324,7 @@ systemctl restart kubelet.service
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kubelet PID limits as kubelet runs on the host cluster nodes. The host cluster administrator is responsible for setting appropriate PID limits. Decide on an appropriate level for this parameter and set it, either via the `--pod-max-pids` command line parameter or the `PodPidsLimit` configuration file setting.
+vCluster does not control kubelet PID limits as kubelet runs on the control plane cluster nodes. The control plane cluster administrator is responsible for setting appropriate PID limits. Decide on an appropriate level for this parameter and set it, either via the `--pod-max-pids` command line parameter or the `PodPidsLimit` configuration file setting.
 
 ## 4.3 kube-proxy
 
@@ -332,4 +332,4 @@ vCluster does not control kubelet PID limits as kubelet runs on the host cluster
 
 **Result:** NOT APPLICABLE
 
-vCluster does not control kube-proxy configuration as kube-proxy runs on the host cluster nodes. The host cluster administrator is responsible for securing kube-proxy metrics endpoints. Modify or remove any values which bind the metrics service to a non-localhost address.
+vCluster does not control kube-proxy configuration as kube-proxy runs on the control plane cluster nodes. The control plane cluster administrator is responsible for securing kube-proxy metrics endpoints. Modify or remove any values which bind the metrics service to a non-localhost address.

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/5-policies.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/5-policies.mdx
@@ -15,7 +15,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 The following section covers specific security policies for Kubernetes elements. The assessment focuses on RBAC configuration and least privilege access, Pod Security Standards and security contexts, and network policies and CNI security.
 
-This section is directly applicable to vCluster environments. Verification involves ensuring proper RBAC configurations are in place, Pod Security Standards are enforced, and network policies are appropriately configured within the virtual cluster.
+This section is directly applicable to vCluster environments. Verification involves ensuring proper RBAC configurations are in place, Pod Security Standards are enforced, and network policies are appropriately configured within the tenant cluster.
 
 :::note Control numbering
 The control numbers used throughout this guide (5.1.1, 5.2.1, etc.) correlate directly to the official CIS Kubernetes Benchmark control numbers. This allows you to cross-reference with the official CIS documentation and maintain consistency with standard security frameworks.
@@ -23,7 +23,7 @@ The control numbers used throughout this guide (5.1.1, 5.2.1, etc.) correlate di
 
 ## Validation using kube-bench
 
-While most CIS Kubernetes Benchmark checks are not directly verifiable via kube-bench due to vCluster's virtualized control plane architecture, the Policies section (Section 5) includes controls that are relevant and testable within the virtual cluster environment. These include namespace-level restrictions, pod security standards, and security contexts that can be enforced from within vCluster.
+While most CIS Kubernetes Benchmark checks are not directly verifiable via kube-bench due to vCluster's virtualized control plane architecture, the Policies section (Section 5) includes controls that are relevant and testable within the tenant cluster environment. These include namespace-level restrictions, pod security standards, and security contexts that can be enforced from within vCluster.
 
 To validate your vCluster's compliance with this section, you can run kube-bench with a customized kubeconfig pointing to the vCluster API server. The following steps outline the procedure to perform the compliance check:
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/self-assessment.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/self-assessment.mdx
@@ -28,7 +28,7 @@ Traditional compliance tools such as [kube-bench](https://github.com/aquasecurit
 The assessment guides provide manual verification methods specifically adapted for vCluster's architecture. Each control is evaluated and categorized to help you understand its applicability to your environment.
 
 :::important Note on Validation Tools
-While tools such as [kube-bench](https://github.com/aquasecurity/kube-bench) are commonly used to validate CIS benchmark compliance in traditional Kubernetes deployments, they cannot be directly applied to vCluster environments due to the fundamental differences in how vCluster operates. vCluster's virtualized control plane architecture means that many components run as containers within the host cluster rather than as traditional system processes, making standard automated assessment tools incompatible with this deployment model.
+While tools such as [kube-bench](https://github.com/aquasecurity/kube-bench) are commonly used to validate CIS benchmark compliance in traditional Kubernetes deployments, they cannot be directly applied to vCluster environments due to the fundamental differences in how vCluster operates. vCluster's virtualized control plane architecture means that many components run as containers within the control plane cluster rather than as traditional system processes, making standard automated assessment tools incompatible with this deployment model.
 
 For vCluster environments, manual verification of controls and custom assessment approaches are necessary to ensure compliance with the benchmark requirements.
 :::

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/1-control-plane-components.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/1-control-plane-components.mdx
@@ -82,13 +82,13 @@ vCluster does not rely on static pod manifests stored on the host such as `/etc/
 
 **Result:** NOT APPLICABLE
 
-vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the host (parent) cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying host cluster as it is not applicable in vCluster environments.
+vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the control plane cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying control plane cluster as it is not applicable in vCluster environments.
 
 ### 1.1.10 Ensure that the Container Network Interface file ownership is set to root:root
 
 **Result:** NOT APPLICABLE
 
-vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the host (parent) cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying host cluster as it is not applicable in vCluster environments.
+vCluster does not configure or manage Container Network Interface (CNI) settings. Networking is handled entirely by the control plane cluster's CNI plugin. As a result, there are no CNI configuration files such as `/etc/cni/net.d/*.conf` present within the vCluster container. You should evaluate this control on the underlying control plane cluster as it is not applicable in vCluster environments.
 
 ### 1.1.11 Ensure that the etcd data directory permissions are set to 700 or more restrictive
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/4-worker-node.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/4-worker-node.mdx
@@ -835,7 +835,7 @@ podPidsLimit: 1000000
 
 kube-proxy runs as a pod inside the vCluster and its configuration is backed by a ConfigMap named "kube-proxy" in the kube-system namespace.
 
-Run the following command inside the virtual cluster:
+Run the following command inside the tenant cluster:
 
 ```bash
 kubectl get cm kube-proxy -n kube-system -o jsonpath='{.data.config\.conf}' | grep metricsBindAddress

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/5-policies.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/5-policies.mdx
@@ -15,7 +15,7 @@ import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
 The following section covers specific security policies for Kubernetes elements. The assessment focuses on RBAC configuration and least privilege access, Pod Security Standards and security contexts, and network policies and CNI security.
 
-This section is directly applicable to vCluster environments. Verification involves ensuring proper RBAC configurations are in place, Pod Security Standards are enforced, and network policies are appropriately configured within the virtual cluster.
+This section is directly applicable to vCluster environments. Verification involves ensuring proper RBAC configurations are in place, Pod Security Standards are enforced, and network policies are appropriately configured within the tenant cluster.
 
 :::note Control numbering
 The control numbers used throughout this guide (5.1.1, 5.2.1, etc.) correlate directly to the official CIS Kubernetes Benchmark control numbers. This allows you to cross-reference with the official CIS documentation and maintain consistency with standard security frameworks.
@@ -23,7 +23,7 @@ The control numbers used throughout this guide (5.1.1, 5.2.1, etc.) correlate di
 
 ## Validation using kube-bench
 
-While most CIS Kubernetes Benchmark checks are not directly verifiable via kube-bench due to vCluster's virtualized control plane architecture, the Policies section (Section 5) includes controls that are relevant and testable within the virtual cluster environment. These include namespace-level restrictions, pod security standards, and security contexts that can be enforced from within vCluster.
+While most CIS Kubernetes Benchmark checks are not directly verifiable via kube-bench due to vCluster's virtualized control plane architecture, the Policies section (Section 5) includes controls that are relevant and testable within the tenant cluster environment. These include namespace-level restrictions, pod security standards, and security contexts that can be enforced from within vCluster.
 
 To validate your vCluster's compliance with this section, you can run kube-bench with a customized kubeconfig pointing to the vCluster API server. The following steps outline the procedure to perform the compliance check:
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/self-assessment.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/self-assessment.mdx
@@ -27,7 +27,7 @@ Traditional compliance tools such as [kube-bench](https://github.com/aquasecurit
 The assessment guides provide manual verification methods specifically adapted for vCluster's architecture. Each control is evaluated and categorized to help you understand its applicability to your environment.
 
 :::important Note on Validation Tools
-While tools such as [kube-bench](https://github.com/aquasecurity/kube-bench) are commonly used to validate CIS benchmark compliance in traditional Kubernetes deployments, they cannot be directly applied to vCluster environments due to the fundamental differences in how vCluster operates. vCluster's virtualized control plane architecture means that many components run as containers within the host cluster rather than as traditional system processes, making standard automated assessment tools incompatible with this deployment model.
+While tools such as [kube-bench](https://github.com/aquasecurity/kube-bench) are commonly used to validate CIS benchmark compliance in traditional Kubernetes deployments, they cannot be directly applied to vCluster environments due to the fundamental differences in how vCluster operates. vCluster's virtualized control plane architecture means that many components run as containers within the control plane cluster rather than as traditional system processes, making standard automated assessment tools incompatible with this deployment model.
 
 For vCluster environments, manual verification of controls and custom assessment approaches are necessary to ensure compliance with the benchmark requirements.
 :::

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx
@@ -8,8 +8,8 @@ import ControlPlaneOptions from '../../../../_fragments/deploy/nested/control-pl
 import WorkerNodeOptions from '../../../../_fragments/deploy/nested/worker-nodes.mdx'
 import Deploy from '../../../../_partials/deploy/deploy.mdx'
 
-By default, vCluster deploys the vCluster control plane pod as a root user on the host cluster, but you can adjust vCluster
-to deploy on a host cluster as a non-root user. There is no upgrade from a vCluster running as a root user to a vCluster running with a non-root user, so 
+By default, vCluster deploys the vCluster control plane pod as a root user on the control plane cluster, but you can adjust vCluster
+to deploy on a control plane cluster as a non-root user. There is no upgrade from a vCluster running as a root user to a vCluster running with a non-root user, so 
 this needs to be enabled upon initial deployment. 
 
 ## Configure to run as non-root user
@@ -45,5 +45,5 @@ However, some settings — such as what type of worker nodes or the backing stor
 
 ## Next steps
 
-Now that you have vCluster running, consider exploring the [platform UI](/platform/install/quick-start-guide) to manage your virtual clusters.
+Now that you have vCluster running, consider exploring the [platform UI](/platform/install/quick-start-guide) to manage your tenant clusters.
 


### PR DESCRIPTION
# Content Description
Replace "virtual cluster" with "tenant cluster" and "host cluster" with "control plane cluster" in prose across `vcluster/deploy/control-plane/` (19 files, ~97 occurrences). Code blocks, YAML comments, CLI commands, and anchor IDs are unchanged.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2105--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics

And other files in the /control-plane section.

## Internal Reference
Part of DOC-1334


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs