### PR TITLE
Document metal3 network data prefix length parameter

### DIFF
--- a/platform/use-platform/machines/machine-config-templates.mdx
+++ b/platform/use-platform/machines/machine-config-templates.mdx
@@ -56,10 +56,9 @@ spec:
     version: 2
     ethernets:
       enp1s0:
-        # AllocatedIP and Gateway are supplied during IP allocation. The prefix
-        # length is hardcoded here; .Values.PrefixLength is only available on KubeVirt.
+        # AllocatedIP, PrefixLength, and Gateway are supplied during IP allocation.
         addresses:
-          - {{ .Values.AllocatedIP }}/24
+          - {{ .Values.AllocatedIP }}/{{ .Values.PrefixLength }}
         gateway4: {{ .Values.Gateway }}
         nameservers:
           addresses: [8.8.8.8, 8.8.4.4]
@@ -103,10 +102,11 @@ The Metal3 provider additionally exposes `.Values.BareMetalHost` (the selected
 | `.Values.Project` | The project the Machine belongs to. |
 | `.Values.Properties` | Merged properties from the NodeProvider, NodeType, NodeEnvironment, and NodeClaim. |
 | `.Values.AllocatedIP` | IP allocated for the Machine from the configured network. |
+| `.Values.PrefixLength` | Network prefix length for the allocated IP. Exposed by the KubeVirt and Metal3 providers. |
 | `.Values.Gateway` | Default gateway for the allocated network. |
 
-The KubeVirt provider additionally exposes `.Values.PrefixLength` (the network
-prefix length). The Metal3 provider additionally exposes `.Values.BareMetalHost`.
+The Metal3 provider additionally exposes `.Values.BareMetalHost` (the selected
+`BareMetalHost`).
 
 ## Reference a template
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

