### PR TITLE
feat: fix UI permalinks for control plane and high availability

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -582,11 +582,11 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 # Control Plane
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/control-plane"
-  to = "/docs/vcluster/category/components"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/"
 
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/control-plane/:version"
-  to = "/docs/vcluster/:version/category/components"
+  to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/"
 
 # Control Plane > Backing Store
 [[redirects]]
@@ -623,6 +623,15 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/control-plane-ingress/:version"
   to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/deployment/ingress"
+
+# Control Plane > High Availability
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/high-availability"
+  to = "/docs/vcluster/deploy/control-plane/kubernetes-pod/high-availability"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/high-availability/:version"
+  to = "/docs/vcluster/:version/deploy/control-plane/kubernetes-pod/high-availability"
 
 # Host Path Mapper
 [[redirects]]


### PR DESCRIPTION
## Summary

Two Platform UI docs links currently 404:

- `/docs/platform-ui-link/vcluster/control-plane` redirects to `/docs/vcluster/category/components`, which doesn't exist. Used by the **Control Plane Docs** button in the *Advanced Control Plane → More Control Plane Settings* subsection of the tenant cluster form.
- `/docs/platform-ui-link/vcluster/high-availability` has no redirect at all. Used by the **High Availability** toggle in the tenant cluster creation wizard (added in `feat(ui) - tenancy model redesign` on 2026-04-22).

## Changes

- Repoint the existing `vcluster/control-plane` redirects to `/docs/vcluster/configure/vcluster-yaml/control-plane/` (returns 200).
- Add new `vcluster/high-availability` redirects (unversioned + versioned) pointing to `/docs/vcluster/deploy/control-plane/kubernetes-pod/high-availability` (returns 200).

## Test plan

- [ ] Once deployed, `curl -sIL https://www.vcluster.com/docs/platform-ui-link/vcluster/control-plane` ends in `HTTP/2 200`
- [ ] `curl -sIL https://www.vcluster.com/docs/platform-ui-link/vcluster/high-availability` ends in `HTTP/2 200`
- [ ] Open a Tenant Cluster Template, hit the "Control Plane Docs" button, confirm it lands on the control plane docs page
- [ ] In the creation wizard, click the "Learn more" next to the High Availability toggle, confirm it lands on the HA page