### PR TITLE
Adds vm-management to NO_PLAN_REQUIRED list

### DIFF
--- a/scripts/sync-feature-tables.js
+++ b/scripts/sync-feature-tables.js
@@ -288,9 +288,10 @@ function insertOrUpdateFeatureTable(filePath, featureIds) {
 // that don't fit the Free/Dev/Prod/Scale plan matrix.
 // To add a feature here, it must be a deliberate decision — not a missing assignment.
 const NO_PLAN_REQUIRED = new Set([
-  'vnode-runtime',              // add-on product, separate pricing
+  'vnode-runtime',             // add-on product, separate pricing
   'vcp-distro-isolated-cp',    // experimental, not GA
   'air-gapped-mode',           // deployment mode, not a plan-gated feature
+  'vm-management',             // enabled on a per-customer basis
 ]);
 
 /**


### PR DESCRIPTION
This feature is only for select customers

Adding to exclusion to unblock the feature table validation

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds vm-management feature to NO_PLAN_REQUIRED list.
The feature is enabled on a customer basis and not part of any particular plan.
Adding to the NO_PLAN_REQUIRED list unblocks the feature table validation.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1475
Related to https://github.com/loft-sh/admin-apis/pull/97.


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

