### PR TITLE
fix(404): add branded 404 page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1771,3 +1771,11 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   path = "/docs/*"
   function = "content-negotiation"
 
+
+# DOC-1473: branded 404 catch-all. Must stay last among redirects.
+# Netlify serves existing static files before applying this, so it only
+# fires for unmatched routes (force defaults to false).
+[[redirects]]
+  from = "/*"
+  to = "/docs/404"
+  status = 404

--- a/src/css/content/not-found.scss
+++ b/src/css/content/not-found.scss
@@ -1,0 +1,50 @@
+.not-found {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 3rem 1.5rem;
+  text-align: center;
+
+  &__inner {
+    max-width: 480px;
+  }
+
+  &__code {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 7rem;
+    font-weight: 700;
+    line-height: 1;
+    color: #FF6600;
+    margin-bottom: 1rem;
+  }
+
+  &__heading {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #050B24;
+    margin-bottom: 0.75rem;
+  }
+
+  &__body {
+    color: #828592;
+    font-size: 1rem;
+    margin-bottom: 2rem;
+  }
+
+  &__link {
+    display: inline-block;
+    background: #FF6600;
+    color: #ffffff !important;
+    padding: 0.625rem 1.5rem;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    text-decoration: none !important;
+    transition: background 0.15s;
+
+    &:hover {
+      background: #FF8433;
+    }
+  }
+}

--- a/src/theme/NotFound/Content/index.js
+++ b/src/theme/NotFound/Content/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+export default function NotFoundContent() {
+  return (
+    <main className="not-found">
+      <div className="not-found__inner">
+        <div className="not-found__code">404</div>
+        <h1 className="not-found__heading">Page not found</h1>
+        <p className="not-found__body">
+          The page you're looking for has moved or doesn't exist.
+        </p>
+        <Link className="not-found__link" to="/docs">
+          Back to docs
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
# Content Description
Adds a branded 404 page to vcluster-docs. Swizzles `NotFound/Content` (the inner sub-component, which resolves consistently across SSR and CSR) to render branded body content, with glob-loaded SCSS in vCluster orange (`#FF6600`). Adds a Netlify catch-all redirect so unmatched routes outside `/docs/` also land on the branded page.

## Key Changes
- `src/theme/NotFound/Content/index.js`: branded 404 body (large `404`, heading, one-liner, link back to `/docs`). Swizzles `NotFound/Content`, not `NotFound`, because the latter causes a hydration mismatch and reverts to the Docusaurus default.
- `src/css/content/not-found.scss`: per-site styling, auto-loaded via the `./src/css/**/*.scss` glob. Orange `#FF6600`, hover `#FF8433`.
- `netlify.toml`: catch-all `/* -> /docs/404` (status 404), placed last so it does not shadow other redirects. Netlify serves existing static files first, so it only fires for genuinely unmatched routes.

## Why a redirect (not Netlify's native 404)
Netlify auto-serves a `404.html` only from the publish root. This site moves the build into `public/docs/`, so the generated 404 lives at `public/docs/404.html`, not the publish root. Netlify's docs prescribe an explicit catch-all redirect for subdirectory-nested 404s, which is what this adds.

## Preview Link
- Branded 404 page: https://deploy-preview-2210--vcluster-docs-site.netlify.app/docs/404
- Redirect check (any unmatched route): https://deploy-preview-2210--vcluster-docs-site.netlify.app/docs/this-page-does-not-exist

## Internal Reference
Closes DOC-1473

Part of DOC-1473, which also covers vnode-docs (separate PR) and vmetal-docs (done, PR #24).


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs