### PR TITLE
fix(receiver): wait for agentapi+api tags before bumping platform pins

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -131,6 +131,35 @@ jobs:
           echo "GOPRIVATE=github.com/loft-sh/vcluster-pro*" >>"$GITHUB_ENV"
           echo "GOPROXY=https://proxy.golang.org,direct" >>"$GITHUB_ENV"
 
+      # loft-enterprise's release pipeline cuts its own tag + release first
+      # (which triggers our dispatch), then creates matching upstream tags
+      # in loft-sh/{agentapi,api} in subsequent steps. Without a wait, the
+      # bump step's `go mod tidy` below races the upstream tag creation
+      # and fails with `unknown revision <version>`. Empirically the gap
+      # was ~30s-2min on v4.7.3-rc.1 (2026-05-27). Polling on the GitHub
+      # API directly (not `go list`) sidesteps Go's module proxy cache,
+      # which can lag tag creation. 10s × 60 = 10 min ceiling.
+      - name: Wait for agentapi + api tags to be published
+        if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          set -eo pipefail
+          for repo in loft-sh/agentapi loft-sh/api; do
+            attempt=0
+            until gh api "repos/${repo}/git/refs/tags/${VERSION}" >/dev/null 2>&1; do
+              attempt=$((attempt + 1))
+              if [ "$attempt" -ge 60 ]; then
+                echo "::error::${repo}: tag ${VERSION} not present after 10 minutes; upstream pipeline never published it" >&2
+                exit 1
+              fi
+              echo "${repo}: waiting for tag ${VERSION} (attempt ${attempt}/60)"
+              sleep 10
+            done
+            echo "::notice::${repo}: tag ${VERSION} present (attempt ${attempt:-0})"
+          done
+
       # The platform partials generator reflects against the loft-sh/api +
       # loft-sh/agentapi types pinned in this repo's go.mod. Without bumping
       # the pins to the just-released version, the regen sees identical


### PR DESCRIPTION
# Content Description
Adds a poll step to `handle-source-release.yml` that waits for `loft-sh/agentapi` and `loft-sh/api` to publish the released-platform tag before running `go mod tidy`. Receiver-side fix for a release-pipeline race that already caused a failed dispatch today.

## Summary
- New step `Wait for agentapi + api tags to be published` runs before `Bump loft-sh/api + loft-sh/agentapi pins` (platform-released only).
- Polls `gh api repos/loft-sh/{agentapi,api}/git/refs/tags/$VERSION` every 10s, up to 60 attempts (10-minute ceiling).
- Hits the GitHub REST API directly, not `go list -m`, so the Go module proxy cache cannot mask a freshly-created tag.
- Clear `::error::` on timeout names the upstream repo and version so the new DEVOPS-904 alert surfaces the real cause instead of a downstream `go mod tidy` confusion.

## Why now
The race fired live today. Run [26529921726](https://github.com/loft-sh/vcluster-docs/actions/runs/26529921726) on `platform-released` v4.7.3-rc.1:

| Time | Event |
| ---- | ----- |
| 17:51:24Z | loft-enterprise published v4.7.3-rc.1 release, dispatched receiver |
| 18:14:32Z | Receiver run started |
| 18:14:59Z | Receiver **failed** at bump step: `unknown revision v4.7.3-rc.1` in agentapi |
| 18:15:30Z | agentapi tag v4.7.3-rc.1 created (31s after failure) |
| 18:16:41Z | api tag v4.7.3-rc.1 created (1m42s after failure) |

loft-enterprise's release pipeline cuts its own tag + release first, fires the dispatch, then in subsequent pipeline steps creates the matching tags in agentapi + api. The receiver assumed a publish-ordering guarantee that doesn't exist.

## Key Changes
- `.github/workflows/handle-source-release.yml`: append one polling step gated on `event == 'platform-released'`. Bump step unchanged.

## Why receiver-side instead of upstream
Fixing in loft-enterprise's release pipeline would require coordinating tag publication ordering across three repos and only helps platform; any future source repo with similar timing skew (e.g. a new product line dispatching ahead of its dependency tags) would re-introduce the race. The receiver-side wait is self-contained and generalizable, and fails fast and clearly on actual typos.

## Dependencies
None. Uses existing `GH_ACCESS_TOKEN` secret (already wired for the git config step) for `gh api` auth.

## TODO
- [ ] Confirm rerun of run 26529921726 succeeds now that the tags exist (in flight as of PR open).
- [ ] Watch the next loft-enterprise release; the wait should pass through inside seconds when tags are already present.

## Scope notes
- Receiver-side only. Sender-side timing skew in vcluster releases for vcluster-cli/vcluster-released paths is not in scope here, those paths don't bump any pins and don't hit the `go mod tidy` cliff.
- Complements PR #2188 (DEVOPS-904 alert). With both merged, this race fails clearly into Slack instead of silently into the Actions tab; without #2188, the explicit `::error::` from the timeout at least makes log triage cheap.

## Preview Link
N/A, workflow-only change, no docs touched.

## Internal Reference
References DEVOPS-904

<!-- Do not change the line below -->
@netlify /docs