### PR TITLE
docs(doc-1409): constrain Highlight colors to brand palette and fix :target step layout

### DIFF
--- a/.claude/skills/vcluster-docs-writer/references/mdx-components.md
+++ b/.claude/skills/vcluster-docs-writer/references/mdx-components.md
@@ -93,6 +93,58 @@ Use `<Flow>` and `<Step>` components for multi-step procedures:
 4. **Use heading levels consistently** within steps (typically h3 `###`)
 5. **Never nest admonitions** inside `<Step>` components
 
+## Highlight Component
+
+Use `<Highlight>` to label which environment a step runs in, typically inside a `<Flow>` / `<Step>` block. It renders a small colored badge inline with the step description.
+
+### Import
+
+```mdx
+import Highlight from '@site/src/components/Highlight/Highlight';
+```
+
+### Available colors
+
+| `color` prop | Hex | Use for |
+|---|---|---|
+| _(none)_ | `#E6E7E9` | Control plane cluster steps (default) |
+| `"secondary"` | `#FFE0CC` | Tenant cluster steps |
+| `"success"` | `--ifm-color-success-lightest` | Admonition-aligned: light green |
+| `"info"` | `--ifm-color-info-lightest` | Admonition-aligned: light blue |
+| `"warning"` | `--ifm-color-warning-lightest` | Admonition-aligned: light yellow |
+| `"danger"` | `--ifm-color-danger-lightest` | Admonition-aligned: light red |
+
+Text color is always `#050B24` (brand black) regardless of background.
+
+### Convention: "Tenant Cluster" always uses `secondary`
+
+Every step that runs inside a tenant cluster must use `color="secondary"`. Default (no color) is used for control plane cluster steps. This pairing creates a consistent visual distinction across all multi-environment walkthroughs.
+
+```mdx
+<Step>
+  <Highlight color="secondary">Tenant Cluster</Highlight> Verify the resource was created
+
+  ```bash
+  kubectl --context="${VCLUSTER_CTX}" get pods
+  ```
+</Step>
+
+<Step>
+  <Highlight>Control Plane Cluster</Highlight> Confirm sync
+
+  ```bash
+  kubectl --context="${HOST_CTX}" get pods -n "${VCLUSTER_NS}"
+  ```
+</Step>
+```
+
+### What not to do
+
+- Do not pass arbitrary hex values or CSS color names — they silently fall back to the default gray.
+- Do not use `color="primary"` — it is not in the allowed set.
+- Do not use `<Highlight>` for general emphasis in prose; it is only for environment labels in step flows.
+- Do not use `color="green"` in new content — it is a legacy alias for `secondary` retained only for versioned docs compatibility.
+
 ## Admonition Types
 
 Docusaurus provides several admonition types. Use them consistently:

--- a/src/components/Flow/index.jsx
+++ b/src/components/Flow/index.jsx
@@ -185,7 +185,7 @@ export class Step extends React.Component {
 
   render() {
     return (
-      <li className={ `${styles.step} ${this.props.current ? styles.current : ""} `} onClick={this.props.onClick} style={this.props.style} >
+      <li className={ `${styles.step} flow-step ${this.props.current ? styles.current : ""} `} onClick={this.props.onClick} style={this.props.style} >
         {this.props.children}
       </li>
     )

--- a/src/components/Highlight/Highlight.js
+++ b/src/components/Highlight/Highlight.js
@@ -4,18 +4,15 @@ import styles from './styles.module.css';
 const COLORS = {
   secondary: '#FFE0CC',
   green:     '#FFE0CC', // deprecated alias for secondary; kept for versioned docs compatibility
-  success:   'var(--ifm-color-success)',
-  info:      'var(--ifm-color-info)',
-  warning:   'var(--ifm-color-warning)',
-  danger:    'var(--ifm-color-danger)',
+  success:   'var(--ifm-color-success-lightest)',
+  info:      'var(--ifm-color-info-lightest)',
+  warning:   'var(--ifm-color-warning-lightest)',
+  danger:    'var(--ifm-color-danger-lightest)',
 };
 
 const DEFAULT_BG = '#E6E7E9';
 
 export default function Highlight({ children, color, className }) {
-  if (color && !COLORS[color]) {
-    console.warn(`Highlight: unknown color "${color}". Valid values: ${Object.keys(COLORS).join(', ')}.`);
-  }
   return (
     <span
       style={{ backgroundColor: (color && COLORS[color]) || DEFAULT_BG, color: '#050B24' }}

--- a/src/components/Highlight/Highlight.js
+++ b/src/components/Highlight/Highlight.js
@@ -1,28 +1,26 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-const colors = {
-  primary: 'var(--ifm-color-primary)',
-  secondary: 'var(--ifm-color-secondary)',
-  success: 'var(--ifm-color-success)',
-  info: 'var(--ifm-color-info)',
-  warning: 'var(--ifm-color-warning)',
-  danger: 'var(--ifm-color-danger)'
+const COLORS = {
+  secondary: '#FFE0CC',
+  success:   'var(--ifm-color-success)',
+  info:      'var(--ifm-color-info)',
+  warning:   'var(--ifm-color-warning)',
+  danger:    'var(--ifm-color-danger)',
 };
 
-export default class Highlight extends React.Component {
-  render() {
-    const { children, color, className, ...props } = this.props;
-    return (
-      <span
-        style={{
-          backgroundColor: color ? (colors[color] || color) : undefined,
-          ...props
-        }}
-        className={`${styles.highlight} ${className || ''}`}
-      >
-        {children}
-      </span>
-    );
+const DEFAULT_BG = '#E6E7E9';
+
+export default function Highlight({ children, color, className }) {
+  if (color && !COLORS[color]) {
+    console.warn(`Highlight: unknown color "${color}". Valid values: ${Object.keys(COLORS).join(', ')}.`);
   }
+  return (
+    <span
+      style={{ backgroundColor: (color && COLORS[color]) || DEFAULT_BG, color: '#050B24' }}
+      className={`${styles.highlight} ${className || ''}`}
+    >
+      {children}
+    </span>
+  );
 }

--- a/src/components/Highlight/Highlight.js
+++ b/src/components/Highlight/Highlight.js
@@ -3,6 +3,7 @@ import styles from './styles.module.css';
 
 const COLORS = {
   secondary: '#FFE0CC',
+  green:     '#FFE0CC', // deprecated alias for secondary; kept for versioned docs compatibility
   success:   'var(--ifm-color-success)',
   info:      'var(--ifm-color-info)',
   warning:   'var(--ifm-color-warning)',

--- a/src/components/Highlight/styles.module.css
+++ b/src/components/Highlight/styles.module.css
@@ -2,8 +2,6 @@
   display: inline-block;
   margin-bottom: 0.4em;
   padding: 0.2em 0.4em 0.2em 0.5em;
-  color: #fff;
   font-weight: 600;
-  background-color: var(--ifm-color-primary);
   border-radius: 4px;
 }

--- a/src/css/content/markdown.scss
+++ b/src/css/content/markdown.scss
@@ -133,9 +133,9 @@ html body pre.prism-code > button {
 // exceptions.
 
 .markdown :target,
-h2:target ~ *:not(h2, h2:target ~ *:where(h1, h2):not(:target) ~ *),
-h3:target ~ *:not(h2, h3, h3:target ~ *:where(h1, h2, h3):not(:target) ~ *),
-h4:target ~ *:not(h2, h3, h4, h4:target ~ *:where(h1, h2, h3, h4):not(:target) ~ *) {
+h2:target ~ *:not(h2, .flow-step, h2:target ~ *:where(h1, h2):not(:target) ~ *),
+h3:target ~ *:not(h2, h3, .flow-step, h3:target ~ *:where(h1, h2, h3):not(:target) ~ *),
+h4:target ~ *:not(h2, h3, h4, .flow-step, h4:target ~ *:where(h1, h2, h3, h4):not(:target) ~ *) {
   &:where(:not(details *))::before {
     content: " ";
     width: 4px;

--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -67,7 +67,7 @@ Self-signed certificates work well for development environments and internal ser
 <Flow id="self-signed-setup">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create a self-signed issuer
+<Highlight color="secondary">Virtual Cluster</Highlight> Create a self-signed issuer
 
 ```yaml title="self-signed-issuer.yaml"
 apiVersion: cert-manager.io/v1
@@ -89,7 +89,7 @@ kubectl --context=$VCLUSTER_CTX apply -f self-signed-issuer.yaml
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create a certificate
+<Highlight color="secondary">Virtual Cluster</Highlight> Create a certificate
 
 ```yaml title="self-signed-certificate.yaml"
 apiVersion: cert-manager.io/v1
@@ -206,7 +206,7 @@ kubectl --context=$HOST_CTX apply -f ca-issuer.yaml
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Issue certificates from your CA
+<Highlight color="secondary">Virtual Cluster</Highlight> Issue certificates from your CA
 
 ```yaml title="ca-signed-certificate.yaml"
 apiVersion: cert-manager.io/v1
@@ -261,7 +261,7 @@ kubectl --context=$VCLUSTER_CTX apply -f ca-signed-certificate.yaml
 <Flow id="acme-setup">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create an ACME issuer
+<Highlight color="secondary">Virtual Cluster</Highlight> Create an ACME issuer
 
 ```yaml title="acme-issuer.yaml"
 apiVersion: cert-manager.io/v1
@@ -291,7 +291,7 @@ spec:
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create an ACME certificate
+<Highlight color="secondary">Virtual Cluster</Highlight> Create an ACME certificate
 
 ```yaml title="acme-certificate.yaml"
 apiVersion: cert-manager.io/v1
@@ -369,7 +369,7 @@ Check that your certificates generate correctly:
 <Flow id="verification">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Check certificate status
+<Highlight color="secondary">Virtual Cluster</Highlight> Check certificate status
 
 ```bash title="Verify certificate creation"
 kubectl --context=$VCLUSTER_CTX describe certificate <certificate-name> -n <namespace>
@@ -381,7 +381,7 @@ Look for `Ready: True` in the status conditions.
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Verify secret creation
+<Highlight color="secondary">Virtual Cluster</Highlight> Verify secret creation
 
 ```bash title="Check certificate secret"
 kubectl --context=$VCLUSTER_CTX get secret <secret-name> -n <namespace> -o yaml
@@ -472,7 +472,7 @@ kubectl --context=$HOST_CTX -n cert-manager get pods
 kubectl --context=$HOST_CTX -n cert-manager logs deployment/cert-manager
 ```
 
-<Highlight color="green">Virtual Cluster</Highlight>
+<Highlight color="secondary">Virtual Cluster</Highlight>
 ```bash title="Verify integration configuration"
 # Check if integration is enabled
 kubectl --context=$VCLUSTER_CTX get configmap vcluster-config -o yaml

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -150,7 +150,7 @@ guide](/vcluster/quick-start/shared-nodes).
   </Step>
   #### Verify that config is mounted
   <Step>
-    <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
+    <Highlight color="secondary">Virtual Cluster</Highlight> Wait for pod running
 
     ```bash title="Wait for pod running"
     kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-virtual-namespace --timeout=300s

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -168,7 +168,7 @@ guide](/vcluster/quick-start/shared-nodes).
 
   #### Verify that Example is updated in vCluster
   <Step>
-    <Highlight color="green">Virtual Cluster</Highlight> Check number of replicas
+    <Highlight color="secondary">Virtual Cluster</Highlight> Check number of replicas
 
     ```bash title="Check example"
     kubectl --context="${VCLUSTER_CTX}" get --namespace default examples.demo.loft.sh

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -141,7 +141,7 @@ guide](/vcluster/quick-start/shared-nodes).
 
   #### Verify pod environment variables
   <Step>
-    <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
+    <Highlight color="secondary">Virtual Cluster</Highlight> Wait for pod running
 
     ```bash title="Wait for pod running"
     kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-namespace --timeout=300s

--- a/vcluster/third-party-integrations/git-operations/flux.mdx
+++ b/vcluster/third-party-integrations/git-operations/flux.mdx
@@ -269,7 +269,7 @@ git push
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Verify deployment
+<Highlight color="secondary">Virtual Cluster</Highlight> Verify deployment
 
 After Flux reconciles the changes, you can connect to your vCluster and verify the application is deployed:
 
@@ -517,7 +517,7 @@ kubectl logs -n flux-system deployment/source-controller
 kubectl logs -n flux-system deployment/helm-controller
 ```
 
-<Highlight color="green">Virtual Cluster</Highlight>
+<Highlight color="secondary">Virtual Cluster</Highlight>
 - Verify that resources are being created in the virtual cluster
 - Check that the `exportKubeConfig` setting is properly configured
 - Ensure the server URL is reachable from the Flux controllers


### PR DESCRIPTION
# Content Description
Constrains the `<Highlight>` component to the approved brand color palette and fixes a layout bug where step numbers were displaced when navigating to an anchor link pointing to a heading inside a Flow component.

## Preview Link
<!-- The preview link or links to the documents-->
- https://deploy-preview-2127--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/integrations/cert-manager/#verify-certificate-creation
  Verify that the badge colors for at the beginning of each step in this section are appropriate light orange and grey instead of bright green and blaze orange.
- https://deploy-preview-2127--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/sync/from-host/configmaps/#verify-that-config-is-mounted
  Verify that the number 4 for the step displays correctly.

## Internal Reference
Closes DOC-1409

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs