### PR TITLE
chore: improve ingress-nginx deprecation notices in platform domain docs

### DIFF
--- a/platform/configure/advanced/cors-policy.mdx
+++ b/platform/configure/advanced/cors-policy.mdx
@@ -17,7 +17,7 @@ Configure Cross-Origin Resource Sharing (CORS) headers at the ingress level so e
 ## Prerequisites
 
 - A deployed vCluster Platform instance with [external access configured](../installation-options/domain.mdx).
-- An ingress controller (such as ingress-nginx) deployed on the host cluster.
+- An ingress controller deployed on the Control Plane Cluster.
 - `helm` v3.10+ and `kubectl` with admin access to the cluster.
 
 ## Overview
@@ -35,6 +35,10 @@ The Platform doesn't set CORS headers by default. Add them through your ingress 
 ## Configure ingress-level CORS {#ingress-cors}
 
 ### ingress-nginx
+
+:::warning ingress-nginx is deprecated
+The [ingress-nginx project](https://kubernetes.github.io/ingress-nginx/) is deprecated upstream. For new deployments, use the [Gateway API CORS filter](#other-ingress-controllers) or another actively maintained ingress controller.
+:::
 
 <Flow>
 <Step>

--- a/platform/configure/installation-options/domain.mdx
+++ b/platform/configure/installation-options/domain.mdx
@@ -37,11 +37,6 @@ The platform, like any other service in Kubernetes, can be exposed in multiple w
 ### [Deprecated]: External access via NGINX ingress controller
 
   </summary>
-
-:::warning ingress-nginx is deprecated
-The [ingress-nginx project](https://kubernetes.github.io/ingress-nginx/) is deprecated upstream. For new deployments, use a LoadBalancer (see below) or a Gateway API-compatible controller. These instructions are preserved for environments that already use ingress-nginx.
-:::
-
   <Tabs
     defaultValue="automatic"
     values={[

--- a/platform/configure/installation-options/domain.mdx
+++ b/platform/configure/installation-options/domain.mdx
@@ -29,7 +29,7 @@ Setting up the platform for access via routable IP or domain name, and securing 
 
 ## External access
 
-The platform, like any other service in Kubernetes, can be exposed in multiple ways. This section outlines how to expose the platform via an ingress controller (using NGINX ingress controller as an example) and via a `LoadBalancer`.
+The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments.
 
 <details>
   <summary>
@@ -37,6 +37,11 @@ The platform, like any other service in Kubernetes, can be exposed in multiple w
 ### [Deprecated]: External access via NGINX ingress controller
 
   </summary>
+
+:::warning ingress-nginx is deprecated
+The [ingress-nginx project](https://kubernetes.github.io/ingress-nginx/) is deprecated upstream. For new deployments, use a LoadBalancer (see below) or a Gateway API-compatible controller. These instructions are preserved for environments that already use ingress-nginx.
+:::
+
   <Tabs
     defaultValue="automatic"
     values={[


### PR DESCRIPTION
# Content Description
Strengthens the ingress-nginx deprecation messaging in the platform domain configuration docs. The `[Deprecated]` label on the NGINX section already existed; this PR adds a visible warning admonition inside the collapsed section and updates the intro paragraph to explicitly recommend the LoadBalancer method for new deployments.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2140--vcluster-docs-site.netlify.app/docs/platform/next/configure/installation-options/domain?x0=1#external-access

## Internal Reference
Closes DOC-1388


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs