### PR TITLE
docs(monitoring): Prometheus node metrics on shared nodes

### DIFF
--- a/.github/styles/Loft/no-latinisms.yml
+++ b/.github/styles/Loft/no-latinisms.yml
@@ -1,0 +1,12 @@
+extends: substitution
+message: "Avoid Latinisms: use '%s' instead of '%s'."
+level: warning
+ignorecase: true
+nonword: true
+action:
+  name: replace
+swap:
+  '\bvia\b': using
+  '\betc\.': 'and so on'
+  '\b(?:eg|e\.g\.)(?=[\s,;])': 'for example'
+  '\b(?:ie|i\.e\.)(?=[\s,;])': 'that is'

--- a/platform/maintenance/monitoring/central-hostpath-mapper.mdx
+++ b/platform/maintenance/monitoring/central-hostpath-mapper.mdx
@@ -1,7 +1,7 @@
 ---
 title: Central HostPath Mapper
 sidebar_label: Central HostPath Mapper
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/monitoring/fleet-monitoring-otel.mdx
+++ b/platform/maintenance/monitoring/fleet-monitoring-otel.mdx
@@ -128,6 +128,10 @@ The architecture comprises the following:
 
 ### Shared nodes
 
+:::note
+For background on why direct Prometheus scraping fails in Shared Nodes mode and how to configure it, see [Prometheus node metrics on shared nodes](./prometheus-shared-nodes.mdx).
+:::
+
 The shared-nodes collector runs on the Control Plane Cluster as a Deployment with 2
 replicas. A Target Allocator discovers vCluster ServiceMonitors and distributes
 cAdvisor and ServiceMonitor scrape targets across replicas using

--- a/platform/maintenance/monitoring/metrics.mdx
+++ b/platform/maintenance/monitoring/metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 sidebar_label: Metrics
-sidebar_position: 4
+sidebar_position: 5
 description: Prometheus-conformant metrics exposed by vCluster Platform, including how to configure scraping with a ServiceMonitor.
 ---
 
@@ -53,7 +53,7 @@ URL `/metrics`
 If the header is not provided, vCluster Platform denies the request.
 
 :::info Turn off metrics authentication
-If you wish to scrape metrics without authentication, you can turn it off via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
+To scrape metrics without authentication, turn it off using the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
 Example of accessing metrics from a specific pod using port-forward:
@@ -80,8 +80,8 @@ vCluster Platform collects metrics from its internal components and merges them 
 
 - **API gateway metrics**: vCluster Platform exposes metrics for its internal api gateway such as the total amount of requests (`apigateway_ENDPOINT_request_total`), request latency (`apigateway_ENDPOINT_request_duration_seconds`) and request sizes (`apigateway_ENDPOINT_response_sizes`) for the different endpoints. The metrics have different labels depending on the endpoint. The following endpoints and metrics are available:
   - **ui**: all requests that target vCluster Platform UI assets (metrics are `apigateway_ui_request_total`, `apigateway_ui_request_duration_seconds`, `apigateway_ui_response_sizes`)
-  - **auth**: all requests that target vCluster Platform authentication endpoints (such as login, token refresh etc.)
-  - **kubernetes**: all forwarded requests that target a kubernetes cluster. The targeted backend is provided by a label and can be either `management` (the integrated vCluster Platform kubernetes api server), `cluster` (a request forwarded to a connected cluster) or `vcluster` (a virtual kubernetes cluster deployed by vCluster Platform). Further labels are provided as well such as kubernetes resource, api version, api group, subresource etc.
+  - **auth**: all requests that target vCluster Platform authentication endpoints (such as login and token refresh)
+  - **kubernetes**: all forwarded requests that target a kubernetes cluster. The targeted backend is provided by a label and can be either `management` (the integrated vCluster Platform kubernetes api server), `cluster` (a request forwarded to a connected cluster) or `vcluster` (a virtual kubernetes cluster deployed by vCluster Platform). Further labels are provided as well such as kubernetes resource, api version, api group, and subresource.
   - **oidc**: all requests that target the internal OIDC server
 - **Integrated Kubernetes API server metrics**: all internal kubernetes api server metrics are exposed. An incomplete list can be found in the [kubernetes repository](https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/metrics/metrics.go)
 - **Integrated Controller manager metrics**: all vCluster Platform management cluster controller metrics are exposed.

