### PR TITLE
fix(sidebar): collapse/expand toggle broken on linked categories after 3.10 upgrade

### DIFF
--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -317,11 +317,6 @@ body .menu {
     margin-right: 0;
     margin-left: auto;
   }
-
-  /* Make sure that clicking on icon opens category overview page (only if category is collapsed) */
-  .menu__list-item.menu__list-item--collapsed & {
-    z-index: -1;
-  }
 }
 
 /* Extra padding bottom for expanded categories */
@@ -349,29 +344,6 @@ body .menu {
 
 .theme-doc-sidebar-item-category.extra-indent .menu__list .menu__link {
   text-indent: 1.1em;
-}
-
-/* Collapse/Expand icon */
-.menu__caret {
-  background-color: transparent !important;
-  position: absolute;
-  top: 0;
-  left: auto;
-  right: 0;
-  bottom: 0;
-  padding-right: 20px;
-  align-items: center;
-  z-index: 1;
-
-  &::before {
-    margin-right: 0;
-    margin-left: auto;
-  }
-
-  /* Make sure that clicking on icon opens category overview page (only if category is collapsed) */
-  .menu__list-item.menu__list-item--collapsed & {
-    z-index: -1;
-  }
 }
 
 button.menu__caret {


### PR DESCRIPTION
# Content Description

Removes a `z-index: -1` trick on `.menu__caret` that prevented users from re-expanding collapsed sidebar categories with overview pages (Deploy, vcluster.yaml). Also removes the duplicate `.menu__caret` block introduced in the same file.

## Preview Link

<!-- The preview link or links to the documents-->
https://deploy-preview-2175--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/ or

https://deploy-preview-2175--vcluster-docs-site.netlify.app/docs/vcluster/deploy/

For either, make sure that you can collapse and then expand the highlighted section in the left nav.

## Internal Reference

Closes DOC-1452

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs