### PR TITLE
docs(connector): document caCert and sslMode on database connector secret

### DIFF
--- a/platform/administer/connector/database.mdx
+++ b/platform/administer/connector/database.mdx
@@ -273,6 +273,36 @@ stringData:
   type: mysql # This can be mysql or postgres. If left blank, the mysql database type is assumed.
 ```
 
+## PostgreSQL TLS
+
+<VersionBadge platformVersion="v4.10.0"/>
+
+Starting with platform v4.10, the PostgreSQL admin connection uses `sslmode=require` as the minimum. Previously the connection silently fell back to plaintext when the server refused TLS. Two optional fields on the connector secret tune this behavior:
+
+| Field | Effect |
+|---|---|
+| `caCert` | PEM-encoded CA bundle. When set, the connection uses `sslmode=verify-full` and the server certificate is validated against this CA. |
+| `sslMode` | Explicit override (`disable`, `require`, `verify-full`, and so on). Wins over the default derived from `caCert`. Set `sslMode: disable` to keep an internal-network PostgreSQL without TLS working after upgrading to v4.10. |
+
+The example below opts out of TLS for a trusted-network PostgreSQL:
+
+```yaml title="Connector secret opting out of TLS"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-no-tls
+  namespace: vcluster-platform
+  labels:
+    loft.sh/connector-type: "shared-database"
+stringData:
+  endpoint: postgres.internal.svc.cluster.local
+  port: "5432"
+  user: admin
+  password: <password>
+  type: postgres
+  sslMode: disable
+```
+
 ## Recreate / restore tenant clusters
 
 To accommodate infrastructure updates or disaster recovery needs, follow this process to restore tenant clusters using a **database connector** powered backing store.

--- a/platform/administer/connector/database.mdx
+++ b/platform/administer/connector/database.mdx
@@ -284,13 +284,13 @@ Starting with platform v4.10, the PostgreSQL admin connection uses `sslmode=requ
 | `caCert` | PEM-encoded CA bundle. When set, the connection uses `sslmode=verify-full` and the server certificate is validated against this CA. |
 | `sslMode` | Explicit override (`disable`, `require`, `verify-full`, and so on). Wins over the default derived from `caCert`. Set `sslMode: disable` to keep an internal-network PostgreSQL without TLS working after upgrading to v4.10. |
 
-The example below opts out of TLS for a trusted-network PostgreSQL:
+The example below enables `sslmode=verify-full` by attaching the CA bundle that signed the PostgreSQL server certificate:
 
-```yaml title="Connector secret opting out of TLS"
+```yaml title="Connector secret with TLS verification"
 apiVersion: v1
 kind: Secret
 metadata:
-  name: postgres-no-tls
+  name: postgres-tls
   namespace: vcluster-platform
   labels:
     loft.sh/connector-type: "shared-database"
@@ -300,7 +300,10 @@ stringData:
   user: admin
   password: <password>
   type: postgres
-  sslMode: disable
+  caCert: |
+    -----BEGIN CERTIFICATE-----
+    <CA certificate that signed the PostgreSQL server certificate>
+    -----END CERTIFICATE-----
 ```
 
 ## Recreate / restore tenant clusters


### PR DESCRIPTION
Closes [ENGCP-900](https://linear.app/loft/issue/ENGCP-900/document-cacert-sslmode-on-the-database-connector-secret).

Follow-up to [ENGCP-857](https://linear.app/loft/issue/ENGCP-857/database-connector-does-not-verify-tls-server-certificates-for) (shipped in [loft-enterprise#7020](https://github.com/loft-sh/loft-enterprise/pull/7020)).

Adds a "PostgreSQL TLS" subsection to `platform/administer/connector/database.mdx` covering the new optional connector-secret fields:

- Behavior change: PostgreSQL admin connection now uses `sslmode=require` minimum.
- `caCert` (PEM): upgrades to `sslmode=verify-full`.
- `sslMode`: explicit override that wins over the `caCert`-derived default. Documented with `sslMode: disable` as the upgrade-path example for trusted-network PostgreSQL without TLS.

Versioned to `v4.10.0` via `<VersionBadge/>`. The 4.9 backport was canceled, so only the unversioned (4.10) doc is touched.
