### PR TITLE
chore(doc-1466): migrate onBrokenMarkdownLinks and refresh node 20 actions

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -13,11 +13,11 @@ jobs:
     if: github.event.pull_request.merged == true ||
         (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-v'))
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Backport Docusaurus Changes
-        uses: loft-sh/docs-backport-action@v1
+        uses: loft-sh/docs-backport-action@v1.3.1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/validate-feature-tables.yml
+++ b/.github/workflows/validate-feature-tables.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/validate-glossary.yml
+++ b/.github/workflows/validate-glossary.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,7 +60,6 @@ const config = {
   ],
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
@@ -73,6 +72,9 @@ const config = {
   themes: ["@saucelabs/theme-github-codeblock", "@docusaurus/theme-mermaid"],
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
   },
 
   presets: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "js-yaml": "^4.1.1"
       },
       "engines": {
-        "node": ">=20.0"
+        "node": ">=22.0"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
# Content Description
Move `siteConfig.onBrokenMarkdownLinks` to `markdown.hooks.onBrokenMarkdownLinks` (deprecated in Docusaurus 3.9, removed in v4) and refresh GitHub Actions that were flagged as running on the soon-deprecated Node 20 runner.

## Summary
- Migrate `onBrokenMarkdownLinks: "warn"` from top-level config to `markdown.hooks.onBrokenMarkdownLinks` per [Docusaurus 3.9 release notes](https://docusaurus.io/blog/releases/3.9). Removes the deprecation warning that fires on every build.
- Pin and bump deprecated Node 20 actions surfaced by the backport workflow's last run.

## Key Changes
- `docusaurus.config.js`: nest `onBrokenMarkdownLinks` under `markdown.hooks` (config behavior is unchanged, still `warn`).
- `.github/workflows/backport-docs.yml`: `actions/checkout@v3` → `@v4`, `loft-sh/docs-backport-action@v1` → `@v1.3.1` (the floating `v1` tag stopped moving in April 2025; v1.3.1 is the maintained release as of May 2026).
- `.github/workflows/validate-feature-tables.yml` and `validate-glossary.yml`: `actions/checkout@v3` → `@v4`, `actions/setup-node@v3` → `@v4`.
- `package-lock.json`: synced engines from npm install (`node: >=20.0` → `>=22.0`, matching `package.json`).

## Preview Link
No user-facing doc pages changed — this is a build-config and CI-only PR. The Netlify preview build is the verification (must succeed without the `siteConfig.onBrokenMarkdownLinks` deprecation warning).

Local verification: `npm run build` completes with `[SUCCESS] Generated static files in "build"` and no `siteConfig.onBrokenMarkdownLinks` deprecation message in the log.

## Dependencies
None.

## TODO
- [ ] CI green (backport-docs / validate-feature-tables / validate-glossary still run as expected on their respective triggers)
- [ ] Netlify preview build succeeds without the deprecation warning

## Internal Reference
Closes DOC-1466

<!-- Do not change the line below -->
@netlify /docs