### PR TITLE
fix: remove stale lastVersion redirects for vcluster 0.33.0 and platform 4.8.0

### DIFF
--- a/.claude/skills/platform-docs-releaser/SKILL.md
+++ b/.claude/skills/platform-docs-releaser/SKILL.md
@@ -27,7 +27,7 @@ The config flip PR changes only the version visibility in `docusaurus.config.js`
 - Updates `lastVersion` to point to the new version
 - Adds the new version to the dropdown with "Stable" label
 - Demotes the previous stable version label (removes "Stable" suffix)
-- Updates SEO sitemap priorities, announcement bar, and netlify redirect
+- Updates SEO sitemap priorities, announcement bar, and netlify redirect (adds new version, removes previous)
 
 This separation means all the heavy lifting (version creation, API partials, content, link fixes) is done during the rc-1 window, and release day is a low-risk config change.
 
@@ -267,13 +267,22 @@ announcementBar: {
 
 #### 5. `netlify.toml` — redirect
 
+**CRITICAL:** Add the redirect for the new `lastVersion` AND remove the redirect for the previous `lastVersion` (X.Z.0). The previous version is still in `onlyIncludeVersions` — its versioned URL serves real content and must not redirect.
+
 ```toml
+# ADD this block for the new lastVersion (canonical URL is the unversioned path)
 [[redirects]]
   from = "/docs/platform/X.Y.0/*"
   to = "/docs/platform/:splat"
   status = 301
   force = true
+
+# REMOVE the block for X.Z.0 — it is now a live versioned URL, not the lastVersion
 ```
+
+Only two categories of versions belong in this redirect section:
+- The current `lastVersion` (whose canonical URL is the unversioned path)
+- Truly EOL/archived versions that are no longer in `onlyIncludeVersions`
 
 #### 6. `hack/test-platform-X.Y.hurl` — create hurl test
 
@@ -290,7 +299,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | `src/config/versionConfig.js` | Add version to `platformHiddenVersions` array | rc-1 |
 | `docusaurus.config.js` | `lastVersion`, labels, SEO, announcement bar | Release day |
 | `src/config/versionConfig.js` | Remove version from `platformHiddenVersions` | Release day |
-| `netlify.toml` | Redirect | Release day |
+| `netlify.toml` | Add redirect for new lastVersion; remove redirect for previous lastVersion | Release day |
 | `hack/test-platform-X.Y.hurl` | New test file | Release day |
 | Platform support dates file | Release/EOL dates | User |
 

--- a/.claude/skills/vcluster-docs-releaser/SKILL.md
+++ b/.claude/skills/vcluster-docs-releaser/SKILL.md
@@ -27,7 +27,7 @@ The config flip PR changes only the version visibility in `docusaurus.config.js`
 - Moves the new version entry from hidden to visible in the dropdown
 - Updates `lastVersion` to point to the new version
 - Demotes the previous stable version label (removes "Stable" suffix)
-- Updates SEO sitemap priorities, announcement bar, and netlify redirect
+- Updates SEO sitemap priorities, announcement bar, and netlify redirect (adds new version, removes previous)
 
 This separation means all the heavy lifting (version creation, content, link fixes) is done during the rc-1 window, and release day is a low-risk config change.
 
@@ -212,13 +212,22 @@ announcementBar: {
 
 #### 6. `netlify.toml` — redirect
 
+**CRITICAL:** Add the redirect for the new `lastVersion` AND remove the redirect for the previous `lastVersion` (0.YY.0). The previous version is still in `onlyIncludeVersions` — its versioned URL serves real content and must not redirect.
+
 ```toml
+# ADD this block for the new lastVersion (canonical URL is the unversioned path)
 [[redirects]]
   from = "/docs/vcluster/0.XX.0/*"
   to = "/docs/vcluster/:splat"
   status = 301
   force = true
+
+# REMOVE the block for 0.YY.0 — it is now a live versioned URL, not the lastVersion
 ```
+
+Only two categories of versions belong in this redirect section:
+- The current `lastVersion` (whose canonical URL is the unversioned path)
+- Truly EOL/archived versions that are no longer in `onlyIncludeVersions`
 
 #### 7. `hack/test-vcluster-0.XX.hurl` — create hurl test
 
@@ -235,7 +244,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | `docusaurus.config.js` | `lastVersion`, labels, SEO, announcement bar | Release day |
 | `src/config/versionConfig.js` | Remove version from `vclusterHiddenVersions` | Release day |
 | `src/config/docsearch.js` | Update `stableVersion` to new stable version string | Release day |
-| `netlify.toml` | Redirect | Release day |
+| `netlify.toml` | Add redirect for new lastVersion; remove redirect for previous lastVersion | Release day |
 | `hack/test-vcluster-0.XX.hurl` | New file | Release day |
 
 ## Division of Responsibilities

--- a/algolia/docsearch.config.js
+++ b/algolia/docsearch.config.js
@@ -26,6 +26,7 @@ new Crawler({
   ],
   renderJavaScript: false,
   ignoreCanonicalTo: true,
+  ignoreNoIndex: true,
   discoveryPatterns: [
     "https://www.vcluster.com/docs/**",
     "https://www.vnode.com/docs/**",

--- a/netlify.toml
+++ b/netlify.toml
@@ -777,19 +777,7 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   force = true
 
 [[redirects]]
-  from = "/docs/vcluster/0.33.0/*"
-  to = "/docs/vcluster/:splat"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/docs/platform/4.9.0/*"
-  to = "/docs/platform/:splat"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/docs/platform/4.8.0/*"
   to = "/docs/platform/:splat"
   status = 301
   force = true


### PR DESCRIPTION
# Content Description

Removes netlify redirects for vCluster 0.33.0 and Platform 4.8.0 that were left over from the 0.34.0 / 4.9.0 release. Both versions are still in `onlyIncludeVersions` and serve real versioned content — the redirects were silently sending users to the current version instead.

Also updates both release skills to include an explicit **CRITICAL** warning: when adding a redirect for the new `lastVersion`, remove the redirect for the previous `lastVersion`.

## Preview Link

<!-- The preview link or links to the documents-->

## Internal Reference

<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs