### PR TITLE
docs(doc-503): add security overview page

### DIFF
--- a/.github/styles/Google/Headings.yml
+++ b/.github/styles/Google/Headings.yml
@@ -40,6 +40,8 @@ exceptions:
   - Windows
   - JSON
   - vCluster
+  - vMetal
+  - vNode
   - \bPro\b
   - OpenCost
   - Helm

--- a/.vale.ini
+++ b/.vale.ini
@@ -38,3 +38,10 @@ Vale.Terms = NO
 [**/quick-start/**]
 BasedOnStyles = Loft, Google, Vale
 Vale.Terms = NO
+
+# Security docs reference camelCase vcluster.yaml keys (e.g., networkPolicy,
+# podSecurityStandard) in inline code spans. Vale.Terms fires on these as
+# false positives since they are config identifiers, not prose.
+[**/security/**]
+BasedOnStyles = Loft, Google, Vale
+Vale.Terms = NO

--- a/hack/check-redirects.sh
+++ b/hack/check-redirects.sh
@@ -213,8 +213,10 @@ detect_changes() {
         [[ -z "$added_path" ]] && continue
         local added_dir="${added_path%/*}"
         local pos
-        pos="$(grep -m1 '^sidebar_position:' "${REPO_ROOT}/${added_path}" 2>/dev/null | awk '{print $2}')"
-        [[ -n "$pos" ]] && ADDED_BY_POS="${ADDED_BY_POS}${added_dir}/${pos}=${added_path}"$'\n'
+        pos="$(grep -m1 '^sidebar_position:' "${REPO_ROOT}/${added_path}" 2>/dev/null | awk '{print $2}')" || true
+        if [[ -n "$pos" ]]; then
+            ADDED_BY_POS="${ADDED_BY_POS}${added_dir}/${pos}=${added_path}"$'\n'
+        fi
     done <<<"$ADDED_FILES"
 }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -126,7 +126,7 @@ command = """
 
 [[redirects]]
   from = "/docs/security/*"
-  to = "https://www.vcluster.com/docs/platform/understand/what-are-virtual-clusters#robust-security-and-isolation"
+  to = "/docs/vcluster/security/"
 
 [[redirects]]
   from = "/docs/syncer/*"

--- a/src/css/content/markdown.scss
+++ b/src/css/content/markdown.scss
@@ -30,6 +30,18 @@ body .markdown {
   margin-top: 0 !important;
 }
 
+.markdown .task-list-item {
+  list-style: none;
+  position: relative;
+  padding-left: 1.5em;
+
+  > input[type="checkbox"] {
+    position: absolute;
+    left: 0;
+    top: 0.3em;
+  }
+}
+
 .markdown > h2 {
   margin-top: 1.4em !important;
   &:target::before {

--- a/vcluster/key-features/isolation.mdx
+++ b/vcluster/key-features/isolation.mdx
@@ -6,14 +6,12 @@ sidebar_position: 4
 
 The vCluster project provides several configuration options pertaining to tenant cluster
 isolation and security. This section briefly covers the primary configuration options. For detailed
-information, see the [policies configuration](/vcluster/configure/vcluster-yaml/policies/).
+information, see the [security overview](../security/README.mdx) and [policies configuration](../configure/vcluster-yaml/policies/overview.mdx).
 
-vCluster provides a configuration option simply named `isolate`. When enabled, this feature
-enables a pod security standard, deploys a resource quota and limit range, and enables a network
-policy to isolate workloads.
+vCluster can isolate workloads by combining a Pod Security Standard, ResourceQuota, LimitRange,
+and NetworkPolicy. These settings are configured explicitly in `vcluster.yaml`.
 
-Enabling of the vCluster `isolate` configuration setting is as simple as setting the appropriate
-value in your tenant cluster or tenant cluster template Helm values as shown below:
+Enable these settings in your tenant cluster or tenant cluster template values:
 
 ```yaml
 policies:
@@ -22,11 +20,11 @@ policies:
     enabled: true
   resourceQuota:
     enabled: true
+  networkPolicy:
+    enabled: true
 ```
 
-All vCluster isolation mode configuration settings are available for further configuration by
-making use of the provided Helm values. Take a look the vCluster docs linked below for much more
-information about both the default settings and available configurations.
+All vCluster isolation settings can be customized through the policy configuration pages.
 
 :::warning CNIs and Network Policies
 Not all CNIs will support all network policies. Make sure you understand what capabilities your

--- a/vcluster/security/README.mdx
+++ b/vcluster/security/README.mdx
@@ -1,0 +1,169 @@
+---
+title: Secure vCluster Deployments
+sidebar_label: Security
+description: Understand vCluster security boundaries and apply baseline guardrails for tenant workloads, the control plane cluster, and the vCluster control plane.
+---
+
+vCluster security depends on where a workload runs, which resources are synchronized, and who controls the configuration. A secure deployment starts by separating three boundaries:
+
+- **Inside the tenant cluster**: Kubernetes RBAC, admission control, resource limits, and tenant-defined network policies control what users and workloads can do inside the tenant environment.
+- **Between the tenant cluster and the control plane cluster**: vCluster sync configuration controls which resources cross the boundary between the tenant cluster and the cluster that hosts the vCluster control plane.
+- **Outside the tenant cluster**: Platform RBAC, approved templates, control plane pod hardening, private nodes, vNode, and vMetal determine who can create tenant clusters and what isolation model they receive.
+
+## Baseline security configuration
+
+`policies.networkPolicy` defaults to `false` and must be explicitly enabled. Start with explicit workload isolation policies and service account token handling:
+
+```yaml title="vcluster.yaml"
+policies:
+  podSecurityStandard: baseline
+  resourceQuota:
+    enabled: true
+  limitRange:
+    enabled: true
+  networkPolicy:
+    enabled: true
+
+sync:
+  toHost:
+    pods:
+      useSecretsForSATokens: true
+```
+
+This configuration:
+
+- applies a Kubernetes [Pod Security Standard](../configure/vcluster-yaml/policies/pod-security-standard.mdx) to namespaces in the tenant cluster
+- creates a [ResourceQuota](../configure/vcluster-yaml/policies/resource-quota.mdx) and [LimitRange](../configure/vcluster-yaml/policies/limit-range.mdx) in the control plane cluster namespace where vCluster runs
+- creates vCluster-managed [NetworkPolicies](../configure/vcluster-yaml/policies/network-policy.mdx) for the vCluster control plane and synced workloads in the control plane cluster namespace
+- stores synced pod service account tokens in Secrets rather than pod annotations; tokens stored in annotations are readable by anyone who can read pod specs, whereas tokens in Secrets are gated by Secret-level RBAC
+
+:::warning NetworkPolicy support
+NetworkPolicies only take effect when the control plane cluster's CNI implements Kubernetes NetworkPolicy. Creating NetworkPolicy resources without a controller that enforces them does not isolate traffic.
+:::
+
+## Workload security inside the tenant cluster
+
+### Kubernetes RBAC
+
+Kubernetes RBAC inside the tenant cluster controls what users and service accounts can do in the tenant environment. This is separate from Platform RBAC, which controls who can create or manage tenant clusters.
+
+Key access to restrict:
+
+- **Pod and workload creation**: Any user who can create a Pod can run arbitrary container images and influence sync behavior. Limit `create` on Pods, Deployments, StatefulSets, and Jobs to subjects that need it.
+- **`exec` and `attach`**: `pods/exec` and `pods/attach` grant interactive shell access to running containers. Grant these verbs only to users who genuinely need them.
+- **Secret access**: Restrict `get`, `list`, and `watch` on Secrets to minimize exposure of credentials and service account tokens.
+- **Cluster-scoped resources**: ClusterRoles, ClusterRoleBindings, and CRDs affect the entire tenant cluster. Prefer namespace-scoped Roles and RoleBindings for tenant users over cluster-scoped grants.
+
+When Platform templates define tenant cluster configuration, review the initial RBAC grants created at cluster instantiation time. Tenants with `cluster-admin` inside the tenant cluster can still be constrained at the sync and Platform governance layers.
+
+### NetworkPolicy
+
+vCluster-managed NetworkPolicies (created by `policies.networkPolicy`) protect traffic in the control plane cluster namespace where vCluster itself runs. These are separate from NetworkPolicies that tenant users create inside the tenant cluster for application-to-application traffic. Both layers require CNI support on their respective clusters.
+
+Use namespace-level NetworkPolicies inside the tenant cluster to restrict lateral movement between applications:
+
+- Apply a default-deny ingress policy in namespaces that do not need cross-namespace traffic.
+- Restrict egress from sensitive workloads to the services they actually call.
+
+### Admission control
+
+Use `policies.podSecurityStandard` when the platform operator needs to enforce a Pod Security Standard uniformly across all tenant namespaces. Tenants cannot remove or loosen PSA labels that vCluster applies.
+
+For granular, platform-managed admission policies that tenants cannot override, use [central admission control](../configure/vcluster-yaml/policies/admission-control.mdx). Central admission control is a vCluster Pro feature. It configures webhooks in the tenant cluster that point through the vCluster proxy to a service in the control plane cluster or to an external policy service. Tenants can install their own admission controllers, but they cannot mutate or delete the centrally configured hooks.
+
+Test admission webhooks with `failurePolicy: Ignore` before switching to `failurePolicy: Fail` in production. A misconfigured webhook with `failurePolicy: Fail` can block all workload creation in the tenant cluster.
+
+## Control plane cluster boundary
+
+vCluster synchronizes selected resources between the tenant cluster and the control plane cluster. Review sync settings before allowing non-admin users to create or modify vCluster configurations.
+
+### Sync to host
+
+Resources under [`sync.toHost`](../configure/vcluster-yaml/sync/to-host/overview.mdx) are created in the control plane cluster after vCluster translates names, labels, and namespaces. This is required for normal workloads such as Pods, Services, ConfigMaps, Secrets, and PersistentVolumeClaims, but it also means tenant-created objects can create real Kubernetes objects in the control plane cluster.
+
+Limit `sync.toHost` to the resources tenants actually need. Treat advanced options such as namespace sync, custom resource sync, service account sync, and host deployments as security-sensitive.
+
+### Sync from host
+
+Resources under [`sync.fromHost`](../configure/vcluster-yaml/sync/from-host/overview.mdx) are copied from the control plane cluster into the tenant cluster. These resources are read-only from the tenant perspective: changes made inside the tenant cluster are not written back to the control plane cluster.
+
+Use selectors and explicit mappings when syncing shared or sensitive resources such as StorageClasses, RuntimeClasses, Secrets, ConfigMaps, and custom resources.
+
+### vCluster RBAC
+
+vCluster automatically generates the control plane cluster RBAC it needs based on enabled features and synchronized resources. This governs what the vCluster syncer can do in the control plane cluster, not what tenant users can do inside the tenant cluster.
+
+For restricted environments, use [RBAC configuration](../configure/vcluster-yaml/rbac.mdx) to disable automatic RBAC generation, use an administrator-managed ServiceAccount, or overwrite the generated rules.
+
+## Harden the vCluster control plane
+
+The vCluster control plane runs as a workload in the control plane cluster. Harden it like any other privileged control plane component:
+
+- Run the vCluster pod as a non-root user with [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx).
+- Configure `controlPlane.statefulSet.security.podSecurityContext` and `controlPlane.statefulSet.security.containerSecurityContext` for user IDs, file system groups, privilege escalation, capabilities, and seccomp settings.
+- Configure the control plane ServiceAccount explicitly when your organization manages RBAC outside of the vCluster Helm chart.
+- Use the [CIS hardening guide](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx) for API server audit logging, EventRateLimit, encryption at rest, admission plugin settings, and hardened Kubernetes component arguments.
+- Use [FIPS images](../deploy/control-plane/kubernetes-pod/security/fips.mdx), [air-gapped deployment](../deploy/control-plane/kubernetes-pod/security/air-gapped.mdx), or [corporate proxy configuration](../deploy/control-plane/kubernetes-pod/security/corporate-proxy.mdx) when required by your environment.
+
+Some options, such as rootless mode, worker node model, and backing store type, must be chosen at initial deployment time. Review security requirements before creating production tenant clusters.
+
+## Platform governance
+
+When users create tenant clusters through vCluster Platform, templates are the main security boundary for vCluster configuration.
+
+- Keep templates required for projects where non-admin users create tenant clusters.
+- Put approved security settings directly into [VirtualClusterTemplates](/platform/administer/templates/create-templates).
+- Limit which templates a project can use with [allowed templates](/platform/administer/projects/allowed/templates).
+- Limit which control plane clusters a project can use with allowed clusters.
+- Use [Platform RBAC](/platform/administer/users-permissions/overview) to separate platform administrators from project users.
+- Use [Least Privilege Mode](/platform/configure/agent-settings/least-privilege-mode) for Platform agents on external control plane clusters when your organization needs reduced agent permissions.
+- Configure [agent security contexts](/platform/configure/agent-settings/security-context) for connected control plane clusters.
+
+Do not allow untrusted project users to create tenant clusters without an approved template. A user with full control over `vcluster.yaml` can loosen sync settings, expose control plane cluster resources, or deploy resources directly to the control plane cluster.
+
+## Tenancy and isolation profiles
+
+Choose an isolation profile based on the level of workload trust and the cost of dedicating infrastructure.
+
+| Profile | Isolation boundary | Best for | Main docs |
+|---|---|---|---|
+| Shared host nodes | Kubernetes container isolation plus vCluster policy controls | General multi-tenant workloads on shared infrastructure | [Isolated workloads](../deploy/worker-nodes/host-nodes/isolated-workloads.mdx), [Policies](../configure/vcluster-yaml/policies/overview.mdx), [Sync](../configure/vcluster-yaml/sync/overview.mdx) |
+| Shared host nodes with vNode | Runtime sandbox on shared nodes | Privileged or higher-risk workloads on shared hardware | [vNode docs](https://www.vnode.com/docs/) |
+| Private nodes | Dedicated Kubernetes nodes per tenant cluster | Stronger node-level tenant isolation | [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx) |
+| Private nodes with vMetal | Dedicated physical servers | Physical isolation, GPU or PCIe device exclusivity, and bare-metal compliance needs | [vMetal docs](https://www.vmetal.ai/docs/) |
+
+### vNode
+
+vCluster defines the tenant cluster boundary. vNode strengthens workload isolation on shared nodes.
+
+Use vNode when tenants share physical nodes but workloads need stronger runtime containment than standard containers provide. This is especially relevant for privileged workloads, Docker-in-Docker, `hostPID`, host path access, GPU workloads, or user-supplied model inference code.
+
+vNode does not replace vCluster policy guardrails. Continue to use Pod Security Standards, NetworkPolicies, quotas, reviewed sync settings, and approved templates.
+
+### Private nodes
+
+Private nodes move tenant workloads off the control plane cluster's shared worker nodes. The vCluster control plane still runs in the control plane cluster, but workload execution moves to nodes dedicated to the tenant cluster.
+
+Use private nodes when tenants require dedicated node capacity, stronger workload isolation, or direct control over node-level Kubernetes behavior.
+
+### vMetal
+
+vMetal provisions private nodes as dedicated physical servers. It adds bare-metal operational security requirements that are outside the scope of vCluster itself, including BMC credential handling, OS image integrity, PXE and provisioning network exposure, Metal3 and Ironic hardening, and BareMetalHost access control.
+
+Use the vCluster security guide to decide when physical isolation is required. Use the vMetal security guide as the source of truth for bare-metal-specific controls.
+
+## Production checklist
+
+Before deploying production tenant clusters, verify:
+
+- The control plane cluster CNI enforces NetworkPolicy.
+- `policies.podSecurityStandard`, `policies.resourceQuota`, `policies.limitRange`, and `policies.networkPolicy` are configured intentionally.
+- `sync.toHost` and `sync.fromHost` are limited to required resources.
+- Tenant RBAC restricts Pod creation, `exec`, Secret access, and cluster-scoped role grants to intended subjects.
+- Central admission control is tested with `failurePolicy: Ignore` before using `failurePolicy: Fail`.
+- vCluster control plane pods run with the required security context, rootless mode, and ServiceAccount model.
+- API server audit logging, EventRateLimit, and encryption settings meet compliance requirements.
+- Non-admin Platform users can create tenant clusters only from approved templates.
+- Platform Agent permissions and security contexts meet the control plane cluster's trust requirements.
+- The isolation profile is explicit: shared nodes, shared nodes with vNode, private nodes, or private nodes with vMetal.
+- vMetal deployments validate BMC credential storage and rotation, OS image checksums, provisioning network segmentation, BareMetalHost and NodeProvider RBAC, and control plane access to BMC networks.

--- a/vcluster/security/README.mdx
+++ b/vcluster/security/README.mdx
@@ -99,6 +99,7 @@ For restricted environments, use [RBAC configuration](../configure/vcluster-yaml
 
 The vCluster control plane runs as a workload in the control plane cluster. Harden it like any other privileged control plane component:
 
+- Apply a Pod Security Standard label to the control plane cluster namespace where vCluster runs. This is independent of `policies.podSecurityStandard`, which labels namespaces inside the tenant cluster — the host namespace label is a backstop on the control plane cluster side. `baseline` enforcement works with the default vCluster deployment. `restricted` enforcement requires [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx) to be enabled first.
 - Run the vCluster pod as a non-root user with [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx).
 - Configure `controlPlane.statefulSet.security.podSecurityContext` and `controlPlane.statefulSet.security.containerSecurityContext` for user IDs, file system groups, privilege escalation, capabilities, and seccomp settings.
 - Configure the control plane ServiceAccount explicitly when your organization manages RBAC outside of the vCluster Helm chart.

--- a/vcluster/security/README.mdx
+++ b/vcluster/security/README.mdx
@@ -4,15 +4,36 @@ sidebar_label: Security
 description: Understand vCluster security boundaries and apply baseline guardrails for tenant workloads, the control plane cluster, and the vCluster control plane.
 ---
 
-vCluster security depends on where a workload runs, which resources are synchronized, and who controls the configuration. A secure deployment starts by separating three boundaries:
+:::note Plan before you deploy
+Several deployment decisions cannot be changed after initial deployment, including rootless mode, worker node type, backing store, and control plane distro. Review the [deployment overview](../deploy/overview.mdx) and this page before deploying production tenant clusters.
+:::
 
-- **Inside the tenant cluster**: Kubernetes RBAC, admission control, resource limits, and tenant-defined network policies control what users and workloads can do inside the tenant environment.
-- **Between the tenant cluster and the control plane cluster**: vCluster sync configuration controls which resources cross the boundary between the tenant cluster and the cluster that hosts the vCluster control plane.
-- **Outside the tenant cluster**: Platform RBAC, approved templates, control plane pod hardening, private nodes, vNode, and vMetal determine who can create tenant clusters and what isolation model they receive.
+vCluster security depends on where a workload runs, which resources vCluster synchronizes, and who controls the configuration. A secure deployment starts by separating three boundaries:
+
+- **Inside the tenant cluster**
+  - Kubernetes RBAC
+  - Admission control
+  - Resource limits
+  - Tenant-defined network policies
+
+- **Between the tenant cluster and the control plane cluster**
+  - vCluster sync configuration
+
+- **Outside the tenant cluster**
+  - Platform RBAC and approved templates
+  - Control plane pod hardening
+  - Private nodes, vNode, and vMetal
 
 ## Baseline security configuration
 
-`policies.networkPolicy` defaults to `false` and must be explicitly enabled. Start with explicit workload isolation policies and service account token handling:
+A hardened baseline combines four controls:
+
+- A [Pod Security Standard](../configure/vcluster-yaml/policies/pod-security-standard.mdx) applied to tenant namespaces blocks privileged containers, host path mounts, and other high-risk pod configurations inside the tenant cluster.
+- A [ResourceQuota](../configure/vcluster-yaml/policies/resource-quota.mdx) and [LimitRange](../configure/vcluster-yaml/policies/limit-range.mdx) in the control plane cluster namespace prevent a runaway or malicious tenant workload from exhausting shared node capacity or etcd storage.
+- [NetworkPolicies](../configure/vcluster-yaml/policies/network-policy.mdx) in the control plane cluster namespace restrict traffic between vCluster components and other workloads on the shared cluster. `policies.networkPolicy` defaults to `false` and requires CNI support to take effect.
+- Storing synced pod [service account tokens](../configure/vcluster-yaml/sync/to-host/core/pods/overview.mdx) in Secrets rather than pod annotations scopes token access to Secret-level RBAC. Anyone who can read pod specs can read tokens stored in annotations.
+
+Enable all four together:
 
 ```yaml title="vcluster.yaml"
 policies:
@@ -30,13 +51,6 @@ sync:
       useSecretsForSATokens: true
 ```
 
-This configuration:
-
-- applies a Kubernetes [Pod Security Standard](../configure/vcluster-yaml/policies/pod-security-standard.mdx) to namespaces in the tenant cluster
-- creates a [ResourceQuota](../configure/vcluster-yaml/policies/resource-quota.mdx) and [LimitRange](../configure/vcluster-yaml/policies/limit-range.mdx) in the control plane cluster namespace where vCluster runs
-- creates vCluster-managed [NetworkPolicies](../configure/vcluster-yaml/policies/network-policy.mdx) for the vCluster control plane and synced workloads in the control plane cluster namespace
-- stores synced pod service account tokens in Secrets rather than pod annotations; tokens stored in annotations are readable by anyone who can read pod specs, whereas tokens in Secrets are gated by Secret-level RBAC
-
 :::warning NetworkPolicy support
 NetworkPolicies only take effect when the control plane cluster's CNI implements Kubernetes NetworkPolicy. Creating NetworkPolicy resources without a controller that enforces them does not isolate traffic.
 :::
@@ -47,7 +61,7 @@ NetworkPolicies only take effect when the control plane cluster's CNI implements
 
 Kubernetes RBAC inside the tenant cluster controls what users and service accounts can do in the tenant environment. This is separate from Platform RBAC, which controls who can create or manage tenant clusters.
 
-Key access to restrict:
+Key access to restrict at the tenant level:
 
 - **Pod and workload creation**: Any user who can create a Pod can run arbitrary container images and influence sync behavior. Limit `create` on Pods, Deployments, StatefulSets, and Jobs to subjects that need it.
 - **`exec` and `attach`**: `pods/exec` and `pods/attach` grant interactive shell access to running containers. Grant these verbs only to users who genuinely need them.
@@ -69,7 +83,7 @@ Use namespace-level NetworkPolicies inside the tenant cluster to restrict latera
 
 Use `policies.podSecurityStandard` when the platform operator needs to enforce a Pod Security Standard uniformly across all tenant namespaces. Tenants cannot remove or loosen PSA labels that vCluster applies.
 
-For granular, platform-managed admission policies that tenants cannot override, use [central admission control](../configure/vcluster-yaml/policies/admission-control.mdx). Central admission control is a vCluster Pro feature. It configures webhooks in the tenant cluster that point through the vCluster proxy to a service in the control plane cluster or to an external policy service. Tenants can install their own admission controllers, but they cannot mutate or delete the centrally configured hooks.
+For granular, platform-managed admission policies that tenants cannot override, use [central admission control](../configure/vcluster-yaml/policies/admission-control.mdx). Central admission control is a vCluster Pro feature. It configures webhooks in the tenant cluster. The webhooks point through the vCluster proxy to a service in the control plane cluster or to an external policy service. Tenants can install their own admission controllers, but they cannot mutate or delete the centrally configured hooks.
 
 Test admission webhooks with `failurePolicy: Ignore` before switching to `failurePolicy: Fail` in production. A misconfigured webhook with `failurePolicy: Fail` can block all workload creation in the tenant cluster.
 
@@ -79,13 +93,13 @@ vCluster synchronizes selected resources between the tenant cluster and the cont
 
 ### Sync to host
 
-Resources under [`sync.toHost`](../configure/vcluster-yaml/sync/to-host/overview.mdx) are created in the control plane cluster after vCluster translates names, labels, and namespaces. This is required for normal workloads such as Pods, Services, ConfigMaps, Secrets, and PersistentVolumeClaims, but it also means tenant-created objects can create real Kubernetes objects in the control plane cluster.
+vCluster creates [`sync.toHost`](../configure/vcluster-yaml/sync/to-host/overview.mdx) resources in the control plane cluster after translating names, labels, and namespaces. Normal workloads such as Pods, Services, ConfigMaps, Secrets, and PersistentVolumeClaims require this. It also means tenant-created objects can create real Kubernetes objects in the control plane cluster.
 
 Limit `sync.toHost` to the resources tenants actually need. Treat advanced options such as namespace sync, custom resource sync, service account sync, and host deployments as security-sensitive.
 
 ### Sync from host
 
-Resources under [`sync.fromHost`](../configure/vcluster-yaml/sync/from-host/overview.mdx) are copied from the control plane cluster into the tenant cluster. These resources are read-only from the tenant perspective: changes made inside the tenant cluster are not written back to the control plane cluster.
+vCluster copies [`sync.fromHost`](../configure/vcluster-yaml/sync/from-host/overview.mdx) resources from the control plane cluster into the tenant cluster. Tenants cannot modify these resources or write changes back to the control plane cluster.
 
 Use selectors and explicit mappings when syncing shared or sensitive resources such as StorageClasses, RuntimeClasses, Secrets, ConfigMaps, and custom resources.
 
@@ -99,14 +113,13 @@ For restricted environments, use [RBAC configuration](../configure/vcluster-yaml
 
 The vCluster control plane runs as a workload in the control plane cluster. Harden it like any other privileged control plane component:
 
-- Apply a Pod Security Standard label to the control plane cluster namespace where vCluster runs. This is independent of `policies.podSecurityStandard`, which labels namespaces inside the tenant cluster — the host namespace label is a backstop on the control plane cluster side. `baseline` enforcement works with the default vCluster deployment. `restricted` enforcement requires [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx) to be enabled first.
+- Apply a [Pod Security Standard label](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-levels) to the control plane cluster namespace where vCluster runs. This is independent of `policies.podSecurityStandard`, which labels namespaces inside the tenant cluster — the host namespace label is a backstop on the control plane cluster side. `baseline` enforcement works with the default vCluster deployment. `restricted` enforcement requires [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx) to be enabled first.
 - Run the vCluster pod as a non-root user with [rootless mode](../deploy/control-plane/kubernetes-pod/security/rootless-mode.mdx).
-- Configure `controlPlane.statefulSet.security.podSecurityContext` and `controlPlane.statefulSet.security.containerSecurityContext` for user IDs, file system groups, privilege escalation, capabilities, and seccomp settings.
-- Configure the control plane ServiceAccount explicitly when your organization manages RBAC outside of the vCluster Helm chart.
+- Configure [`controlPlane.statefulSet.security.podSecurityContext` and `controlPlane.statefulSet.security.containerSecurityContext`](../deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/5-policies.mdx) for user IDs, file system groups, privilege escalation, capabilities, and seccomp settings.
+- Configure the [control plane ServiceAccount](../configure/vcluster-yaml/rbac.mdx) explicitly when your organization manages RBAC outside of the vCluster Helm chart.
 - Use the [CIS hardening guide](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx) for API server audit logging, EventRateLimit, encryption at rest, admission plugin settings, and hardened Kubernetes component arguments.
 - Use [FIPS images](../deploy/control-plane/kubernetes-pod/security/fips.mdx), [air-gapped deployment](../deploy/control-plane/kubernetes-pod/security/air-gapped.mdx), or [corporate proxy configuration](../deploy/control-plane/kubernetes-pod/security/corporate-proxy.mdx) when required by your environment.
 
-Some options, such as rootless mode, worker node model, and backing store type, must be chosen at initial deployment time. Review security requirements before creating production tenant clusters.
 
 ## Platform governance
 
@@ -124,47 +137,36 @@ Do not allow untrusted project users to create tenant clusters without an approv
 
 ## Tenancy and isolation profiles
 
-Choose an isolation profile based on the level of workload trust and the cost of dedicating infrastructure.
-
-| Profile | Isolation boundary | Best for | Main docs |
-|---|---|---|---|
-| Shared host nodes | Kubernetes container isolation plus vCluster policy controls | General multi-tenant workloads on shared infrastructure | [Isolated workloads](../deploy/worker-nodes/host-nodes/isolated-workloads.mdx), [Policies](../configure/vcluster-yaml/policies/overview.mdx), [Sync](../configure/vcluster-yaml/sync/overview.mdx) |
-| Shared host nodes with vNode | Runtime sandbox on shared nodes | Privileged or higher-risk workloads on shared hardware | [vNode docs](https://www.vnode.com/docs/) |
-| Private nodes | Dedicated Kubernetes nodes per tenant cluster | Stronger node-level tenant isolation | [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx) |
-| Private nodes with vMetal | Dedicated physical servers | Physical isolation, GPU or PCIe device exclusivity, and bare-metal compliance needs | [vMetal docs](https://www.vmetal.ai/docs/) |
+These controls apply to the baseline profile, where tenant workloads run on shared nodes of the control plane cluster. Two additional profiles move the isolation boundary further out.
 
 ### vNode
 
-vCluster defines the tenant cluster boundary. vNode strengthens workload isolation on shared nodes.
+vCluster defines the tenant cluster boundary. vNode strengthens workload isolation on shared nodes using a runtime sandbox.
 
 Use vNode when tenants share physical nodes but workloads need stronger runtime containment than standard containers provide. This is especially relevant for privileged workloads, Docker-in-Docker, `hostPID`, host path access, GPU workloads, or user-supplied model inference code.
 
-vNode does not replace vCluster policy guardrails. Continue to use Pod Security Standards, NetworkPolicies, quotas, reviewed sync settings, and approved templates.
+vNode does not replace vCluster policy guardrails. Continue to use Pod Security Standards, NetworkPolicies, quotas, reviewed sync settings, and approved templates. See the [vNode docs](https://www.vnode.com/docs/) for configuration details.
 
 ### Private nodes
 
 Private nodes move tenant workloads off the control plane cluster's shared worker nodes. The vCluster control plane still runs in the control plane cluster, but workload execution moves to nodes dedicated to the tenant cluster.
 
-Use private nodes when tenants require dedicated node capacity, stronger workload isolation, or direct control over node-level Kubernetes behavior.
+Use private nodes when tenants require dedicated node capacity, stronger workload isolation, or direct control over node-level Kubernetes behavior. See [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx) for deployment details.
 
-### vMetal
-
-vMetal provisions private nodes as dedicated physical servers. It adds bare-metal operational security requirements that are outside the scope of vCluster itself, including BMC credential handling, OS image integrity, PXE and provisioning network exposure, Metal3 and Ironic hardening, and BareMetalHost access control.
-
-Use the vCluster security guide to decide when physical isolation is required. Use the vMetal security guide as the source of truth for bare-metal-specific controls.
+For GPU or PCIe device exclusivity, bare-metal compliance, or sovereign deployments, private nodes can be provisioned as dedicated physical servers using vMetal. vMetal adds bare-metal operational security requirements outside the scope of vCluster itself, including BMC credential handling, OS image integrity, PXE and provisioning network exposure, Metal3 and Ironic hardening, and BareMetalHost access control. See the [vMetal docs](https://www.vmetal.ai/docs/) for bare-metal-specific controls.
 
 ## Production checklist
 
 Before deploying production tenant clusters, verify:
 
-- The control plane cluster CNI enforces NetworkPolicy.
-- `policies.podSecurityStandard`, `policies.resourceQuota`, `policies.limitRange`, and `policies.networkPolicy` are configured intentionally.
-- `sync.toHost` and `sync.fromHost` are limited to required resources.
-- Tenant RBAC restricts Pod creation, `exec`, Secret access, and cluster-scoped role grants to intended subjects.
-- Central admission control is tested with `failurePolicy: Ignore` before using `failurePolicy: Fail`.
-- vCluster control plane pods run with the required security context, rootless mode, and ServiceAccount model.
-- API server audit logging, EventRateLimit, and encryption settings meet compliance requirements.
-- Non-admin Platform users can create tenant clusters only from approved templates.
-- Platform Agent permissions and security contexts meet the control plane cluster's trust requirements.
-- The isolation profile is explicit: shared nodes, shared nodes with vNode, private nodes, or private nodes with vMetal.
-- vMetal deployments validate BMC credential storage and rotation, OS image checksums, provisioning network segmentation, BareMetalHost and NodeProvider RBAC, and control plane access to BMC networks.
+- [ ] The control plane cluster CNI enforces NetworkPolicy.
+- [ ] `policies.podSecurityStandard`, `policies.resourceQuota`, `policies.limitRange`, and `policies.networkPolicy` are configured intentionally.
+- [ ] `sync.toHost` and `sync.fromHost` are limited to required resources.
+- [ ] Tenant RBAC restricts Pod creation, `exec`, Secret access, and cluster-scoped role grants to intended subjects.
+- [ ] Central admission control is tested with `failurePolicy: Ignore` before using `failurePolicy: Fail`.
+- [ ] vCluster control plane pods run with the required security context, rootless mode, and ServiceAccount model.
+- [ ] API server audit logging, EventRateLimit, and encryption settings meet compliance requirements.
+- [ ] Non-admin Platform users can create tenant clusters only from approved templates.
+- [ ] Platform Agent permissions and security contexts meet the control plane cluster's trust requirements.
+- [ ] The isolation profile is explicit: shared nodes, shared nodes with vNode, private nodes, or private nodes with vMetal.
+- [ ] vMetal deployments validate BMC credential storage and rotation, OS image checksums, provisioning network segmentation, BareMetalHost and NodeProvider RBAC, and control plane access to BMC networks.

--- a/vcluster/security/_category_.json
+++ b/vcluster/security/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Security",
+  "position": 5,
+  "collapsible": true,
+  "collapsed": false
+}


### PR DESCRIPTION
# Content Description

Adds a consolidated vCluster security guide at `vcluster/security/README.mdx`. The page covers the three isolation boundaries (inside tenant cluster, sync boundary, outside/platform), a baseline hardening `vcluster.yaml`, workload RBAC/NetworkPolicy/admission control with per-layer guidance, control plane hardening, Platform governance, tenancy and isolation profiles (shared nodes, vNode, private nodes, vMetal), and a production checklist. Also updates `isolation.mdx` to link to the new page and removes the stale reference to the legacy `isolate` flag.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2169--vcluster-docs-site.netlify.app/docs/vcluster/next/security/

## Internal Reference

Closes DOC-503

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs