### PR TITLE
Fix a codeblock in vCluster Standalone docs

### DIFF
--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -186,25 +186,25 @@ Use <Link to="/docs/platform">vCluster Platform</Link> to:
 
 <InterpolatedCodeBlock
   code={`controlPlane:
-  standalone:
-    enabled: true
-    autoNodes:
-      provider: [[GLOBAL:NODE_PROVIDER]] # Node provider you want to use
-      quantity: 1 # Number of nodes (HA requires embedded etcd or external DB)
-  distro:
-    k8s:
-      image:
-        tag: [[GLOBAL:K8S_VERSION]] # Kubernetes version you want to use
+    standalone:
+      enabled: true
+      autoNodes:
+        provider: [[GLOBAL:NODE_PROVIDER]] # Node provider you want to use
+        quantity: 1 # Number of nodes (HA requires embedded etcd or external DB)
+    distro:
+      k8s:
+        image:
+          tag: [[GLOBAL:K8S_VERSION]] # Kubernetes version you want to use
 
-# Worker nodes
-privateNodes:
-  enabled: true
-  autoNodes: # (optional) Add worker nodes with Auto Nodes
-    - provider: [[GLOBAL:NODE_PROVIDER]]
-      dynamic:
-        - name: aws-pool-1`}
-  title="vcluster.yaml for a standalone control plane managed by vCluster Platform"
-  language="yaml"
+  # Worker nodes
+  privateNodes:
+    enabled: true
+    autoNodes: # (optional) Add worker nodes with Auto Nodes
+      - provider: [[GLOBAL:NODE_PROVIDER]]
+        dynamic:
+          - name: aws-pool-1`}
+    title="vcluster.yaml for a standalone control plane managed by vCluster Platform"
+    language="yaml"
 />
 
 After provisioning completes, <Link to="/docs/platform">vCluster Platform</Link> manages the control plane node lifecycle. Worker node lifecycle also remains managed through the platform UI when <Link to="/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/">Auto Nodes</Link> are used.


### PR DESCRIPTION
Page in question: Deploy > Control Plane > As a binary > Install

Previously something about the way it was formatted was breaking the alignment of the YAML and thus it created invalid vcluster.yaml

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->

## Preview Link 
<!-- The preview link or links to the documents-->



AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

