### PR TITLE
fix(docs): add missing _category_.json files to 0.34 vcluster-yaml sidebar

### DIFF
--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/integrations/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/integrations/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "integrations",
+  "position": 5,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/networking/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/networking/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "networking",
+  "position": 6,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/policies/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/policies/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "policies",
+  "position": 7,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/private-nodes/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/private-nodes/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "privateNodes",
+  "position": 2,
+  "className": "free private-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "sync",
+  "position": 4,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/from-host/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/from-host/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "fromHost",
+  "position": 2,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/to-host/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/to-host/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "toHost",
+  "position": 1,
+  "className": "host-nodes"
+}

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/to-host/core/pods/_category_.json
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/sync/to-host/core/pods/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "pods",
+  "position": 1,
+  "className": "host-nodes"
+}


### PR DESCRIPTION
# Content Description

Eight `_category_.json` files were missing from the `vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/` folder tree. Docusaurus falls back to the `sidebar_label` frontmatter in `README.mdx` when no category file is present, which is `"Overview"` for every section — producing a sidebar full of identical "Overview" labels. This copies the missing files from the main (unversioned) docs.

Affected sections: `integrations`, `networking`, `policies`, `private-nodes`, `sync`, `sync/from-host`, `sync/to-host`, `sync/to-host/core/pods`.

## Preview Link

<!-- The preview link or links to the documents-->
https://deploy-preview-2242--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml

## Internal Reference

Closes DOC-1486

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs