### PR TITLE
fix(sidebar): repair docusaurus 3.10 regressions in left nav

### DIFF
--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -2,6 +2,31 @@
   --doc-sidebar-width: 360px !important;
 }
 
+/* Docusaurus 3.10+ compatibility:
+   The Link and Category components now wrap the label in an inner <span>
+   (.linkLabel / .categoryLinkLabel) with overflow:hidden + -webkit-line-clamp.
+   That clips our negative text-indent ("hanging indent" used by
+   .logical-grouping items) and forces multi-line truncation we don't want.
+   Override so text flows naturally to the parent .menu__link, which already
+   handles single-line ellipsis truncation via white-space:nowrap. */
+.menu__link > span {
+  overflow: visible !important;
+  display: inline !important;
+  flex: none !important;
+  -webkit-line-clamp: unset !important;
+  line-clamp: unset !important;
+}
+
+/* Docusaurus 3.10+ compatibility:
+   .menu__list-item-collapsible is now display:flex with flex-wrap:wrap.
+   Combined with our .menu__link { width: 100% }, the chevron button would
+   wrap onto a new line. Even though our .menu__caret is position:absolute,
+   the flex layout's box sizing changed enough that we need to prevent
+   wrapping explicitly. */
+.menu__list-item-collapsible {
+  flex-wrap: nowrap !important;
+}
+
 /* Sidebar links */
 .menu__list-item {
   /* code-styled font for vcluster.yaml nav links */
@@ -350,9 +375,14 @@ body .menu {
 }
 
 button.menu__caret {
-  transform: scale(0.7) rotate(180deg);
+  /* Docusaurus 3.10+ compatibility:
+     .menu__caret is now display:flex with align-items:center, which centers
+     the ::before icon inside the button's padding box. Use translateY(-50%)
+     to center the button itself within the collapsible row regardless of
+     the row's actual height (calc(50% - 18px) hardcoded the old layout). */
   right: -4px;
-  top: calc(50% - 18px);
+  top: 50%;
+  transform: translateY(-50%) scale(0.7) rotate(180deg);
 }
 
 .menu__list-item--collapsed .menu__link--sublist:after, .menu__list-item--collapsed .menu__caret:before {


### PR DESCRIPTION
## Summary

Repairs two sidebar regressions introduced by the docusaurus 3.10 upgrade (#2172):

- **Label cutoff** — 3.10's `<DocSidebarItem/Link>` and `<DocSidebarItem/Category>` now wrap the label in an inner `<span>` (`.linkLabel` / `.categoryLinkLabel`) with `overflow:hidden` + `-webkit-line-clamp:2`. That clipped the negative `text-indent: -1rem` used as a hanging indent on `.logical-grouping` items — first ~2 characters of items like `backingStore`, `coredns`, `statefulSet` disappeared.
- **Misaligned chevron** — `.menu__list-item-collapsible` changed to `display:flex; flex-wrap:wrap` and `.menu__caret` became `display:flex; align-items:center`. Our `top: calc(50% - 18px)` was calibrated for the old layout where the icon sat at the top of the button, so the chevron rendered below the link text.

## Fix

In `src/css/sidebar.scss`:
- Force the inner label `<span>` to `display:inline; overflow:visible` so text-indent flows naturally to the parent link (which still single-line-truncates via `white-space:nowrap` + `text-overflow:ellipsis`).
- `flex-wrap:nowrap` on `.menu__list-item-collapsible` to keep the chevron from wrapping.
- Switch the chevron to `top:50%; transform: translateY(-50%) scale(0.7) rotate(180deg)` so vertical centering is independent of row height.

Refs DOC-1433.

## Test plan

- [ ] Local dev server renders all sidebar labels in full (no left-side cutoff)
- [ ] Chevron is vertically centered next to each collapsible category
- [ ] PRO / FREE / ENTERPRISE badges still position correctly
- [ ] Logical groupings (COMPONENTS, DEPLOYMENT, etc.) still render as uppercase section headers