### PR TITLE
docs(doc-1410): terminology — platform/configure/ + install/ batch 3

### DIFF
--- a/platform/configure/advanced/cors-policy.mdx
+++ b/platform/configure/advanced/cors-policy.mdx
@@ -17,7 +17,7 @@ Configure Cross-Origin Resource Sharing (CORS) headers at the ingress level so e
 ## Prerequisites
 
 - A deployed vCluster Platform instance with [external access configured](../installation-options/domain.mdx).
-- An ingress controller deployed on the Control Plane Cluster.
+- An ingress controller deployed on the control plane cluster.
 - `helm` v3.10+ and `kubectl` with admin access to the cluster.
 
 ## Overview

--- a/platform/configure/agent-settings/customization.mdx
+++ b/platform/configure/agent-settings/customization.mdx
@@ -1,6 +1,6 @@
 ---
-title: Per-host cluster customization
-sidebar_label: Per-Host Cluster Customization
+title: Per-control plane cluster customization
+sidebar_label: Per-Control Plane Cluster Customization
 sidebar_position: 2
 ---
 
@@ -12,11 +12,11 @@ import Input from "@site/src/components/Input";
 import Expander from "@site/src/components/Expander";
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
-As described in [installation modes][install-modes], the vCluster Platform Agent can be installed using the same `vcluster-platform` chart by setting `agentOnly: true`. The configuration of the agent by default will be decided by the configuration of the platform in the primary host cluster and the `agentValues` content.
+As described in [installation modes][install-modes], the vCluster Platform Agent can be installed using the same `vcluster-platform` chart by setting `agentOnly: true`. The configuration of the agent by default will be decided by the configuration of the platform in the primary control plane cluster and the `agentValues` content.
 
 [install-modes]: ../installation-options/overview#installation-modes
 
-However, this means that all host clusters connecting to the platform will share the same configuration. If different connected host clusters require different agent configurations, there are two supported approaches.
+However, this means that all control plane clusters connecting to the platform will share the same configuration. If different connected control plane clusters require different agent configurations, there are two supported approaches.
 
 ## `loft.sh/agent-values` annotation {#loftsh-annotations}
 Add the `loft.sh/agent-values` annotation to a specific Cluster resource (via the UI or YAML). This annotation overrides the platform-level `agentValues`. The override applies only to the annotated Cluster. For example:
