### PR TITLE
fix(doc-1464): render example lists in config-field descriptions

### DIFF
--- a/src/css/content/config-fields.scss
+++ b/src/css/content/config-fields.scss
@@ -61,6 +61,22 @@ body .markdown .config-field {
         opacity: 1;
         overflow: visible;
       }
+
+      // Field descriptions may contain markdown lists (e.g. the `Examples:`
+      // block on dataSource/identityProvider). Those render as a <ul>/<ol>
+      // sibling inside the summary, which the base `summary > * { display:none }`
+      // rule hides. Restore them when the field is open/non-expandable so the
+      // examples actually show. See DOC-1464.
+      > ul,
+      > ol {
+        display: block;
+        opacity: 1;
+        margin: 0.2em 0 0.4em;
+
+        li {
+          display: list-item;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Content Description
Config reference fields hid any markdown `Examples:` list in their description. Most visibly, the `dataSource` and `identityProvider` examples on the external database page never rendered, so readers saw the text end at "Examples:" with the connection-string bullets missing. This restores those lists via a one-file CSS fix.

## Summary
The config-field `<summary>` hides every direct child (`summary > * { display: none }`) and the open state only re-showed `p:first-of-type`. A markdown list parses to a sibling `<ul>`, so it stayed hidden. Now `<ul>`/`<ol>` (and `<li>`) are restored when a field is open or non-expandable, scoped so collapsed previews still ellipsize to one line.

## Key Changes
- `src/css/content/config-fields.scss`: un-hide `> ul`/`> ol` (with `li { display: list-item }`) in the open / `data-expandable="false"` summary state.

## Dependencies
None.

## Backporting
The fix is in shared, non-versioned CSS (`src/css/`), so it applies to every doc version at once. No `versioned_docs` edits and no partial regeneration are needed. Affected partials include the external/embedded database, controlPlane, backingStore, advanced, and platform config references.

## Preview Link
- External database config reference (dataSource / identityProvider examples): https://deploy-preview-2204--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external#external-dataSource

## Internal Reference
Closes DOC-1464

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs