### PR TITLE
Update the formatting on the lifecycle dates for platform and vcluster

### DIFF
--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -18,39 +18,39 @@ Any previous versions which are not on the following list, are no longer in any 
   <tbody>
     <tr>
       <td>v4.9</td>
-      <td>April 29, 2026</td>
-      <td>October 29, 2026</td>
-      <td>January 29, 2027</td>
+      <td>2026-Apr-29</td>
+      <td>2026-Oct-29</td>
+      <td>2027-Jan-29</td>
     </tr>
     <tr>
       <td>v4.8</td>
-      <td>March 16, 2026</td>
-      <td>September 16, 2026</td>
-      <td>December 16, 2026</td>
+      <td>2026-Mar-16</td>
+      <td>2026-Sep-16</td>
+      <td>2026-Dec-16</td>
     </tr>
     <tr>
       <td>v4.7</td>
-      <td>February 18, 2026</td>
-      <td>August 18, 2026</td>
-      <td>November 18, 2026</td>
+      <td>2026-Feb-18</td>
+      <td>2026-Aug-18</td>
+      <td>2026-Nov-18</td>
     </tr>
     <tr>
       <td>v4.6</td>
-      <td>January 29, 2026</td>
-      <td>July 29, 2026</td>
-      <td>October 29, 2026</td>
+      <td>2026-Jan-29</td>
+      <td>2026-Jul-29</td>
+      <td>2026-Oct-29</td>
     </tr>
     <tr>
       <td>v4.5</td>
-      <td>October 29, 2025</td>
-      <td>April 29, 2026</td>
-      <td>July 29, 2026</td>
+      <td>2025-Oct-29</td>
+      <td>2026-Apr-29</td>
+      <td>2026-Jul-29</td>
     </tr>
     <tr>
       <td>v4.4</td>
-      <td>September 9, 2025</td>
-      <td>March 9, 2026</td>
-      <td>June 9, 2026</td>
+      <td>2025-Sep-09</td>
+      <td>2026-Mar-09</td>
+      <td>2026-Jun-09</td>
     </tr>
     <tr>
       <td colspan="4" align="center">
@@ -59,33 +59,33 @@ Any previous versions which are not on the following list, are no longer in any 
     </tr>
     <tr>
       <td>v4.3</td>
-      <td>June 3, 2025</td>
-      <td>December 3, 2025</td>
-      <td>March 6, 2026</td>
+      <td>2025-Jun-03</td>
+      <td>2025-Dec-03</td>
+      <td>2026-Mar-06</td>
     </tr>
     <tr>
       <td>v4.2</td>
-      <td>December 17, 2024</td>
-      <td>September 17, 2025</td>
-      <td>December 17, 2025</td>
+      <td>2024-Dec-17</td>
+      <td>2025-Sep-17</td>
+      <td>2025-Dec-17</td>
     </tr>
     <tr>
       <td>v4.1</td>
-      <td>November 12, 2024</td>
-      <td>February 12, 2025</td>
-      <td>May 12, 2025</td>
+      <td>2024-Nov-12</td>
+      <td>2025-Feb-12</td>
+      <td>2025-May-12</td>
     </tr>
     <tr>
       <td>v4.0</td>
-      <td>October 15, 2024</td>
-      <td>January 15, 2025</td>
-      <td>April 15, 2025</td>
+      <td>2024-Oct-15</td>
+      <td>2025-Jan-15</td>
+      <td>2025-Apr-15</td>
     </tr>
     <tr>
       <td>v3.4</td>
-      <td>February 29, 2024</td>
-      <td>April 1, 2025*</td>
-      <td>July 1, 2025</td>
+      <td>2024-Feb-29</td>
+      <td>2025-Apr-01*</td>
+      <td>2025-Jul-01</td>
     </tr>
   </tbody>
 </table>

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -6,7 +6,13 @@ Any previous versions which are not on the following list, are no longer in any 
 
 ## Platform supported versions
 
-<table>
+<table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
+  <colgroup>
+    <col style={{width: '15%'}} />
+    <col style={{width: '28%'}} />
+    <col style={{width: '28%'}} />
+    <col style={{width: '29%'}} />
+  </colgroup>
   <thead>
     <tr>
       <th>Release</th>
@@ -18,39 +24,39 @@ Any previous versions which are not on the following list, are no longer in any 
   <tbody>
     <tr>
       <td>v4.9</td>
-      <td>2026-Apr-29</td>
-      <td>2026-Oct-29</td>
-      <td>2027-Jan-29</td>
+      <td>2026 Apr 29</td>
+      <td>2026 Oct 29</td>
+      <td>2027 Jan 29</td>
     </tr>
     <tr>
       <td>v4.8</td>
-      <td>2026-Mar-16</td>
-      <td>2026-Sep-16</td>
-      <td>2026-Dec-16</td>
+      <td>2026 Mar 16</td>
+      <td>2026 Sep 16</td>
+      <td>2026 Dec 16</td>
     </tr>
     <tr>
       <td>v4.7</td>
-      <td>2026-Feb-18</td>
-      <td>2026-Aug-18</td>
-      <td>2026-Nov-18</td>
+      <td>2026 Feb 18</td>
+      <td>2026 Aug 18</td>
+      <td>2026 Nov 18</td>
     </tr>
     <tr>
       <td>v4.6</td>
-      <td>2026-Jan-29</td>
-      <td>2026-Jul-29</td>
-      <td>2026-Oct-29</td>
+      <td>2026 Jan 29</td>
+      <td>2026 Jul 29</td>
+      <td>2026 Oct 29</td>
     </tr>
     <tr>
       <td>v4.5</td>
-      <td>2025-Oct-29</td>
-      <td>2026-Apr-29</td>
-      <td>2026-Jul-29</td>
+      <td>2025 Oct 29</td>
+      <td>2026 Apr 29</td>
+      <td>2026 Jul 29</td>
     </tr>
     <tr>
       <td>v4.4</td>
-      <td>2025-Sep-09</td>
-      <td>2026-Mar-09</td>
-      <td>2026-Jun-09</td>
+      <td>2025 Sep 09</td>
+      <td>2026 Mar 09</td>
+      <td>2026 Jun 09</td>
     </tr>
     <tr>
       <td colspan="4" align="center">
@@ -59,33 +65,33 @@ Any previous versions which are not on the following list, are no longer in any 
     </tr>
     <tr>
       <td>v4.3</td>
-      <td>2025-Jun-03</td>
-      <td>2025-Dec-03</td>
-      <td>2026-Mar-06</td>
+      <td>2025 Jun 03</td>
+      <td>2025 Dec 03</td>
+      <td>2026 Mar 06</td>
     </tr>
     <tr>
       <td>v4.2</td>
-      <td>2024-Dec-17</td>
-      <td>2025-Sep-17</td>
-      <td>2025-Dec-17</td>
+      <td>2024 Dec 17</td>
+      <td>2025 Sep 17</td>
+      <td>2025 Dec 17</td>
     </tr>
     <tr>
       <td>v4.1</td>
-      <td>2024-Nov-12</td>
-      <td>2025-Feb-12</td>
-      <td>2025-May-12</td>
+      <td>2024 Nov 12</td>
+      <td>2025 Feb 12</td>
+      <td>2025 May 12</td>
     </tr>
     <tr>
       <td>v4.0</td>
-      <td>2024-Oct-15</td>
-      <td>2025-Jan-15</td>
-      <td>2025-Apr-15</td>
+      <td>2024 Oct 15</td>
+      <td>2025 Jan 15</td>
+      <td>2025 Apr 15</td>
     </tr>
     <tr>
       <td>v3.4</td>
-      <td>2024-Feb-29</td>
-      <td>2025-Apr-01*</td>
-      <td>2025-Jul-01</td>
+      <td>2024 Feb 29</td>
+      <td>2025 Apr 01<sup>*</sup></td>
+      <td>2025 Jul 01</td>
     </tr>
   </tbody>
 </table>

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -8,7 +8,13 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
 
 ## vCluster releases
 