@@ -28,7 +28,7 @@ Add the `loft.sh/agent-values` annotation to a specific Cluster resource (via th
         memory: 2Gi
   ```
 ## Override values
-When installing the agent directly on a host cluster, you can override values by passing a custom values file to Helm. But first, you should tell vCluster Platform to ignore the agent of the specific cluster by adding annotation:
+When installing the agent directly on a control plane cluster, you can override values by passing a custom values file to Helm. But first, you should tell vCluster Platform to ignore the agent of the specific cluster by adding annotation:
 ```
 kubectl annotate cluster cluster-B loft.sh/cluster-ignore-agent="true"
 ```
@@ -40,7 +40,7 @@ helm install vcluster-platform vcluster-platform \
 --values custom-values.yaml
 ```
 <!-- vale on -->
-This approach allows full control over agent configuration at installation time for that specific host cluster.
+This approach allows full control over agent configuration at installation time for that specific control plane cluster.
 
 You can also update the agent settings in vCluster Platform UI.
 <Flow id="cluster-extravalues-vcluster-platform-agent">

--- a/platform/configure/agent-settings/least-privilege-mode.mdx
+++ b/platform/configure/agent-settings/least-privilege-mode.mdx
@@ -3,7 +3,7 @@ title: Least Privilege Mode
 sidebar_label: Least Privilege Mode
 sidebar_position: 5
 sidebar_class_name: pro
-description: Reduce the permissions granted to vCluster Platform Agents on connected host clusters by disabling features that aren't required.
+description: Reduce the permissions granted to vCluster Platform Agents on connected control plane clusters by disabling features that aren't required.
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';
@@ -15,7 +15,7 @@ By default, to minimize operational overhead, the **vCluster Platform Agent** re
 If your organization follows strict RBAC policies, **Least Privilege Mode** can be used to limit the **vCluster Platform Agent** permissions only to your deployment needs.
 
 :::important Scope
-**Least Privilege Mode** applies only to agents deployed on **external host clusters**. It does **not** apply to the agent running in the cluster where the platform is installed.
+**Least Privilege Mode** applies only to agents deployed on **external control plane clusters**. It does **not** apply to the agent running in the cluster where the platform is installed.
 :::
 
 :::important Agent Upgrades
@@ -33,11 +33,11 @@ See [**Self-managed agents / Disable agent upgrades**](agent-upgrade.mdx#disable
 The following configuration options are available:
  - **Feature toggles** - Enable/disable toggles for the features that should be supported by the agent (ClusterAccess, ProjectQuotas, Secrets, SleepMode).
  - **Cluster scope permissions** – Controls the cluster scope permissions granted to the vCluster Platform Agent. Permissions can be extended to accommodate permissions for custom resources.
- - **Managed namespaces scope permissions** – Controls the permissions granted to the vCluster Platform Agent into the namespaces where virtual cluster instances are installed.
+ - **Managed namespaces scope permissions** – Controls the permissions granted to the vCluster Platform Agent into the namespaces where tenant cluster instances are installed.
 
 When a feature toggle is disabled, the corresponding permissions will not be requested and the internal Kubernetes controllers will not be started.
 
-Requests for the disabled features will not be fulfilled. For example, if the ProjectQuotas feature is disabled, the project quotas will not be enforced for the virtual cluster instances deployed on the connected cluster.
+Requests for the disabled features will not be fulfilled. For example, if the ProjectQuotas feature is disabled, the project quotas will not be enforced for the tenant cluster instances deployed on the connected cluster.
 
 See the [Configuration reference](#configuration-reference) section for feature specific disabled state handling.
 
@@ -96,7 +96,7 @@ agentValues:
         ##### `enabled` <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span>
         Controls whether the agent supports the vCluster Platform **Project Quotas** feature.
       </summary>
-      If set to `false`, project quotas will not be enforced for the virtual cluster instances deployed on the connected cluster.
+      If set to `false`, project quotas will not be enforced for the tenant cluster instances deployed on the connected cluster.
     </details>
   </details>
   <details className="config-field" data-expandable="true">
@@ -122,7 +122,7 @@ agentValues:
         ##### `enabled` <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span>
         Controls whether the agent supports the vCluster Platform **SleepMode** feature.
       </summary>
-      If set to `false`, sleep/auto-sleep/wake actions will be ignored for the virtual cluster instances deployed on the connected cluster.
+      If set to `false`, sleep/auto-sleep/wake actions will be ignored for the tenant cluster instances deployed on the connected cluster.
     </details>
   </details>
   <details className="config-field" data-expandable="true">
@@ -168,8 +168,8 @@ agentValues:
       Managed namespace admin configuration
     </summary>
 
-    The vCluster Platform Agent namespace-admin Role provides permissions to allow the agent to manage virtual cluster instances within a managed namespace, without cluster-admin level permissions.
-    As part of the virtual cluster instances reconciliation loop, the namespace-admin role is created in the managed namespace and assigned to the vCluster Platform Agent service account.
+    The vCluster Platform Agent namespace-admin Role provides permissions to allow the agent to manage tenant cluster instances within a managed namespace, without cluster-admin level permissions.
+    As part of the tenant cluster instances reconciliation loop, the namespace-admin role is created in the managed namespace and assigned to the vCluster Platform Agent service account.
 
     <details className="config-field" data-expandable="true" open>
       <summary>
@@ -182,7 +182,7 @@ agentValues:
     <details className="config-field" data-expandable="true">
       <summary>
         ##### `extraRules` <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span>
-        Allows granting additional permissions to the vCluster Platform Agent within the managed namespaces where virtual cluster instances are installed.
+        Allows granting additional permissions to the vCluster Platform Agent within the managed namespaces where tenant cluster instances are installed.
       </summary>
 
       ```yaml title="platform.yaml"
@@ -231,7 +231,7 @@ A typical rollout looks like this:
 1. Confirm that the vCluster Platform managed [agent upgrades](agent-upgrade.mdx#disable-agent-upgrades) is disabled for the connected clusters.
 2. Enable **Least Privilege Mode** and **disable** all optional features.
 3. Verify deployment:
-   - Confirm that virtual cluster instances can be deployed as expected.
+   - Confirm that tenant cluster instances can be deployed as expected.
    - Validate deployment compliance with your organization's policies.
 4. Enable required features one by one and repeat the verification steps.
 5. Test agent behavior in a non-production environment.
@@ -248,6 +248,6 @@ A typical rollout looks like this:
 If the agent stops working after enabling **Least Privilege Mode**:
 
 - Review agent logs for RBAC permission errors. `agentValues.env.KUBERNETES_VERBOSITY_LEVEL: "4"` option can be used to gain visibility into the vCluster Platform Agent Kubernetes API requests.
-- Confirm that you are applying this only to the agents running on external host clusters
+- Confirm that you are applying this only to the agents running on external control plane clusters
 
 If you need more help troubleshooting agent behavior, see [Troubleshooting](troubleshooting.mdx).

--- a/platform/configure/agent-settings/overview.mdx
+++ b/platform/configure/agent-settings/overview.mdx
@@ -25,19 +25,19 @@ import ConnectPlatform from '../../_fragments/cli-steps/connect-platform.mdx';
 
 
 # Overview
-When a **vCluster Platform** is deployed on a host cluster (or, primary host cluster), it can act as a centralized control plane. Other host clusters can connect to the vCluster Platform running on the primary host cluster and be managed by it. In this architecture:
-- The primary host cluster runs the vCluster Platform.
-- Other host clusters connect to the primary host cluster and run the vCluster Platform Agent.
-- The Platform coordinates and manages all connected host clusters through their agents.
-- There are both vCluster Platform and vCluster Platform agent running on the primary host cluster. The vCluster Platform manages the primary host cluster through its vCluster Platform Agent as well.
+When a **vCluster Platform** is deployed on a control plane cluster (or, primary control plane cluster), it can act as a centralized control plane. Other control plane clusters can connect to the vCluster Platform running on the primary control plane cluster and be managed by it. In this architecture:
+- The primary control plane cluster runs the vCluster Platform.
+- Other control plane clusters connect to the primary control plane cluster and run the vCluster Platform Agent.
+- The Platform coordinates and manages all connected control plane clusters through their agents.
+- There are both vCluster Platform and vCluster Platform agent running on the primary control plane cluster. The vCluster Platform manages the primary control plane cluster through its vCluster Platform Agent as well.
 
-Agent settings are the content in the [`values.yaml`](../introduction.mdx) under the `agentValues`. It controls the behavior of vCluster Platform Agents installed in the host clusters 
+Agent settings are the content in the [`values.yaml`](../introduction.mdx) under the `agentValues`. It controls the behavior of vCluster Platform Agents installed in the control plane clusters 
 that are managed by the vCluster Platform.
 
 The `agentValues` behavior is as follows:
 - By default, `agentValues` is an empty object `{}`.
-- An empty `agentValues` object means that agents installed on connected host clusters will inherit the same configuration as the platform running on the primary host cluster.
-- You can populate `agentValues` to override the default agent configuration globally for all connected host clusters.
+- An empty `agentValues` object means that agents installed on connected control plane clusters will inherit the same configuration as the platform running on the primary control plane cluster.
+- You can populate `agentValues` to override the default agent configuration globally for all connected control plane clusters.
 
 ## Connect to platform {#connect-to-platform}
 A new cluster can be connected to the platform through the UI or CLI:

--- a/platform/configure/agent-settings/security-context.mdx
+++ b/platform/configure/agent-settings/security-context.mdx
@@ -78,7 +78,7 @@ agentValues:
 ```
 
 #### Cluster-specific security context
-As mentioned [here](customization.mdx), you can customize the agent in each connected host cluster independently.
+As mentioned [here](customization.mdx), you can customize the agent in each connected control plane cluster independently.
 
 To achieve cluster-specific security context, you can override security contexts for specific clusters using the [`loft.sh/agent-values` annotation](overview#loftsh-annotations):
 

--- a/platform/configure/installation-options/overview.mdx
+++ b/platform/configure/installation-options/overview.mdx
@@ -9,7 +9,7 @@ Installation options are the content in the [`values.yaml`](../introduction.mdx)
 It contains fields like `resources`, `replicas`, `ingress` and also custom fields like `admin`, `product`, `agentOnly`.
 
 You set values of installation options to customize the deployment of vCluster Platform. These installation options are not available in the vCluster Platform UI after the vCluster Platform 
-is installed in the host cluster but can only be [applied using `helm`](../introduction#applying-configuration) before the deployment.
+is installed in the control plane cluster but can only be [applied using `helm`](../introduction#applying-configuration) before the deployment.
 
 ## Installation modes
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -19,8 +19,8 @@ Audit logging in the platform provides a security-relevant, chronological set of
 
 The platform can log activities related to:
 
-- Management instance changes, such as creation of new virtual clusters, spaces, etc.
-- Changes within a virtual cluster or space
+- Management instance changes, such as creation of new tenant clusters, spaces, etc.
+- Changes within a tenant cluster or space
 - Changes within a connected cluster
 
 Auditing in the platform is similar to [auditing Kubernetes clusters](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) in general.
@@ -62,7 +62,7 @@ The audit logging feature increases the memory consumption of the platform becau
 The platform provides audit levels, which are preconfigured audit policies for the most common use cases. These levels range from 1 to 4 where 1 logs the fewest requests, while 4 logs the most:
 
 - **Level 1**: Logs modifying requests such as creation / modification or deletion of any objects
-- **Level 2**: Like Level 1 but also logs the metadata of reading requests, such as listing pods inside a virtual cluster or space. It won't log the response or request payload and instead only the metadata such as request origin, target, etc.
+- **Level 2**: Like Level 1 but also logs the metadata of reading requests, such as listing pods inside a tenant cluster or space. It won't log the response or request payload and instead only the metadata such as request origin, target, etc.
 - **Level 3**: Like Level 2 but instead of only logging the request metadata also logs the complete request payload sent to the platform
 - **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester
 

--- a/platform/configure/platform-configs/cost-control.mdx
+++ b/platform/configure/platform-configs/cost-control.mdx
@@ -7,12 +7,12 @@ description: Learn how to configure the Cost Control Dashboard and its supportin
 
 import VersionBadge from '@site/src/components/VersionBadge';
 
-The platform comes with the cost control dashboard enabled by default, offering insights into potential [cost savings](https://www.vcluster.com/cost-savings) through virtual clusters.
+The platform comes with the cost control dashboard enabled by default, offering insights into potential [cost savings](https://www.vcluster.com/cost-savings) through tenant clusters.
 
 <VersionBadge platformVersion="v4.2.0" vclusterVersion="v0.22.0"/>
 
 To track allocations and calculate savings for workloads running inside
-virtual clusters the platform deploys and manages [Prometheus](https://prometheus.io/) and
+tenant clusters the platform deploys and manages [Prometheus](https://prometheus.io/) and
 [OpenCost](https://www.opencost.io/) on each connected cluster. Prometheus uses a time series database that requires
 persistent volume storage to retain metrics over time. The platform-managed
 Prometheus is configured to collect the minimum metrics required for the cost

--- a/platform/install/air-gapped/with-offline-license-key.mdx
+++ b/platform/install/air-gapped/with-offline-license-key.mdx
@@ -17,7 +17,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="air-gapped-mode" />
 
 
-This guide walks you through installing vCluster Platform and deploying virtual clusters in environments without internet access, referred to as air-gapped environments. It covers setting up a private OCI-compliant registry, populating it with container images and Helm charts, configuring vCluster Platform and agents to pull from the registry, and deploying virtual clusters securely and offline.
+This guide walks you through installing vCluster Platform and deploying tenant clusters in environments without internet access, referred to as air-gapped environments. It covers setting up a private OCI-compliant registry, populating it with container images and Helm charts, configuring vCluster Platform and agents to pull from the registry, and deploying tenant clusters securely and offline.
 
 If you want to run a dedicated offline license service in-cluster, see [With Offline License Server](./with-offline-license-server.mdx).
 
@@ -27,10 +27,10 @@ There are several artifacts that are typically accessed using an internet connec
 
 <!-- vale off -->
 - **vCluster Platform Helm chart** - This Helm chart is typically accessed through the vCluster Labs charts repository and is used for installing vCluster Platform and connecting hosts (for example installing agents).
-- **vCluster Helm chart** - This Helm chart is typically accessed through the vCluster Labs charts repository and is used for deploying virtual clusters.
+- **vCluster Helm chart** - This Helm chart is typically accessed through the vCluster Labs charts repository and is used for deploying tenant clusters.
 - **Images used in the Helm charts**  - These images are typically accessed through different container registries.
 
-After populating the registry with the artifacts, install vCluster Platform, connect host clusters and then deploy virtual clusters. Each step requires additional configuration to use your private registry.
+After populating the registry with the artifacts, install vCluster Platform, connect control plane clusters and then deploy tenant clusters. Each step requires additional configuration to use your private registry.
 
 ## Prerequisites
 
@@ -41,7 +41,7 @@ Ensure you have the following:
 <details>
 <summary>Registry prerequisites</summary>
 
-- **OCI-compliant private registry with a `/charts` folder** - A private registry accessible to both the Kubernetes cluster for the platform and connected host clusters and a separate, internet-connected machine.
+- **OCI-compliant private registry with a `/charts` folder** - A private registry accessible to both the Kubernetes cluster for the platform and connected control plane clusters and a separate, internet-connected machine.
 
 - **Ability to push to your OCI-compliant private registry** - Write access for uploading images and charts.
 
@@ -87,7 +87,7 @@ Contact sales@loft.sh to purchase a license key or request a trial license key f
 <details>
 <summary>Network and resource prerequisites </summary>
 
-- **Host cluster access to platform domain** - Connected host clusters must reach the domain where vCluster Platform is hosted.
+- **Control plane cluster access to platform domain** - Connected control plane clusters must reach the domain where vCluster Platform is hosted.
 
 - **vCluster Platform Pod Resource Requirements**
 
@@ -427,7 +427,7 @@ envValueFrom:
 - Set the **imageRef** to be used by the vCluster Platform Helm chart to the image in the private registry.
 - Set the **default registry** for pulling images used in installing vCluster Platform or connecting hosts (i.e. deploying agents).
 - Set the **default chart registry** in the `vcluster-platform.yaml` as the
-default Helm repository when creating virtual clusters. This should prefix with `oci://` to ensure it's being
+default Helm repository when creating tenant clusters. This should prefix with `oci://` to ensure it's being
 deployed using OCI protocol as well as the `/charts` folder.
 
 ```yaml title="Setting the image for vCluster Platform and the default private registry"
@@ -455,7 +455,7 @@ agentValues:
 - Set the **imageRef** to be used by the vCluster Platform Helm chart to the image in the private registry.
 - Set the **default registry** for pulling images used in installing vCluster Platform or connecting hosts (i.e. deploying agents).
 - Set the **default chart registry** in the `vcluster-platform.yaml` as the
-default Helm repository when creating virtual clusters. This should prefix with `oci://` to ensure it's being
+default Helm repository when creating tenant clusters. This should prefix with `oci://` to ensure it's being
 deployed using OCI protocol as well as the `/charts` folder.
 - For registries that require authentication, create a Kubernetes secret in the namespace where you deploy the vCluster Platform or agent.
 - Reference the **secret** to use those credentials for the registries.
@@ -500,7 +500,7 @@ agentValues:
 ```
 
 :::warning
-This only configures the registry authentication for managing virtual clusters with Helm.
+This only configures the registry authentication for managing tenant clusters with Helm.
 - See [App Reference](../../api/resources/apps.mdx#app-reference) to configure the chart [repository URL](../../api/resources/apps.mdx#spec-config-chart-repoURL) with [username](../../api/resources/apps.mdx#spec-config-chart-usernameRef) and [password](../../api/resources/apps.mdx#spec-config-chart-passwordRef) authentication.
 - See `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) to configure [repository](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-repo) with [username](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-username) and [password](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-password) authentication.
 :::
@@ -564,20 +564,20 @@ config:
 ```
 
 :::warning
-The `loftHost` value must be resolvable by all connected host clusters.
+The `loftHost` value must be resolvable by all connected control plane clusters.
 :::
 
 </details>
 
 ### Install the platform {#install-platform}
 
-It is recommended to install vCluster Platform on its own host cluster.
+It is recommended to install vCluster Platform on its own control plane cluster.
 
 #### Install vCluster Platform {#install-vcluster-platform}
 
 <Flow id="install-vcluster-platform">
   <Step>
-  On the host cluster, create the namespace for the platform, where vCluster Platform and optionally login credentials are to be deployed in.
+  On the control plane cluster, create the namespace for the platform, where vCluster Platform and optionally login credentials are to be deployed in.
 
   ```bash title="Create vCluster Platform namespace"
   export PLATFORM_NAMESPACE=vcluster-platform
@@ -624,18 +624,18 @@ vCluster Platform exclusively supports the default `secret` backend for storing 
 
 </Flow>
 
-### Connect host clusters
+### Connect control plane clusters
 
-After installing the platform, connect host clusters by deploying an agent on each host. The host clusters must be able to access the domain where vCluster Platform is hosted.
+After installing the platform, connect control plane clusters by deploying an agent on each host. The control plane clusters must be able to access the domain where vCluster Platform is hosted.
 
 Deploying an agent is deploying the vCluster Platform Helm chart and `vcluster-platform.yaml`.  The only difference is when deploying the vCluster Platform Helm
 chart is adding additional variables to figure out how to connect to the platform.
 
-#### Deploy agents to connect host clusters
+#### Deploy agents to connect control plane clusters
 
 <Flow id="install-agent">
   <Step>
-  On the host cluster, create the namespace for the agent installation, where the agent and optionally login credentials are to be deployed in.
+  On the control plane cluster, create the namespace for the agent installation, where the agent and optionally login credentials are to be deployed in.
 
   ```bash title="Create vCluster Platform namespace"
   export AGENT_NAMESPACE=vcluster-platform
@@ -663,7 +663,7 @@ chart is adding additional variables to figure out how to connect to the platfor
   </Step>
 
   <Step>
-    Create the Cluster resource on the Platform cluster (not the new host cluster you're trying to connect)
+    Create the Cluster resource on the Platform cluster (not the new control plane cluster you're trying to connect)
 
     ```bash title="Create Cluster resource on the Platform cluster"
     export CLUSTER_NAME=<cluster-name>
@@ -730,28 +730,28 @@ vCluster Platform exclusively supports the default `secret` backend for storing 
   </Step>
 </Flow>
 
-## Deploy virtual clusters in air-gapped environments
+## Deploy tenant clusters in air-gapped environments
 
-With your vCluster Platform now installed and configured for air-gapped environments, you can deploy virtual clusters. The platform automatically uses your configured private registry settings.
+With your vCluster Platform now installed and configured for air-gapped environments, you can deploy tenant clusters. The platform automatically uses your configured private registry settings.
 
 :::tip Choose the Right Guide
 
-After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual virtual clusters](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped):
+After you complete the platform setup, stay on this page if you need to complete additional platform configuration or proceed to the vCluster guide for [deploying individual tenant clusters](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped):
 
 **Continue with this platform air-gapped guide if you need to:**
-- Create virtual clusters and connect more host cluster agents without internet access.
+- Create tenant clusters and connect more control plane cluster agents without internet access.
 - Configure additional platform-wide private registry settings.
 
 **Use the [vCluster air-gapped deployment guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/security/air-gapped) to:**
-- Create virtual clusters after the platform is set up.
+- Create tenant clusters after the platform is set up.
 - Review detailed vCluster configuration options for air-gapped environments.
 :::
 
-## Configure and deploy virtual clusters {#configure-deploy-virtual-clusters}
+## Configure and deploy tenant clusters {#configure-deploy-virtual-clusters}
 
-### Virtual cluster configuration {#virtual-cluster-configuration}
+### Tenant cluster configuration {#virtual-cluster-configuration}
 
-The `vcluster.yaml` file defines all configuration settings for your virtual cluster deployment.
+The `vcluster.yaml` file defines all configuration settings for your tenant cluster deployment.
 
 <details>
   <summary>Use a private registry without credentials</summary>
@@ -786,8 +786,8 @@ controlPlane:
 ```
 
 :::warning
-When using virtual clusters in air-gapped environments, the
-`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
+When using tenant clusters in air-gapped environments, the
+`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for tenant cluster deployments.
 :::
 
 </details>
@@ -860,7 +860,7 @@ In the options for the config, there is a section called `Host namespace`, add t
   </Step>
   <Step>
 
-  Create a Kubernetes secret using the **access key** in a namespace on the host cluster.
+  Create a Kubernetes secret using the **access key** in a namespace on the control plane cluster.
 
  ```bash title="Create platform API key namespace and secret for platform API key"
   export APIKEY_NAMESPACE=api-key-namespace

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -25,7 +25,7 @@ This guide details installing the platform using GitOps practices, specifically 
 
 ### ArgoCD
 
-ArgoCD needs to be installed and configured on the host cluster. Follow the [Argo CD Installation Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install it.
+ArgoCD needs to be installed and configured on the control plane cluster. Follow the [Argo CD Installation Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install it.
 
 ### Resource requirements
 
@@ -642,7 +642,7 @@ If resources continue showing as out-of-sync:
 
 ## Next steps
 
-### Create virtual clusters
+### Create tenant clusters
 
 <InstallNextSteps />
 

--- a/platform/install/helm.mdx
+++ b/platform/install/helm.mdx
@@ -144,8 +144,8 @@ ingress:
   host: vcluster-platform.mytld.com
 ```
 - `env`—Defines environment variables for the vCluster platform components. By default, this field is empty.
-A common use case is configuring network access between the vCluster platform and managed virtual clusters to allow API communication.
-If both the platform and the virtual clusters run on the same host cluster, you should also configure the `NO_PROXY` (or `no_proxy`) environment variable to bypass proxies for internal traffic if you are using proxies.
+A common use case is configuring network access between the vCluster platform and managed tenant clusters to allow API communication.
+If both the platform and the tenant clusters run on the same control plane cluster, you should also configure the `NO_PROXY` (or `no_proxy`) environment variable to bypass proxies for internal traffic if you are using proxies.
 Otherwise, the platform will be unable to reach the vCluster control plane Service, and features such as the Cost Control dashboard will fail to function properly.
 ```yaml title="values.yaml"
 env:
@@ -190,6 +190,6 @@ the credentials you set in `values.yaml` and complete the profile setup.
 
 ## Next steps
 
-### Create virtual clusters
+### Create tenant clusters
 
 <InstallNextSteps />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Replaces "virtual cluster(s)" → "tenant cluster(s)" and "host cluster(s)" → "control plane cluster(s)" across 11 files in `platform/configure/` and `platform/install/`. Five files in scope had hits only inside fenced code blocks (terminal output / YAML comments) and were left unchanged. Code blocks, inline code, Kubernetes API type names, and import lines are unchanged throughout.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2130--vcluster-docs-site.netlify.app/docs/platform/next/configure/introduction
Covers all pages in the "Configure" section.

https://deploy-preview-2130--vcluster-docs-site.netlify.app/docs/platform/next/install/quick-start-guide
Covers all pages in the "Install" section.

## Internal Reference
DOC-1410


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs