### PR TITLE
docs(doc-1410): terminology — platform/use-platform/ batch 2

### DIFF
--- a/platform/use-platform/apps/updating.mdx
+++ b/platform/use-platform/apps/updating.mdx
@@ -18,14 +18,14 @@ updated versions will show up with a warning indicating that a newer App version
 
 ### Updating An Installed App's Version
 
-You can change the version of an installed App in a space, cluster, or virtual cluster to a
+You can change the version of an installed App in a space, cluster, or tenant cluster to a
 newer (or older!) version in the vCluster Platform UI.
 
 <Tabs
   defaultValue="cluster"
   values={[
     { label: "(Physical) Cluster", value: "cluster" },
-    { label: "Virtual Cluster", value: "vcluster" },
+    { label: "Tenant Cluster", value: "vcluster" },
   ]}
 >
   <TabItem value="cluster">
@@ -68,18 +68,18 @@ newer (or older!) version in the vCluster Platform UI.
         Select the <NavStep>Projects</NavStep> field on the left menu bar.
       </Step>
       <Step>
-        Select the project containing the virtual cluster that you'd like to
+        Select the project containing the tenant cluster that you'd like to
         install the App in from the Project drop down menu.
       </Step>
       <Step>
-        From the Projects sub-menu, select the Virtual Clusters option.
+        From the Projects sub-menu, select the Tenant Clusters option.
       </Step>
       <Step>
-        Find the virtual cluster containing the App you would like to upgrade,
-        click on that virtual cluster.
+        Find the tenant cluster containing the App you would like to upgrade,
+        click on that tenant cluster.
       </Step>
       <Step>
-        In the Virtual Cluster Management view, click the <Button>Apps</Button>{" "}
+        In the Tenant Cluster Management view, click the <Button>Apps</Button>{" "}
         button.
       </Step>
       <Step>

--- a/platform/use-platform/apps/use-in-templates.mdx
+++ b/platform/use-platform/apps/use-in-templates.mdx
@@ -13,15 +13,15 @@ import Label from "@site/src/components/Label";
 
 
 Apps are a way for admins to package applications and scripts in consumable packages.
-These applications can then be deployed into namespaces or virtual clusters through their templates.
+These applications can then be deployed into namespaces or tenant clusters through their templates.
 
-Virtual clusters or namespaces combined with Apps are a great way to create repeatable, pre-packaged
+Tenant clusters or namespaces combined with Apps are a great way to create repeatable, pre-packaged
 development, testing, or even production environments. Once an App has been created in the vCluster Platform
-instance, it can be installed into any virtual cluster or namespace -- either at time of creation, or into
+instance, it can be installed into any tenant cluster or namespace -- either at time of creation, or into
 existing resources. This gives administrators the capability to create fully populated
 development, test, or even production, environments in a single easy to manage package.
 
-Templates can take this combination of virtual clusters/namespaces and apps to the next
+Templates can take this combination of tenant clusters/namespaces and apps to the next
 level, by creating simple, reusable, version-able templates that define a reproducible environment.When an App is included in
 a template, that app will be deployed in the given resource upon creation. 
 
@@ -30,17 +30,17 @@ a template, that app will be deployed in the given resource upon creation.
     Select the <NavStep>Templates</NavStep> field on the left menu bar.
   </Step>
   <Step>
-    From the Templates sub-menu, select the Virtual Clusters option.
+    From the Templates sub-menu, select the Tenant Clusters option.
   </Step>
   <Step>
-    Edit an existing template, or create a new virtual cluster template.
+    Edit an existing template, or create a new tenant cluster template.
   </Step>
   <Step>
     Click the <Label>Apps</Label> configuration tab. <br></br>
     <br></br>
     <b>Note: </b>
     the apps defined in this section of the template configuration are apps to
-    be deployed *in* the virtual cluster!
+    be deployed *in* the tenant cluster!
   </Step>
   <Step>
     From the drop down menu <Label>Add a new App ...</Label> select an App
@@ -63,8 +63,8 @@ a template, that app will be deployed in the given resource upon creation.
     <br></br>
     <br></br>
     <b>Note:</b> the apps defined in this section of the template configuration
-    are apps to be deployed in the *space* the virtual cluster will be deployed
-    in (not inside the virtual cluster itself).
+    are apps to be deployed in the *space* the tenant cluster will be deployed
+    in (not inside the tenant cluster itself).
   </Step>
   <Step>
     From the drop down menu <Label>Add a new App ...</Label> select an App

--- a/platform/use-platform/apps/use-on-demand.mdx
+++ b/platform/use-platform/apps/use-on-demand.mdx
@@ -18,7 +18,7 @@ These applications can then be deployed into clusters, namespaces, or tenant clu
 This can be a useful tool for adding pre-defined applications to newly connected clusters, or to
 newly created namespaces or tenant clusters that are not already using a template that includes Apps.
 
-## Installing Apps on a Tenant Cluster
+## Install apps on a tenant cluster
 
 Tenant clusters combined with Apps are a great way to create repeatable, pre-packaged
 development, testing, or even production environments. Once an App has been created in the vCluster Platform

--- a/platform/use-platform/apps/use-on-demand.mdx
+++ b/platform/use-platform/apps/use-on-demand.mdx
@@ -14,36 +14,36 @@ import PartialVirtualClusterInstallApp from "../../_partials/vcluster/add-app-ui
 
 
 Apps are a way for admins to package applications and scripts in consumable packages.
-These applications can then be deployed into clusters, namespaces, or virtual clusters managed by vCluster Platform.
+These applications can then be deployed into clusters, namespaces, or tenant clusters managed by vCluster Platform.
 This can be a useful tool for adding pre-defined applications to newly connected clusters, or to
-newly created namespaces or virtual clusters that are not already using a template that includes Apps.
+newly created namespaces or tenant clusters that are not already using a template that includes Apps.
 
-## Installing Apps on a Virtual Cluster
+## Installing Apps on a Tenant Cluster
 
-Virtual clusters combined with Apps are a great way to create repeatable, pre-packaged
+Tenant clusters combined with Apps are a great way to create repeatable, pre-packaged
 development, testing, or even production environments. Once an App has been created in the vCluster Platform
-instance, it can be installed into any virtual cluster -- either at time of creation, or into
-existing virtual clusters. This gives administrators the capability to create fully populated
+instance, it can be installed into any tenant cluster -- either at time of creation, or into
+existing tenant clusters. This gives administrators the capability to create fully populated
 development, test, or even production, environments in a single easy to manage package.
 
 <Tabs
   defaultValue="creation"
   values={[
-    { label: "During Virtual Cluster Creation", value: "creation" },
-    { label: "On Existing Virtual Cluster", value: "existing" },
+    { label: "During Tenant Cluster Creation", value: "creation" },
+    { label: "On Existing Tenant Cluster", value: "existing" },
   ]}
 >
   <TabItem value="creation">
     <Flow id="install-app-virtualcluster-creation">
       <Step>
           From the project drop-down menu (top left corner), select the project you'd like to create the
-          virtual cluster in.
+          tenant cluster in.
       </Step>
       <Step>
-        Click on <NavStep>Virtual Clusters</NavStep>.
+        Click on <NavStep>Tenant Clusters</NavStep>.
       </Step>
       <Step>
-        Click the <Button>New Virtual Cluster</Button> button. Do not select a template.
+        Click the <Button>New Tenant Cluster</Button> button. Do not select a template.
       </Step>
       <Step>
         <b>[Optional]</b> Select the cluster in which to create the virtual
@@ -57,7 +57,7 @@ development, test, or even production, environments in a single easy to manage p
         <br></br>
         <b>Note:</b>
         The apps defined in this section of the configuration are apps to
-        be deployed *in* the virtual cluster.
+        be deployed *in* the tenant cluster.
       </Step>
       <Step>
         From the drop down menu <Label>Please select an App...</Label>, select an
@@ -73,9 +73,9 @@ development, test, or even production, environments in a single easy to manage p
         can also configure the Helm release-name.
       </Step>
       <Step>
-        Finish configuring anything else you'd like on your virtual cluster,
+        Finish configuring anything else you'd like on your tenant cluster,
         then click the
-        <Button>Create Virtual Cluster</Button> button.
+        <Button>Create Tenant Cluster</Button> button.
       </Step>
     </Flow>
   </TabItem>

--- a/platform/use-platform/machines/overview.mdx
+++ b/platform/use-platform/machines/overview.mdx
@@ -8,7 +8,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <FeatureTable names="machine-management" />
 
-A Machine is a provisioned server — physical or virtual — managed by vCluster Platform through a node provider. Machines abstract the provisioning details so that platform administrators can offer self-service access to compute resources. Users request Machines either indirectly through virtual cluster auto-nodes, or directly when they need standalone servers outside the virtual cluster lifecycle.
+A Machine is a provisioned server — physical or virtual — managed by vCluster Platform through a node provider. Machines abstract the provisioning details so that platform administrators can offer self-service access to compute resources. Users request Machines either indirectly through tenant cluster auto-nodes, or directly when they need standalone servers outside the tenant cluster lifecycle.
 
 Each Machine is backed by a [node provider](../../administer/node-providers/overview.mdx) that handles the actual provisioning — creating VMs, provisioning bare metal servers, or running Terraform scripts.
 
@@ -16,8 +16,8 @@ Each Machine is backed by a [node provider](../../administer/node-providers/over
 
 Machines are created in two ways:
 
-- **Auto nodes**: When a virtual cluster is configured with [private nodes and auto nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/), the platform automatically creates scalable pools of Machines. [Karpenter](/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes) decides when nodes are needed, and the platform provisions them through the configured node provider. The Machine joins the virtual cluster as a worker node.
-- **Manual**: Machines can also be created independently, without being connected to a virtual cluster. This is useful for provisioning servers that are managed outside of the virtual cluster lifecycle.
+- **Auto nodes**: When a tenant cluster is configured with [private nodes and auto nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/), the platform automatically creates scalable pools of Machines. [Karpenter](/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes) decides when nodes are needed, and the platform provisions them through the configured node provider. The Machine joins the tenant cluster as a worker node.
+- **Manual**: Machines can also be created independently, without being connected to a tenant cluster. This is useful for provisioning servers that are managed outside of the tenant cluster lifecycle.
 
 In both cases, the node provider determines how the Machine is provisioned — what OS image is installed, what user data is applied, and how the server is configured.
 

--- a/platform/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
+++ b/platform/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
@@ -7,7 +7,7 @@ import Expander from '@site/src/components/Expander'
 
 <Flow id="sleep-automatic-ui">
   <Step>
-    In the <NavStep>Projects > {props.name === "virtual cluster" ? "Virtual Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto-delete for
+    In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto-delete for
   </Step>
   <Step>
     Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}

--- a/platform/use-platform/namespaces/_partials/sleep/configure-ui.mdx
+++ b/platform/use-platform/namespaces/_partials/sleep/configure-ui.mdx
@@ -10,7 +10,7 @@ import CreateSpaceStep2 from '@site/static/media/ui/screenshots/spaces/create-sp
 
 <Flow id="sleep-automatic-ui">
   <Step>
-    In the <NavStep>Projects > {props.name === "virtual cluster" ? "Virtual Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto sleep for
+    In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
     Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}

--- a/platform/use-platform/namespaces/_partials/sleep/manual-cli.mdx
+++ b/platform/use-platform/namespaces/_partials/sleep/manual-cli.mdx
@@ -2,7 +2,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 <p>To put a {props.name} to sleep using vCluster CLI, run:</p>
 <CodeBlock>
-vcluster platform sleep {props.name === "virtual cluster" ? "vcluster" : "namespace"} [name]
+vcluster platform sleep {props.name === "tenant cluster" ? "vcluster" : "namespace"} [name]
 </CodeBlock>
 
 :::tip Automatic Wakeup

--- a/platform/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
+++ b/platform/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
@@ -7,7 +7,7 @@ import Expander from '@site/src/components/Expander'
 
 <Flow id="sleep-automatic-constraint-schedule-ui">
   <Step>
-    In the <NavStep>Projects > {props.name === "virtual cluster" ? "Virtual Clusters" : "Namespaces"}</NavStep> view, hover over {props.name} that you want to configure auto sleep for
+    In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
     Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}

--- a/platform/use-platform/namespaces/_partials/sleep/wake-cli.mdx
+++ b/platform/use-platform/namespaces/_partials/sleep/wake-cli.mdx
@@ -2,5 +2,5 @@ import CodeBlock from '@theme/CodeBlock';
 
 <p>To wake up a sleeping {props.name} using vCluster CLI, run:</p>
 <CodeBlock>
-vcluster platform wakeup {props.name === "virtual cluster" ? "vcluster" : "namespace"} [name]
+vcluster platform wakeup {props.name === "tenant cluster" ? "vcluster" : "namespace"} [name]
 </CodeBlock>

--- a/platform/use-platform/namespaces/_partials/sleep/wake-ui.mdx
+++ b/platform/use-platform/namespaces/_partials/sleep/wake-ui.mdx
@@ -5,7 +5,7 @@ import Label from '@site/src/components/Label'
 
 <Flow id="wakeup-manual-ui">
   <Step>
-    In the <NavStep>Projects > {props.name === "virtual cluster" ? "Virtual Clusters" : "Namespaces"}</NavStep> view, hover over the <Label>Status</Label> column of the {props.name} that you want to wake up
+    In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the <Label>Status</Label> column of the {props.name} that you want to wake up
   </Step>
   <Step>
     While hovering over the row, you will see a tooltip appear that provide information about the sleep state of this {props.name}

--- a/platform/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform/use-platform/namespaces/key-features/custom-links.mdx
@@ -14,8 +14,8 @@ import Label from '@site/src/components/Label'
 You can add custom links to namespaces that point to external resources such as GitHub pull requests, Jira issues, or documentation. 
 This allows team members to access all relevant resources directly from the namespace view.
 
-:::tip Virtual cluster custom links
-For more information on configuring custom links for virtual clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+:::tip Tenant cluster custom links
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform/use-platform/troubleshooting/troubleshooting.mdx
+++ b/platform/use-platform/troubleshooting/troubleshooting.mdx
@@ -63,7 +63,7 @@ By default, Global Admins, Management Admins, and Project Admins can access Debu
 :::
 
 Administrators can grant additional access by allowing the `virtualclusterinstances/debug-shell` and `virtualclusterinstances/debug-shell-pods` subresources.
-This role should be assigned to users who already have access to the virtual cluster.
+This role should be assigned to users who already have access to the tenant cluster.
 For example, the following project role grants access:
 
 ```yaml

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -1,8 +1,8 @@
 ---
-title: Add existing virtual clusters
-sidebar_label: Add Existing Virtual Clusters
+title: Add existing tenant clusters
+sidebar_label: Add Existing Tenant Clusters
 sidebar_position: 2
-description: Add externally deployed virtual clusters to Platform with visibility-only or full management capabilities
+description: Add externally deployed tenant clusters to Platform with visibility-only or full management capabilities
 ---
 
 import Tabs from "@theme/Tabs";
@@ -18,12 +18,12 @@ import FragmentVirtualClustersSelect from '../../_fragments/ui-steps/virtual-clu
 import FragmentConnectPlatform from '../../_fragments/cli-steps/connect-platform.mdx'
 import FragmentPlatformAddCluster from '../../_fragments/cli-steps/platform-add-cluster.mdx'
 
-# Add existing virtual clusters
+# Add existing tenant clusters
 
-Any running virtual cluster can be added to the Platform. When adding a virtual cluster to the Platform, you can choose between two integration levels based on your needs.
+Any running tenant cluster can be added to the Platform. When adding a tenant cluster to the Platform, you can choose between two integration levels based on your needs.
 
 :::tip Related documentation
-For conceptual understanding of externally vs. Platform-deployed virtual clusters, see [Externally deployed virtual clusters](/docs/platform/understand/externally-vs-platform-deployed).
+For conceptual understanding of externally vs. Platform-deployed tenant clusters, see [Externally deployed tenant clusters](/docs/platform/understand/externally-vs-platform-deployed).
 :::
 
 ## Integration levels
@@ -47,7 +47,7 @@ graph LR
 - **Full Platform management** - Platform takes over complete lifecycle management, enabling all Platform features like templates, auto sleep, and auto-delete
 
 :::info Technical details
-The Platform uses a VirtualClusterInstance resource to track virtual clusters. The management level is controlled automatically based on how you add the vCluster. For more details, see the [VirtualClusterInstance API reference](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx).
+The Platform uses a VirtualClusterInstance resource to track tenant clusters. The management level is controlled automatically based on how you add the vCluster. For more details, see the [VirtualClusterInstance API reference](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx).
 :::
 
 ## Add for visibility and access
@@ -59,8 +59,8 @@ Use this approach when you want to keep managing the vCluster with your existing
     <FragmentConnectPlatform />
   </Step>
   <Step>
-    **Add Virtual Cluster to the Platform**: before running this command, be sure that your kubecontext is set to the
-    host cluster running the vCluster that you want to add.
+    **Add Tenant Cluster to the Platform**: before running this command, be sure that your kubecontext is set to the
+    control plane cluster running the vCluster that you want to add.
 
     <InterpolatedCodeBlock
       code={`VCLUSTER_NAME=[[VAR:VCLUSTER_NAME:my-vcluster]]
@@ -76,18 +76,18 @@ vcluster platform add vcluster $VCLUSTER_NAME \\
     This creates a VirtualClusterInstance with `external: true`, meaning the Platform will not manage the lifecycle.
   </Step>
   <Step>
-    **Add Host Cluster to the Platform (Optional)**: for additional visibility of the host cluster in the Platform UI, you can also add the host cluster itself.
-    Before running this command, be sure that your kubecontext is set to the host cluster.
+    **Add Control Plane Cluster to the Platform (Optional)**: for additional visibility of the control plane cluster in the Platform UI, you can also add the control plane cluster itself.
+    Before running this command, be sure that your kubecontext is set to the control plane cluster.
 
     <InterpolatedCodeBlock
       code={`CLUSTER=[[VAR:CLUSTER:my-host-cluster]]
-DISPLAY_NAME="[[VAR:DISPLAY_NAME:My Host Cluster]]"
+DISPLAY_NAME="[[VAR:DISPLAY_NAME:My Control Plane Cluster]]"
 vcluster platform add cluster $CLUSTER --display-name "$DISPLAY_NAME"`}
       language="bash"
-      title="Connect host cluster to platform."
+      title="Connect control plane cluster to platform."
     />
 
-    This step is optional and provides additional management capabilities for the host cluster infrastructure.
+    This step is optional and provides additional management capabilities for the control plane cluster infrastructure.
   </Step>
 </Flow>
 
@@ -121,7 +121,7 @@ First, login with the platform [access key](/docs/platform/next/administer/authe
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
 
-Then, add the virtual cluster to the platform by running:
+Then, add the tenant cluster to the platform by running:
 <InterpolatedCodeBlock
   code={`# Assuming you have already deployed a vCluster using Helm, Argo CD, or another tool
 
@@ -134,7 +134,7 @@ vcluster platform add vcluster [[VAR:VCLUSTER_NAME:vc-name]] \\
 />
 
 You can also use Helm values by updating the `vcluster.yaml` to include the access key of the platform as follows and then upgrade or restart
-the virtual cluster.
+the tenant cluster.
 ```yaml
 platform:
   apiKey:
@@ -173,7 +173,7 @@ The Platform must create and manage the namespace when `external: false`. Pre-ex
 
 ### GitOps with VirtualClusterInstance
 
-For [GitOps deployments](/docs/platform/install/gitops), create the [VirtualClusterInstance](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx) directly in your Git repository. Tools like [Argo CD](/docs/platform/integrations/argocd) or Flux will apply the CRD, and the Platform will manage the virtual cluster:
+For [GitOps deployments](/docs/platform/install/gitops), create the [VirtualClusterInstance](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx) directly in your Git repository. Tools like [Argo CD](/docs/platform/integrations/argocd) or Flux will apply the CRD, and the Platform will manage the tenant cluster:
 
 ```yaml title="gitops/vcluster-instance.yaml"
 apiVersion: storage.loft.sh/v1
@@ -258,7 +258,7 @@ vcluster platform list vcluster`}
 
 ## Verification
 
-Verify that the virtual cluster is correctly managed by the Platform. You can check this using the CLI:
+Verify that the tenant cluster is correctly managed by the Platform. You can check this using the CLI:
 
 <InterpolatedCodeBlock
   code={`# List all VirtualClusterInstances
@@ -269,7 +269,7 @@ kubectl get virtualclusterinstances.storage.loft.sh [[VAR:NAME:vc-name]] \\
   -n p-[[VAR:PROJECT:default]] \\
   -o jsonpath='{.spec.external}'
 
-# Check Platform-managed virtual clusters
+# Check Platform-managed tenant clusters
 vcluster list --driver=platform
 
 # Access Platform UI
@@ -285,7 +285,7 @@ Once `external: false` is set, the following Platform features become available:
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
 - **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
 - **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
-- **[Project assignment](/docs/platform/administer/projects/create)**: Organize virtual clusters into projects with quotas
+- **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
 - **[Resource quotas](/docs/platform/administer/projects/quotas)**: Enforce resource limits via <GlossaryTerm term="project">project</GlossaryTerm> settings
@@ -296,7 +296,7 @@ Once `external: false` is set, the following Platform features become available:
 
 ### Architectural considerations
 
-**Single source of truth principle:** when `external: false`, the Platform becomes the sole manager of the virtual cluster. This means:
+**Single source of truth principle:** when `external: false`, the Platform becomes the sole manager of the tenant cluster. This means:
 - Avoid making changes through the original deployment tool (Helm, Argo CD)
 - Configuration updates should be done through Platform UI or by modifying the VirtualClusterInstance
 - Competing reconciliation loops can cause conflicts and unpredictable behavior
@@ -304,7 +304,7 @@ Once `external: false` is set, the following Platform features become available:
 ### Technical requirements
 
 - **Namespace management**: The Platform must create and manage the namespace when `external: false`. Pre-existing namespaces will cause deployment failures with error: "namespace exists and is not managed"
-- **Reconciliation conflicts**: If external tools continue to manage the virtual cluster after setting `external: false`, both systems may fight to enforce their desired state
+- **Reconciliation conflicts**: If external tools continue to manage the tenant cluster after setting `external: false`, both systems may fight to enforce their desired state
 - **Version compatibility**: Requires vCluster v0.20.0 or later for full Platform integration
 
 ### Alternative approaches
@@ -313,13 +313,13 @@ For specific scenarios where full Platform management isn't suitable:
 
 1. **Hybrid management**: Keep `external: true` to maintain external lifecycle management while still gaining Platform features like SSO and monitoring
 
-2. **GitOps compatibility**: Use VirtualClusterInstance CRDs in your GitOps repository, letting Argo CD deploy them while Platform manages the resulting virtual clusters
+2. **GitOps compatibility**: Use VirtualClusterInstance CRDs in your GitOps repository, letting Argo CD deploy them while Platform manages the resulting tenant clusters
 
 3. **Gradual migration**: Start with external management, evaluate Platform features, then transition to full management when ready
 
 ## Next steps
 
-- Learn about [managing virtual cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
+- Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
 - Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform/use-platform/virtual-clusters/create/create-no-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-no-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manually configure a virtual cluster
+title: Manually configure a tenant cluster
 sidebar_label: Configure Manually
 sidebar_position: 2
 ---
@@ -9,28 +9,28 @@ import PartialVirtualClusterCreateCLI from "../../../_partials/vcluster/create-c
 import PartialVirtualClusterCreateUINoTemplate from "../../../_partials/vcluster/create-ui-no-template.mdx";
 import PartialVirtualClusterAirGapped from "../../../_partials/vcluster/air-gapped-helm-charts.mdx";
 
-Each virtual cluster belongs to a [project](../../../understand/what-are-projects.mdx). Projects control whether users can create virtual clusters with or without [templates](../../../understand/what-are-templates.mdx).
+Each tenant cluster belongs to a [project](../../../understand/what-are-projects.mdx). Projects control whether users can create tenant clusters with or without [templates](../../../understand/what-are-templates.mdx).
 
-## Who can create virtual clusters without a template
+## Who can create tenant clusters without a template
 
-By default, projects require templates for virtual cluster creation. This means:
+By default, projects require templates for tenant cluster creation. This means:
 
-- **Project users** can only create virtual clusters from [allowed templates](../../../administer/projects/allowed/templates.mdx) configured by the project admin.
-- **Project admins and platform admins** can always create virtual clusters without a template, regardless of project settings.
+- **Project users** can only create tenant clusters from [allowed templates](../../../administer/projects/allowed/templates.mdx) configured by the project admin.
+- **Project admins and platform admins** can always create tenant clusters without a template, regardless of project settings.
 
-If project admins disable the `requireTemplate` setting, project users can also create virtual clusters without templates. Keep this setting enabled in production environments to maintain security controls.
+If project admins disable the `requireTemplate` setting, project users can also create tenant clusters without templates. Keep this setting enabled in production environments to maintain security controls.
 
 ## Create without template
 
 :::warning Security consideration
 
-Creating virtual clusters without a template bypasses the security controls that templates provide. Users with this capability can configure any vCluster settings, including sync configurations that could grant elevated access to host cluster resources.
+Creating tenant clusters without a template bypasses the security controls that templates provide. Users with this capability can configure any vCluster settings, including sync configurations that could grant elevated access to control plane cluster resources.
 
 For production environments:
 - Keep templates required for all projects (the default `requireTemplate` setting)
-- Grant project admin roles only to users who need to create virtual clusters without templates
+- Grant project admin roles only to users who need to create tenant clusters without templates
 - Control who can create projects, since project creators become project admins. See [project membership](../../../administer/users-permissions/permissions/project.mdx) for details on project roles
-- Use [hardened templates](../../../administer/templates/create-templates.mdx#security-hardening) to control which resources can be synced to and from the host cluster
+- Use [hardened templates](../../../administer/templates/create-templates.mdx#security-hardening) to control which resources can be synced to and from the control plane cluster
 
 :::
 

--- a/platform/use-platform/virtual-clusters/create/create-with-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-with-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create a virtual cluster from a template
+title: Create a tenant cluster from a template
 sidebar_label: Create Using Template
 sidebar_position: 1
 ---
@@ -10,20 +10,20 @@ import PartialVirtualClusterCreateUI from "../../../_partials/vcluster/create-ui
 import PartialVirtualClusterCreateCLI from "../../../_partials/vcluster/create-cli.mdx";
 import PartialVirtualClusterAirGapped from "../../../_partials/vcluster/air-gapped-helm-charts.mdx";
 
-Each virtual cluster that is created in the platform belongs to a [project](../../../understand/what-are-projects.mdx). There are two primary ways which
-virtual clusters can be created: from a template or manually.
+Each tenant cluster that is created in the platform belongs to a [project](../../../understand/what-are-projects.mdx). There are two primary ways which
+tenant clusters can be created: from a template or manually.
 
-Virtual clusters created from a [template](../../../understand/what-are-templates.mdx) inherit all template
-settings. Standard project users (non project admins) are only allowed to create virtual clusters
-from templates that the project admin has allowed. This ensures that virtual clusters in
+Tenant clusters created from a [template](../../../understand/what-are-templates.mdx) inherit all template
+settings. Standard project users (non project admins) are only allowed to create tenant clusters
+from templates that the project admin has allowed. This ensures that tenant clusters in
 each project adhere to the standards set by the project admin.
 
-Project admins and platform admins can create virtual clusters manually, that is without a template.
+Project admins and platform admins can create tenant clusters manually, that is without a template.
 
 
-Once you have created a virtual cluster template you can then refer to that template when
-creating a new virtual cluster. All template configurations will be automatically applied to the
-newly created virtual cluster. Virtual clusters referring to templates can be created in the UI
+Once you have created a tenant cluster template you can then refer to that template when
+creating a new tenant cluster. All template configurations will be automatically applied to the
+newly created tenant cluster. Tenant clusters referring to templates can be created in the UI
 or via the vCluster CLI.
 
 <Tabs
@@ -43,21 +43,21 @@ or via the vCluster CLI.
 
 ## Template Version Strings
 
-Regardless of how you create a virtual cluster from a template, either by the UI or the CLI, you will be prompted to provide a template version string. If you do not provide this string, the latest
+Regardless of how you create a tenant cluster from a template, either by the UI or the CLI, you will be prompted to provide a template version string. If you do not provide this string, the latest
 version will be automatically selected for you. If you _do_ provide the string though, you can
 do something very neat -- you can set any of the MAJOR, MINOR, PATCH version components to an
-`X` wildcard character. This allows the virtual cluster to be automatically updated to a more recent
+`X` wildcard character. This allows the tenant cluster to be automatically updated to a more recent
 template version that matches your provided template string.
 
-For example, given a template with a version of 1.0.0, and a virtual cluster created from this
+For example, given a template with a version of 1.0.0, and a tenant cluster created from this
 template with a version string "1.X.X". Adding a new template version "1.1.0", will cause this
-virtual cluster to be automatically updated. Whereas adding a new version "2.0.0", will _not_
-cause the virtual cluster to be upgraded.
+tenant cluster to be automatically updated. Whereas adding a new version "2.0.0", will _not_
+cause the tenant cluster to be upgraded.
 
-This is a very handy way to keep virtual clusters up to date with the latest templates without
+This is a very handy way to keep tenant clusters up to date with the latest templates without
 having to manually upgrade them.
 
-Note that you can even set the version to "X.X.X" to _always_ have your virtual cluster updated
+Note that you can even set the version to "X.X.X" to _always_ have your tenant cluster updated
 to the latest template version.
 
 <PartialVirtualClusterAirGapped />

--- a/platform/use-platform/virtual-clusters/key-features/custom-links.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/custom-links.mdx
@@ -10,7 +10,7 @@ import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
-vCluster Platform lets you associate custom links to virtual cluster instances, for example to point to a github pull request or jira issue.
+vCluster Platform lets you associate custom links to tenant cluster instances, for example to point to a github pull request or jira issue.
 
 <Tabs
     defaultValue="ui"
@@ -19,12 +19,12 @@ vCluster Platform lets you associate custom links to virtual cluster instances, 
         {label: 'CLI', value: 'cli'},
     ]}>
     <TabItem value="ui">
-    1. Go to the <NavStep>Virtual Clusters</NavStep> view using the menu on the left
-    1. Edit an existing Virtual Cluster or create a new one
+    1. Go to the <NavStep>Tenant Clusters</NavStep> view using the menu on the left
+    1. Edit an existing Tenant Cluster or create a new one
     1. Click <Label>Add Link</Label> to add a new link or <Label>Change</Label> to edit existing ones.
     1. Enter a URL and optionally a label for your link.
     1. Save your links by clicking <Label>Save</Label>.
-    1. Click on the <Button>Create Virtual Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing virtual cluster, to apply all changes.
+    1. Click on the <Button>Create Tenant Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing tenant cluster, to apply all changes.
     </TabItem>
 <TabItem value="cli">
 

--- a/platform/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
@@ -12,11 +12,11 @@ import NavStep from "@site/src/components/NavStep";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-Accidental deletion of virtual clusters is something that can not be reverted. In order to prevent deletion of virtual clusters, a setting can be enabled on the virtual cluster instance.
+Accidental deletion of tenant clusters is something that can not be reverted. In order to prevent deletion of tenant clusters, a setting can be enabled on the tenant cluster instance.
 
 :::note
-If you want to delete this virtual cluster in the future, you need to remove the label either in the YAML manifest or through the toggle in the UI.
-Once you have done this, you can delete the virtual cluster as usual.
+If you want to delete this tenant cluster in the future, you need to remove the label either in the YAML manifest or through the toggle in the UI.
+Once you have done this, you can delete the tenant cluster as usual.
 :::
 
 <Tabs
@@ -27,7 +27,7 @@ Once you have done this, you can delete the virtual cluster as usual.
   ]}
 >
 <TabItem value="yaml">
-  You can prevent virtual cluster deletion, by setting the annotation `loft.sh/non-deletable: "true"` in the YAML manifest of the virtual cluster instance.
+  You can prevent tenant cluster deletion, by setting the annotation `loft.sh/non-deletable: "true"` in the YAML manifest of the tenant cluster instance.
 
 ```yaml {6}
 apiVersion: management.loft.sh/v1
@@ -50,13 +50,13 @@ spec:
 <Flow id="vcluster-prevent-deletion-ui">
   <Step>
     From the project drop-down menu (top left corner), select the project you'd like to create the
-    virtual cluster in.
+    tenant cluster in.
   </Step>
   <Step>
-    Click on <NavStep>Virtual Clusters</NavStep>.
+    Click on <NavStep>Tenant Clusters</NavStep>.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
+    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
   </Step>
   <Step>
     Navigate to <Label>Advanced</Label> section on the left.

--- a/platform/use-platform/virtual-clusters/key-features/sleep-mode.mdx
+++ b/platform/use-platform/virtual-clusters/key-features/sleep-mode.mdx
@@ -13,39 +13,39 @@ import FeatureTable from '@site/src/components/FeatureTable';
 Platform auto sleep has been integrated into the standard sleep configuration and is no longer a separate feature.
 :::
 
-# Auto sleep and auto delete for virtual clusters
+# Auto sleep and auto delete for tenant clusters
 
 The platform provides two features to reduce Kubernetes costs:
 
-- **Auto Sleep** puts virtual clusters to sleep when nobody is using them. This removes all pods while keeping all resources inside the virtual clusters during periods of inactivity.
-- **Auto-delete** deletes virtual clusters that have been idle for a while.
+- **Auto Sleep** puts tenant clusters to sleep when nobody is using them. This removes all pods while keeping all resources inside the tenant clusters during periods of inactivity.
+- **Auto-delete** deletes tenant clusters that have been idle for a while.
 
 Both features rely on the platform's inactivity detection.
 
 ## Configure auto sleep
 
-Auto sleep can be configured per virtual cluster instance. When enabled, the platform monitors activity and puts the virtual cluster to sleep after a configured period of inactivity.
+Auto sleep can be configured per tenant cluster instance. When enabled, the platform monitors activity and puts the tenant cluster to sleep after a configured period of inactivity.
 
 To configure auto sleep in the Platform UI:
 
-1. Navigate to the **Virtual Clusters** view.
-2. Select the virtual cluster you want to configure.
+1. Navigate to the **Tenant Clusters** view.
+2. Select the tenant cluster you want to configure.
 3. Click **Edit** and navigate to the **Sleep Mode** section.
 4. Enable auto sleep and configure the inactivity timeout.
 5. Click **Save**.
 
-You can also start sleep manually from the virtual cluster's ellipsis menu in the Platform UI.
+You can also start sleep manually from the tenant cluster's ellipsis menu in the Platform UI.
 
 For detailed vCluster-specific sleep mode configuration and examples, including `vcluster.yaml` settings, scheduled sleep, and advanced configuration, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep).
 
 ## Configure auto-delete
 
-The platform lets you configure auto-delete for virtual clusters that have not been used for a certain period of time.
+The platform lets you configure auto-delete for tenant clusters that have not been used for a certain period of time.
 
 To configure auto-delete in the Platform UI:
 
-1. Navigate to the **Virtual Clusters** view.
-2. Select the virtual cluster you want to configure.
+1. Navigate to the **Tenant Clusters** view.
+2. Select the tenant cluster you want to configure.
 3. Click **Edit** and navigate to the **Auto-Delete** section.
 4. Enable auto-delete and configure the inactivity timeout.
 5. Click **Save**.
@@ -54,8 +54,8 @@ For detailed configuration options, see the [vCluster auto-delete documentation]
 
 ## Inactivity detection
 
-All requests that are made through the platform count as activity in the virtual cluster. This includes `kubectl` requests, API requests, and access through the platform UI.
+All requests that are made through the platform count as activity in the tenant cluster. This includes `kubectl` requests, API requests, and access through the platform UI.
 
-The platform tracks activity based on requests that are proxied through the platform. Direct access to the virtual cluster API server (for example, via ingress access) is not tracked by the platform's inactivity detection.
+The platform tracks activity based on requests that are proxied through the platform. Direct access to the tenant cluster API server (for example, via ingress access) is not tracked by the platform's inactivity detection.
 
 If you need more advanced activity detection, see the [vCluster sleep mode documentation](/docs/vcluster/configure/vcluster-yaml/sleep) for configuration options including custom activity annotations.

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -1,5 +1,5 @@
 ---
-title: Share access to the virtual cluster
+title: Share access to the tenant cluster
 sidebar_label: Share Access
 sidebar_position: 4
 ---
@@ -13,9 +13,9 @@ import Button from "@site/src/components/Button";
 import PartialVirtualClusterShareUI from '../../_partials/vcluster/share-ui.mdx'
 import PartialVirtualClusterShareCLI from '../../_partials/vcluster/share-cli.mdx'
 
-# Grant access to a virtual cluster
+# Grant access to a tenant cluster
 
-Grant users or teams access to a virtual cluster using either the Loft UI or CLI. 
+Grant users or teams access to a tenant cluster using either the Loft UI or CLI. 
 
 <br />
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Replaces "virtual cluster(s)" → "tenant cluster(s)" and "host cluster" → "control plane cluster" across all 19 files in `platform/use-platform/`. Code blocks, inline code, Kubernetes API type names (`VirtualClusterInstance`, `virtualclusterinstances`, etc.), and import lines are unchanged.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2129--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/virtual-clusters/add-virtual-clusters
(The PR covers all pages in the "For Users" section.)

## Internal Reference
DOC-1410


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs