### PR TITLE
docs(doc-1468): replace mermaid diagrams with branded SVGs and style pass on node providers overview

### DIFF
--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -38,7 +38,9 @@ JavaScript
 [jJ]ob
 apiserver
 kubeadm
+Karpenter
 KubeVirt
+Virt
 kubelet
 Let's Encrypt
 LimitRange

--- a/platform/administer/node-providers/overview.mdx
+++ b/platform/administer/node-providers/overview.mdx
@@ -4,30 +4,24 @@ sidebar_label: Overview
 sidebar_position: 1
 ---
 
-Nodes providers allow you to configure sources for private nodes for tenant clusters in an automatic fashion. The following supported node providers currently exist:
+import NodeProvidersOverviewDiagram from '@site/static/media/diagrams/node-providers-overview-diagram.svg';
+import NodeClaimsDiagram from '@site/static/media/diagrams/node-claims-diagram.svg';
+import NodeEnvironmentDiagram from '@site/static/media/diagrams/node-environment-diagram.svg';
+
+Node providers let you configure sources for private nodes for tenant clusters automatically. Platform supports the following node providers:
 * [Terraform](./terraform.mdx) (powered by [OpenTofu](https://opentofu.org) under the hood)
 * [KubeVirt](./kubevirt.mdx) <!-- vale Vale.Terms = NO -->
 * [Nvidia Base Command Manager](./bcm.mdx) <!-- vale Vale.Terms = NO -->
-* [Metal3](./metal3.mdx) (bare metal provisioning via Metal3/Ironic)
+* [vMetal](./metal3.mdx) (bare metal provisioning using Metal3/Ironic)
 
-Each node provider defines provider specific configuration and its node types, which then are used by the tenant clusters to choose from.
-When a vCluster requests a new node it will create a new node claim, telling the platform to create a new node with the given requirements. The platform will then match these requirements to the cheapest available node type and consequentially create a new node from that type.
+Each node provider defines provider-specific configuration and node types that tenant clusters select from.
+When a tenant cluster requests a new node, it creates a node claim, telling the platform to provision a node with the given requirements. The platform then matches these requirements to the cheapest available node type and creates a node from that type.
 
-<br />
-```mermaid
-flowchart LR;
-  vClusterPlatform -->|creates| Provider[NodeProvider]
-  Provider -->|defines| NodeType
-  vCluster -->|creates| Claim[NodeClaim]
-  Claim -->|references| NodeType
+<figure>
+  <NodeProvidersOverviewDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Node providers overview diagram" />
+</figure>
 
-  NodeClaim("Node Claim")
-  NodeType("Node Type")
-  NodeProvider("Node Provider")
-  vClusterPlatform("vCluster Platform")
-```
-
-An example node provider with two distinct node types could look like this:
+An example node provider with two distinct node types:
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: NodeProvider
@@ -53,7 +47,7 @@ spec:
           instance-type: large
 ```
 
-This would create a new node provider with a terraform node template. For each node claim the platform would execute the terraform script. The vCluster could then use this node provider via:
+This creates a node provider with a Terraform node template. For each node claim, the platform executes the Terraform script. Reference this node provider in your tenant cluster using:
 ```yaml
 # Use this in your vcluster.yaml
 privateNodes:
@@ -66,25 +60,25 @@ privateNodes:
       - name: my-node-pool
 ```
 
-:::info Single Node Provider many vCluster
-You should not create a node provider per vCluster instead create a single node provider and use it among different vCluster.
+:::info Single node provider, many tenant clusters
+Do not create a node provider per tenant cluster. Create a single node provider and share it across tenant clusters.
 :::
 
 ## Node types 
 
-Node types are machine types that are chosen by vCluster based on its properties, resources and cost. 
-Usually you would create a node type for each instance type you want to allow vCluster to choose from, for example this could be different VM sizes or different cloud instance types. 
+Node types are machine types that vCluster selects based on properties, resources, and cost.
+Create a node type for each instance type you want vCluster to choose from, such as different VM sizes or cloud instance types.
 
-vCluster will then choose automatically the best fitting node type based on its requirements. 
-If there are no requirements or multiple node types match, the cheapest available node type will be selected.
+vCluster automatically selects the best fitting node type based on requirements.
+If there are no requirements or multiple node types match, vCluster selects the cheapest available node type.
 
 ### Properties
 
-Properties on a node type are similar to labels and let users specify specific traits that can be later used to include or exclude certain node types when vCluster are created. Users can define their own custom properties while there are also in-built properties always available to use. 
+Properties on a node type are similar to labels and let users specify traits to include or exclude certain node types when tenant clusters are created. Users can define custom properties in addition to the always-available built-in properties.
 
 #### Use properties
 
-Within vCluster you can use properties via the `requirements` field under `autoNodes` node pools. These allow you to select properties and how node types should be included or excluded:
+Use properties through the `requirements` field under `autoNodes` node pools to include or exclude node types:
 ```yaml
 # Inside your vcluster.yaml
 privateNodes:
@@ -122,7 +116,7 @@ The following operators are available (and similar to [Kubernetes set-based requ
 
 #### Custom properties
 
-Custom properties can be defined via the `properties` field and map a certain key to one or multiple values. For example:
+Custom properties are defined using the `properties` field and map a key to one or multiple values. For example:
 ```yaml
 ...
 kind: NodeProvider
@@ -141,91 +135,63 @@ spec:
           my-property-all: "*"
 ```
 
-Keep in mind that property values need to adhere to the [syntax and character set of Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) as they will be set as a label on the created nodes later on.
+Property values must adhere to the [syntax and character set of Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set), as they are set as labels on created nodes.
 
 #### In-built properties
 
-These properties will automatically be added by the platform and can be used as well:
-* `vcluster.com/node-type`: The name of the node type to use. Makes it possible to map vCluster node pools to only use a specific node type. Since node type names are globally unique, they also always map to a single node provider.
-* `node.kubernetes.io/instance-type`: Same as `vcluster.com/node-type`, but just the official Kubernetes label.
-* `kubernetes.io/os`: Currently is always fixed to `linux`.
-* `topology.kubernetes.io/zone`: Maps to the `spec.zone` field of the node type. If unspecified, will be `global`.
-* `karpenter.sh/capacity-type`: Currently always `on-demand` as we don't distinguish between capacity types for now.
+The platform automatically adds these properties:
+* `vcluster.com/node-type`: The name of the node type. Maps vCluster node pools to a specific node type. Since node type names are globally unique, they always map to a single node provider.
+* `node.kubernetes.io/instance-type`: Same as `vcluster.com/node-type`, but the official Kubernetes label.
+* `kubernetes.io/os`: Always `linux`.
+* `topology.kubernetes.io/zone`: Maps to the `spec.zone` field of the node type. Defaults to `global` if unspecified.
+* `karpenter.sh/capacity-type`: Always `on-demand`. Capacity type distinctions are not currently supported.
 
 ### Resources
 
-Resources are a required field of node types and specify what computing resources a node of this type would have. Certain node providers (such as bcm or kubevirt) are able to auto discover resources, while others require you to specify at least `cpu` and `memory` for each node type.
+The `resources` field is required on each node type and specifies the computing resources nodes of that type provide. Certain node providers (such as BCM or KubeVirt) auto-discover resources, while others require you to specify at least `cpu` and `memory` for each node type.
 Resources are specified according to the [Kubernetes resource units](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
-In addition you can also specify your own resources, such as `nvidia.com/gpu`, which then will be used for scheduling inside the vCluster as well. The platform will not schedule a node claim to a node type with custom resources, if these custom resources are not explicitly requested. In other words, if a vCluster doesn't request a GPU, no GPU node type will ever be provisioned for this vCluster, even if they are the only ones left.
+You can also specify custom resources such as `nvidia.com/gpu`, used for scheduling inside the tenant cluster. The platform does not schedule a node claim to a node type with custom resources unless those resources are explicitly requested. A tenant cluster that does not request a GPU is never assigned a GPU node type, even if it is the only available type.
 
 ### Cost
 
-Each node type has an associated cost to it, either manually specified by the user via the `spec.cost` field or calculated based on the `resources`. The cost unit is on purpose unspecified, so it is not measured in a currency and instead just a value which will be used by vCluster and the platform to decide if a node type is cheaper than another node type if both could be selected.
+Each node type has an associated cost, either set manually using `spec.cost` or calculated from `resources`. The cost unit is intentionally unspecified. It is not a currency but a relative value vCluster and the platform use to select the cheapest matching node type.
 
-By default, each resource has the following cost associated if not specified manually:
+Default costs when not specified manually:
 * Each `cpu` costs `10`
 * Each GB of `memory` costs `2`
-* Each other resource costs `10000` to avoid scheduling on these "expensive" resources. 
+* Each other resource costs `10000`, discouraging scheduling on specialized resources.
 
-Karpenter will always try to find the cheapest node possible and automatically provision or deprovision nodes if costs change.
+Karpenter always tries to find the cheapest node and automatically provisions or deprovisions nodes as costs change.
 
 ### Capacity
 
-Capacity is the amount of available nodes for a given node type. Specifying this depends on the scenario, so for example for bare-metal it makes sense to have a limit of VMs or machines that are usable. 
+Capacity is the number of available nodes for a given node type. The appropriate limit depends on the scenario. For bare-metal, for example, you may want to cap the number of usable machines.
 
-Depending on the provider, this can be either set manually or is automatically discovered:
-* *Terraform*: can be set via the `maxCapacity` field or otherwise unlimited
-* *KubeVirt*: can be set via the `maxCapacity` field or otherwise unlimited
+Depending on the provider, capacity is set manually or discovered automatically:
+* *Terraform*: set using `maxCapacity`, otherwise unlimited
+* *KubeVirt*: set using `maxCapacity`, otherwise unlimited
 * *BCM*: is automatically discovered
 * *Metal3*: determined by available BareMetalHosts matching the node type's label selector
 
-If specified, the platform will keep track of how many nodes were already created of this type and eventually mark the node type as unavailable. vCluster will then not try to use this node type anymore until nodes are deprovisioned again.
+If specified, the platform tracks how many nodes of this type have been created and marks the node type as unavailable once the limit is reached. vCluster stops using that node type until nodes are deprovisioned.
 
 ## Node claims
 
-When vCluster requests a new node for its cluster, either dynamically decided by [Karpenter](https://karpenter.sh/) or statically configured, vCluster will create a new node claim object in the platform with requirements. The platform will then decide based on these requirements which node type will fulfill the request. If multiple node types match the requirements, the cheapest available node type will be chosen.
+When a tenant cluster requests a new node, either dynamically using [Karpenter](https://karpenter.sh/) or through static configuration, vCluster creates a node claim in the platform with requirements. The platform then selects the node type that best fulfills those requirements. If multiple node types match, the platform chooses the cheapest available one.
 
 You can restrict the node types a project's NodeClaims may use with [`spec.allowedNodeTypes`](../projects/allowed/node-types.mdx).
 
-<br />
-```mermaid
-flowchart-elk LR;
-  vCluster -->|creates| NodeClaim
-  Node -->|joins| vCluster
+<figure>
+  <NodeClaimsDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Node claims diagram" />
+</figure>
 
-  subgraph two["vCluster Platform"]
-  NodeClaim -->|schedules| NodeType
-  NodeType -->|references| NodeProvider
-  NodeProvider -->|creates| Node
-  end
+## Node environments
 
-  vCluster("vCluster")
-  NodeClaim("Node Claim")
-  NodeType("Node Type")
-  NodeProvider("Node Provider")
-```
+Node environments are optional and scoped to a single tenant cluster and node provider. Some node providers require one-time setup before they can create nodes. For example, a tenant cluster in AWS using the Terraform provider needs a VPC, routing tables, and subnets before deploying any nodes.
 
-## Node Environments
+The platform creates node environments lazily, only when a tenant cluster first selects that provider. Once the environment is ready, node creation proceeds.
 
-Node environments are created on a per vCluster basis based on the node provider and are optional. Certain node providers need to configure certain prerequisites once per vCluster before being able to create actual nodes for them.
-For example, when thinking of a vCluster created in AWS via the terraform provider, you would want to create a VPC, routing tables, subnets etc. once before deploying the actual nodes.
-
-Node environments are created in a lazy fashion, which means they are only created when actually needed. This usually means as soon as a node is selected for a specific provider the node environment is created before the first node once. As soon as the environment is available, the node creation process follows.
-
-<br />
-```mermaid
-flowchart-elk LR;
-  vCluster -->|creates| NodeClaim
-
-  subgraph two["vCluster Platform"]
-  NodeClaim -->|needs| NodeEnvironment
-  NodeEnvironment -->|references| NodeProvider
-  NodeProvider -->|creates| NodeEnvironment
-  end
-
-  vCluster("vCluster")
-  NodeClaim("Node Claim")
-  NodeEnvironment("Node Environment")
-  NodeProvider("Node Provider")
-```
+<figure>
+  <NodeEnvironmentDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Node environment diagram" />
+</figure>

--- a/static/media/diagrams/node-claims-diagram.svg
+++ b/static/media/diagrams/node-claims-diagram.svg
@@ -1,0 +1,94 @@
+<svg viewBox="0 0 1000 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vCluster node providers architecture diagram">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <!-- Dark arrowhead (main flow) -->
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+
+    <!-- Orange arrowhead (joins arc) -->
+    <marker id="arr-o" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FF6600"/>
+    </marker>
+  </defs>
+
+  <!-- ─── Subgraph: vCluster Platform ─── -->
+  <rect x="185" y="90" width="780" height="160"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="205" y="113"
+        font-size="12" font-weight="500" fill="#828592">vCluster Platform</text>
+
+  <!-- ─── Nodes ─── -->
+
+  <!-- vCluster (outside subgraph, orange accent) -->
+  <rect x="35" y="147" width="130" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="100" y="170"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">vCluster</text>
+
+  <!-- Node Claim -->
+  <rect x="225" y="147" width="140" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="295" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Claim</text>
+
+  <!-- Node Type -->
+  <rect x="415" y="147" width="130" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="480" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Type</text>
+
+  <!-- Node Provider -->
+  <rect x="605" y="147" width="140" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="675" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Provider</text>
+
+  <!-- Node -->
+  <rect x="805" y="147" width="100" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="855" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node</text>
+
+  <!-- ─── Arrows ─── -->
+
+  <!-- vCluster → creates → Node Claim -->
+  <line x1="165" y1="170" x2="223" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="194" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <!-- Node Claim → schedules → Node Type -->
+  <line x1="365" y1="170" x2="413" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="389" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">schedules</text>
+
+  <!-- Node Type → references → Node Provider -->
+  <line x1="545" y1="170" x2="603" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="574" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">references</text>
+
+  <!-- Node Provider → creates → Node -->
+  <line x1="745" y1="170" x2="803" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="774" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <!-- Node → joins → vCluster (orange arc below diagram) -->
+  <path d="M 855 193 C 855 285 100 285 100 193"
+        stroke="#FF6600" stroke-width="1.5" fill="none"
+        marker-end="url(#arr-o)"/>
+  <text x="478" y="305"
+        font-size="11" fill="#FF6600" text-anchor="middle">joins</text>
+</svg>

--- a/static/media/diagrams/node-environment-diagram.svg
+++ b/static/media/diagrams/node-environment-diagram.svg
@@ -1,0 +1,76 @@
+<svg viewBox="0 0 870 310" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vCluster node environment diagram">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <!-- Dark arrowhead (main flow) -->
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+  </defs>
+
+  <!-- ─── Subgraph: vCluster Platform ─── -->
+  <rect x="155" y="80" width="685" height="205"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="175" y="103"
+        font-size="12" font-weight="500" fill="#828592">vCluster Platform</text>
+
+  <!-- ─── Nodes ─── -->
+
+  <!-- vCluster (outside subgraph, orange accent) -->
+  <rect x="25" y="147" width="110" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="80" y="170"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">vCluster</text>
+
+  <!-- Node Claim -->
+  <rect x="215" y="147" width="130" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="280" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Claim</text>
+
+  <!-- Node Environment -->
+  <rect x="420" y="147" width="160" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="500" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Environment</text>
+
+  <!-- Node Provider -->
+  <rect x="645" y="147" width="140" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="715" y="170"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Provider</text>
+
+  <!-- ─── Arrows ─── -->
+
+  <!-- vCluster → creates → Node Claim -->
+  <line x1="135" y1="170" x2="213" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="174" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <!-- Node Claim → needs → Node Environment -->
+  <line x1="345" y1="170" x2="418" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="382" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">needs</text>
+
+  <!-- Node Environment → references → Node Provider -->
+  <line x1="580" y1="170" x2="643" y2="170"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="612" y="162"
+        font-size="11" fill="#828592" text-anchor="middle">references</text>
+
+  <!-- Node Provider → creates → Node Environment (arc below) -->
+  <path d="M 715 193 C 715 258 500 258 500 193"
+        stroke="#050B24" stroke-width="1.5" fill="none"
+        marker-end="url(#arr)"/>
+  <text x="608" y="264"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+</svg>

--- a/static/media/diagrams/node-providers-overview-diagram.svg
+++ b/static/media/diagrams/node-providers-overview-diagram.svg
@@ -1,0 +1,76 @@
+<svg viewBox="0 0 700 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vCluster node provider overview diagram">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+  </defs>
+
+  <!-- ─── Nodes ─── -->
+
+  <!-- vCluster Platform (top-left, orange accent) -->
+  <rect x="30" y="87" width="160" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="110" y="110"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">vCluster Platform</text>
+
+  <!-- vCluster (bottom-left, orange accent) -->
+  <rect x="55" y="187" width="110" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="110" y="210"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">vCluster</text>
+
+  <!-- Node Provider (top-middle) -->
+  <rect x="280" y="87" width="140" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="350" y="110"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Provider</text>
+
+  <!-- Node Claim (bottom-middle) -->
+  <rect x="280" y="187" width="130" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="345" y="210"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Claim</text>
+
+  <!-- Node Type (right, vertically centred between the two rows) -->
+  <rect x="520" y="137" width="120" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="580" y="160"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node Type</text>
+
+  <!-- ─── Arrows ─── -->
+
+  <!-- vCluster Platform → creates → Node Provider (horizontal) -->
+  <line x1="190" y1="110" x2="278" y2="110"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="234" y="102"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <!-- Node Provider → defines → Node Type (diagonal down-right) -->
+  <!-- Line hits Node Type left edge at approx (519, 141) -->
+  <line x1="420" y1="110" x2="519" y2="141"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="473" y="117"
+        font-size="11" fill="#828592" text-anchor="middle">defines</text>
+
+  <!-- vCluster → creates → Node Claim (horizontal) -->
+  <line x1="165" y1="210" x2="278" y2="210"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="222" y="202"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <!-- Node Claim → references → Node Type (diagonal up-right) -->
+  <!-- Line hits Node Type left edge at approx (519, 178) -->
+  <line x1="410" y1="210" x2="519" y2="179"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="497" y="212"
+        font-size="11" fill="#828592" text-anchor="middle">references</text>
+</svg>


### PR DESCRIPTION
# Content Description

Replaces the three Mermaid diagrams on the node providers overview page with branded SVGs. Also does a full prose style pass: present tense throughout, active voice, updated terminology (tenant cluster, control plane cluster), and a clean vale run.

## Preview Link

<!-- The preview link or links to the documents-->
https://deploy-preview-2201--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/overview

## Internal Reference

Closes DOC-1468

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs