### PR TITLE
chore: deprecate ingress-nginx in vcluster expose docs

### DIFF
--- a/vcluster/configure/vcluster-yaml/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/deploy.mdx
@@ -14,16 +14,6 @@ import DeployConfig from '../../_partials/config/deploy.mdx';
 
 vCluster supports addons that extend the capabilities of your tenant cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
 
-### [Deprecated]: Ingress Nginx
-<TenancySupport privateNodes="true" hostNodes="true" />
-
-vCluster can install [ingress nginx](https://kubernetes.github.io/ingress-nginx/) into the vCluster. This can be enabled via:
-```yaml title="Enable Ingress Nginx"
-deploy:
-  ingressNginx:
-    enabled: true
-```
-
 ### Metrics Server
 <TenancySupport privateNodes="true" hostNodes="true" />
 

--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -208,15 +208,56 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
 :::
 
 <Tabs
-    defaultValue="ingress"
+    defaultValue="tlsroute"
     values={[
-        { label: 'Ingress', value: 'ingress', },
-        { label: 'Ingress without SSL-Passthrough', value: 'ingress-wo-ssl', },
+        { label: 'Gateway API (TLSRoute)', value: 'tlsroute', },
+        { label: 'Ingress (Deprecated)', value: 'ingress', },
+        { label: 'Ingress without SSL (Deprecated)', value: 'ingress-wo-ssl', },
         { label: 'Load Balancer Service', value: 'load-balancer-service', },
         { label: 'NodePort Service', value: 'node-port-service', },
         { label: 'From Host Cluster', value: 'from-host-cluster', },
     ]}>
+<TabItem value="tlsroute">
+
+The Gateway API [TLSRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute) is the recommended way to expose the tenant cluster's API server with TLS passthrough. It requires a Gateway API-compatible controller (such as Envoy Gateway, Istio, or Cilium) installed on the control plane cluster with a `Gateway` resource configured for TLS passthrough.
+
+Configure your `vcluster.yaml` to create a `TLSRoute` pointing at an existing `Gateway`:
+
+```yaml title="vcluster.yaml"
+controlPlane:
+  proxy:
+    extraSANs:
+    - my-vcluster.example.com
+  tlsRoute:
+    enabled: true
+    host: my-vcluster.example.com
+    parentRefs:
+    - name: my-gateway
+      namespace: my-gateway-namespace
+```
+
+Create the tenant cluster:
+```
+vcluster create my-vcluster -n my-vcluster --connect=false -f vcluster.yaml
+```
+
+Retrieve the kube config:
+```
+vcluster connect my-vcluster -n my-vcluster --print --server=https://my-vcluster.example.com > kubeconfig.yaml
+```
+
+Access the tenant cluster:
+```
+export KUBECONFIG=./kubeconfig.yaml
+kubectl get ns
+```
+
+</TabItem>
 <TabItem value="ingress">
+
+:::warning ingress-nginx is deprecated
+The [ingress-nginx project](https://kubernetes.github.io/ingress-nginx/) is deprecated upstream. Use the **Gateway API (TLSRoute)** tab for new deployments. If you are using a different ingress controller that supports SSL passthrough, refer to that controller's documentation for the equivalent annotation configuration.
+:::
 
   An [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) with SSL passthrough support provide the best user experience, but there is a workaround if this feature is not natively supported.
 
@@ -313,6 +354,10 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   ```
 </TabItem>
 <TabItem value="ingress-wo-ssl">
+
+:::warning ingress-nginx is deprecated
+The annotations in the example below are specific to ingress-nginx, which is deprecated upstream. If you are using a different ingress controller, refer to its documentation for the equivalent configuration.
+:::
 
   If you cannot configure your ingress controller to use ssl-passthrough, you can also create an ingress similar to this:
   ```


### PR DESCRIPTION
# Content Description
Remove the deprecated ingress-nginx addon section from `vcluster/configure/vcluster-yaml/deploy.mdx` and update the expose tabs in `vcluster/manage/accessing-vcluster.mdx` to lead with a new Gateway API (TLSRoute) tab as the recommended default, with deprecation admonitions on the existing ingress tabs.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2141--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/accessing-vcluster#expose-vcluster

See the new "Gateway API" tab under the "As Container" tab.


## Internal Reference
Closes DOC-1388


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs