### PR TITLE
DOC-1184 add virtual machine management docs

### DIFF
--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -17,7 +17,7 @@ specific `NodeType` requested.
 
 To inspect and operate KubeVirt VMs directly from vCluster Platform, see [Virtual Machines](../virtual-machines/overview.mdx).
 
-This enables you to offer different "flavors" of virtual machines, for example small, medium, large, and different operating systems, as nodes for your vCluster,
+This enables you to offer different "flavors" of virtual machines, for example small, medium, and large compute shapes, as nodes for your vCluster,
 all managed from a central configuration.
 
 ```mermaid
@@ -60,7 +60,7 @@ KubeVirt control plane cluster.
 This approach allows for customizations like:
 
 * **Resource Overrides**: Easily create node types with different amounts of CPU or memory.
-* **Template Merging**: Modify specific parts of the base template, like adding taints or changing the disk image.
+* **Template Merging**: Modify specific parts of the base template, like adding taints or labels.
 * **Template Replacement**: Define completely distinct virtual machine templates for specialized use cases.
 
 ## How it works: Cloud-init Node registration
@@ -496,7 +496,7 @@ A partial disk entry that is deep-merged onto the default root disk (`bus: virti
 
 ### Network configuration
 
-KubeVirt node types support additional properties for network configuration with cloud-init:
+KubeVirt provisioning supports additional properties for network configuration with cloud-init:
 
 #### `kubevirt.vcluster.com/network-cidr`
 
@@ -513,7 +513,7 @@ Specifies a CIDR range for allocating IP addresses to the VM. Example: `10.100.0
 **Type:** `string`
 **Required with:** network configuration
 
-The name of the network interface in the VM to configure, for example `eth0`, `eth1`, or `enp1s0`.
+The name of the network interface in the VM to configure, for example `eth0`, `eth1`, or `enp1s0`. It should normally match the default name from the operating system's device enumeration.
 
 #### `kubevirt.vcluster.com/network-ip-range`
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -94,6 +94,9 @@ metadata:
   name: kubevirt-provider-minimal
 spec:
   displayName: "KubeVirt Minimal Provider"
+  properties:
+    kubevirt.vcluster.com/image-url: docker://quay.io/containerdisks/ubuntu:22.04
+    kubevirt.vcluster.com/root-disk-size: 20Gi
   kubeVirt:
     # clusterRef allows configuration of where KubeVirt is running and where VirtualMachines will be created.
     clusterRef:
@@ -102,35 +105,13 @@ spec:
     # Base template for all Virtual Machines created by this provider
     virtualMachineTemplate:
       spec:
-        dataVolumeTemplates:
-        - metadata:
-            name: containerdisk
-          spec:
-            source:
-              registry:
-                url: docker://quay.io/containerdisks/ubuntu:22.04
-            pvc:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: '20Gi'
         template:
           spec:
             domain:
-              devices:
-                disks:
-                - name: containerdisk
-                  disk:
-                    bus: virtio
               resources:
                 requests:
                   cpu: "1"
                   memory: "2Gi"
-            volumes:
-            - name: containerdisk
-              dataVolume:
-                name: containerdisk
     # Define the types of nodes users can request
     nodeTypes:
     - name: "small-ubuntu-vm"
@@ -249,6 +230,9 @@ metadata:
   name: kubevirt-provider-advanced
 spec:
   displayName: "KubeVirt Advanced Provider"
+  properties:
+    kubevirt.vcluster.com/image-url: docker://quay.io/containerdisks/ubuntu:22.04
+    kubevirt.vcluster.com/root-disk-size: 20Gi
   kubeVirt:
     clusterRef:
       cluster: test-kubevirt-1
@@ -258,27 +242,10 @@ spec:
         labels:
           provider: kubevirt
       spec:
-        dataVolumeTemplates:
-        - metadata:
-            name: containerdisk
-          spec:
-            source:
-              registry:
-                url: docker://quay.io/containerdisks/ubuntu:22.04
-            pvc:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: '20Gi'
         template:
           spec:
             domain:
               devices:
-                disks:
-                - name: containerdisk
-                  disk:
-                    bus: virtio
                 interfaces:
                 - name: default
                   masquerade: {}
@@ -289,10 +256,6 @@ spec:
             networks:
             - name: default
               pod: {}
-            volumes:
-            - name: containerdisk
-              dataVolume:
-                name: containerdisk
     nodeTypes:
     - name: "standard-node"
       displayName: "Standard Ubuntu VM (KubeVirt)"
@@ -608,33 +571,19 @@ kind: NodeProvider
 metadata:
   name: kubevirt-netris-provider
 spec:
+  properties:
+    kubevirt.vcluster.com/image-url: docker://quay.io/containerdisks/ubuntu:22.04
+    kubevirt.vcluster.com/root-disk-size: 20Gi
   kubeVirt:
     clusterRef:
       cluster: kubevirt-host
       namespace: vcluster-platform
     virtualMachineTemplate:
       spec:
-        dataVolumeTemplates:
-        - metadata:
-            name: containerdisk
-          spec:
-            source:
-              registry:
-                url: docker://quay.io/containerdisks/ubuntu:22.04
-            pvc:
-              accessModes:
-              - ReadWriteOnce
-              resources:
-                requests:
-                  storage: '20Gi'
         template:
           spec:
             domain:
               devices:
-                disks:
-                - name: containerdisk
-                  disk:
-                    bus: virtio
                 interfaces:
                 - name: multus
                   bridge: {}
@@ -646,10 +595,6 @@ spec:
             - name: multus
               multus:
                 networkName: netris-bridge
-            volumes:
-            - name: containerdisk
-              dataVolume:
-                name: containerdisk
     nodeTypes:
     - name: netris-vms
       maxCapacity: 2

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -15,7 +15,9 @@ The KubeVirt provider allows you to use [KubeVirt](https://kubevirt.io/) to auto
 When a vCluster requests a new node, the platform creates a KubeVirt `VirtualMachine` based on the template defined in the `NodeProvider` and the
 specific `NodeType` requested.
 
-This enables you to offer different "flavors" of virtual machines (e.g., small, medium, large, different operating systems) as nodes for your vCluster,
+To inspect and operate KubeVirt VMs directly from vCluster Platform, see [Virtual Machines](../virtual-machines/overview.mdx).
+
+This enables you to offer different "flavors" of virtual machines, for example small, medium, large, and different operating systems, as nodes for your vCluster,
 all managed from a central configuration.
 
 ```mermaid
@@ -427,7 +429,7 @@ test-kubevirt-node-1-9xm54   Ready    &lt;none&gt;   27s   v1.33.4
 
 Properties are key-value pairs on the NodeProvider, NodeType, or NodeClaim that control provisioning behavior. NodeClaim properties take precedence over NodeType. NodeType properties take precedence over NodeProvider.
 
-### Inline VM template
+### Inline template
 
 #### `kubevirt.vcluster.com/vm-template`
 
@@ -511,7 +513,7 @@ Specifies a CIDR range for allocating IP addresses to the VM. Example: `10.100.0
 **Type:** `string`
 **Required with:** network configuration
 
-The name of the network interface in the VM to configure, e.g. `eth0`, `eth1`, `enp1s0`.
+The name of the network interface in the VM to configure, for example `eth0`, `eth1`, or `enp1s0`.
 
 #### `kubevirt.vcluster.com/network-ip-range`
 

--- a/platform/administer/node-providers/overview.mdx
+++ b/platform/administer/node-providers/overview.mdx
@@ -10,7 +10,7 @@ import NodeEnvironmentDiagram from '@site/static/media/diagrams/node-environment
 
 Node providers let you configure sources for private nodes for tenant clusters automatically. Platform supports the following node providers:
 * [Terraform](./terraform.mdx) (powered by [OpenTofu](https://opentofu.org) under the hood)
-* [KubeVirt](./kubevirt.mdx) <!-- vale Vale.Terms = NO -->
+* [KubeVirt](./kubevirt.mdx) <!-- vale Vale.Terms = NO --> for VM-backed private nodes. To inspect and operate KubeVirt VMs directly, see [Virtual Machines](../virtual-machines/overview.mdx).
 * [Nvidia Base Command Manager](./bcm.mdx) <!-- vale Vale.Terms = NO -->
 * [vMetal](./metal3.mdx) (bare metal provisioning using Metal3/Ironic)
 

--- a/platform/administer/secrets/_category_.json
+++ b/platform/administer/secrets/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Secrets",
-  "position": 4,
+  "position": 7,
   "className": "free",
   "collapsible": true,
   "collapsed": true

--- a/platform/administer/virtual-machines/_category_.json
+++ b/platform/administer/virtual-machines/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Virtual Machines",
+  "position": 6,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -38,6 +38,13 @@ metadata:
   name: [[VAR:NODE_PROVIDER:kubevirt-vms]]
 spec:
   displayName: "KubeVirt VMs"
+  # Defaults that apply to Machines created through this provider.
+  properties:
+    # Use vcluster.com/os-image instead when you have a reusable OSImage resource.
+    kubevirt.vcluster.com/image-url: docker://quay.io/containerdisks/ubuntu:22.04
+    kubevirt.vcluster.com/root-disk-size: 20Gi
+    # Optional: reference a NodeEnvironment for network defaults.
+    # vcluster.com/network-environment: [[VAR:NETWORK_ENVIRONMENT:default]]
   kubeVirt:
     # Create VMs in this connected Control Plane Cluster.
     clusterRef:
@@ -54,19 +61,10 @@ spec:
         template:
           spec:
             domain:
-              devices:
-                disks:
-                - name: rootdisk
-                  disk:
-                    bus: virtio
               resources:
                 requests:
                   cpu: "1"
                   memory: 2Gi
-            volumes:
-            - name: rootdisk
-              containerDisk:
-                image: quay.io/containerdisks/ubuntu:22.04
     nodeTypes:
     - name: small-ubuntu
       displayName: "Small Ubuntu VM"
@@ -74,7 +72,7 @@ spec:
   }
 />
 
-This configuration creates a KubeVirt provider with one VM size. vCluster Platform uses the provider template when it creates VMs.
+This configuration creates a KubeVirt provider with one VM size. vCluster Platform uses the provider template and properties when it creates VMs.
 
 Apply the provider to the management cluster:
 
@@ -89,10 +87,10 @@ Apply the provider to the management cluster:
 
 Virtual machines are a good fit when teams need VM-level isolation or guest operating system control while keeping provisioning inside Kubernetes. Common use cases include:
 
-- **Self-service compute**: Give teams a catalog of VM sizes and images without granting direct access to the KubeVirt cluster.
+- **Self-service compute**: Give teams a catalog of VM sizes without granting direct access to the KubeVirt cluster.
 - **Isolated workloads**: Run workloads that need stronger isolation than containers, custom kernels, or full guest operating systems.
 - **Tenant cluster private nodes**: Provision VMs that join tenant clusters as private worker nodes through [auto nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/).
-- **Reusable templates**: Standardize VM CPU, memory, storage, networking, and image settings through node types and templates.
+- **Reusable templates**: Standardize VM CPU and memory through node types and templates. Configure images and network defaults with properties.
 
 ## Prerequisites
 
@@ -136,7 +134,7 @@ Use this workflow to configure a provider, create a VM-backed machine, and verif
   <Step>
     ### Define available VM sizes
 
-    Define one or more node types that represent available VM sizes or images.
+    Define one or more node types that represent available VM sizes.
     Each node type can override or merge parts of the provider template.
   </Step>
 
@@ -163,18 +161,24 @@ kubectl get virtualmachineinstances -n vcluster-platform
 
 ## Configure images, storage, and networking
 
-KubeVirt VM configuration is controlled by the provider template, node types, and Machine properties.
+KubeVirt VM configuration is controlled by the provider template, node types, Machine properties, and reusable resources.
 
 Common properties include:
 
 | Property | Description |
 |---|---|
-| `vcluster.com/os-image` | References an `OSImage` resource. |
+| `vcluster.com/os-image` | References an `OSImage` resource. Use this for reusable image defaults. |
 | `vcluster.com/ssh-keys` | References one or more `SSHKey` resources. |
+| `vcluster.com/network-environment` | References a `NodeEnvironment` whose properties merge into the Machine. |
+| `vcluster.com/user-data` | Provides inline cloud-init user data. |
+| `vcluster.com/user-data-template` | Renders user data from an inline Go template. |
+| `vcluster.com/user-data-template-secret` | References a Secret that contains a user-data template. |
 | `kubevirt.vcluster.com/vm-template` | Supplies a full VM template override. |
 | `kubevirt.vcluster.com/merge-virtual-machine-template` | Merges VM template changes into the provider template. |
 | `kubevirt.vcluster.com/image-url` | Uses an HTTP, HTTPS, or `docker://` image source. |
 | `kubevirt.vcluster.com/image-datasource` | References a CDI `DataSource`. |
+| `kubevirt.vcluster.com/root-disk-size` | Sets the root disk size when image configuration is used. |
+| `kubevirt.vcluster.com/network-data` | Provides base64-encoded cloud-init network data. |
 | `kubevirt.vcluster.com/network-attachment-definition` | Attaches the VM to a NetworkAttachmentDefinition. |
 
 For the full provider configuration, template behavior, image properties, and Netris networking example, see the [KubeVirt node provider documentation](../node-providers/kubevirt.mdx).

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -1,0 +1,182 @@
+---
+title: Overview
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+import Flow, {Step} from "@site/src/components/Flow";
+import FeatureTable from '@site/src/components/FeatureTable';
+import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
+
+<FeatureTable names="vm-management" />
+
+:::warning Experimental Feature
+Virtual machine management is experimental. Breaking changes may occur between releases. The feature is enabled on a per-customer basis. Don't use it for production workloads without guidance from vCluster Labs.
+:::
+
+vCluster Platform integrates with [KubeVirt](https://kubevirt.io/) to manage virtual machines (VMs) on connected Control Plane Clusters.
+Administrators can deploy KubeVirt, create reusable VM templates, and manage KubeVirt `VirtualMachine` resources from the platform UI.
+
+## Basic setup
+
+Create a [KubeVirt node provider](../node-providers/kubevirt.mdx) to connect vCluster Platform to a cluster where VMs should run.
+The provider can deploy KubeVirt automatically, or it can use an existing KubeVirt installation.
+
+<InterpolatedCodeBlock
+  language="yaml"
+  title="kubevirt-vms.yaml"
+  code={
+`# Connect vCluster Platform to the KubeVirt cluster.
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: [[VAR:NODE_PROVIDER:kubevirt-vms]]
+spec:
+  displayName: "KubeVirt VMs"
+  kubeVirt:
+    # Create VMs in this connected Control Plane Cluster.
+    clusterRef:
+      cluster: [[VAR:CLUSTER_NAME:my-kubevirt-cluster]]
+      namespace: [[VAR:NAMESPACE:vcluster-platform]]
+    # Deploy KubeVirt automatically if it isn't already installed.
+    deploy:
+      kubevirt:
+        enabled: true
+    # Base KubeVirt VirtualMachine template for this provider.
+    virtualMachineTemplate:
+      spec:
+        runStrategy: Always
+        template:
+          spec:
+            domain:
+              devices:
+                disks:
+                - name: rootdisk
+                  disk:
+                    bus: virtio
+              resources:
+                requests:
+                  cpu: "1"
+                  memory: 2Gi
+            volumes:
+            - name: rootdisk
+              containerDisk:
+                image: quay.io/containerdisks/ubuntu:22.04
+    nodeTypes:
+    - name: small-ubuntu
+      displayName: "Small Ubuntu VM"
+      maxCapacity: 10`
+  }
+/>
+
+This configuration creates a KubeVirt provider with one VM size. vCluster Platform uses the provider template when it creates VMs.
+
+Apply the provider to the management cluster:
+
+<InterpolatedCodeBlock
+  language="bash"
+  code={
+`kubectl apply -f [[VAR:FILE:kubevirt-vms.yaml]]`
+  }
+/>
+
+## When to use virtual machines
+
+Virtual machines are a good fit when teams need VM-level isolation or guest operating system control while keeping provisioning inside Kubernetes. Common use cases include:
+
+- **Self-service compute**: Give teams a catalog of VM sizes and images without granting direct access to the KubeVirt cluster.
+- **Isolated workloads**: Run workloads that need stronger isolation than containers, custom kernels, or full guest operating systems.
+- **Tenant cluster private nodes**: Provision VMs that join tenant clusters as private worker nodes through [auto nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/).
+- **Reusable templates**: Standardize VM CPU, memory, storage, networking, and image settings through node types and templates.
+
+## Prerequisites
+
+Before managing virtual machines, you need:
+
+- A connected Control Plane Cluster where VMs should run.
+- KubeVirt installed on that cluster, or a KubeVirt node provider configured with `spec.kubeVirt.deploy.kubevirt.enabled: true`.
+- Containerized disk images, Containerized Data Importer (CDI) data volumes, or data sources that KubeVirt can use for VM storage.
+- Optional [OS images](../../use-platform/machines/os-images.mdx) and [SSH keys](../../use-platform/machines/ssh-keys.mdx) for reusable provisioning configuration.
+
+## Manage virtual machines
+
+After the provider is configured, administrators can use the platform's virtual machine views to inspect and operate KubeVirt resources across connected clusters.
+
+The VM management views cover:
+
+| Resource | Purpose |
+|---|---|
+| `VirtualMachine` | Desired VM configuration and run strategy. |
+| `VirtualMachineInstance` | Running VM instance status, phase, IP addresses, and console access. |
+| `DataVolume` | Persistent disk content imported or cloned through CDI. |
+| `VirtualMachineSnapshot` | Snapshot request for a VM. |
+| `VirtualMachineRestore` | Restore request from a VM snapshot. |
+
+Available actions depend on KubeVirt state and user permissions.
+For example, administrators can start, stop, restart, pause, and unpause VMs.
+They can also open a VM console, inspect guest logs, create snapshots, and restore from snapshots.
+
+## Workflow
+
+Use this workflow to configure a provider, create a VM-backed machine, and verify the KubeVirt VM on the target cluster.
+
+<Flow>
+  <Step>
+    ### Configure the provider
+
+    Create a KubeVirt `NodeProvider` with a base `virtualMachineTemplate`.
+    The provider controls where VMs run and which base template they use.
+  </Step>
+
+  <Step>
+    ### Define available VM sizes
+
+    Define one or more node types that represent available VM sizes or images.
+    Each node type can override or merge parts of the provider template.
+  </Step>
+
+  <Step>
+    ### Create a Machine
+
+    Create a Machine from the platform UI.
+    A tenant cluster can also create a Machine through auto nodes.
+  </Step>
+
+  <Step>
+    ### Verify the VM
+
+    Verify the platform-created VM on the KubeVirt cluster:
+
+```bash
+kubectl get virtualmachines -n vcluster-platform
+kubectl get virtualmachineinstances -n vcluster-platform
+```
+
+    Use the platform UI to view VM status, open the console, inspect logs, and manage snapshots.
+  </Step>
+</Flow>
+
+## Configure images, storage, and networking
+
+KubeVirt VM configuration is controlled by the provider template, node types, and Machine properties.
+
+Common properties include:
+
+| Property | Description |
+|---|---|
+| `vcluster.com/os-image` | References an `OSImage` resource. |
+| `vcluster.com/ssh-keys` | References one or more `SSHKey` resources. |
+| `kubevirt.vcluster.com/vm-template` | Supplies a full VM template override. |
+| `kubevirt.vcluster.com/merge-virtual-machine-template` | Merges VM template changes into the provider template. |
+| `kubevirt.vcluster.com/image-url` | Uses an HTTP, HTTPS, or `docker://` image source. |
+| `kubevirt.vcluster.com/image-datasource` | References a CDI `DataSource`. |
+| `kubevirt.vcluster.com/network-attachment-definition` | Attaches the VM to a NetworkAttachmentDefinition. |
+
+For the full provider configuration, template behavior, image properties, and Netris networking example, see the [KubeVirt node provider documentation](../node-providers/kubevirt.mdx).
+
+## Access control
+
+Virtual machine management uses platform permissions and Kubernetes role-based access control (RBAC) on the connected cluster.
+Users must have permission to view or operate the relevant KubeVirt resources before the platform can show VM details or perform actions on their behalf.
+
+If a user shouldn't manage infrastructure, don't grant access to the VM management views or the underlying KubeVirt resources.

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -17,6 +17,17 @@ Virtual machine management is experimental. Breaking changes may occur between r
 vCluster Platform integrates with [KubeVirt](https://kubevirt.io/) to manage virtual machines (VMs) on connected Control Plane Clusters.
 Administrators can deploy KubeVirt, create reusable VM templates, and manage KubeVirt `VirtualMachine` resources from the platform UI.
 
+```mermaid
+flowchart LR
+    Platform["vCluster Platform"] --> Provider["KubeVirt NodeProvider"]
+    Provider --> Cluster["Connected Control Plane Cluster"]
+    Cluster --> VM["KubeVirt VirtualMachine"]
+    VM --> Machine["Machine"]
+    Machine --> Tenant["Tenant cluster private node"]
+    Platform --> Operations["VM operations: console, logs, snapshots"]
+    Operations --> VM
+```
+
 ## Basic setup
 
 Create a [KubeVirt node provider](../node-providers/kubevirt.mdx) to connect vCluster Platform to a cluster where VMs should run.

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -7,6 +7,7 @@ sidebar_position: 1
 import Flow, {Step} from "@site/src/components/Flow";
 import FeatureTable from '@site/src/components/FeatureTable';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
+import VirtualMachinesDiagram from '@site/static/media/diagrams/virtual-machines-diagram.svg';
 
 <FeatureTable names="vm-management" />
 
@@ -17,16 +18,9 @@ Virtual machine management is experimental. Breaking changes may occur between r
 vCluster Platform integrates with [KubeVirt](https://kubevirt.io/) to manage virtual machines (VMs) on connected Control Plane Clusters.
 Administrators can deploy KubeVirt, create reusable VM templates, and manage KubeVirt `VirtualMachine` resources from the platform UI.
 
-```mermaid
-flowchart LR
-    Platform["vCluster Platform"] --> Provider["KubeVirt NodeProvider"]
-    Provider --> Cluster["Connected Control Plane Cluster"]
-    Cluster --> VM["KubeVirt VirtualMachine"]
-    VM --> Machine["Machine"]
-    Machine --> Tenant["Tenant cluster private node"]
-    Platform --> Operations["VM operations: console, logs, snapshots"]
-    Operations --> VM
-```
+<figure>
+  <VirtualMachinesDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Virtual machine management diagram" />
+</figure>
 
 ## Basic setup
 

--- a/platform/use-platform/machines/overview.mdx
+++ b/platform/use-platform/machines/overview.mdx
@@ -11,6 +11,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 A Machine is a provisioned server — physical or virtual — managed by vCluster Platform through a node provider. Machines abstract the provisioning details so that platform administrators can offer self-service access to compute resources. Users request Machines either indirectly through tenant cluster auto-nodes, or directly when they need standalone servers outside the tenant cluster lifecycle.
 
 Each Machine is backed by a [node provider](../../administer/node-providers/overview.mdx) that handles the actual provisioning — creating VMs, provisioning bare metal servers, or running Terraform scripts.
+For KubeVirt-backed infrastructure, administrators can also manage KubeVirt VMs directly from the [Virtual Machines](../../administer/virtual-machines/overview.mdx) page.
 
 ## How machines are created
 

--- a/src/data/features.yaml
+++ b/src/data/features.yaml
@@ -316,3 +316,4 @@ features:
   vm-management:
     name: "VM Management with KubeVirt"
     description: "VM Management with KubeVirt allows administrators to manage virtual machines with KubeVirt."
+    docs_url: "/docs/platform/administer/virtual-machines/overview"

--- a/static/media/diagrams/virtual-machines-diagram.svg
+++ b/static/media/diagrams/virtual-machines-diagram.svg
@@ -1,0 +1,113 @@
+<svg viewBox="0 0 1000 360" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vCluster virtual machine management diagram">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <!-- Dark arrowhead (main flow) -->
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+
+    <!-- Orange arrowhead (tenant node arc) -->
+    <marker id="arr-o" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FF6600"/>
+    </marker>
+  </defs>
+
+  <!-- vCluster Platform group -->
+  <rect x="30" y="60" width="430" height="235"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="50" y="83"
+        font-size="12" font-weight="500" fill="#828592">vCluster Platform</text>
+
+  <!-- Connected Control Plane Cluster group -->
+  <rect x="560" y="60" width="410" height="235"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="580" y="83"
+        font-size="12" font-weight="500" fill="#828592">Connected Control Plane Cluster</text>
+
+  <!-- Platform UI -->
+  <rect x="70" y="126" width="160" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="150" y="149"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Platform UI</text>
+
+  <!-- KubeVirt NodeProvider -->
+  <rect x="295" y="126" width="150" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="370" y="145"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">KubeVirt</text>
+  <text x="370" y="162"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">NodeProvider</text>
+
+  <!-- Machine -->
+  <rect x="295" y="216" width="150" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="370" y="239"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Machine</text>
+
+  <!-- KubeVirt VirtualMachine -->
+  <rect x="630" y="126" width="170" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="715" y="145"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">KubeVirt</text>
+  <text x="715" y="162"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">VirtualMachine</text>
+
+  <!-- VM resources -->
+  <rect x="835" y="126" width="120" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="895" y="145"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">DataVolume</text>
+  <text x="895" y="162"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Snapshot</text>
+
+  <!-- Tenant cluster -->
+  <rect x="630" y="216" width="170" height="46"
+        rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="715" y="239"
+        font-size="13" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Tenant cluster</text>
+
+  <!-- Arrows -->
+  <line x1="230" y1="149" x2="293" y2="149"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="262" y="141"
+        font-size="11" fill="#828592" text-anchor="middle">configures</text>
+
+  <line x1="445" y1="149" x2="628" y2="149"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="536" y="141"
+        font-size="11" fill="#828592" text-anchor="middle">creates</text>
+
+  <line x1="800" y1="149" x2="833" y2="149"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="817" y="141"
+        font-size="11" fill="#828592" text-anchor="middle">uses</text>
+
+  <path d="M 150 172 C 150 238 232 239 293 239"
+        stroke="#050B24" stroke-width="1.5" fill="none"
+        marker-end="url(#arr)"/>
+  <text x="195" y="234"
+        font-size="11" fill="#828592" text-anchor="middle">manages</text>
+
+  <line x1="445" y1="239" x2="628" y2="239"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="536" y="231"
+        font-size="11" fill="#828592" text-anchor="middle">backs</text>
+
+  <line x1="715" y1="172" x2="715" y2="214"
+        stroke="#FF6600" stroke-width="1.5" marker-end="url(#arr-o)"/>
+  <text x="736" y="197"
+        font-size="11" fill="#FF6600">joins</text>
+</svg>

--- a/static/media/diagrams/virtual-machines-diagram.svg
+++ b/static/media/diagrams/virtual-machines-diagram.svg
@@ -87,7 +87,7 @@
 
   <line x1="445" y1="149" x2="628" y2="149"
         stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="536" y="141"
+  <text x="510" y="141"
         font-size="11" fill="#828592" text-anchor="middle">creates</text>
 
   <line x1="800" y1="149" x2="833" y2="149"
@@ -98,12 +98,12 @@
   <path d="M 150 172 C 150 238 232 239 293 239"
         stroke="#050B24" stroke-width="1.5" fill="none"
         marker-end="url(#arr)"/>
-  <text x="195" y="234"
+  <text x="185" y="258"
         font-size="11" fill="#828592" text-anchor="middle">manages</text>
 
   <line x1="445" y1="239" x2="628" y2="239"
         stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="536" y="231"
+  <text x="510" y="231"
         font-size="11" fill="#828592" text-anchor="middle">backs</text>
 
   <line x1="715" y1="172" x2="715" y2="214"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds a new Administer/Virtual Machine section and overview page to the Platform docs for the vm-management feature.


## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2222--vcluster-docs-site.netlify.app/docs/platform/next/administer/virtual-machines/overview

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1184


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