--- a/platform/maintenance/monitoring/overview.mdx
+++ b/platform/maintenance/monitoring/overview.mdx
@@ -27,7 +27,7 @@ For a single connected cluster, install the `kube-prometheus-stack` app from the
 2. Navigate to the **Apps** tab.
 3. Click the **kube-prometheus-stack** recommended app and click **Install**.
 
-After installation, you have a complete monitoring setup with Prometheus scraping cluster metrics and Grafana for visualization.
+After installation, you have a complete monitoring setup with Prometheus scraping cluster metrics and Grafana for visualization. If your tenant clusters run in Shared Nodes mode, see [Prometheus node metrics on shared nodes](./prometheus-shared-nodes) to configure kubelet scraping.
 
 :::warning
 Do not use `kube-prometheus-stack` if you want to aggregate metrics across multiple tenant clusters. Use the OpenTelemetry fleet monitoring approach below instead.
@@ -39,7 +39,6 @@ For aggregating workload metrics across multiple tenant clusters, use the OpenTe
 
 - [Aggregating metrics with OpenTelemetry](./aggregating-metrics) — step-by-step setup with Prometheus, OpenTelemetry Collector, and Grafana
 - [Fleet monitoring with OpenTelemetry](./fleet-monitoring-otel) — advanced configuration including remote_write for both Shared Nodes and Private Nodes tenancy models
-- [Prometheus node metrics on shared nodes](./prometheus-shared-nodes) — set up Prometheus to scrape kubelet and cAdvisor metrics from tenant clusters running on shared nodes
 
 ## Platform health metrics
 

--- a/platform/maintenance/monitoring/overview.mdx
+++ b/platform/maintenance/monitoring/overview.mdx
@@ -39,6 +39,7 @@ For aggregating workload metrics across multiple tenant clusters, use the OpenTe
 
 - [Aggregating metrics with OpenTelemetry](./aggregating-metrics) — step-by-step setup with Prometheus, OpenTelemetry Collector, and Grafana
 - [Fleet monitoring with OpenTelemetry](./fleet-monitoring-otel) — advanced configuration including remote_write for both Shared Nodes and Private Nodes tenancy models
+- [Prometheus node metrics on shared nodes](./prometheus-shared-nodes) — set up Prometheus to scrape kubelet and cAdvisor metrics from tenant clusters running on shared nodes
 
 ## Platform health metrics
 

--- a/platform/maintenance/monitoring/prometheus-shared-nodes.mdx
+++ b/platform/maintenance/monitoring/prometheus-shared-nodes.mdx
@@ -1,0 +1,90 @@
+---
+title: "Prometheus node metrics on shared nodes"
+sidebar_label: "Prometheus on shared nodes"
+sidebar_position: 6
+description: "Troubleshoot Prometheus failing to scrape kubelet and cAdvisor node metrics from tenant clusters running on shared nodes, and choose a fix based on your setup."
+---
+
+When Prometheus tries to scrape kubelet or cAdvisor metrics from a tenant cluster running in Shared Nodes mode, the scrape targets time out or refuse connections even though nodes are visible and workloads are running.
+
+## Root cause
+
+vCluster enables kubelet proxying by default (`networking.advanced.proxyKubelets.byIP: true` and `byHostname: true` in the default Helm values). This feature intercepts kubelet traffic going into the tenant cluster so vCluster can rewrite pod names and namespaces from host-cluster values to their virtual equivalents.
+
+As a side effect, each node synced into the tenant cluster is given a virtual identity:
+
+- With `byIP: true`, the node's IP address is replaced by the ClusterIP of a per-node Kubernetes Service created in the vCluster namespace on the control plane cluster.
+- With `byHostname: true`, the node hostname is replaced with a synthetic name like `<node-name>.nodes.vcluster.com`.
+
+Prometheus discovers scrape targets by reading node objects from the tenant cluster's Kubernetes API. It then attempts to open a connection to those virtual addresses (for example `https://10.96.42.1:10250/metrics/cadvisor`). If the per-node service ClusterIP is not routable from where Prometheus runs — most commonly when Prometheus is outside the tenant cluster or on a separate connected cluster — the scrape times out.
+
+## Affected tenancy models
+
+| Tenancy model | Affected | Reason |
+|---|---|---|
+| Shared Nodes | Yes | Node IPs are virtualized by default via `proxyKubelets` |
+| Private Nodes | No | The tenant cluster has dedicated real nodes with reachable IPs |
+
+## Fix
+
+Choose an approach based on where Prometheus runs and your operational requirements.
+
+### Option 1: OTel fleet monitoring (recommended for production)
+
+The recommended production approach is to deploy an OpenTelemetry Collector on the Control Plane Cluster. The collector scrapes cAdvisor and kubelet metrics using the control plane cluster's real node IPs, then pushes enriched metrics to a central Prometheus via `remote_write`. Because the collector operates at the control plane cluster level, it never reads tenant cluster node objects or depends on virtual node IPs.
+
+This approach also adds per-tenant identity labels (`vcluster_name`, `vcluster_project`, etc.) to every metric, making it suitable for multi-tenant observability.
+
+See [Fleet monitoring with OpenTelemetry](./fleet-monitoring-otel.mdx) for a complete setup guide covering both Shared Nodes and Private Nodes tenancy models.
+
+<!-- vale off -->
+### Option 2: API server proxy scraping (Prometheus inside the tenant cluster)
+<!-- vale on -->
+
+If Prometheus runs inside the tenant cluster (for example, via `kube-prometheus-stack`), configure it to route kubelet and cAdvisor scrapes through the Kubernetes API server proxy instead of connecting to node IPs directly. Requests that go through the API server are intercepted by vCluster, forwarded to the real kubelet on the control plane cluster, and returned with pod names and namespaces already rewritten to virtual equivalents.
+
+Replace direct node address targeting with the API server proxy path:
+
+```yaml title="Prometheus scrape config for cAdvisor via API server proxy"
+scrape_configs:
+  - job_name: cadvisor
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+```
+
+Apply the same pattern to the kubelet metrics job, using `/metrics` instead of `/metrics/cadvisor` in the `__metrics_path__` replacement.
+
+### Option 3: Disable kubelet proxying
+
+If your setup requires Prometheus to scrape node IPs directly, disable the kubelet proxy feature in your `vcluster.yaml`. Setting both options to `false` causes vCluster to pass through the real node addresses from the control plane cluster unchanged, making them discoverable and reachable by Prometheus.
+
+```yaml title="vcluster.yaml"
+networking:
+  advanced:
+    proxyKubelets:
+      byHostname: false
+      byIP: false
+```
+
+:::warning Trade-offs
+Disabling `proxyKubelets` has two consequences:
+
+- **Metrics are not rewritten.** Pod and namespace labels in the returned metrics reflect the control plane cluster's internal naming, not the tenant cluster's virtual names. If multiple tenant clusters share the same node, metrics from different tenant clusters will have overlapping pod/namespace label values.
+- **Infrastructure exposure.** Real node IPs reveal the control plane cluster's internal network topology to anyone with access to the tenant cluster's node objects.
+
+Only use this option if the tenant cluster is fully trusted and metric label overlap is acceptable.
+:::

--- a/platform/maintenance/monitoring/prometheus-shared-nodes.mdx
+++ b/platform/maintenance/monitoring/prometheus-shared-nodes.mdx
@@ -1,39 +1,38 @@
 ---
 title: "Prometheus node metrics on shared nodes"
 sidebar_label: "Prometheus on shared nodes"
-sidebar_position: 6
-description: "Troubleshoot Prometheus failing to scrape kubelet and cAdvisor node metrics from tenant clusters running on shared nodes, and choose a fix based on your setup."
+sidebar_position: 4
+description: "Configure Prometheus to scrape kubelet and cAdvisor node metrics from tenant clusters running in Shared Nodes mode."
 ---
 
-When Prometheus tries to scrape kubelet or cAdvisor metrics from a tenant cluster running in Shared Nodes mode, the scrape targets time out or refuse connections even though nodes are visible and workloads are running.
+In the Shared Nodes tenancy model, vCluster virtualizes node IP addresses by default as part of its kubelet proxying feature. Prometheus requires specific configuration to scrape kubelet and cAdvisor metrics in this environment.
 
-## Root cause
+This does not affect Private Nodes tenant clusters, which have dedicated real nodes with directly reachable IPs.
 
-vCluster enables kubelet proxying by default (`networking.advanced.proxyKubelets.byIP: true` and `byHostname: true` in the default Helm values). This feature intercepts kubelet traffic going into the tenant cluster so vCluster can rewrite pod names and namespaces from host-cluster values to their virtual equivalents.
+## How it works
 
-As a side effect, each node synced into the tenant cluster is given a virtual identity:
+vCluster enables kubelet proxying by default (`networking.advanced.proxyKubelets.byIP: true` and `byHostname: true` in the Helm values). This feature lets vCluster intercept kubelet traffic and rewrite pod names and namespaces from host-cluster values to their virtual equivalents.
 
-- With `byIP: true`, the node's IP address is replaced by the ClusterIP of a per-node Kubernetes Service created in the vCluster namespace on the control plane cluster.
-- With `byHostname: true`, the node hostname is replaced with a synthetic name like `<node-name>.nodes.vcluster.com`.
+As part of this, vCluster assigns each synced node a virtual identity:
 
-Prometheus discovers scrape targets by reading node objects from the tenant cluster's Kubernetes API. It then attempts to open a connection to those virtual addresses (for example `https://10.96.42.1:10250/metrics/cadvisor`). If the per-node service ClusterIP is not routable from where Prometheus runs — most commonly when Prometheus is outside the tenant cluster or on a separate connected cluster — the scrape times out.
+- With `byIP: true`, vCluster replaces the node's IP address with the ClusterIP of a per-node Kubernetes Service in the vCluster namespace on the control plane cluster.
+- With `byHostname: true`, vCluster replaces the node hostname with a synthetic name like `<node-name>.nodes.vcluster.com`.
 
-## Affected tenancy models
+Prometheus discovers scrape targets by reading node objects from the tenant cluster's Kubernetes API. It then attempts to connect to those virtual addresses. If the per-node service ClusterIP is not routable from where Prometheus runs, the scrape times out. This most commonly happens when Prometheus is outside the tenant cluster or on a separate connected cluster,
 
-| Tenancy model | Affected | Reason |
-|---|---|---|
-| Shared Nodes | Yes | Node IPs are virtualized by default via `proxyKubelets` |
-| Private Nodes | No | The tenant cluster has dedicated real nodes with reachable IPs |
+## Approaches
 
-## Fix
+The right approach depends on where Prometheus runs:
 
-Choose an approach based on where Prometheus runs and your operational requirements.
+- **Prometheus outside the tenant cluster** (on the control plane cluster or a central monitoring instance): use [Option 1](#option-1-otel-fleet-monitoring-recommended).
+- **Prometheus inside the tenant cluster**: use [Option 2](#option-2-api-server-proxy-scraping-prometheus-inside-the-tenant-cluster).
+- **Specific requirements that prevent Options 1 or 2**: use [Option 3](#option-3-disable-kubelet-proxying).
 
-### Option 1: OTel fleet monitoring (recommended for production)
+### Option 1: OTel fleet monitoring (recommended)
 
-The recommended production approach is to deploy an OpenTelemetry Collector on the Control Plane Cluster. The collector scrapes cAdvisor and kubelet metrics using the control plane cluster's real node IPs, then pushes enriched metrics to a central Prometheus via `remote_write`. Because the collector operates at the control plane cluster level, it never reads tenant cluster node objects or depends on virtual node IPs.
+Deploy an OpenTelemetry Collector on the Control Plane Cluster. The collector scrapes cAdvisor and kubelet metrics using the control plane cluster's real node IPs, then pushes enriched metrics to a central Prometheus using `remote_write`. Because the collector operates at the control plane cluster level, it never reads tenant cluster node objects or depends on virtual node IPs.
 
-This approach also adds per-tenant identity labels (`vcluster_name`, `vcluster_project`, etc.) to every metric, making it suitable for multi-tenant observability.
+This approach also adds per-tenant identity labels such as `vcluster_name` and `vcluster_project` to every metric, making it suitable for multi-tenant observability.
 
 See [Fleet monitoring with OpenTelemetry](./fleet-monitoring-otel.mdx) for a complete setup guide covering both Shared Nodes and Private Nodes tenancy models.
 
@@ -41,11 +40,11 @@ See [Fleet monitoring with OpenTelemetry](./fleet-monitoring-otel.mdx) for a com
 ### Option 2: API server proxy scraping (Prometheus inside the tenant cluster)
 <!-- vale on -->
 
-If Prometheus runs inside the tenant cluster (for example, via `kube-prometheus-stack`), configure it to route kubelet and cAdvisor scrapes through the Kubernetes API server proxy instead of connecting to node IPs directly. Requests that go through the API server are intercepted by vCluster, forwarded to the real kubelet on the control plane cluster, and returned with pod names and namespaces already rewritten to virtual equivalents.
+Configure Prometheus to route kubelet and cAdvisor scrapes through the Kubernetes API server proxy instead of connecting to node IPs directly. vCluster intercepts requests that go through the API server, forwards them to the real kubelet on the control plane cluster, and returns them with pod names and namespaces already rewritten to their virtual equivalents, so no additional relabeling is needed.
 
-Replace direct node address targeting with the API server proxy path:
+Configure the cAdvisor and kubelet jobs to target the API server and set the metrics path to the node proxy endpoint:
 
-```yaml title="Prometheus scrape config for cAdvisor via API server proxy"
+```yaml title="Prometheus scrape config using the API server proxy"
 scrape_configs:
   - job_name: cadvisor
     scheme: https
@@ -64,13 +63,29 @@ scrape_configs:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
-```
 
-Apply the same pattern to the kubelet metrics job, using `/metrics` instead of `/metrics/cadvisor` in the `__metrics_path__` replacement.
+  - job_name: kubelet
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/$1/proxy/metrics
+```
 
 ### Option 3: Disable kubelet proxying
 
-If your setup requires Prometheus to scrape node IPs directly, disable the kubelet proxy feature in your `vcluster.yaml`. Setting both options to `false` causes vCluster to pass through the real node addresses from the control plane cluster unchanged, making them discoverable and reachable by Prometheus.
+Setting `byHostname` and `byIP` to `false` causes vCluster to pass through real node addresses from the control plane cluster unchanged. Prometheus can then discover and scrape them directly.
 
 ```yaml title="vcluster.yaml"
 networking:
@@ -80,11 +95,9 @@ networking:
       byIP: false
 ```
 
-:::warning Trade-offs
-Disabling `proxyKubelets` has two consequences:
+:::info
+With kubelet proxying disabled:
 
-- **Metrics are not rewritten.** Pod and namespace labels in the returned metrics reflect the control plane cluster's internal naming, not the tenant cluster's virtual names. If multiple tenant clusters share the same node, metrics from different tenant clusters will have overlapping pod/namespace label values.
-- **Infrastructure exposure.** Real node IPs reveal the control plane cluster's internal network topology to anyone with access to the tenant cluster's node objects.
-
-Only use this option if the tenant cluster is fully trusted and metric label overlap is acceptable.
+- **vCluster does not rewrite metrics.** Pod and namespace labels reflect the control plane cluster's internal naming, not the tenant cluster's virtual names. On a shared node, metrics from different tenant clusters will have overlapping pod/namespace label values.
+- **Real node IPs are visible** in the tenant cluster's node objects, which reveals control plane network topology to tenant cluster users.
 :::


### PR DESCRIPTION
# Content Description

Documents how Prometheus node metrics scraping works in the Shared Nodes tenancy model, where vCluster virtualizes node IPs by default as part of its kubelet proxying feature. Adds three configuration approaches with full scrape configs, a cross-reference from the fleet monitoring guide, and a Vale rule to catch Latinisms site-wide.

## Preview Link

- https://deploy-preview-2180--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/monitoring/prometheus-shared-nodes

## Internal Reference

Closes DOC-1446

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs