### PR TITLE
docs(doc-1474): add default k8s version fragment to quick-start and deploy pages

### DIFF
--- a/.claude/skills/vcluster-docs-releaser/SKILL.md
+++ b/.claude/skills/vcluster-docs-releaser/SKILL.md
@@ -115,7 +115,21 @@ versions: {
 }
 ```
 
-#### 2. Update `src/config/versionConfig.js` — hide from dropdown
+#### 2. Update `vcluster/_fragments/default-k8s-version.mdx` — default Kubernetes version
+
+Check the default k8s version for this release. The source of truth is `controlPlane.distro.k8s.image.tag` in `config/values.yaml` of the [vcluster OSS repo](https://github.com/loft-sh/vcluster).
+
+If the tag changed from the previous release, update the fragment:
+
+```mdx
+:::note
+vCluster deploys Kubernetes **vX.YY.Z** by default. To use a different version, set `controlPlane.distro.k8s.image.tag` in your `vcluster.yaml`.
+:::
+```
+
+This fragment is used on quick-start and deploy pages. Because it lives in `vcluster/_fragments/`, the versioning command snapshots it into the new versioned docs folder automatically — older docs retain their pinned version.
+
+#### 3. Update `src/config/versionConfig.js` — hide from dropdown
 
 Add the version to the hidden array so it doesn't appear in the version dropdown:
 
@@ -137,8 +151,9 @@ AI performs:
 1. ✅ Verify versioned docs exist: `ls -la vcluster_versioned_docs/version-0.XX.0/`
 2. ✅ Count CLI docs: `ls vcluster_versioned_docs/version-0.XX.0/cli/*.md | wc -l` (expect 90+)
 3. ✅ Check vcluster_versions.json includes new version
-4. ✅ All config changes applied
-5. ✅ Version is hidden from dropdown (in `vclusterHiddenVersions` array in `versionConfig.js`)
+4. ✅ Default k8s version fragment updated if version changed (`vcluster/_fragments/default-k8s-version.mdx`)
+5. ✅ All config changes applied
+6. ✅ Version is hidden from dropdown (in `vclusterHiddenVersions` array in `versionConfig.js`)
 
 User performs:
 1. Build check: `npm run build` (not AI's responsibility)
@@ -240,6 +255,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | File | Changes | Phase |
 |------|---------|-------|
 | `docusaurus.config.js` | Add to `onlyIncludeVersions`, add version with `banner: "unreleased"` + `noIndex: true` | rc-1 |
+| `vcluster/_fragments/default-k8s-version.mdx` | Update default k8s version if it changed (check `config/values.yaml` in vcluster OSS repo) | rc-1 |
 | `src/config/versionConfig.js` | Add version to `vclusterHiddenVersions` array | rc-1 |
 | `docusaurus.config.js` | `lastVersion`, labels, SEO, announcement bar | Release day |
 | `src/config/versionConfig.js` | Remove version from `vclusterHiddenVersions` | Release day |

--- a/vcluster/_fragments/default-k8s-version.mdx
+++ b/vcluster/_fragments/default-k8s-version.mdx
@@ -1,0 +1,3 @@
+:::note
+vCluster deploys Kubernetes **v1.35.0** by default. To use a different version, set `controlPlane.distro.k8s.image.tag` in your `vcluster.yaml`.
+:::

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -39,10 +39,10 @@ controlPlane:
       image:
         registry: ghcr.io           # Default: ghcr.io (can be overridden globally with controlPlane.advanced.defaultImageRegistry)
         repository: loft-sh/kubernetes  # Default: loft-sh/kubernetes
-        tag: v1.32.1                # Default: v1.32.1 (or matches host Kubernetes version)
+        tag: v1.35.0                # Default: v1.35.0
 ```
 
-The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">control plane cluster</GlossaryTerm>'s Kubernetes version.
+The `tag` field specifies the Kubernetes version to use. When omitted, vCluster deploys **v1.35.0** by default.
 
 :::note
 The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.

--- a/vcluster/deploy/control-plane/binary/basics.mdx
+++ b/vcluster/deploy/control-plane/binary/basics.mdx
@@ -13,6 +13,7 @@ import StandaloneFlags from '../../../_fragments/deploy/standalone-flags.mdx'
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 import PageVariables from '@site/src/components/PageVariables';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
+import DefaultK8sVersion from '../../../_fragments/default-k8s-version.mdx';
 
 <TenancySupport standalone="true" />
 
@@ -105,7 +106,9 @@ Perform all steps on the control plane node as root.
           title="Create config directory"
           language="bash"
         />
-        Save a `vcluster.yaml` configuration file for vCluster Standalone on the control plane node. The configuration file is optional — if omitted, the installer uses its bundled Kubernetes version. Provide one when you need to pin the Kubernetes version or customize other settings.
+        Save a `vcluster.yaml` configuration file for vCluster Standalone on the control plane node. The configuration file is optional. Provide one when you need to pin the Kubernetes version or customize other settings.
+
+<DefaultK8sVersion/>
         <InterpolatedCodeBlock
           code={"cat <<EOF > [[GLOBAL:CONFIG_DIRECTORY]]/vcluster.yaml\ncontrolPlane:\n  distro:\n    k8s:\n      version: v1.34.0\nEOF"}
           title="Create vCluster config file"
@@ -135,7 +138,7 @@ Adding additional control plane nodes is not supported unless you follow the [hi
         Expected output:
         ```bash
         NAME               STATUS   ROLES                  AGE   VERSION
-        ip-192-168-3-131   Ready    control-plane,master   11m   v1.32.1
+        ip-192-168-3-131   Ready    control-plane,master   11m   v1.35.0
         ```
 
         ```bash title="Verify cluster components are running"

--- a/vcluster/deploy/control-plane/docker-container/basics.mdx
+++ b/vcluster/deploy/control-plane/docker-container/basics.mdx
@@ -8,6 +8,7 @@ sidebar_class_name: standalone docker
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 import InstallCLIFragment from '../../../_partials/deploy/install-cli.mdx'
 import DockerConfig from '../../../_partials/config/experimental/docker.mdx';
+import DefaultK8sVersion from '../../../_fragments/default-k8s-version.mdx';
 
 vCluster in Docker (vind) allows you to deploy a complete Kubernetes cluster using Docker containers without requiring a host Kubernetes cluster. This deployment method is ideal for local development, testing, and CI/CD scenarios.
 
@@ -109,6 +110,8 @@ Deploy with default configuration:
   code="vcluster create [[VAR:VCLUSTER_NAME:my-vcluster]]"
   language="bash"
 />
+
+<DefaultK8sVersion/>
 
 Or deploy with custom configuration:
 

--- a/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
@@ -10,6 +10,7 @@ import ControlPlaneOptions from '../../../_fragments/deploy/control-plane.mdx'
 
 import PreRequisites from '../../../_partials/quick-start-guide/pre-requisites.mdx'
 import Deploy from '../../../_partials/deploy/deploy.mdx'
+import DefaultK8sVersion from '../../../_fragments/default-k8s-version.mdx'
 
 There are multiple ways to deploy and manage your vCluster. Review the different choices and choose the one that suits your needs.
 
@@ -34,6 +35,8 @@ Detailed instructions are provided for specific Control Plane Cluster environmen
 If you're not sure which options to configure, you can update most settings later by upgrading your vCluster with an updated `vcluster.yaml`.
 However, some settings — such as what type of worker nodes or the backing store — can only be set during the initial deployment and cannot be changed during an upgrade.
 :::
+
+<DefaultK8sVersion/>
 
 <Deploy />
 

--- a/vcluster/quick-start/docker.mdx
+++ b/vcluster/quick-start/docker.mdx
@@ -9,6 +9,7 @@ sidebar_class_name: standalone
 import Flow, { Step } from "@site/src/components/Flow";
 import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
+import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
 
 You want a full Kubernetes cluster running locally for development, testing, or CI. You don't want the setup overhead of a cloud environment or the limitations of KinD.
 
@@ -49,6 +50,8 @@ This guide covers deployment, pause and resume, LoadBalancer services, and virtu
     ```bash
     vcluster create my-vcluster
     ```
+
+<DefaultK8sVersion/>
 
     When deployment finishes, the CLI connects and switches your kube context into the cluster.
   </Step>

--- a/vcluster/quick-start/private-nodes.mdx
+++ b/vcluster/quick-start/private-nodes.mdx
@@ -10,6 +10,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 import PageVariables from '@site/src/components/PageVariables';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
+import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
 
 You're building a platform where tenants need real hardware isolation. Think GPU workloads that can't share a node pool, regulated environments that require dedicated infrastructure, or AI cloud customers who expect hyperscaler-grade separation.
 
@@ -58,16 +59,12 @@ An existing tenant cluster cannot be migrated from shared to private nodes. This
       vpn:
         enabled: true
 
-    controlPlane:
-      distro:
-        k8s:
-          image:
-            tag: v1.35.0
-
     networking:
       podCIDR: 10.64.0.0/16
       serviceCIDR: 10.128.0.0/16
     ```
+
+<DefaultK8sVersion/>
   </Step>
   <Step>
     Deploy the tenant cluster.

--- a/vcluster/quick-start/shared-nodes.mdx
+++ b/vcluster/quick-start/shared-nodes.mdx
@@ -9,6 +9,7 @@ sidebar_class_name: host-nodes
 import Flow, { Step } from "@site/src/components/Flow";
 import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
+import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
 
 You're running a Kubernetes cluster and want to give teams, tenants, or CI pipelines their own isolated Kubernetes environments. You don't want to spin up new infrastructure for each one.
 
@@ -34,6 +35,8 @@ By the end you'll have a working tenant cluster and a clear picture of how the i
    ```bash
    vcluster create my-vcluster --namespace team-x
    ```
+
+<DefaultK8sVersion/>
 
     When the deployment finishes, the CLI automatically connects and switches your kube context into the tenant cluster.
   </Step>

--- a/vcluster/quick-start/standalone.mdx
+++ b/vcluster/quick-start/standalone.mdx
@@ -9,6 +9,7 @@ sidebar_class_name: standalone private-nodes
 import Flow, { Step } from "@site/src/components/Flow";
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
+import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
 
 The first problem is always the same. To run vCluster, you need a Kubernetes cluster. But getting a Kubernetes cluster onto bare metal normally requires another tool first. vCluster Standalone breaks this loop. It installs a complete Kubernetes control plane directly on a Linux machine as a binary, with no existing distribution required.
 
@@ -43,6 +44,8 @@ Run these commands on the control plane machine as root.
       code={"curl -sfL https://github.com/loft-sh/vcluster/releases/download/v[[VAR:VCLUSTER_VERSION:__VCLUSTER_VERSION__]]/install-standalone.sh \\\n  | sh -s -- --vcluster-name standalone"}
       language="bash"
     />
+
+<DefaultK8sVersion/>
 
     The installer downloads Kubernetes binaries, configures the control plane, and writes a kubeconfig to `/var/lib/vcluster/kubeconfig.yaml`. Installation takes about 2 minutes.
   </Step>


### PR DESCRIPTION
# Content Description

Adds a reusable `:::note` fragment (`vcluster/_fragments/default-k8s-version.mdx`) that states the default Kubernetes version (v1.35.0) and surfaces it on all quick-start and deploy pages where users create a tenant cluster without specifying a version. Removes the hardcoded `tag: v1.35.0` from the private-nodes quick-start yaml so there is one place to update per release.

## Preview Link
<!-- The preview link or links to the documents-->
- [Shared nodes quickstart](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/shared-nodes#deploy-a-tenant-cluster) (look at the note under step 1)
- [Private node quickstart](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/private-nodes#create-the-tenant-cluster) (look at the note under step 2)
- [Docker quick start](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/docker#deploy-a-cluster) (look at the note under step 2)
- [Standalone quick start](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/quick-start/standalone#install-vcluster-standalone) (look at the note under step 2)
- [Deploy as binary](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary/basics#self-managed)
- [Deploy as Kubernetes pod](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics#deploy-vcluster) (see second note)
- [Deploy on Docker](https://deploy-preview-2209--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/docker-container/basics#step-4-deploy-the-vcluster)

## Internal Reference

Closes DOC-1474

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs