### PR TITLE
docs(multi-region): document management API access pattern

### DIFF
--- a/platform/administer/authentication/access-keys.mdx
+++ b/platform/administer/authentication/access-keys.mdx
@@ -13,6 +13,13 @@ import Label from "@site/src/components/Label";
 
 Access keys provide authentication credentials for the platform. Users can use these keys with the vCluster CLI or HTTP tools like curl to interact with the platform.
 
+:::info Multi-region platforms
+On a [multi-region platform](../clusters/advanced/multi-region.mdx), an access
+key is the only supported way to reach the management API. See
+[Access the management API](../clusters/advanced/multi-region.mdx#access-the-management-api)
+for the endpoint shape and worked examples.
+:::
+
 ## How access keys work
 
 Access keys in vCluster platform function as authentication tokens that inherit the exact permissions of the user who creates them. When a user generates an access key, that key can perform any action the user has permission to perform. Any authenticated user on the vCluster platform can generate their own access keys through the user interface or API.

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1060,6 +1060,114 @@ deployment** with:
 -   Route 53 latency-based routing with health checks for automatic failover
 -   Platform deployed on both clusters sharing the same Kine database
 
+## Access the management API
+
+Multi-region platforms run an embedded Kubernetes API server inside each
+region's vCluster Platform pod. The `v1.management.loft.sh` aggregated
+APIService that exists on a standard platform deployment is **not** registered
+on the host EKS cluster — each region registers it inside its own embedded API
+server instead. This changes how automation and integrations such as Argo CD
+or Terraform call the management API.
+
+The aggregated APIService is cluster-scoped, so a single host EKS cluster can
+register only one. With multiple region pods sharing the same host cluster,
+that one registration can't route correctly to all of them. Each region
+therefore registers the APIService locally, and the platform's own HTTPS
+endpoint is the integration surface.
+
+### Standard vs. multi-region behavior
+
+| Aspect | Standard platform | Multi-region platform |
+| --- | --- | --- |
+| `v1.management.loft.sh` location | Aggregated APIService on the host EKS cluster | Local APIService inside each region's embedded API server |
+| Endpoint | `${EKS_ENDPOINT}/apis/management.loft.sh/v1/...` | `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/...` |
+| Authentication | Host cluster bearer token (for example, an EKS IAM token) | [Platform access key](../../authentication/access-keys.mdx) |
+| `kubectl get apiservice v1.management.loft.sh` on host EKS | Returns the registration | Returns nothing — by design |
+
+### Call the management API
+
+Build requests against:
+
+```text
+https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/<resource>
+```
+
+Authenticate with a platform access key as a bearer token. For instructions on
+[creating an access key](../../authentication/access-keys.mdx#create-an-access-key),
+scope it to the project, user, or tenant cluster the caller needs.
+
+#### kubectl
+
+<InterpolatedCodeBlock
+  code={
+`kubectl --server https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management \\
+  --token "$LOFT_ACCESS_KEY" \\
+  get virtualclusterinstances -A`
+  }
+  language="bash"
+/>
+
+#### curl
+
+<InterpolatedCodeBlock
+  code={
+`curl -H "Authorization: Bearer $LOFT_ACCESS_KEY" \\
+  https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management/apis/management.loft.sh/v1/projects`
+  }
+  language="bash"
+/>
+
+#### Argo CD declarative cluster
+
+Register the platform as an Argo CD cluster by creating a `cluster`-type
+secret in the Argo CD namespace. Argo CD treats `server` as the API endpoint
+and authenticates with `bearerToken`:
+
+<InterpolatedCodeBlock
+  code={
+`apiVersion: v1
+kind: Secret
+metadata:
+  name: platform-[[VAR:REGION:region-a]]
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+stringData:
+  name: platform-[[VAR:REGION:region-a]]
+  server: https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management
+  config: |
+    {
+      "bearerToken": "[[VAR:LOFT_ACCESS_KEY:<spec.key from your AccessKey>]]",
+      "tlsClientConfig": { "insecure": false }
+    }`
+  }
+  language="yaml"
+/>
+
+For the wider Argo CD integration (project import, SSO, AppProject sync), see
+[Argo CD integration](../../../integrations/argocd.mdx).
+
+### Upgrading from 4.7.x to 4.8.0
+
+This routing change shipped in platform version 4.8.0 and applies to
+multi-region deployments only. Automation that called the management API via
+the host EKS endpoint stops working after the upgrade — there is no in-place
+compatibility shim. Update callers to use the platform HTTPS endpoint above,
+and switch authentication from your host-cluster bearer token (for example,
+an EKS IAM token) to a platform access key.
+
+Standard (non-multi-region) platform deployments are unaffected. The host EKS
+APIService keeps working as before.
+
+### Troubleshooting
+
+| Symptom | Cause | Resolution |
+| --- | --- | --- |
+| `404` from `${EKS_ENDPOINT}/apis/management.loft.sh/...` | Caller is using the host EKS endpoint on a multi-region platform | Switch to `https://<platform-url>/kubernetes/management/...` |
+| `kubectl get apiservice v1.management.loft.sh` returns nothing on host EKS | Expected on multi-region — the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
+| `401` or `403` via the platform endpoint | Access key is invalid, expired, or scoped without permission for the requested resource | Regenerate the key or widen its scope; check the owning user's role bindings |
+| TLS verification errors against the platform endpoint | Caller doesn't trust the platform's certificate chain | Configure the same CA bundle the platform UI uses; avoid `insecure=true` in production |
+
 ## Upgrade a multi-region deployment
 
 This runbook describes how to upgrade vCluster Platform across regions with

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1153,7 +1153,7 @@ multi-region deployments only. Automation that called the management API using
 the host EKS endpoint stops working after the upgrade. There's no in-place
 compatibility shim.
 
-Update callers to use the platform HTTPS endpoint above. Switch authentication
+Update callers to use the platform HTTPS endpoint. Switch authentication
 from your host-cluster bearer token (for example, an EKS IAM token) to a
 platform access key.
 

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1149,7 +1149,7 @@ For the wider Argo CD integration (project import, SSO, AppProject sync), see
 ### Upgrade from 4.7.x to 4.8.0
 
 This routing change shipped in platform version 4.8.0 and applies to
-multi-region deployments only. Automation that called the management API via
+multi-region deployments only. Automation that called the management API using
 the host EKS endpoint stops working after the upgrade. There's no in-place
 compatibility shim.
 

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1081,7 +1081,7 @@ endpoint is the integration surface.
 | `v1.management.loft.sh` location | Aggregated APIService on the host EKS cluster | Local APIService inside each region's embedded API server |
 | Endpoint | `${EKS_ENDPOINT}/apis/management.loft.sh/v1/<resource>` | `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/<resource>` |
 | Authentication | Host cluster bearer token (for example, an EKS IAM token) | [Platform access key](../../authentication/access-keys.mdx) |
-| `kubectl get apiservice v1.management.loft.sh` on host EKS | Returns the registration | Returns nothing — by design |
+| `kubectl get apiservice v1.management.loft.sh` on host EKS | Returns the registration | Returns nothing |
 
 ### Call the management API
 

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -3,6 +3,7 @@ sidebar_label: Multi-Region Platform
 sidebar_position: 9
 title: Multi-Region Platform
 description: Deploy vCluster Platform across multiple AWS regions with shared database, latency-based DNS failover, and regional ALB ingress.
+toc_max_heading_level: 3
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1165,7 +1165,7 @@ APIService keeps working as before.
 | Symptom | Cause | Resolution |
 | --- | --- | --- |
 | `404` from `${EKS_ENDPOINT}/apis/management.loft.sh/<resource>` | Caller is using the host EKS endpoint on a multi-region platform | Switch to `https://<platform-url>/kubernetes/management/<resource>` |
-| `kubectl get apiservice v1.management.loft.sh` returns nothing on host EKS | Expected on multi-region — the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
+| `kubectl get apiservice v1.management.loft.sh` returns nothing on host EKS | Expected on multi-region, as the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
 | `401` or `403` via the platform endpoint | Access key is invalid, expired, or scoped without permission for the requested resource | Regenerate the key or widen its scope; check the owning user's role bindings |
 | TLS verification errors against the platform endpoint | Caller doesn't trust the platform's certificate chain | Configure the same CA bundle the platform UI uses; avoid `insecure=true` in production |
 

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1075,12 +1075,12 @@ that one registration can't route correctly to all of them. Each region
 therefore registers the APIService locally, and the platform's own HTTPS
 endpoint is the integration surface.
 
-### Standard vs. multi-region behavior
+### Compare standard and multi-region behavior
 
 | Aspect | Standard platform | Multi-region platform |
 | --- | --- | --- |
 | `v1.management.loft.sh` location | Aggregated APIService on the host EKS cluster | Local APIService inside each region's embedded API server |
-| Endpoint | `${EKS_ENDPOINT}/apis/management.loft.sh/v1/...` | `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/...` |
+| Endpoint | `${EKS_ENDPOINT}/apis/management.loft.sh/v1/<resource>` | `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/<resource>` |
 | Authentication | Host cluster bearer token (for example, an EKS IAM token) | [Platform access key](../../authentication/access-keys.mdx) |
 | `kubectl get apiservice v1.management.loft.sh` on host EKS | Returns the registration | Returns nothing — by design |
 
@@ -1096,7 +1096,7 @@ Authenticate with a platform access key as a bearer token. For instructions on
 [creating an access key](../../authentication/access-keys.mdx#create-an-access-key),
 scope it to the project, user, or tenant cluster the caller needs.
 
-#### kubectl
+#### Use kubectl
 
 <InterpolatedCodeBlock
   code={
@@ -1107,7 +1107,7 @@ scope it to the project, user, or tenant cluster the caller needs.
   language="bash"
 />
 
-#### curl
+#### Use curl
 
 <InterpolatedCodeBlock
   code={
@@ -1117,7 +1117,7 @@ scope it to the project, user, or tenant cluster the caller needs.
   language="bash"
 />
 
-#### Argo CD declarative cluster
+#### Register an Argo CD cluster
 
 Register the platform as an Argo CD cluster by creating a `cluster`-type
 secret in the Argo CD namespace. Argo CD treats `server` as the API endpoint
@@ -1147,7 +1147,7 @@ stringData:
 For the wider Argo CD integration (project import, SSO, AppProject sync), see
 [Argo CD integration](../../../integrations/argocd.mdx).
 
-### Upgrading from 4.7.x to 4.8.0
+### Upgrade from 4.7.x to 4.8.0
 
 This routing change shipped in platform version 4.8.0 and applies to
 multi-region deployments only. Automation that called the management API via
@@ -1159,11 +1159,11 @@ an EKS IAM token) to a platform access key.
 Standard (non-multi-region) platform deployments are unaffected. The host EKS
 APIService keeps working as before.
 
-### Troubleshooting
+### Troubleshoot common errors
 
 | Symptom | Cause | Resolution |
 | --- | --- | --- |
-| `404` from `${EKS_ENDPOINT}/apis/management.loft.sh/...` | Caller is using the host EKS endpoint on a multi-region platform | Switch to `https://<platform-url>/kubernetes/management/...` |
+| `404` from `${EKS_ENDPOINT}/apis/management.loft.sh/<resource>` | Caller is using the host EKS endpoint on a multi-region platform | Switch to `https://<platform-url>/kubernetes/management/<resource>` |
 | `kubectl get apiservice v1.management.loft.sh` returns nothing on host EKS | Expected on multi-region — the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
 | `401` or `403` via the platform endpoint | Access key is invalid, expired, or scoped without permission for the requested resource | Regenerate the key or widen its scope; check the owning user's role bindings |
 | TLS verification errors against the platform endpoint | Caller doesn't trust the platform's certificate chain | Configure the same CA bundle the platform UI uses; avoid `insecure=true` in production |

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1168,9 +1168,9 @@ APIService keeps working as before.
 
 | Symptom | Cause | Resolution |
 | --- | --- | --- |
-| `404` from `${EKS_ENDPOINT}/apis/management.loft.sh/<resource>` | Caller is using the host EKS endpoint on a multi-region platform | Switch to `https://<platform-url>/kubernetes/management/<resource>` |
-| `kubectl get apiservice v1.management.loft.sh` returns nothing on host EKS | Expected on multi-region, as the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
-| `401` or `403` via the platform endpoint | Access key is invalid, expired, or scoped without permission for the requested resource | Regenerate the key or widen its scope; check the owning user's role bindings |
+| `404` from the host EKS endpoint | Caller is using the host EKS endpoint on a multi-region platform | Switch to the platform HTTPS endpoint shown in [Call the management API](#call-the-management-api) |
+| The host EKS cluster has no `v1.management.loft.sh` APIService | Expected on multi-region, as the APIService lives inside the embedded API server | None; verify from inside the embedded API server if needed |
+| `401` or `403` from the platform endpoint | Access key is invalid, expired, or scoped without permission for the requested resource | Regenerate the key or widen its scope; check the owning user's role bindings |
 | TLS verification errors against the platform endpoint | Caller doesn't trust the platform's certificate chain | Configure the same CA bundle the platform UI uses; avoid `insecure=true` in production |
 
 ## Upgrade a multi-region deployment

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1064,10 +1064,9 @@ deployment** with:
 
 Multi-region platforms run an embedded Kubernetes API server inside each
 region's vCluster Platform pod. The `v1.management.loft.sh` aggregated
-APIService that exists on a standard platform deployment is **not** registered
-on the host EKS cluster — each region registers it inside its own embedded API
-server instead. This changes how automation and integrations such as Argo CD
-or Terraform call the management API.
+APIService isn't registered on the host EKS cluster. Each region registers it
+inside its own embedded API server instead. This changes how automation and
+integrations such as Argo CD or Terraform call the management API.
 
 The aggregated APIService is cluster-scoped, so a single host EKS cluster can
 register only one. With multiple region pods sharing the same host cluster,
@@ -1101,7 +1100,7 @@ scope it to the project, user, or tenant cluster the caller needs.
 <InterpolatedCodeBlock
   code={
 `kubectl --server https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management \\
-  --token "$LOFT_ACCESS_KEY" \\
+  --token "$ACCESS_KEY" \\
   get virtualclusterinstances -A`
   }
   language="bash"
@@ -1111,7 +1110,7 @@ scope it to the project, user, or tenant cluster the caller needs.
 
 <InterpolatedCodeBlock
   code={
-`curl -H "Authorization: Bearer $LOFT_ACCESS_KEY" \\
+`curl -H "Authorization: Bearer $ACCESS_KEY" \\
   https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management/apis/management.loft.sh/v1/projects`
   }
   language="bash"
@@ -1137,7 +1136,7 @@ stringData:
   server: https://[[VAR:PLATFORM_HOST:platform.example.com]]/kubernetes/management
   config: |
     {
-      "bearerToken": "[[VAR:LOFT_ACCESS_KEY:<spec.key from your AccessKey>]]",
+      "bearerToken": "[[VAR:ACCESS_KEY:<spec.key from your AccessKey>]]",
       "tlsClientConfig": { "insecure": false }
     }`
   }
@@ -1151,10 +1150,12 @@ For the wider Argo CD integration (project import, SSO, AppProject sync), see
 
 This routing change shipped in platform version 4.8.0 and applies to
 multi-region deployments only. Automation that called the management API via
-the host EKS endpoint stops working after the upgrade — there is no in-place
-compatibility shim. Update callers to use the platform HTTPS endpoint above,
-and switch authentication from your host-cluster bearer token (for example,
-an EKS IAM token) to a platform access key.
+the host EKS endpoint stops working after the upgrade. There's no in-place
+compatibility shim.
+
+Update callers to use the platform HTTPS endpoint above. Switch authentication
+from your host-cluster bearer token (for example, an EKS IAM token) to a
+platform access key.
 
 Standard (non-multi-region) platform deployments are unaffected. The host EKS
 APIService keeps working as before.

--- a/platform/administer/clusters/advanced/multi-region.mdx
+++ b/platform/administer/clusters/advanced/multi-region.mdx
@@ -1078,10 +1078,14 @@ endpoint is the integration surface.
 
 | Aspect | Standard platform | Multi-region platform |
 | --- | --- | --- |
-| `v1.management.loft.sh` location | Aggregated APIService on the host EKS cluster | Local APIService inside each region's embedded API server |
-| Endpoint | `${EKS_ENDPOINT}/apis/management.loft.sh/v1/<resource>` | `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/<resource>` |
+| APIService location | Aggregated on the host EKS cluster | Local, inside each region's embedded API server |
 | Authentication | Host cluster bearer token (for example, an EKS IAM token) | [Platform access key](../../authentication/access-keys.mdx) |
-| `kubectl get apiservice v1.management.loft.sh` on host EKS | Returns the registration | Returns nothing |
+| APIService visibility on host EKS | Shows the registration | Shows nothing |
+
+The endpoint shape differs by deployment type:
+
+- **Standard platform**: `${EKS_ENDPOINT}/apis/management.loft.sh/v1/<resource>`
+- **Multi-region platform**: `https://<platform-url>/kubernetes/management/apis/management.loft.sh/v1/<resource>`
 
 ### Call the management API
 

--- a/platform/integrations/argocd.mdx
+++ b/platform/integrations/argocd.mdx
@@ -15,9 +15,9 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="argo-integration" />
 
 :::info Multi-region platforms
-If you target a [multi-region platform](../administer/clusters/advanced/multi-region.mdx)
-as an Argo CD cluster, register it against the platform HTTPS endpoint with a
-platform access key — the host EKS endpoint is not a valid target on
+On a [multi-region platform](../administer/clusters/advanced/multi-region.mdx),
+register the platform as an Argo CD cluster against the platform HTTPS endpoint
+with a platform access key. The host EKS endpoint isn't a valid target on
 multi-region deployments. See
 [Access the management API](../administer/clusters/advanced/multi-region.mdx#access-the-management-api)
 for a worked Argo CD cluster secret example.

--- a/platform/integrations/argocd.mdx
+++ b/platform/integrations/argocd.mdx
@@ -14,6 +14,14 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <FeatureTable names="argo-integration" />
 
+:::info Multi-region platforms
+If you target a [multi-region platform](../administer/clusters/advanced/multi-region.mdx)
+as an Argo CD cluster, register it against the platform HTTPS endpoint with a
+platform access key — the host EKS endpoint is not a valid target on
+multi-region deployments. See
+[Access the management API](../administer/clusters/advanced/multi-region.mdx#access-the-management-api)
+for a worked Argo CD cluster secret example.
+:::
 
 vCluster Platform provides several points of integration with [Argo CD](https://argo-cd.readthedocs.io/en/stable/),
 a popular GitOps tool for Kubernetes. The Argo CD integration is designed to help users take advantage

--- a/platform/integrations/argocd.mdx
+++ b/platform/integrations/argocd.mdx
@@ -20,7 +20,7 @@ register the platform as an Argo CD cluster against the platform HTTPS endpoint
 with a platform access key. The host EKS endpoint isn't a valid target on
 multi-region deployments. See
 [Access the management API](../administer/clusters/advanced/multi-region.mdx#access-the-management-api)
-for a worked Argo CD cluster secret example.
+for a working Argo CD cluster secret example.
 :::
 
 vCluster Platform provides several points of integration with [Argo CD](https://argo-cd.readthedocs.io/en/stable/),


### PR DESCRIPTION
# Content Description

Documents the multi-region management API access pattern that changed in platform 4.8.0. A new `Access the management API` section on the multi-region admin page covers the standard-vs-multi-region behavior table, kubectl / curl / Argo CD examples, a 4.7.x → 4.8.0 upgrade note, and a troubleshooting matrix. Cross-link callouts on the Access Keys and Argo CD integration pages send readers to the new section from adjacent contexts.

## Preview Link

- [Multi-region: Access the management API](https://deploy-preview-2152--vcluster-docs-site.netlify.app/docs/platform/next/administer/clusters/advanced/multi-region#access-the-management-api)
- [Access keys (callout)](https://deploy-preview-2152--vcluster-docs-site.netlify.app/docs/platform/next/administer/authentication/access-keys)
- [Argo CD integration (callout)](https://deploy-preview-2152--vcluster-docs-site.netlify.app/docs/platform/next/integrations/argocd)

## Internal Reference

Closes ENGPLAT-649

Related:
- Source PR (private): loft-sh/loft-enterprise#6274
- Originating ticket: ENGPLAT-87

<!-- Do not change the line below -->
@netlify /docs/platform/next/administer/clusters/advanced/multi-region#access-the-management-api