### PR TITLE
docs(doc-913): document storageNamespace fix for snapshots with cross-namespace Flux HelmRelease

### DIFF
--- a/vcluster/third-party-integrations/git-operations/flux.mdx
+++ b/vcluster/third-party-integrations/git-operations/flux.mdx
@@ -680,3 +680,31 @@ kubectl get secret -n <vcluster-namespace> <kubeconfig-secret-name> -o jsonpath=
 ```yaml title="Recommended server URL format"
 server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
 ```
+
+#### Snapshots fail when HelmRelease is in a different namespace {#snapshot-namespace-mismatch}
+
+When you deploy a tenant cluster through a `HelmRelease` resource that lives in a different namespace than the tenant cluster itself (for example, `HelmRelease` in `flux-system` and the tenant cluster in `mytestcluster`), Flux stores the Helm release secret in the `HelmRelease` namespace. The snapshot controller searches for the Helm release secret in the tenant cluster's namespace and fails to find it, which causes snapshots to fail.
+
+To fix this, set `spec.storageNamespace` in the `HelmRelease` to the tenant cluster's namespace:
+
+```yaml title="Set storageNamespace to match the tenant cluster namespace"
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: my-vcluster
+  namespace: flux-system
+spec:
+  storageNamespace: mytestcluster  # Must match the tenant cluster namespace
+  targetNamespace: mytestcluster
+  interval: 10m
+  chart:
+    spec:
+      chart: vcluster
+      version: "0.26.x"
+      sourceRef:
+        kind: HelmRepository
+        name: vcluster
+        namespace: flux-system
+```
+
+With `storageNamespace` set, Flux stores the `helm.sh/release.v1` secret in `mytestcluster`, where the snapshot controller can find it.

--- a/vcluster/third-party-integrations/git-operations/flux.mdx
+++ b/vcluster/third-party-integrations/git-operations/flux.mdx
@@ -687,7 +687,7 @@ When you deploy a tenant cluster through a `HelmRelease` resource that lives in 
 
 To fix this, set `spec.storageNamespace` in the `HelmRelease` to the tenant cluster's namespace:
 
-```yaml title="Set storageNamespace to match the tenant cluster namespace"
+```yaml title="Set storageNamespace to match the tenant cluster namespace" {7}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
# Content Description

Documents the `storageNamespace` fix for vCluster snapshots failing when a Flux `HelmRelease` resource lives in a different namespace than the tenant cluster. Adds a troubleshooting entry to the Flux integration page explaining the root cause and the fix.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2150--vcluster-docs-site.netlify.app/docs/vcluster/next/third-party-integrations/git-operations/flux#snapshot-namespace-mismatch

## Internal Reference

Closes DOC-913
Closes loft-sh/vcluster#3061

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs