### PR TITLE
fix(quick-start): fix broken card links when navigating via React Router

### DIFF
--- a/vcluster/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster/introduction/what-are-virtual-clusters.mdx
@@ -12,7 +12,7 @@ vCluster provisions fully isolated Kubernetes environments, called <GlossaryTerm
 
 The control plane is completely invisible to tenants. There are no shared control plane nodes, no in-cluster agent pods, and no lateral path between environments. vCluster suits any environment where isolation is a hard requirement, from developer platforms and CI/CD pipelines to GPU cloud infrastructure serving paying tenants.
 
-Ready to deploy? See the [Quick Start](/docs/vcluster) to choose the path that fits your environment.
+Ready to deploy? See the [Quick Start](../quick-start/overview.mdx) to choose the path that fits your environment.
 
 ## How it works
 

--- a/vcluster/quick-start/overview.mdx
+++ b/vcluster/quick-start/overview.mdx
@@ -10,6 +10,19 @@ pagination_prev: null
 ---
 
 import Link from '@docusaurus/Link';
+import {useLocation} from '@docusaurus/router';
+
+export const QuickStartCard = ({path, icon, title, description}) => {
+  const location = useLocation();
+  const base = location.pathname.replace(/\/?$/, '/');
+  return (
+    <Link to={base + path} className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
+      <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>{icon}</span>
+      <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>{title}</h3>
+      <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>{description}</p>
+    </Link>
+  );
+};
 
 vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can go on your existing infrastructure, or they can be built from scratch on bare metal and VMs. Each tenant gets a full Kubernetes API experience while the virtualized control plane stays completely invisible to them.
 
@@ -19,26 +32,10 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
 `}} />
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '1rem', marginBottom: '2rem', marginTop: '1rem'}}>
-  <Link to="./quick-start/shared-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>group</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Shared Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You have a Kubernetes cluster and want isolated tenant environments. Tenant workloads run on the existing node pool. No extra infrastructure needed. Works with OSS CLI or Platform.</p>
-  </Link>
-  <Link to="./quick-start/private-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>lock</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Private Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for hard tenancy: GPU clouds, regulated platforms, and sovereign deployments. Requires vCluster Platform (free mode OK).</p>
-  </Link>
-  <Link to="./quick-start/docker" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>laptop</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Docker (vind)</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You want an ephemeral cluster for local development or CI. No Kubernetes required — just Docker.</p>
-  </Link>
-  <Link to="./quick-start/standalone" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>storage</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Standalone</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You're building a managed Kubernetes platform from bare metal or VMs. Bootstrap a Control Plane Cluster and install Platform in one pass.</p>
-  </Link>
+  <QuickStartCard path="quick-start/shared-nodes" icon="group" title="Shared Nodes" description="You have a Kubernetes cluster and want isolated tenant environments. Tenant workloads run on the existing node pool. No extra infrastructure needed. Works with OSS CLI or Platform." />
+  <QuickStartCard path="quick-start/private-nodes" icon="lock" title="Private Nodes" description="You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for hard tenancy: GPU clouds, regulated platforms, and sovereign deployments. Requires vCluster Platform (free mode OK)." />
+  <QuickStartCard path="quick-start/docker" icon="laptop" title="Docker (vind)" description="You want an ephemeral cluster for local development or CI. No Kubernetes required — just Docker." />
+  <QuickStartCard path="quick-start/standalone" icon="storage" title="Standalone" description="You're building a managed Kubernetes platform from bare metal or VMs. Bootstrap a Control Plane Cluster and install Platform in one pass." />
 </div>
 
 ## Match your situation to a guide

--- a/vcluster_versioned_docs/version-0.34.0/introduction/what-are-virtual-clusters.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/introduction/what-are-virtual-clusters.mdx
@@ -12,7 +12,7 @@ vCluster provisions fully isolated Kubernetes environments, called <GlossaryTerm
 
 The control plane is completely invisible to tenants. There are no shared control plane nodes, no in-cluster agent pods, and no lateral path between environments. vCluster suits any environment where isolation is a hard requirement, from developer platforms and CI/CD pipelines to GPU cloud infrastructure serving paying tenants.
 
-Ready to deploy? See the [Quick Start](/docs/vcluster) to choose the path that fits your environment.
+Ready to deploy? See the [Quick Start](../quick-start/index.mdx) to choose the path that fits your environment.
 
 ## How it works
 

--- a/vcluster_versioned_docs/version-0.34.0/quick-start/index.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/quick-start/index.mdx
@@ -10,6 +10,19 @@ pagination_prev: null
 ---
 
 import Link from '@docusaurus/Link';
+import {useLocation} from '@docusaurus/router';
+
+export const QuickStartCard = ({path, icon, title, description}) => {
+  const location = useLocation();
+  const base = location.pathname.replace(/\/?$/, '/');
+  return (
+    <Link to={base + path} className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
+      <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>{icon}</span>
+      <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>{title}</h3>
+      <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>{description}</p>
+    </Link>
+  );
+};
 
 vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can go on your existing infrastructure, or they can be built from scratch on bare metal and VMs. Each tenant gets a full Kubernetes API experience while the virtualized control plane stays completely invisible to them.
 
@@ -19,26 +32,10 @@ vCluster provisions isolated Kubernetes tenant clusters. The tenant clusters can
 `}} />
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: '1rem', marginBottom: '2rem', marginTop: '1rem'}}>
-  <Link to="./quick-start/shared-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>group</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Shared Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You have a Kubernetes cluster and want isolated tenant environments. Tenant workloads run on the existing node pool. No extra infrastructure needed. Works with OSS CLI or Platform.</p>
-  </Link>
-  <Link to="./quick-start/private-nodes" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>lock</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Private Nodes</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for hard tenancy: GPU clouds, regulated platforms, and sovereign deployments. Requires vCluster Platform (free mode OK).</p>
-  </Link>
-  <Link to="./quick-start/docker" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>laptop</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Docker (vind)</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You want an ephemeral cluster for local development or CI. No Kubernetes required — just Docker.</p>
-  </Link>
-  <Link to="./quick-start/standalone" className="card deploy-card" style={{padding: '1rem 1.25rem', textDecoration: 'none', color: 'inherit', display: 'block'}}>
-    <span className="material-icons-outlined" style={{fontSize: '28px', color: 'var(--ifm-color-primary)', marginBottom: '0.5rem', display: 'block'}}>storage</span>
-    <h3 style={{margin: '0 0 0.4rem 0', fontSize: '1rem'}}>Standalone</h3>
-    <p style={{margin: 0, fontSize: '0.9rem', color: 'var(--ifm-color-content-secondary)'}}>You're building a managed Kubernetes platform from bare metal or VMs. Bootstrap a Control Plane Cluster and install Platform in one pass.</p>
-  </Link>
+  <QuickStartCard path="quick-start/shared-nodes" icon="group" title="Shared Nodes" description="You have a Kubernetes cluster and want isolated tenant environments. Tenant workloads run on the existing node pool. No extra infrastructure needed. Works with OSS CLI or Platform." />
+  <QuickStartCard path="quick-start/private-nodes" icon="lock" title="Private Nodes" description="You need dedicated infrastructure per tenant. Each tenant cluster runs on its own nodes. Best for hard tenancy: GPU clouds, regulated platforms, and sovereign deployments. Requires vCluster Platform (free mode OK)." />
+  <QuickStartCard path="quick-start/docker" icon="laptop" title="Docker (vind)" description="You want an ephemeral cluster for local development or CI. No Kubernetes required — just Docker." />
+  <QuickStartCard path="quick-start/standalone" icon="storage" title="Standalone" description="You're building a managed Kubernetes platform from bare metal or VMs. Bootstrap a Control Plane Cluster and install Platform in one pass." />
 </div>
 
 ## Match your situation to a guide


### PR DESCRIPTION
# Content Description

Quick-start landing page card links 404'd when arriving via client-side navigation (e.g. clicking the "Quick Start" link from the What is vCluster? page). Root causes were two separate issues stacked on top of each other:

1. **Card links used relative `<Link to="./quick-start/...">` resolved at runtime by React Router.** The page has `slug: /` (plugin root), so without a trailing slash the `./quick-start/` path resolved one level too high — `/docs/quick-start/...` instead of `/docs/vcluster/quick-start/...`. Fixed by replacing the inline cards with a `QuickStartCard` component that uses `useLocation` to normalise the current pathname to a trailing-slash base before constructing the link.

2. **The referring link in `what-are-virtual-clusters.mdx` used an absolute `/docs/vcluster/` path,** hardcoding the 0.34 default version regardless of which version the reader was browsing. Users on the `next` version would land on 0.34 quick-start cards. Fixed by switching to a relative MDX path (`../quick-start/overview.mdx`) so Docusaurus resolves it to the correct version at build time.

Both fixes applied to the current (`next`) version and to `version-0.34.0`, which is `lastVersion` and actually served at `/docs/vcluster`.

## Preview Link

<!-- The preview link or links to the documents-->

- https://deploy-preview-2176--vcluster-docs-site.netlify.app/docs/vcluster/introduction/what-are-virtual-clusters/

Start there. Click on the `Quick Start` link in the intro (3rd paragraph, top of page). Then make sure all of the cards on the Quick Start page link correctly to their quick start.

Repeat the test for the `main` version, as well.

## Internal Reference

Closes DOC-1451

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs