### PR TITLE
ci: add renovate config

### DIFF
--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,18 @@
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+
+permissions: {}
+
+jobs:
+  validate-renovate:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: loft-sh/github-actions/.github/workflows/validate-renovate.yaml@b52efbd927586ea78282073f79d2423e552c9f62 # validate-renovate/v1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "baseBranchPatterns": ["main"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
+  "schedule": ["before 6am on monday"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "ignorePaths": [
+    "**/node_modules/**",
+    "vendor/**",
+    "vcluster_versioned_docs/**",
+    "platform_versioned_docs/**"
+  ],
+  "postUpdateOptions": ["gomodTidy"],
+  "terraform": {
+    "description": "All .tf files in this repo are documentation examples (partials), not real infrastructure",
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "npm gets a longer stabilization window (more yanked/compromised releases)",
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Group non-major npm updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm-non-major"
+    },
+    {
+      "description": "Docusaurus packages must move in lockstep",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@docusaurus/{/,}**"],
+      "groupName": "docusaurus"
+    },
+    {
+      "description": "Group Go patch updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "go-patch-updates"
+    },
+    {
+      "description": "Kubernetes Go deps must move in lockstep",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["k8s.io/{/,}**", "sigs.k8s.io/{/,}**"],
+      "groupName": "k8s-go-deps"
+    },
+    {
+      "description": "loft-sh/api and loft-sh/agentapi pins track released platform versions and are bumped by the handle-source-release.yml automation; Renovate updates would conflict with the docs-sync pipeline",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/loft-sh/api{/,}**",
+        "github.com/loft-sh/agentapi{/,}**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "invopop/jsonschema is pinned to the loft-sh fork via a replace directive: managed manually",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/invopop/jsonschema",
+        "github.com/loft-sh/jsonschema"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Node.js is pinned in .nvmrc, netlify.toml, and the devcontainer image: bump them together",
+      "matchDepNames": [
+        "node",
+        "mcr.microsoft.com/devcontainers/javascript-node"
+      ],
+      "groupName": "node-version"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Node.js version in the netlify.toml build environment (must match .nvmrc)",
+      "managerFilePatterns": ["/^netlify\\.toml$/"],
+      "matchStrings": ["\\n\\s*NODE_VERSION\\s*=\\s*\"(?<currentValue>[\\d.]+)\""],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ]
+}


### PR DESCRIPTION
# Content Description
Onboards Renovate dependency automation following company conventions: org baseline (`config:recommended` + semantic commits + digest-pinned GitHub Actions), weekly schedule with security alerts bypassing it, 3-day release stabilization, plus a `validate-renovate` CI workflow so config edits are validated on every PR.

**Covered:**

| Surface | Manager | Notes |
|---|---|---|
| `package.json` + lock (root, `tests/`, `tests/wdio/`) | npm | 7-day stabilization, non-major grouped, `@docusaurus/*` grouped in lockstep |
| `go.mod` + `hack/{annotations,redirect-resolver,vcluster-cli}/go.mod` | gomod | `gomodTidy`, patch updates grouped, k8s.io/sigs.k8s.io grouped; `vendor/` re-vendored automatically |
| `.github/workflows/*` | github-actions | grouped; first run opens a PR pinning tag-referenced actions to SHAs |
| `.nvmrc`, `.devcontainer/devcontainer.json`, `netlify.toml` `NODE_VERSION` | nvm, devcontainer, custom regex | grouped as `node-version` so all three Node pins move together |

**Deliberately unmanaged** (each has `enabled: false` + description in the config):

- `github.com/loft-sh/api` + `github.com/loft-sh/agentapi` — pinned to released platform versions and bumped by the `handle-source-release.yml` docs-sync automation; Renovate updates would conflict with that pipeline
- `github.com/invopop/jsonschema` — pinned to the loft-sh fork via a `replace` directive; managed manually
- terraform manager disabled — all 21 `.tf` files in the repo are documentation examples (partials), not real infrastructure
- `vendor/**`, `vcluster_versioned_docs/**`, `platform_versioned_docs/**` in `ignorePaths` — vendored deps and CI-backported versioned docs must not be touched
- `node-version`/`go-version` pins in workflow `setup-*` steps — coarse major pins, deliberate manual choices

There was no `.github/dependabot.yml` to remove.

**Test plan:**

- [x] `renovate-config-validator renovate.json` passes
- [x] `--platform=local --dry-run=extract` confirms coverage: github-actions (22 files / 104 deps), gomod (4 / 109), npm (3 / 38), nvm, devcontainer, custom regex (netlify.toml); terraform and vendor excluded
- [x] custom manager regex verified to match exactly once in `netlify.toml`
- [x] `actionlint` + `zizmor` on the new workflow: zero findings
- [x] `validate-renovate` check triggers on this PR (it touches `renovate.json`) and passes

**Post-merge checklist:**

- [ ] Confirm the repo is enabled in the Renovate runner (no `hostRules`/`RENOVATE_GITHUB_TOKEN` needed: all managed deps are public)
- [ ] Dependency Dashboard issue appears and the first run resolves all managers
- [ ] Existing GitHub security alerts start getting `security`-labeled PRs

## Preview Link
Not applicable, CI/tooling change only, no docs content touched.

## Internal Reference
Part of DEVOPS-568


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs