### PR TITLE
docs(doc-1408): add vind air-gapped deployment guide

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -45,3 +45,10 @@ Vale.Terms = NO
 [**/security/**]
 BasedOnStyles = Loft, Google, Vale
 Vale.Terms = NO
+
+# Docker container deploy guides use the same <Flow>/<Step> pattern and contain
+# vcluster CLI commands and file paths (e.g. /loft-sh/vcluster/releases/) inside
+# <Step> components. Same root cause as quick-start above.
+[**/deploy/control-plane/docker-container/**]
+BasedOnStyles = Loft, Google, Vale
+Vale.Terms = NO

--- a/src/css/content/code.scss
+++ b/src/css/content/code.scss
@@ -74,10 +74,14 @@
 .markdown *:not(pre) > code,
   .contents code {
     white-space: nowrap;
+    vertical-align: baseline;
   }
   
   /* Styles for InterpolatedCodeBlock component */
   .interpolated-code-wrapper {
+    /* Match the top spacing of a standard code block */
+    margin-top: var(--ifm-leading);
+
     /* Base styles for the wrapper */
     .theme-code-block {
       margin-top: 0;

--- a/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
+++ b/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
@@ -1,0 +1,219 @@
+---
+title: Deploy vind in an air-gapped environment
+sidebar_label: Air-gapped
+sidebar_position: 2
+sidebar_class_name: standalone docker
+description: Configure vind for environments without internet access, covering registry mirrors, image overrides, and the vm-container bootstrap.
+---
+
+import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
+import PageVariables from '@site/src/components/PageVariables';
+
+<PageVariables
+  VCLUSTER_VERSION="0.34.0"
+  REGISTRY="your-registry.internal"
+/>
+
+vind makes five distinct network calls during cluster creation and operation. In an air-gapped environment where Docker containers cannot reach public registries or GitHub, each one must be handled separately.
+
+## How vind uses the network
+
+| Step | When | What vind contacts | Configurable? |
+|------|------|--------------------|---------------|
+| 1 | Before `vcluster create` | Pulls `alpine` on the Docker host for pre-creation checks | No — pre-pull required |
+| 2 | Inside the vm-container at bootstrap | Downloads `install-standalone.sh` from GitHub | No — custom image or bridge proxy required |
+| 3 | During vCluster startup | Pulls internal vCluster images (k3s, CoreDNS, syncer) | Yes — `controlPlane.advanced.defaultImageRegistry` |
+| 4 | When workloads run | Pulls workload container images | Yes — containerd registry mirror using a volume mount |
+| 5 | For StatefulSet pods | Pulls `alpine` for the rewriteHosts init container | Yes — `sync.toHost.pods.rewriteHosts.initContainer.image` |
+
+Steps 1 and 2 have no native config override. The sections below cover each step with its workaround.
+
+## Prerequisites
+
+- Docker installed and running with access to your internal registry
+- vCluster CLI installed — see [Deployment basics](./basics.mdx#step-1-install-vcluster-cli)
+- `install-standalone.sh` and the `vcluster-linux-<arch>-standalone` binary downloaded from the [vCluster releases page](https://github.com/loft-sh/vcluster/releases) on an internet-connected machine
+- Required images mirrored to your internal registry (`images.txt` is listed under [vCluster release assets](https://github.com/loft-sh/vcluster/releases))
+
+## Step 1: Pre-pull Alpine on the Docker host
+
+Before `vcluster create` runs, vind pulls `alpine` directly on the host for pre-creation checks including port availability, containerd socket detection, and network reachability. There is no config flag to override this image name.
+
+Pull Alpine from your internal registry and retag it so vind finds it under the expected name:
+
+<InterpolatedCodeBlock
+  code={`docker pull [[GLOBAL:REGISTRY]]/library/alpine:latest
+docker tag [[GLOBAL:REGISTRY]]/library/alpine:latest alpine:latest`}
+  language="bash"
+/>
+
+vind's registry proxy (enabled by default) then serves this image from the host Docker cache for all subsequent pulls inside the cluster, so the network is not contacted again.
+
+## Step 2: Provide the vm-container bootstrap assets
+
+After the vm-container starts, the vCluster binary inside it downloads `install-standalone.sh` from GitHub. This URL is hardcoded in the CLI binary. Choose one of the following workarounds.
+
+### Option A: Build a custom vm-container image (recommended)
+
+On an internet-connected machine, build a custom image that pre-downloads the install script and binary:
+
+<InterpolatedCodeBlock
+  code={`FROM ghcr.io/loft-sh/vm-container:latest
+RUN mkdir -p /vcluster-install && \\
+    curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/install-standalone.sh \\
+      -o /vcluster-install/install-standalone.sh && \\
+    curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/vcluster-linux-amd64-standalone \\
+      -o /vcluster-install/vcluster && \\
+    chmod +x /vcluster-install/vcluster`}
+  language="dockerfile"
+/>
+
+Push the image to your internal registry:
+
+<InterpolatedCodeBlock
+  code={`docker build -t [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped .
+docker push [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
+  language="bash"
+/>
+
+Reference the image in your `vcluster.yaml`:
+
+<InterpolatedCodeBlock
+  code={`experimental:
+  docker:
+    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
+  language="yaml"
+/>
+
+### Option B: Serve the assets from the Docker bridge network
+
+If you cannot build a custom image, run a file server on the Docker host that is reachable from inside the vind containers.
+
+Find the Docker bridge gateway IP:
+
+```bash
+docker network inspect bridge | grep Gateway
+```
+
+This is usually `172.17.0.1`. Serve the install script and binary at the expected GitHub URL path:
+
+<InterpolatedCodeBlock
+  code={`mkdir -p /tmp/vcluster-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]
+cp install-standalone.sh vcluster-linux-amd64-standalone \\
+  /tmp/vcluster-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/
+cd /tmp/vcluster-mirror && python3 -m http.server 9999 --bind 0.0.0.0`}
+  language="bash"
+/>
+
+Configure the container to use the server as a proxy:
+
+<InterpolatedCodeBlock
+  code={`experimental:
+  docker:
+    env:
+      - HTTPS_PROXY=http://[[VAR:GATEWAY_IP:172.17.0.1]]:9999`}
+  language="yaml"
+/>
+
+:::warning
+The proxy must listen on the Docker bridge interface, not loopback (`127.0.0.1`). A proxy bound to loopback on the host is not reachable from inside the vm-container.
+:::
+
+## Step 3: Redirect internal vCluster images
+
+`controlPlane.advanced.defaultImageRegistry` prepends a registry prefix to all images vCluster deploys internally, including k3s, CoreDNS, syncer, etcd, and backing store images. It does not affect workload images.
+
+Mirror all images listed in `images.txt` from the [vCluster release assets](https://github.com/loft-sh/vcluster/releases) into your registry at the same repository path, then configure:
+
+<InterpolatedCodeBlock
+  code={`controlPlane:
+  advanced:
+    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/`}
+  language="yaml"
+/>
+
+## Step 4: Route workload image pulls through a registry mirror
+
+Workload images are pulled by the k3s containerd runtime inside the cluster. Configure containerd mirrors by mounting a `registries.yaml` file into the vind container.
+
+Create `registries.yaml` on the host:
+
+<InterpolatedCodeBlock
+  code={`mirrors:
+  docker.io:
+    endpoint:
+      - "https://[[GLOBAL:REGISTRY]]"
+  ghcr.io:
+    endpoint:
+      - "https://[[GLOBAL:REGISTRY]]"
+configs:
+  "[[GLOBAL:REGISTRY]]":
+    auth:
+      username: [[VAR:USERNAME:username]]
+      password: [[VAR:PASSWORD:password]]`}
+  language="yaml"
+/>
+
+Mount it into the vind container in your `vcluster.yaml`:
+
+<InterpolatedCodeBlock
+  code={`experimental:
+  docker:
+    volumes:
+      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"`}
+  language="yaml"
+/>
+
+## Step 5: Override the rewriteHosts init container image
+
+When syncing StatefulSet pods, vCluster runs a short-lived init container using `mirror.gcr.io/library/alpine:3.20` to rewrite FQDNs. Override this in your `vcluster.yaml`:
+
+<InterpolatedCodeBlock
+  code={`sync:
+  toHost:
+    pods:
+      rewriteHosts:
+        initContainer:
+          image:
+            registry: [[GLOBAL:REGISTRY]]
+            repository: library/alpine
+            tag: "3.20"`}
+  language="yaml"
+/>
+
+The `image` field takes `registry`, `repository`, and `tag` sub-fields, not a plain string. This format was introduced in v0.27.0.
+
+## Complete vcluster.yaml
+
+The following combines all configurable layers. Replace registry, version, and path values for your environment.
+
+<InterpolatedCodeBlock
+  code={`controlPlane:
+  advanced:
+    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/
+
+experimental:
+  docker:
+    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped
+    volumes:
+      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"
+
+sync:
+  toHost:
+    pods:
+      rewriteHosts:
+        initContainer:
+          image:
+            registry: [[GLOBAL:REGISTRY]]
+            repository: library/alpine
+            tag: "3.20"`}
+  language="yaml"
+/>
+
+After preparing the host (Steps 1 and 2), create the cluster:
+
+```bash
+vcluster create my-cluster --values vcluster.yaml
+```
+
+For next steps, see the [Docker (vind) Quick Start](../../../quick-start/docker.mdx) to verify your cluster is working and explore pause/resume, LoadBalancer services, and worker nodes.

--- a/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
+++ b/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
@@ -84,9 +84,9 @@ docker push [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
     Create a `vcluster.yaml` file and add the following. You will add more settings to this file in Steps 3–5, then pass it to `vcluster create` at the end.
 
     <InterpolatedCodeBlock
-      code={`experimental:
-  docker:
-    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
+      code={"experimental:\n" +
+        "  docker:\n" +
+        "    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped"}
       language="yaml"
     />
   </Step>
@@ -121,16 +121,16 @@ cd /tmp/vind-mirror && python3 -m http.server 9999 --bind 0.0.0.0`}
     Create a `vcluster.yaml` file and add the following, substituting the gateway IP from Step 1. You will add more settings to this file in Steps 3–5, then pass it to `vcluster create` at the end.
 
     <InterpolatedCodeBlock
-      code={`experimental:
-  docker:
-    env:
-      - HTTPS_PROXY=http://[[VAR:GATEWAY_IP:172.17.0.1]]:9999`}
+      code={"experimental:\n" +
+        "  docker:\n" +
+        "    env:\n" +
+        "      - HTTPS_PROXY=http://[[VAR:GATEWAY_IP:172.17.0.1]]:9999"}
       language="yaml"
     />
 
-    :::warning
-    The proxy must listen on the Docker bridge interface, not loopback (`127.0.0.1`). A proxy bound to loopback on the host is not reachable from inside the vm-container.
-    :::
+:::warning
+The proxy must listen on the Docker bridge interface, not loopback (`127.0.0.1`). A proxy bound to loopback on the host is not reachable from inside the vm-container.
+:::
   </Step>
 </Flow>
 
@@ -141,9 +141,9 @@ cd /tmp/vind-mirror && python3 -m http.server 9999 --bind 0.0.0.0`}
 Mirror all images listed in `images.txt` from the [vCluster release assets](https://github.com/loft-sh/vcluster/releases) into your registry at the same repository path, then add the following to your `vcluster.yaml`:
 
 <InterpolatedCodeBlock
-  code={`controlPlane:
-  advanced:
-    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/`}
+  code={"controlPlane:\n" +
+    "  advanced:\n" +
+    "    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/"}
   language="yaml"
 />
 
@@ -157,33 +157,46 @@ Complete this step if your workloads pull images from public registries like `do
 
 Workload images are pulled by the k3s containerd runtime inside the cluster. Configure containerd mirrors by mounting a `registries.yaml` file into the vind container.
 
-Create `registries.yaml` on the host:
+<Flow>
+  <Step>
+    Create a `registries.yaml` file on the host that redirects pulls for `docker.io` and `ghcr.io` to your internal registry:
 
-<InterpolatedCodeBlock
-  code={`mirrors:
-  docker.io:
-    endpoint:
-      - "https://[[GLOBAL:REGISTRY]]"
-  ghcr.io:
-    endpoint:
-      - "https://[[GLOBAL:REGISTRY]]"
-configs:
-  "[[GLOBAL:REGISTRY]]":
-    auth:
-      username: [[VAR:USERNAME:username]]
-      password: [[VAR:PASSWORD:password]]`}
-  language="yaml"
-/>
+    <InterpolatedCodeBlock
+      code={"mirrors:\n" +
+        "  docker.io:\n" +
+        "    endpoint:\n" +
+        '      - "https://[[GLOBAL:REGISTRY]]"\n' +
+        "  ghcr.io:\n" +
+        "    endpoint:\n" +
+        '      - "https://[[GLOBAL:REGISTRY]]"'}
+      language="yaml"
+    />
+  </Step>
+  <Step>
+    If your registry requires authentication, add a `configs` section to the `registries.yaml` file:
 
-Add the following to your `vcluster.yaml`:
+    <InterpolatedCodeBlock
+      code={"configs:\n" +
+        '  "[[GLOBAL:REGISTRY]]":\n' +
+        "    auth:\n" +
+        "      username: [[VAR:USERNAME:username]]\n" +
+        "      password: [[VAR:PASSWORD:password]]"}
+      language="yaml"
+    />
+  </Step>
+  <Step>
+    Add a `volumes` entry to the `docker` block in your `vcluster.yaml`. The `image` key was added in Step 2:
 
-<InterpolatedCodeBlock
-  code={`experimental:
-  docker:
-    volumes:
-      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"`}
-  language="yaml"
-/>
+    <InterpolatedCodeBlock
+      code={"experimental:\n" +
+        "  docker:\n" +
+        "    image: ...  # from Step 2\n" +
+        "    volumes:\n" +
+        '      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"'}
+      language="yaml"
+    />
+  </Step>
+</Flow>
 
 ## Step 5: Override the rewriteHosts init container image
 
@@ -192,51 +205,104 @@ Complete this step if you are running StatefulSets inside the cluster. vCluster 
 Add the following to your `vcluster.yaml`:
 
 <InterpolatedCodeBlock
-  code={`sync:
-  toHost:
-    pods:
-      rewriteHosts:
-        initContainer:
-          image:
-            registry: [[GLOBAL:REGISTRY]]
-            repository: library/alpine
-            tag: "3.20"`}
+  code={"sync:\n" +
+    "  toHost:\n" +
+    "    pods:\n" +
+    "      rewriteHosts:\n" +
+    "        initContainer:\n" +
+    "          image:\n" +
+    "            registry: [[GLOBAL:REGISTRY]]\n" +
+    "            repository: library/alpine\n" +
+    '            tag: "3.20"'}
   language="yaml"
 />
 
 The `image` field takes `registry`, `repository`, and `tag` sub-fields, not a plain string. This format was introduced in v0.27.0.
 
-## Complete vcluster.yaml
+## Step 6: Create the cluster
 
-The following combines all configurable layers. Replace registry, version, and path values for your environment.
-
-<InterpolatedCodeBlock
-  code={`controlPlane:
-  advanced:
-    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/
-
-experimental:
-  docker:
-    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped
-    volumes:
-      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"
-
-sync:
-  toHost:
-    pods:
-      rewriteHosts:
-        initContainer:
-          image:
-            registry: [[GLOBAL:REGISTRY]]
-            repository: library/alpine
-            tag: "3.20"`}
-  language="yaml"
-/>
-
-After preparing the host (Steps 1 and 2), create the cluster:
+After preparing the host (Steps 1 and 2), switch to the Docker driver and create the cluster:
 
 ```bash
+vcluster use driver docker
 vcluster create my-cluster --values vcluster.yaml
 ```
 
 For next steps, see the [Docker (vind) Quick Start](../../../quick-start/docker.mdx) to verify your cluster is working and explore pause/resume, LoadBalancer services, and worker nodes.
+
+## Troubleshoot
+
+### Cluster creation times out due to unreachable kubectl context
+
+```
+fatal Get "https://<ip>:6443/api/v1/namespaces/vcluster-my-cluster": dial tcp <ip>:6443: i/o timeout
+```
+
+The vCluster CLI checks the active kubectl context at startup. If that context points to an unreachable cluster (for example, a stopped Multipass VM), the command times out before Docker driver mode is entered.
+
+Check your current context and switch to one that is reachable:
+
+```bash
+kubectl config get-contexts
+kubectl config use-context <your-context>
+```
+
+If the correct context is not listed, your shell may have a `KUBECONFIG` environment variable pointing to a separate kubeconfig file. Unset it to fall back to `~/.kube/config`:
+
+```bash
+unset KUBECONFIG
+kubectl config get-contexts
+kubectl config use-context <your-context>
+```
+
+### vCluster Pro features error when not logged into Platform
+
+```
+fatal you have vCluster pro features enabled, but seems like you are not logged in ... Please make sure to log into vCluster Platform to use vCluster pro features or run this command with --add=false
+```
+
+This occurs when the CLI has a vCluster Platform connection configured but you are not actively logged in. Pass `--add=false` to create the cluster without registering it with Platform:
+
+```bash
+vcluster create my-cluster --values vcluster.yaml --add=false
+```
+
+### Permission denied creating staging directory
+
+```
+fatal create staging directory: mkdir /Users/<you>/.vcluster/docker/vcluster/<version>.downloading: permission denied
+```
+
+A previous `sudo vcluster create` run left files in `~/.vcluster/docker/` owned by root. Fix the ownership and retry:
+
+```bash
+sudo chown -R $(whoami) ~/.vcluster/
+vcluster create my-cluster --values vcluster.yaml
+```
+
+## Example complete vcluster.yaml
+
+The following combines all configurable layers. Replace registry, version, and path values for your environment.
+
+<InterpolatedCodeBlock
+  code={"controlPlane:\n" +
+    "  advanced:\n" +
+    "    defaultImageRegistry: [[GLOBAL:REGISTRY]]/vcluster/\n" +
+    "\n" +
+    "experimental:\n" +
+    "  docker:\n" +
+    "    image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped\n" +
+    "    volumes:\n" +
+    '      - "[[VAR:HOST_PATH:/path/to/registries.yaml]]:/etc/rancher/k3s/registries.yaml"\n' +
+    "\n" +
+    "sync:\n" +
+    "  toHost:\n" +
+    "    pods:\n" +
+    "      rewriteHosts:\n" +
+    "        initContainer:\n" +
+    "          image:\n" +
+    "            registry: [[GLOBAL:REGISTRY]]\n" +
+    "            repository: library/alpine\n" +
+    '            tag: "3.20"'}
+  language="yaml"
+/>

--- a/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
+++ b/vcluster/deploy/control-plane/docker-container/air-gapped.mdx
@@ -8,6 +8,7 @@ description: Configure vind for environments without internet access, covering r
 
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 import PageVariables from '@site/src/components/PageVariables';
+import Flow, { Step } from '@site/src/components/Flow';
 
 <PageVariables
   VCLUSTER_VERSION="0.34.0"
@@ -55,75 +56,89 @@ After the vm-container starts, the vCluster binary inside it downloads `install-
 
 ### Option A: Build a custom vm-container image (recommended)
 
-On an internet-connected machine, build a custom image that pre-downloads the install script and binary:
+<Flow>
+  <Step>
+    On an internet-connected machine, create an empty directory and add a plain text file named `Dockerfile` (no extension) with the following content. Replace `amd64` with `arm64` if building on Apple Silicon.
 
-<InterpolatedCodeBlock
-  code={`FROM ghcr.io/loft-sh/vm-container:latest
+    <InterpolatedCodeBlock
+      code={`FROM ghcr.io/loft-sh/vm-container:latest
 RUN mkdir -p /vcluster-install && \\
     curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/install-standalone.sh \\
       -o /vcluster-install/install-standalone.sh && \\
     curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/vcluster-linux-amd64-standalone \\
       -o /vcluster-install/vcluster && \\
     chmod +x /vcluster-install/vcluster`}
-  language="dockerfile"
-/>
+      language="dockerfile"
+    />
+  </Step>
+  <Step>
+    From that same directory, build, and push the image to your registry:
 
-Push the image to your internal registry:
-
-<InterpolatedCodeBlock
-  code={`docker build -t [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped .
+    <InterpolatedCodeBlock
+      code={`docker build -t [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped .
 docker push [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
-  language="bash"
-/>
+      language="bash"
+    />
+  </Step>
+  <Step>
+    Create a `vcluster.yaml` file and add the following. You will add more settings to this file in Steps 3–5, then pass it to `vcluster create` at the end.
 
-Reference the image in your `vcluster.yaml`:
-
-<InterpolatedCodeBlock
-  code={`experimental:
+    <InterpolatedCodeBlock
+      code={`experimental:
   docker:
     image: [[GLOBAL:REGISTRY]]/vind:v[[GLOBAL:VCLUSTER_VERSION]]-airgapped`}
-  language="yaml"
-/>
+      language="yaml"
+    />
+  </Step>
+</Flow>
 
 ### Option B: Serve the assets from the Docker bridge network
 
 If you cannot build a custom image, run a file server on the Docker host that is reachable from inside the vind containers.
 
-Find the Docker bridge gateway IP:
+<Flow>
+  <Step>
+    Find the Docker bridge gateway IP:
 
-```bash
-docker network inspect bridge | grep Gateway
-```
+    ```bash
+    docker network inspect bridge | grep Gateway
+    ```
 
-This is usually `172.17.0.1`. Serve the install script and binary at the expected GitHub URL path:
+    Note the IP address — this is usually `172.17.0.1`. You will use it in Step 3.
+  </Step>
+  <Step>
+    Run the following commands to create a directory structure that mirrors the GitHub URL path, copy the assets into it, and start a local file server:
 
-<InterpolatedCodeBlock
-  code={`mkdir -p /tmp/vcluster-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]
+    <InterpolatedCodeBlock
+      code={`mkdir -p /tmp/vind-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]
 cp install-standalone.sh vcluster-linux-amd64-standalone \\
-  /tmp/vcluster-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/
-cd /tmp/vcluster-mirror && python3 -m http.server 9999 --bind 0.0.0.0`}
-  language="bash"
-/>
+  /tmp/vind-mirror/loft-sh/vcluster/releases/download/v[[GLOBAL:VCLUSTER_VERSION]]/
+cd /tmp/vind-mirror && python3 -m http.server 9999 --bind 0.0.0.0`}
+      language="bash"
+    />
+  </Step>
+  <Step>
+    Create a `vcluster.yaml` file and add the following, substituting the gateway IP from Step 1. You will add more settings to this file in Steps 3–5, then pass it to `vcluster create` at the end.
 
-Configure the container to use the server as a proxy:
-
-<InterpolatedCodeBlock
-  code={`experimental:
+    <InterpolatedCodeBlock
+      code={`experimental:
   docker:
     env:
       - HTTPS_PROXY=http://[[VAR:GATEWAY_IP:172.17.0.1]]:9999`}
-  language="yaml"
-/>
+      language="yaml"
+    />
 
-:::warning
-The proxy must listen on the Docker bridge interface, not loopback (`127.0.0.1`). A proxy bound to loopback on the host is not reachable from inside the vm-container.
-:::
+    :::warning
+    The proxy must listen on the Docker bridge interface, not loopback (`127.0.0.1`). A proxy bound to loopback on the host is not reachable from inside the vm-container.
+    :::
+  </Step>
+</Flow>
 
 ## Step 3: Redirect internal vCluster images
 
 `controlPlane.advanced.defaultImageRegistry` prepends a registry prefix to all images vCluster deploys internally, including k3s, CoreDNS, syncer, etcd, and backing store images. It does not affect workload images.
 
-Mirror all images listed in `images.txt` from the [vCluster release assets](https://github.com/loft-sh/vcluster/releases) into your registry at the same repository path, then configure:
+Mirror all images listed in `images.txt` from the [vCluster release assets](https://github.com/loft-sh/vcluster/releases) into your registry at the same repository path, then add the following to your `vcluster.yaml`:
 
 <InterpolatedCodeBlock
   code={`controlPlane:
@@ -132,7 +147,13 @@ Mirror all images listed in `images.txt` from the [vCluster release assets](http
   language="yaml"
 />
 
+:::note
+Steps 4 and 5 are not required for a basic air-gapped cluster. Complete the remaining steps only if your environment needs them.
+:::
+
 ## Step 4: Route workload image pulls through a registry mirror
+
+Complete this step if your workloads pull images from public registries like `docker.io` or `ghcr.io`. Without it, workload containers fail to start in an air-gapped environment.
 
 Workload images are pulled by the k3s containerd runtime inside the cluster. Configure containerd mirrors by mounting a `registries.yaml` file into the vind container.
 
@@ -154,7 +175,7 @@ configs:
   language="yaml"
 />
 
-Mount it into the vind container in your `vcluster.yaml`:
+Add the following to your `vcluster.yaml`:
 
 <InterpolatedCodeBlock
   code={`experimental:
@@ -166,7 +187,9 @@ Mount it into the vind container in your `vcluster.yaml`:
 
 ## Step 5: Override the rewriteHosts init container image
 
-When syncing StatefulSet pods, vCluster runs a short-lived init container using `mirror.gcr.io/library/alpine:3.20` to rewrite FQDNs. Override this in your `vcluster.yaml`:
+Complete this step if you are running StatefulSets inside the cluster. vCluster pulls `mirror.gcr.io/library/alpine:3.20` to rewrite FQDNs for StatefulSet pods. Without this override, that pull will fail in an air-gapped environment.
+
+Add the following to your `vcluster.yaml`:
 
 <InterpolatedCodeBlock
   code={`sync:

--- a/vcluster/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster/deploy/control-plane/docker-container/basics.mdx
@@ -60,6 +60,10 @@ Set vCluster to use the Docker driver:
   language="bash"
 />
 
+:::note Air-gapped environments
+If your Docker containers cannot reach public registries or GitHub, follow the [air-gapped setup](./air-gapped.mdx) guide to prepare your host and configure your `vcluster.yaml` before proceeding.
+:::
+
 ### Step 3: Create vCluster configuration (optional)
 
 Create a `vcluster.yaml` file to customize your Docker deployment:

--- a/vcluster/quick-start/docker.mdx
+++ b/vcluster/quick-start/docker.mdx
@@ -36,6 +36,10 @@ This guide covers deployment, pause and resume, LoadBalancer services, and virtu
 
 ## Deploy a cluster
 
+:::note Air-gapped environments
+If your Docker containers cannot reach public registries or GitHub, complete the [air-gapped setup](../deploy/control-plane/docker-container/air-gapped.mdx) before running these steps.
+:::
+
 <Flow>
   <Step>
     Configure vCluster to use the Docker driver.
@@ -177,6 +181,7 @@ All Docker containers and networks created for the cluster are removed. On macOS
 ## Next steps
 
 - [vind configuration](../configure/vcluster-yaml/experimental/docker.mdx) — ports, volumes, registry proxy, multi-node options
+- [Air-gapped environments](../deploy/control-plane/docker-container/air-gapped.mdx) — registry mirrors, image overrides, and offline bootstrap for corporate networks
 - [vCluster VPN](../configure/vcluster-yaml/private-nodes/vpn.mdx) — join real cloud nodes to a vind cluster
 - [Shared nodes](./shared-nodes.mdx) — when you're ready to move to a real Kubernetes cluster
 - [vcluster.yaml reference](../configure/what-is-vcluster-yaml.mdx) — full configuration reference


### PR DESCRIPTION
<!--
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it.
In this case, follow the instructions from vale and fix the linting issues.
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

New page documenting how to deploy vind in air-gapped environments, covering all five network layers vind contacts during cluster creation and operation. Also includes two CSS fixes for inline code baseline alignment and interpolated code block spacing.

## Preview Link

<!-- The preview link or links to the documents-->
https://deploy-preview-2200--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/docker-container/air-gapped

## Internal Reference

Closes DOC-1408

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs