### PR TITLE
chore(ci): bump ci-test-notify to skip cancelled and skipped runs

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -275,7 +275,7 @@ jobs:
       # logs a warning and no-ops, so this step never breaks the workflow.
       - name: Notify Slack on receiver failure
         if: failure() && steps.classify.outputs.skip != 'true'
-        uses: loft-sh/github-actions/.github/actions/ci-test-notify@85d7023c5749421d369f59430c7849f2d00ad694 # ci-test-notify/v1
+        uses: loft-sh/github-actions/.github/actions/ci-test-notify@b5a50da8a53ca1021b783290630061078bdb12cf # ci-test-notify/v1
         with:
           test-name: "docs-sync receiver — ${{ steps.inputs.outputs.event }} ${{ steps.inputs.outputs.version }}"
           status: failure


### PR DESCRIPTION
## What

Bump the pinned `ci-test-notify` action to the released `ci-test-notify/v1` commit (`b5a50da`), which carries the cancelled/skipped no-op fix.

## Why

Cancelled GitHub Actions runs were posting Slack alerts as if they had failed. The action now treats `cancelled` and `skipped` statuses as no-ops and sends nothing; only `success` and `failure` notify. This repo was still pinned to the pre-fix commit (`85d7023`), so it kept firing false alerts on cancelled runs.

References DEVOPS-960
