### PR TITLE
docs(standalone): fix quickstart to require no CLI or config file

### DIFF
--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -105,16 +105,11 @@ Perform all steps on the control plane node as root.
           title="Create config directory"
           language="bash"
         />
-        Save a basic `vcluster.yaml` configuration file for vCluster Standalone on the control plane node.
+        Save a `vcluster.yaml` configuration file for vCluster Standalone on the control plane node. The configuration file is optional — if omitted, the installer uses its bundled Kubernetes version. Provide one when you need to pin the Kubernetes version or customize other settings.
         <InterpolatedCodeBlock
-          code={`cat <<EOF > [[GLOBAL:CONFIG_DIRECTORY]]/vcluster.yaml
-  controlPlane:
-    distro:
-      k8s:
-        version: v1.34.0
-  EOF`}
+          code={"cat <<EOF > [[GLOBAL:CONFIG_DIRECTORY]]/vcluster.yaml\ncontrolPlane:\n  distro:\n    k8s:\n      version: v1.34.0\nEOF"}
           title="Create vCluster config file"
-          language="yaml"
+          language="bash"
         />
 
 :::warning

--- a/vcluster/quick-start/standalone.mdx
+++ b/vcluster/quick-start/standalone.mdx
@@ -2,17 +2,16 @@
 title: Standalone Quick Start
 sidebar_label: Standalone
 sidebar_position: 4
-description: Bootstrap a Control Plane Cluster from bare metal or VMs using vCluster Standalone, then install vCluster Platform on it.
+description: Bootstrap a Control Plane Cluster from bare metal or VMs using vCluster Standalone. No Helm, no CLI, no existing Kubernetes required.
 sidebar_class_name: standalone private-nodes
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";
-import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 The first problem is always the same. To run vCluster, you need a Kubernetes cluster. But getting a Kubernetes cluster onto bare metal normally requires another tool first. vCluster Standalone breaks this loop. It installs a complete Kubernetes control plane directly on a Linux machine as a binary, with no existing distribution required.
 
-This guide takes you from a bare Linux machine to a running Control Plane Cluster with vCluster Platform installed on it. Once Platform is running, you can provision tenant clusters with dedicated private nodes in seconds. That's the path AI clouds use to deliver hyperscaler-grade isolation to their customers.
+This guide takes you from a bare Linux machine to a fully functional Kubernetes cluster that you can go on to use as a Control Plane Cluster in about two minutes. No Helm, no CLI, no existing Kubernetes required.
 
 ## Prerequisites
 
@@ -22,10 +21,6 @@ This guide takes you from a bare Linux machine to a running Control Plane Cluste
   - Outbound internet access for image pulls
 - The machine must be reachable from your local workstation (SSH access)
 
-## Install the vCluster CLI
-
-<InstallCLIFragment />
-
 <!-- vale Google.Headings off -->
 ## Install vCluster Standalone
 <!-- vale Google.Headings on -->
@@ -34,35 +29,19 @@ Run these commands on the control plane machine as root.
 
 <Flow>
   <Step>
-    Set the version and config directory.
-
-    <InterpolatedCodeBlock
-      code={"export VCLUSTER_VERSION=[[VAR:VCLUSTER_VERSION:__VCLUSTER_VERSION__]]\nexport CONFIG_DIRECTORY=/etc/vcluster\nmkdir -p $CONFIG_DIRECTORY"}
-      language="bash"
-    />
-  </Step>
-  <Step>
-    Create a minimal `vcluster.yaml` configuration.
+    Switch to root.
 
     ```bash
-    cat <<EOF > $CONFIG_DIRECTORY/vcluster.yaml
-    controlPlane:
-      distro:
-        k8s:
-          version: v1.35.0
-    EOF
+    sudo su -
     ```
-
-    Standalone uses the same `vcluster.yaml` format as tenant clusters. See the [vcluster.yaml reference](../configure/what-is-vcluster-yaml.mdx) for all available configuration fields.
   </Step>
   <Step>
     Run the installer.
 
-    ```bash
-    sudo su -
-    curl -sfL https://github.com/loft-sh/vcluster/releases/download/${VCLUSTER_VERSION}/install-standalone.sh \
-      | sh -s -- --vcluster-name standalone
-    ```
+    <InterpolatedCodeBlock
+      code={"curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[VAR:VCLUSTER_VERSION:__VCLUSTER_VERSION__]]/install-standalone.sh \\\n  | sh -s -- --vcluster-name standalone"}
+      language="bash"
+    />
 
     The installer downloads Kubernetes binaries, configures the control plane, and writes a kubeconfig to `/var/lib/vcluster/kubeconfig.yaml`. Installation takes about 2 minutes.
   </Step>
@@ -76,8 +55,8 @@ Run these commands on the control plane machine as root.
     Output is similar to:
 
     ```
-    NAME               STATUS   ROLES                  AGE   VERSION
-    ip-192-168-3-131   Ready    control-plane,master   2m    v1.35.0
+    NAME                  STATUS   ROLES                  AGE   VERSION
+    vcluster-standalone   Ready    control-plane,master   88s   v1.35.0
     ```
   </Step>
 </Flow>
@@ -105,42 +84,13 @@ Verify access from your workstation:
 kubectl get nodes
 ```
 
-<!-- vale Google.Headings off -->
-## Install vCluster Platform
-<!-- vale Google.Headings on -->
-
-With the Control Plane Cluster running, install vCluster Platform on it. Platform is free to use and provides tenant cluster provisioning, access controls, auto-sleep, and node automation.
-
-```bash
-vcluster platform start
-```
-
-This installs Platform into the `vcluster-platform` namespace. When complete, the CLI prints your login credentials and a URL:
-
-```
-##########################   LOGIN   ############################
-
-Username: admin
-Password: <generated-password>
-
-Login via UI:  https://<subdomain>.loft.host
-Login via CLI: vcluster platform login https://<subdomain>.loft.host
-
-#################################################################
-```
-
-The UI opens automatically. Create your administrator account and you are logged in.
-
 ## What you have now
 
 - A bare-metal or VM-based Kubernetes cluster running as a vCluster Standalone instance
-- vCluster Platform installed and running on it
-- A foundation for provisioning tenant clusters with private nodes
+- A Control Plane Cluster ready to host tenant clusters and vCluster Platform
 
 ## Next steps
 
-- [Private nodes quick start](./private-nodes.mdx) — provision a tenant cluster with dedicated worker nodes on this Control Plane Cluster
-- [Node providers](/docs/platform/administer/node-providers/overview) — automate worker node provisioning through Platform (AWS, GCP, bare metal)
+- [Install vCluster Platform](/docs/platform/install/helm) — add the Platform management UI to this cluster for tenant cluster provisioning, access controls, and node automation
 - [High availability](../deploy/control-plane/binary/high-availability.mdx) — add control plane nodes for production resilience
-- [Manage Standalone](../deploy/control-plane/binary/manage.mdx) — upgrade versions and manage configuration through Platform
 - [Building a GPU cloud platform](../introduction/gpu-cloud-platform.mdx) — end-to-end architecture for AI cloud deployments


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Remove the vCluster CLI install section and `vcluster.yaml` creation step from the standalone quickstart. The installer works with zero user-provided config, using its bundled Kubernetes version. Also fix a heredoc bug in `basics.mdx` where an indented `EOF` would never terminate the heredoc, and note the config file is optional.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2182--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/standalone

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1460


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs