### PR TITLE
fix(receiver): narrow goprivate to unblock go mod tidy after platform pin bump

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -109,11 +109,18 @@ jobs:
           go-version-file: go.mod
 
       # vcluster's full module graph (pulled in by the cli generator's
-      # imports) and platform's loft-sh/api dependencies both transitively
-      # reference private loft-sh/* modules. Without git auth + GOPRIVATE,
-      # `go run` falls through to the public proxy, hits 404, then tries
-      # an unauthenticated `git ls-remote` and fails. Mirrors the pattern
-      # the legacy sync-config-schema.yaml used.
+      # imports) transitively references private loft-sh/* modules
+      # (vcluster-pro). Without git auth, `go run` falls through to the
+      # public proxy, hits 404, then tries an unauthenticated `git
+      # ls-remote` and fails.
+      #
+      # GOPRIVATE is narrowed to the actually-private patterns. A broad
+      # `github.com/loft-sh/*` pattern forces direct VCS for public deps
+      # too — including the indirect github.com/loft-sh/external-types,
+      # whose sparse-then-dense git history reproducibly triggers a
+      # `git fetch --unshallow` race ("shallow file has changed since
+      # we read it") in `go mod tidy` after the platform pin bump.
+      # Mirrors loft-enterprise#6910.
       - name: Configure git for private loft-sh modules
         if: steps.classify.outputs.skip != 'true'
         env:
@@ -121,7 +128,8 @@ jobs:
         run: |
           set -eo pipefail
           git config --global url."https://${GH_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
-          echo "GOPRIVATE=github.com/loft-sh/*" >>"$GITHUB_ENV"
+          echo "GOPRIVATE=github.com/loft-sh/vcluster-pro*" >>"$GITHUB_ENV"
+          echo "GOPROXY=https://proxy.golang.org,direct" >>"$GITHUB_ENV"
 
       # The platform partials generator reflects against the loft-sh/api +
       # loft-sh/agentapi types pinned in this repo's go.mod. Without bumping


### PR DESCRIPTION
# Content Description
Workflow-only fix. The receiver's broad `GOPRIVATE=github.com/loft-sh/*` forced direct VCS for every loft-sh transitive dep, including the public `github.com/loft-sh/external-types`. `go mod tidy` after the platform pin bump triggers `git fetch --unshallow` against external-types' sparse-then-dense history and dies with `fatal: shallow file has changed since we read it`. Narrowing `GOPRIVATE` to `vcluster-pro*` (the only actually-private loft-sh module reachable transitively from this repo's generators) lets the public deps route through `proxy.golang.org`. Mirrors `loft-enterprise#6910` (sync-api.yaml).

## Summary
- Narrow `GOPRIVATE` from `github.com/loft-sh/*` → `github.com/loft-sh/vcluster-pro*`.
- Add explicit `GOPROXY=https://proxy.golang.org,direct`.
- Preserve `url.insteadOf` token rewrite — auth still works for direct-VCS fetches of vcluster-pro.

## Key Changes
- `.github/workflows/handle-source-release.yml` — env wiring in "Configure git for private loft-sh modules" step.

## Dependencies
None.

## TODO
- [x] Verify on platform-released path (the failing case).
- [x] Confirm vcluster-released path still succeeds (already passed earlier today on backfill, no behavior change for it).

## Preview Link
N/A — workflow-only change, no docs touched.

## Internal Reference
References DEVOPS-904

Context: surfaced while running DEVOPS-904 discovery. Today's backfill dispatch for `v4.9.1-rc.1` failed twice (runs `26518317840` attempt 1 + 2) at the same step. Test dispatch from this branch (run [`26518947466`](https://github.com/loft-sh/vcluster-docs/actions/runs/26518947466)) succeeded in 2:23 and produced PR #2179 (`docs-sync/platform-released-v4.9.1-rc.1`).

<!-- Do not change the line below -->
@netlify /docs