-<table>
+<table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
+  <colgroup>
+    <col style={{width: '15%'}} />
+    <col style={{width: '28%'}} />
+    <col style={{width: '28%'}} />
+    <col style={{width: '29%'}} />
+  </colgroup>
   <thead>
     <tr>
       <th>Release</th>
@@ -20,102 +26,102 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
   <tbody>
     <tr>
       <td>v0.34</td>
-      <td>2026-Apr-29</td>
-      <td>2026-Jul-29</td>
-      <td>2026-Oct-29</td>
+      <td>2026 Apr 29</td>
+      <td>2026 Jul 29</td>
+      <td>2026 Oct 29</td>
     </tr>
     <tr>
       <td>v0.33</td>
-      <td>2026-Mar-13</td>
-      <td>2026-Jun-13</td>
-      <td>2026-Sep-13</td>
+      <td>2026 Mar 13</td>
+      <td>2026 Jun 13</td>
+      <td>2026 Sep 13</td>
     </tr>
     <tr>
       <td>v0.32</td>
-      <td>2026-Feb-18</td>
-      <td>2026-May-18</td>
-      <td>2026-Aug-18</td>
+      <td>2026 Feb 18</td>
+      <td>2026 May 18</td>
+      <td>2026 Aug 18</td>
     </tr>
     <tr>
       <td>v0.31</td>
-      <td>2026-Jan-29</td>
-      <td>2026-Apr-29</td>
-      <td>2026-Jul-29</td>
+      <td>2026 Jan 29</td>
+      <td>2026 Apr 29</td>
+      <td>2026 Jul 29</td>
     </tr>
     <tr>
       <td colspan="4" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.30</td>
-      <td>2025-Oct-28</td>
-      <td>2026-Jan-28</td>
-      <td>2026-Apr-28</td>
+      <td>2025 Oct 28</td>
+      <td>2026 Jan 28</td>
+      <td>2026 Apr 28</td>
     </tr>
     <tr>
       <td>v0.29</td>
-      <td>2025-Oct-01</td>
-      <td>2026-Jan-01</td>
-      <td>2026-Apr-01</td>
+      <td>2025 Oct 01</td>
+      <td>2026 Jan 01</td>
+      <td>2026 Apr 01</td>
     </tr>
     <tr>
       <td>v0.28</td>
-      <td>2025-Sep-08</td>
-      <td>2025-Dec-08</td>
-      <td>2026-Mar-08</td>
+      <td>2025 Sep 08</td>
+      <td>2025 Dec 08</td>
+      <td>2026 Mar 08</td>
     </tr>
     <tr>
       <td>v0.27</td>
-      <td>2025-Aug-12</td>
-      <td>2025-Nov-12</td>
-      <td>2026-Feb-12</td>
+      <td>2025 Aug 12</td>
+      <td>2025 Nov 12</td>
+      <td>2026 Feb 12</td>
     </tr>
     <tr>
       <td>v0.26</td>
-      <td>2025-Jun-26</td>
-      <td>2025-Sep-26</td>
-      <td>2025-Dec-26</td>
+      <td>2025 Jun 26</td>
+      <td>2025 Sep 26</td>
+      <td>2025 Dec 26</td>
     </tr>
     <tr>
       <td>v0.25</td>
-      <td>2025-May-15</td>
-      <td>2025-Aug-15</td>
-      <td>2025-Nov-15</td>
+      <td>2025 May 15</td>
+      <td>2025 Aug 15</td>
+      <td>2025 Nov 15</td>
     </tr>
     <tr>
       <td>v0.24</td>
-      <td>2025-Mar-18</td>
-      <td>2025-Jun-16</td>
-      <td>2025-Sep-14</td>
+      <td>2025 Mar 18</td>
+      <td>2025 Jun 16</td>
+      <td>2025 Sep 14</td>
     </tr>
     <tr>
       <td>v0.23</td>
-      <td>2025-Feb-26</td>
-      <td>2025-May-25</td>
-      <td>2025-Aug-26</td>
+      <td>2025 Feb 26</td>
+      <td>2025 May 25</td>
+      <td>2025 Aug 26</td>
     </tr>
     <tr>
       <td>v0.22</td>
-      <td>2024-Dec-18</td>
-      <td>2025-Mar-18</td>
-      <td>2025-Jun-18</td>
+      <td>2024 Dec 18</td>
+      <td>2025 Mar 18</td>
+      <td>2025 Jun 18</td>
     </tr>
     <tr>
       <td>v0.21</td>
-      <td>2024-Nov-11</td>
-      <td>2025-Feb-11</td>
-      <td>2025-May-11</td>
+      <td>2024 Nov 11</td>
+      <td>2025 Feb 11</td>
+      <td>2025 May 11</td>
     </tr>
     <tr>
       <td>v0.20</td>
-      <td>2024-Aug-14</td>
-      <td>2024-Nov-14</td>
-      <td>2025-Feb-14</td>
+      <td>2024 Aug 14</td>
+      <td>2024 Nov 14</td>
+      <td>2025 Feb 14</td>
     </tr>
     <tr>
       <td>v0.19</td>
-      <td>2024-Feb-12</td>
-      <td>2025-Apr-01*</td>
-      <td>2025-Jul-01</td>
+      <td>2024 Feb 12</td>
+      <td>2025 Apr 01<sup>*</sup></td>
+      <td>2025 Jul 01</td>
     </tr>
   </tbody>
 </table>

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -20,102 +20,102 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
   <tbody>
     <tr>
       <td>v0.34</td>
-      <td>April 29, 2026</td>
-      <td>July 29, 2026</td>
-      <td>October 29, 2026</td>
+      <td>2026-Apr-29</td>
+      <td>2026-Jul-29</td>
+      <td>2026-Oct-29</td>
     </tr>
     <tr>
       <td>v0.33</td>
-      <td>March 13, 2026</td>
-      <td>June 13, 2026</td>
-      <td>September 13, 2026</td>
+      <td>2026-Mar-13</td>
+      <td>2026-Jun-13</td>
+      <td>2026-Sep-13</td>
     </tr>
     <tr>
       <td>v0.32</td>
-      <td>February 18, 2026</td>
-      <td>May 18, 2026</td>
-      <td>August 18, 2026</td>
+      <td>2026-Feb-18</td>
+      <td>2026-May-18</td>
+      <td>2026-Aug-18</td>
     </tr>
     <tr>
       <td>v0.31</td>
-      <td>January 29, 2026</td>
-      <td>April 29, 2026</td>
-      <td>July 29, 2026</td>
+      <td>2026-Jan-29</td>
+      <td>2026-Apr-29</td>
+      <td>2026-Jul-29</td>
     </tr>
     <tr>
       <td colspan="4" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.30</td>
-      <td>October 28, 2025</td>
-      <td>January 28, 2026</td>
-      <td>April 28, 2026</td>
+      <td>2025-Oct-28</td>
+      <td>2026-Jan-28</td>
+      <td>2026-Apr-28</td>
     </tr>
     <tr>
       <td>v0.29</td>
-      <td>October 1, 2025</td>
-      <td>January 1, 2026</td>
-      <td>April 1, 2026</td>
+      <td>2025-Oct-01</td>
+      <td>2026-Jan-01</td>
+      <td>2026-Apr-01</td>
     </tr>
     <tr>
       <td>v0.28</td>
-      <td>September 8, 2025</td>
-      <td>December 8, 2025</td>
-      <td>March 8, 2026</td>
+      <td>2025-Sep-08</td>
+      <td>2025-Dec-08</td>
+      <td>2026-Mar-08</td>
     </tr>
     <tr>
       <td>v0.27</td>
-      <td>August 12, 2025</td>
-      <td>November 12, 2025</td>
-      <td>February 12, 2026</td>
+      <td>2025-Aug-12</td>
+      <td>2025-Nov-12</td>
+      <td>2026-Feb-12</td>
     </tr>
     <tr>
       <td>v0.26</td>
-      <td>June 26, 2025</td>
-      <td>September 26, 2025</td>
-      <td>December 26, 2025</td>
+      <td>2025-Jun-26</td>
+      <td>2025-Sep-26</td>
+      <td>2025-Dec-26</td>
     </tr>
     <tr>
       <td>v0.25</td>
-      <td>May 15, 2025</td>
-      <td>Aug 15, 2025</td>
-      <td>November 15, 2025</td>
+      <td>2025-May-15</td>
+      <td>2025-Aug-15</td>
+      <td>2025-Nov-15</td>
     </tr>
     <tr>
       <td>v0.24</td>
-      <td>March 18, 2025</td>
-      <td>June 16, 2025</td>
-      <td>September 14, 2025</td>
+      <td>2025-Mar-18</td>
+      <td>2025-Jun-16</td>
+      <td>2025-Sep-14</td>
     </tr>
     <tr>
       <td>v0.23</td>
-      <td>February 26, 2025</td>
-      <td>May 25, 2025</td>
-      <td>August 26, 2025</td>
+      <td>2025-Feb-26</td>
+      <td>2025-May-25</td>
+      <td>2025-Aug-26</td>
     </tr>
     <tr>
       <td>v0.22</td>
-      <td>December 18, 2024</td>
-      <td>March 18, 2025</td>
-      <td>June 18, 2025</td>
+      <td>2024-Dec-18</td>
+      <td>2025-Mar-18</td>
+      <td>2025-Jun-18</td>
     </tr>
     <tr>
       <td>v0.21</td>
-      <td>November 11, 2024</td>
-      <td>February 11, 2025</td>
-      <td>May 11, 2025</td>
+      <td>2024-Nov-11</td>
+      <td>2025-Feb-11</td>
+      <td>2025-May-11</td>
     </tr>
     <tr>
       <td>v0.20</td>
-      <td>August 14, 2024</td>
-      <td>November 14, 2024</td>
-      <td>February 14, 2025</td>
+      <td>2024-Aug-14</td>
+      <td>2024-Nov-14</td>
+      <td>2025-Feb-14</td>
     </tr>
     <tr>
       <td>v0.19</td>
-      <td>February 12, 2024</td>
-      <td>April 1, 2025*</td>
-      <td>July 1, 2025</td>
+      <td>2024-Feb-12</td>
+      <td>2025-Apr-01*</td>
+      <td>2025-Jul-01</td>
     </tr>
   </tbody>
 </table>

--- a/scripts/generate-lifecycle-json.js
+++ b/scripts/generate-lifecycle-json.js
@@ -23,37 +23,49 @@ const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
 
 /**
- * Parse date from "Month Day, Year" format to ISO 8601 (YYYY-MM-DD)
+ * Parse date to ISO 8601 (YYYY-MM-DD).
+ * Supports "YYYY Mon DD" (e.g. "2026 Apr 29") and legacy "Month Day, Year".
  */
 function parseDate(dateStr) {
   if (!dateStr || dateStr.trim() === '') return null;
 
-  // Handle special cases like "April 1, 2025*" (with asterisk)
   const cleaned = dateStr.replace(/\*/, '').trim();
 
   const months = {
     'January': '01', 'February': '02', 'March': '03', 'April': '04',
     'May': '05', 'June': '06', 'July': '07', 'August': '08',
     'September': '09', 'October': '10', 'November': '11', 'December': '12',
-    'Aug': '08'  // Handle abbreviated months
+    'Jan': '01', 'Feb': '02', 'Mar': '03', 'Apr': '04',
+    'Jun': '06', 'Jul': '07', 'Aug': '08',
+    'Sep': '09', 'Oct': '10', 'Nov': '11', 'Dec': '12'
   };
 
-  // Parse "Month Day, Year"
-  const match = cleaned.match(/(\w+)\s+(\d+),\s+(\d{4})/);
-  if (!match) {
-    console.warn(`Warning: Could not parse date "${dateStr}"`);
-    return null;
+  // "YYYY Mon DD" — current format
+  const ymdMatch = cleaned.match(/(\d{4})\s+(\w+)\s+(\d+)/);
+  if (ymdMatch) {
+    const [_, year, month, day] = ymdMatch;
+    const monthNum = months[month];
+    if (!monthNum) {
+      console.warn(`Warning: Unknown month "${month}" in date "${dateStr}"`);
+      return null;
+    }
+    return `${year}-${monthNum}-${day.padStart(2, '0')}`;
   }
 
-  const [_, month, day, year] = match;
-  const monthNum = months[month];
-
-  if (!monthNum) {
-    console.warn(`Warning: Unknown month "${month}" in date "${dateStr}"`);
-    return null;
+  // "Month Day, Year" — legacy format
+  const legacyMatch = cleaned.match(/(\w+)\s+(\d+),\s+(\d{4})/);
+  if (legacyMatch) {
+    const [_, month, day, year] = legacyMatch;
+    const monthNum = months[month];
+    if (!monthNum) {
+      console.warn(`Warning: Unknown month "${month}" in date "${dateStr}"`);
+      return null;
+    }
+    return `${year}-${monthNum}-${day.padStart(2, '0')}`;
   }
 
-  return `${year}-${monthNum}-${day.padStart(2, '0')}`;
+  console.warn(`Warning: Could not parse date "${dateStr}"`);
+  return null;
 }
 
 /**

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -4,80 +4,80 @@
   "versions": [
     {
       "version": "4.9.0",
-      "releaseDate": null,
+      "releaseDate": "2026-04-29",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-10-29",
+      "eolDate": "2027-01-29"
     },
     {
       "version": "4.8.0",
-      "releaseDate": null,
+      "releaseDate": "2026-03-16",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-09-16",
+      "eolDate": "2026-12-16"
     },
     {
       "version": "4.7.0",
-      "releaseDate": null,
+      "releaseDate": "2026-02-18",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-08-18",
+      "eolDate": "2026-11-18"
     },
     {
       "version": "4.6.0",
-      "releaseDate": null,
+      "releaseDate": "2026-01-29",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-07-29",
+      "eolDate": "2026-10-29"
     },
     {
       "version": "4.5.0",
-      "releaseDate": null,
-      "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "releaseDate": "2025-10-29",
+      "status": "eos",
+      "eosDate": "2026-04-29",
+      "eolDate": "2026-07-29"
     },
     {
       "version": "4.4.0",
-      "releaseDate": null,
-      "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "releaseDate": "2025-09-09",
+      "status": "eos",
+      "eosDate": "2026-03-09",
+      "eolDate": "2026-06-09"
     },
     {
       "version": "4.3.0",
-      "releaseDate": null,
+      "releaseDate": "2025-06-03",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-12-03",
+      "eolDate": "2026-03-06"
     },
     {
       "version": "4.2.0",
-      "releaseDate": null,
+      "releaseDate": "2024-12-17",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-09-17",
+      "eolDate": "2025-12-17"
     },
     {
       "version": "4.1.0",
-      "releaseDate": null,
+      "releaseDate": "2024-11-12",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-02-12",
+      "eolDate": "2025-05-12"
     },
     {
       "version": "4.0.0",
-      "releaseDate": null,
+      "releaseDate": "2024-10-15",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-01-15",
+      "eolDate": "2025-04-15"
     },
     {
       "version": "3.4.0",
-      "releaseDate": null,
+      "releaseDate": "2024-02-29",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null,
+      "eosDate": "2025-04-01",
+      "eolDate": "2025-07-01",
       "notes": "Extended support: Due to breaking changes, this version has extended support period."
     }
   ]

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -1,83 +1,83 @@
 {
   "product": "Platform",
-  "lastUpdated": "2026-04-30",
+  "lastUpdated": "2026-05-19",
   "versions": [
     {
       "version": "4.9.0",
-      "releaseDate": "2026-04-29",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-10-29",
-      "eolDate": "2027-01-29"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.8.0",
-      "releaseDate": "2026-03-16",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-09-16",
-      "eolDate": "2026-12-16"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.7.0",
-      "releaseDate": "2026-02-18",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-08-18",
-      "eolDate": "2026-11-18"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.6.0",
-      "releaseDate": "2026-01-29",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-07-29",
-      "eolDate": "2026-10-29"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.5.0",
-      "releaseDate": "2025-10-29",
-      "status": "eos",
-      "eosDate": "2026-04-29",
-      "eolDate": "2026-07-29"
+      "releaseDate": null,
+      "status": "active",
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.4.0",
-      "releaseDate": "2025-09-09",
-      "status": "eos",
-      "eosDate": "2026-03-09",
-      "eolDate": "2026-06-09"
+      "releaseDate": null,
+      "status": "active",
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.3.0",
-      "releaseDate": "2025-06-03",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-12-03",
-      "eolDate": "2026-03-06"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.2.0",
-      "releaseDate": "2024-12-17",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-09-17",
-      "eolDate": "2025-12-17"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.1.0",
-      "releaseDate": "2024-11-12",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-02-12",
-      "eolDate": "2025-05-12"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "4.0.0",
-      "releaseDate": "2024-10-15",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-01-15",
-      "eolDate": "2025-04-15"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "3.4.0",
-      "releaseDate": "2024-02-29",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-04-01",
-      "eolDate": "2025-07-01",
+      "eosDate": null,
+      "eolDate": null,
       "notes": "Extended support: Due to breaking changes, this version has extended support period."
     }
   ]

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -1,118 +1,118 @@
 {
   "product": "vCluster",
-  "lastUpdated": "2026-04-30",
+  "lastUpdated": "2026-05-19",
   "versions": [
     {
       "version": "0.34.0",
-      "releaseDate": "2026-04-29",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-07-29",
-      "eolDate": "2026-10-29"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.33.0",
-      "releaseDate": "2026-03-13",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-06-13",
-      "eolDate": "2026-09-13"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.32.0",
-      "releaseDate": "2026-02-18",
+      "releaseDate": null,
       "status": "active",
-      "eosDate": "2026-05-18",
-      "eolDate": "2026-08-18"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.31.0",
-      "releaseDate": "2026-01-29",
-      "status": "eos",
-      "eosDate": "2026-04-29",
-      "eolDate": "2026-07-29"
+      "releaseDate": null,
+      "status": "active",
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.30.0",
-      "releaseDate": "2025-10-28",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2026-01-28",
-      "eolDate": "2026-04-28"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.29.0",
-      "releaseDate": "2025-10-01",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2026-01-01",
-      "eolDate": "2026-04-01"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.28.0",
-      "releaseDate": "2025-09-08",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-12-08",
-      "eolDate": "2026-03-08"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.27.0",
-      "releaseDate": "2025-08-12",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-11-12",
-      "eolDate": "2026-02-12"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.26.0",
-      "releaseDate": "2025-06-26",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-09-26",
-      "eolDate": "2025-12-26"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.25.0",
-      "releaseDate": "2025-05-15",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-08-15",
-      "eolDate": "2025-11-15"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.24.0",
-      "releaseDate": "2025-03-18",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-06-16",
-      "eolDate": "2025-09-14"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.23.0",
-      "releaseDate": "2025-02-26",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-05-25",
-      "eolDate": "2025-08-26"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.22.0",
-      "releaseDate": "2024-12-18",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-03-18",
-      "eolDate": "2025-06-18"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.21.0",
-      "releaseDate": "2024-11-11",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-02-11",
-      "eolDate": "2025-05-11"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.20.0",
-      "releaseDate": "2024-08-14",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2024-11-14",
-      "eolDate": "2025-02-14"
+      "eosDate": null,
+      "eolDate": null
     },
     {
       "version": "0.19.0",
-      "releaseDate": "2024-02-12",
+      "releaseDate": null,
       "status": "eol",
-      "eosDate": "2025-04-01",
-      "eolDate": "2025-07-01",
+      "eosDate": null,
+      "eolDate": null,
       "notes": "Extended support: Due to breaking changes, this version has extended support period."
     }
   ]

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -4,115 +4,115 @@
   "versions": [
     {
       "version": "0.34.0",
-      "releaseDate": null,
+      "releaseDate": "2026-04-29",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-07-29",
+      "eolDate": "2026-10-29"
     },
     {
       "version": "0.33.0",
-      "releaseDate": null,
+      "releaseDate": "2026-03-13",
       "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-06-13",
+      "eolDate": "2026-09-13"
     },
     {
       "version": "0.32.0",
-      "releaseDate": null,
-      "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "releaseDate": "2026-02-18",
+      "status": "eos",
+      "eosDate": "2026-05-18",
+      "eolDate": "2026-08-18"
     },
     {
       "version": "0.31.0",
-      "releaseDate": null,
-      "status": "active",
-      "eosDate": null,
-      "eolDate": null
+      "releaseDate": "2026-01-29",
+      "status": "eos",
+      "eosDate": "2026-04-29",
+      "eolDate": "2026-07-29"
     },
     {
       "version": "0.30.0",
-      "releaseDate": null,
+      "releaseDate": "2025-10-28",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-01-28",
+      "eolDate": "2026-04-28"
     },
     {
       "version": "0.29.0",
-      "releaseDate": null,
+      "releaseDate": "2025-10-01",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2026-01-01",
+      "eolDate": "2026-04-01"
     },
     {
       "version": "0.28.0",
-      "releaseDate": null,
+      "releaseDate": "2025-09-08",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-12-08",
+      "eolDate": "2026-03-08"
     },
     {
       "version": "0.27.0",
-      "releaseDate": null,
+      "releaseDate": "2025-08-12",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-11-12",
+      "eolDate": "2026-02-12"
     },
     {
       "version": "0.26.0",
-      "releaseDate": null,
+      "releaseDate": "2025-06-26",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-09-26",
+      "eolDate": "2025-12-26"
     },
     {
       "version": "0.25.0",
-      "releaseDate": null,
+      "releaseDate": "2025-05-15",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-08-15",
+      "eolDate": "2025-11-15"
     },
     {
       "version": "0.24.0",
-      "releaseDate": null,
+      "releaseDate": "2025-03-18",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-06-16",
+      "eolDate": "2025-09-14"
     },
     {
       "version": "0.23.0",
-      "releaseDate": null,
+      "releaseDate": "2025-02-26",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-05-25",
+      "eolDate": "2025-08-26"
     },
     {
       "version": "0.22.0",
-      "releaseDate": null,
+      "releaseDate": "2024-12-18",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-03-18",
+      "eolDate": "2025-06-18"
     },
     {
       "version": "0.21.0",
-      "releaseDate": null,
+      "releaseDate": "2024-11-11",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2025-02-11",
+      "eolDate": "2025-05-11"
     },
     {
       "version": "0.20.0",
-      "releaseDate": null,
+      "releaseDate": "2024-08-14",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null
+      "eosDate": "2024-11-14",
+      "eolDate": "2025-02-14"
     },
     {
       "version": "0.19.0",
-      "releaseDate": null,
+      "releaseDate": "2024-02-12",
       "status": "eol",
-      "eosDate": null,
-      "eolDate": null,
+      "eosDate": "2025-04-01",
+      "eolDate": "2025-07-01",
       "notes": "Extended support: Due to breaking changes, this version has extended support period."
     }
   ]


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Updates the formatting of the dates on the lifecycle partials for better consistency.

## Preview Link 
<!-- The preview link or links to the documents-->
- https://deploy-preview-2151--vcluster-docs-site.netlify.app/docs/platform/maintenance/upgrade-migrate/lifecycle-policy
- https://deploy-preview-2151--vcluster-docs-site.netlify.app/docs/vcluster/manage/upgrade/supported_versions


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
No linked issue.


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

