### PR TITLE
docs: add confidential compute guidance

### DIFF
--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -25,6 +25,7 @@ DHCP
 disable[d]
 DNS
 [eE]mail
+figcaption
 FIPS
 [Ee][Kk][Ss]
 GitOps
@@ -39,6 +40,7 @@ JavaScript
 apiserver
 kubeadm
 Karpenter
+Kata
 KubeVirt
 Virt
 kubelet

--- a/static/media/diagrams/confidential-compute-architecture.svg
+++ b/static/media/diagrams/confidential-compute-architecture.svg
@@ -56,10 +56,10 @@
   <rect x="720" y="383" width="175" height="45" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.2"/>
   <text x="807.5" y="402" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Pod attestation</text>
   <text x="807.5" y="418" font-size="10" fill="#828592" text-anchor="middle">quote verification</text>
-  <text x="552" y="443" font-size="11" fill="#828592">RuntimeClass and attestation service required</text>
+  <text x="552" y="443" font-size="11" fill="#828592">RuntimeClass and attestation verification required</text>
 
   <rect x="347.5" y="472" width="305" height="34" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="1.5"/>
-  <text x="500" y="494" font-size="12" font-weight="600" fill="#050B24" text-anchor="middle">TDX or SEV-SNP hardware-backed TEE</text>
+  <text x="500" y="494" font-size="12" font-weight="600" fill="#050B24" text-anchor="middle">Hardware-backed TEE</text>
 
   <line x1="250" y1="123" x2="313" y2="123" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
   <text x="281.5" y="102" font-size="11" fill="#828592" text-anchor="middle">

--- a/static/media/diagrams/confidential-compute-architecture.svg
+++ b/static/media/diagrams/confidential-compute-architecture.svg
@@ -1,7 +1,6 @@
-<svg viewBox="0 0 1000 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime">
+<svg viewBox="0 0 1000 530" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Confidential compute architecture with vCluster, private nodes, optional vMetal and vNode, and separate Confidential VM and pod-level runtime paths">
   <defs>
     <style><![CDATA[
-      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
       text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
     ]]></style>
 
@@ -12,61 +11,81 @@
     <marker id="confidential-compute-arrow-orange" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#FF6600"/>
     </marker>
+
   </defs>
 
-  <rect x="30" y="30" width="940" height="410" rx="8" fill="#F8F9FB" stroke="#E6E7E9" stroke-width="1.5"/>
-  <text x="50" y="58" font-size="12" font-weight="500" fill="#828592">Confidential compute platform layers</text>
+  <rect x="30" y="30" width="940" height="480" rx="8" fill="#F8F9FB" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="50" y="58" font-size="12" font-weight="500" fill="#828592">Confidential compute with private nodes</text>
 
   <rect x="65" y="88" width="185" height="70" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
   <text x="157.5" y="116" font-size="14" font-weight="600" fill="#050B24" text-anchor="middle">vCluster</text>
   <text x="157.5" y="138" font-size="11" fill="#828592" text-anchor="middle">tenant Kubernetes API</text>
 
   <rect x="315" y="88" width="185" height="70" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
-  <text x="407.5" y="116" font-size="14" font-weight="600" fill="#050B24" text-anchor="middle">Auto Nodes</text>
+  <text x="407.5" y="116" font-size="14" font-weight="600" fill="#050B24" text-anchor="middle">Auto nodes</text>
   <text x="407.5" y="138" font-size="11" fill="#828592" text-anchor="middle">selects node type</text>
 
   <rect x="565" y="88" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="657.5" y="116" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Private Node</text>
-  <text x="657.5" y="138" font-size="11" fill="#828592" text-anchor="middle">dedicated tenant compute</text>
+  <text x="657.5" y="116" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Private node</text>
+  <text x="657.5" y="138" font-size="11" fill="#828592" text-anchor="middle">tenant worker capacity</text>
 
-  <rect x="315" y="205" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="407.5" y="233" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vMetal</text>
-  <text x="407.5" y="255" font-size="11" fill="#828592" text-anchor="middle">provisions bare metal</text>
+  <rect x="315" y="197" width="185" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="407.5" y="222" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vMetal</text>
+  <text x="407.5" y="243" font-size="11" fill="#828592" text-anchor="middle">optional bare metal prep</text>
 
-  <rect x="565" y="205" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="657.5" y="233" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vNode</text>
-  <text x="657.5" y="255" font-size="11" fill="#828592" text-anchor="middle">tenant workload isolation</text>
+  <rect x="790" y="197" width="145" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="862.5" y="222" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vNode</text>
+  <text x="862.5" y="243" font-size="11" fill="#828592" text-anchor="middle">optional isolation</text>
 
-  <rect x="790" y="205" width="145" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="862.5" y="230" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Kata / CoCo</text>
-  <text x="862.5" y="252" font-size="11" fill="#828592" text-anchor="middle">RuntimeClass</text>
+  <rect x="65" y="310" width="405" height="145" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="87" y="338" font-size="14" font-weight="600" fill="#050B24">Confidential VM path</text>
+  <text x="87" y="360" font-size="11" fill="#828592">TEE covers the whole private node VM</text>
+  <rect x="87" y="383" width="150" height="45" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="162" y="411" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Standard containers</text>
+  <rect x="255" y="383" width="175" height="45" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="342.5" y="402" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Bootstrap attestation</text>
+  <text x="342.5" y="418" font-size="10" fill="#828592" text-anchor="middle">before node joins</text>
+  <text x="87" y="443" font-size="11" fill="#828592">No RuntimeClass required</text>
 
-  <rect x="565" y="325" width="185" height="70" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="657.5" y="353" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">TDX or SEV-SNP</text>
-  <text x="657.5" y="375" font-size="11" fill="#828592" text-anchor="middle">hardware-backed TEE</text>
+  <rect x="530" y="310" width="405" height="145" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="552" y="338" font-size="14" font-weight="600" fill="#050B24">Pod-level runtime path</text>
+  <text x="552" y="360" font-size="11" fill="#828592">Each pod runs in a TEE-backed pod VM</text>
+  <rect x="552" y="383" width="150" height="45" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="627" y="402" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Kata / CoCo</text>
+  <text x="627" y="418" font-size="10" fill="#828592" text-anchor="middle">RuntimeClass</text>
+  <rect x="720" y="383" width="175" height="45" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="807.5" y="402" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Pod attestation</text>
+  <text x="807.5" y="418" font-size="10" fill="#828592" text-anchor="middle">quote verification</text>
+  <text x="552" y="443" font-size="11" fill="#828592">RuntimeClass and attestation service required</text>
 
-  <rect x="790" y="325" width="145" height="70" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="862.5" y="353" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Attestation</text>
-  <text x="862.5" y="375" font-size="11" fill="#828592" text-anchor="middle">verification service</text>
+  <rect x="347.5" y="472" width="305" height="34" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="1.5"/>
+  <text x="500" y="494" font-size="12" font-weight="600" fill="#050B24" text-anchor="middle">TDX or SEV-SNP hardware-backed TEE</text>
 
   <line x1="250" y1="123" x2="313" y2="123" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="281.5" y="113" font-size="11" fill="#828592" text-anchor="middle">requests</text>
+  <text x="281.5" y="102" font-size="11" fill="#828592" text-anchor="middle">
+    <tspan x="281.5" dy="0">requests</tspan>
+    <tspan x="281.5" dy="13">capacity</tspan>
+  </text>
 
   <line x1="500" y1="123" x2="563" y2="123" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="531.5" y="113" font-size="11" fill="#828592" text-anchor="middle">provisions</text>
+  <text x="531.5" y="113" font-size="11" fill="#828592" text-anchor="middle">adds node</text>
 
-  <path d="M 407.5 205 C 407.5 166 565 166 616 158" stroke="#FF6600" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow-orange)"/>
-  <text x="493" y="185" font-size="11" fill="#FF6600" text-anchor="middle">prepares and joins</text>
+  <path d="M 407.5 197 C 407.5 172 565 174 616 158" stroke="#FF6600" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow-orange)"/>
+  <text x="538" y="184" font-size="11" fill="#FF6600" text-anchor="middle">prepares and joins node</text>
 
   <line x1="657.5" y1="158" x2="657.5" y2="203" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="698" y="183" font-size="11" fill="#828592">runs workloads</text>
 
-  <line x1="750" y1="240" x2="788" y2="240" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="769" y="230" font-size="11" fill="#828592" text-anchor="middle">uses</text>
+  <rect x="575" y="205" width="165" height="46" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="657.5" y="225" font-size="11" font-weight="500" fill="#050B24" text-anchor="middle">
+    <tspan x="657.5" dy="0">Choose</tspan>
+    <tspan x="657.5" dy="14">runtime path</tspan>
+  </text>
 
-  <path d="M 862.5 275 C 862.5 308 712 302 679 325" stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="760" y="303" font-size="11" fill="#828592" text-anchor="middle">executes on</text>
+  <line x1="740" y1="228" x2="790" y2="228" stroke="#828592" stroke-width="1.5" stroke-dasharray="5 4"/>
 
-  <line x1="862.5" y1="325" x2="862.5" y2="277" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
-  <text x="903" y="304" font-size="11" fill="#828592">verifies</text>
+  <path d="M 657.5 251 C 570 288 430 302 267.5 308" stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow)"/>
+  <path d="M 657.5 251 C 700 288 722 302 732.5 308" stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow)"/>
+
+  <line x1="267.5" y1="455" x2="408" y2="472" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <line x1="732.5" y1="455" x2="592" y2="472" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
 </svg>

--- a/static/media/diagrams/confidential-compute-architecture.svg
+++ b/static/media/diagrams/confidential-compute-architecture.svg
@@ -1,0 +1,72 @@
+<svg viewBox="0 0 1000 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <marker id="confidential-compute-arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+
+    <marker id="confidential-compute-arrow-orange" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#FF6600"/>
+    </marker>
+  </defs>
+
+  <rect x="30" y="30" width="940" height="410" rx="8" fill="#F8F9FB" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="50" y="58" font-size="12" font-weight="500" fill="#828592">Confidential compute platform layers</text>
+
+  <rect x="65" y="88" width="185" height="70" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="157.5" y="116" font-size="14" font-weight="600" fill="#050B24" text-anchor="middle">vCluster</text>
+  <text x="157.5" y="138" font-size="11" fill="#828592" text-anchor="middle">tenant Kubernetes API</text>
+
+  <rect x="315" y="88" width="185" height="70" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="407.5" y="116" font-size="14" font-weight="600" fill="#050B24" text-anchor="middle">Auto Nodes</text>
+  <text x="407.5" y="138" font-size="11" fill="#828592" text-anchor="middle">selects node type</text>
+
+  <rect x="565" y="88" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="657.5" y="116" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Private Node</text>
+  <text x="657.5" y="138" font-size="11" fill="#828592" text-anchor="middle">dedicated tenant compute</text>
+
+  <rect x="315" y="205" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="407.5" y="233" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vMetal</text>
+  <text x="407.5" y="255" font-size="11" fill="#828592" text-anchor="middle">provisions bare metal</text>
+
+  <rect x="565" y="205" width="185" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="657.5" y="233" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">vNode</text>
+  <text x="657.5" y="255" font-size="11" fill="#828592" text-anchor="middle">tenant workload isolation</text>
+
+  <rect x="790" y="205" width="145" height="70" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="862.5" y="230" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Kata / CoCo</text>
+  <text x="862.5" y="252" font-size="11" fill="#828592" text-anchor="middle">RuntimeClass</text>
+
+  <rect x="565" y="325" width="185" height="70" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="657.5" y="353" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">TDX or SEV-SNP</text>
+  <text x="657.5" y="375" font-size="11" fill="#828592" text-anchor="middle">hardware-backed TEE</text>
+
+  <rect x="790" y="325" width="145" height="70" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="862.5" y="353" font-size="14" font-weight="500" fill="#050B24" text-anchor="middle">Attestation</text>
+  <text x="862.5" y="375" font-size="11" fill="#828592" text-anchor="middle">verification service</text>
+
+  <line x1="250" y1="123" x2="313" y2="123" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="281.5" y="113" font-size="11" fill="#828592" text-anchor="middle">requests</text>
+
+  <line x1="500" y1="123" x2="563" y2="123" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="531.5" y="113" font-size="11" fill="#828592" text-anchor="middle">provisions</text>
+
+  <path d="M 407.5 205 C 407.5 166 565 166 616 158" stroke="#FF6600" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow-orange)"/>
+  <text x="493" y="185" font-size="11" fill="#FF6600" text-anchor="middle">prepares and joins</text>
+
+  <line x1="657.5" y1="158" x2="657.5" y2="203" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="698" y="183" font-size="11" fill="#828592">runs workloads</text>
+
+  <line x1="750" y1="240" x2="788" y2="240" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="769" y="230" font-size="11" fill="#828592" text-anchor="middle">uses</text>
+
+  <path d="M 862.5 275 C 862.5 308 712 302 679 325" stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="760" y="303" font-size="11" fill="#828592" text-anchor="middle">executes on</text>
+
+  <line x1="862.5" y1="325" x2="862.5" y2="277" stroke="#050B24" stroke-width="1.5" marker-end="url(#confidential-compute-arrow)"/>
+  <text x="903" y="304" font-size="11" fill="#828592">verifies</text>
+</svg>

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -1,0 +1,188 @@
+---
+title: Confidential compute
+sidebar_label: Confidential compute
+sidebar_position: 8
+description: Understand how vCluster, private nodes, vMetal, and vNode fit with confidential compute requirements.
+sidebar_class_name: private-nodes standalone
+---
+
+import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
+import ConfidentialComputeArchitecture from '@site/static/media/diagrams/confidential-compute-architecture.svg';
+
+<TenancySupport privateNodes="true" standalone="true" />
+
+Confidential compute protects workload code and data while it is in use by
+running it inside a hardware-backed trusted execution environment, such as
+Intel TDX or AMD SEV-SNP. A confidential compute platform combines hardware,
+firmware, a confidential runtime, workload policy, attestation, and tenant
+Kubernetes isolation.
+
+vCluster, vNode, and vMetal fit into that build as platform layers around the
+confidential runtime:
+
+- **vCluster** provides each tenant with an isolated Kubernetes control plane
+  and a scheduling boundary for workloads.
+- **Private nodes** give the tenant dedicated worker nodes for workloads that
+  require dedicated compute.
+- **Auto nodes** connect workload demand to node provisioning through vCluster
+  Platform.
+- **vMetal** provisions and recycles physical servers that have the required
+  CPU, firmware, OS image, drivers, and runtime configuration.
+- **vNode** adds a runtime isolation layer for privileged or untrusted
+  workloads inside the tenant environment.
+- **Kata Containers, Confidential Containers, and attestation services** provide
+  the hardware-backed confidential runtime and verification flow.
+
+## Reference architecture
+
+Use vCluster as the tenant Kubernetes layer, vMetal as the bare-metal lifecycle
+layer, and vNode as an additional tenant workload isolation layer. Then install
+and operate the confidential compute runtime on the private nodes selected for
+confidential workloads.
+
+<figure>
+  <ConfidentialComputeArchitecture style={{width: '100%', height: 'auto'}} role="img" aria-label="Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime" />
+  <figcaption>Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime</figcaption>
+</figure>
+
+In this model, vCluster decides which tenant gets access to which Kubernetes
+environment, auto nodes selects the right capacity, vMetal prepares and joins
+the machine, vNode strengthens the workload boundary, and the confidential
+runtime executes the workload in the hardware-backed environment.
+
+## Implementation checklist
+
+1. Select hardware that supports the target confidential compute technology.
+2. Configure firmware and host OS images for TDX, SEV-SNP, or your selected
+   hardware-backed environment.
+3. Install and configure Kata Containers, Confidential Containers, runtime
+   classes, and attestation services on the private node image.
+4. Register the hardware in vMetal or another node provider.
+5. Add node type properties that describe the confidential compute capability.
+6. Configure `privateNodes.autoNodes` to select those node types.
+7. Add vNode where tenant workloads need stronger runtime isolation.
+8. Validate scheduling, RuntimeClass selection, attestation, and workload
+   execution from inside the tenant vCluster.
+
+## Build the capacity layer
+
+Start by creating node types that represent confidential-capable hardware.
+Node type properties become selector requirements, so you can expose hardware
+features such as `tdx`, `sev-snp`, GPU model, firmware track, or image family
+to vCluster auto nodes.
+
+```yaml title="NodeProvider with confidential-capable node type"
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: bare-metal
+spec:
+  # Use the Metal3 node provider when capacity comes from physical servers.
+  metal3:
+    clusterRef:
+      cluster: datacenter
+      namespace: metal3
+    nodeTypes:
+      - name: tdx-large
+        resources:
+          cpu: "64"
+          memory: 512Gi
+        # Expose confidential compute traits as node type properties.
+        properties:
+          confidential-compute: tdx
+        bareMetalHosts:
+          # Select only BareMetalHost resources prepared for TDX workloads.
+          selector:
+            matchLabels:
+              confidential-compute: tdx
+```
+
+This node provider creates a `tdx-large` node type. Auto nodes can select this
+node type when a tenant cluster requests TDX-capable capacity.
+
+Use [vMetal](https://www.vmetal.ai/docs/) when the confidential-capable
+capacity comes from physical servers. vMetal can register servers, select them
+through `BareMetalHost` labels, provision the OS image, and join the server to
+the tenant cluster as a private node.
+
+Prepare the OS image and bootstrap flow for the confidential runtime before
+offering the node type to tenants. This typically includes firmware settings,
+kernel support, container runtime configuration, a RuntimeClass, and access
+to the attestation service used by your environment.
+
+## Route workloads to confidential nodes
+
+Configure private nodes with auto nodes and require the confidential-capable
+node type property. vCluster Platform provisions matching nodes when the tenant
+cluster needs capacity.
+
+```yaml title="vcluster.yaml"
+privateNodes:
+  # Enable dedicated worker nodes for this tenant cluster.
+  enabled: true
+  autoNodes:
+    - provider: bare-metal
+      dynamic:
+        - name: confidential-workers
+          # Require a node type that advertises TDX support.
+          nodeTypeSelector:
+            - property: confidential-compute
+              operator: In
+              values:
+                - tdx
+```
+
+This configuration lets vCluster Platform provision matching private nodes when
+the tenant cluster needs confidential-capable worker capacity.
+
+Tenant workloads can then use the RuntimeClass that your node image exposes
+for Kata Containers or Confidential Containers.
+
+```yaml title="Confidential workload"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: confidential-workload
+spec:
+  # Use the confidential runtime configured on the private node image.
+  runtimeClassName: kata-qemu-tdx
+  # Schedule only onto nodes that advertise TDX support.
+  nodeSelector:
+    confidential-compute: tdx
+  containers:
+    - name: app
+      image: ghcr.io/example/confidential-app:1.0.0
+```
+
+This pod runs with the confidential RuntimeClass and schedules onto nodes
+that match the confidential compute property.
+
+## Add vNode for tenant isolation
+
+vNode adds a runtime isolation layer for tenant workloads. It is useful when
+tenants need privileged workloads, host-like APIs, or stronger node-level
+boundaries without giving those workloads direct access to the underlying host.
+
+For confidential compute builds, use vNode as an isolation layer around tenant
+workloads and pair it with the confidential RuntimeClass exposed on prepared
+private nodes. This is a useful pattern for platform teams that need both tenant
+isolation and hardware-backed workload execution.
+
+Review the [vNode architecture](https://www.vnode.com/docs/architecture/) and
+[vNode limitations](https://www.vnode.com/docs/limitations/) while designing
+the runtime stack. Validate vNode, Kata Containers, Confidential Containers,
+the node image, and the target hardware together before publishing the node
+type to tenant teams.
+
+## Learn more
+
+Use these upstream resources to plan the confidential runtime and attestation
+parts of the platform.
+
+| Resource | Use it for |
+|---|---|
+| [Kata Containers](https://katacontainers.io/) | Lightweight virtualized containers |
+| [Kata Containers documentation](https://github.com/kata-containers/kata-containers/tree/main/docs) | Runtime architecture and configuration |
+| [Confidential Containers](https://confidentialcontainers.org/) | Kubernetes workloads that use hardware-backed trusted execution environments |
+| [Confidential Containers documentation](https://github.com/confidential-containers/documentation) | Operator, runtime, and attestation guidance |
+| [CNCF TAG Confidential Computing](https://tag-confidential-computing.cncf.io/) | Community resources and ecosystem background |

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -26,6 +26,21 @@ hardware-backed protection covers workload data on the worker nodes. Tenants get
 hardware-backed workload protection combined with Kubernetes-level isolation from
 other tenants on the same platform.
 
+Where the TEE sits in the stack determines how you configure the node image and
+what tenants need to do to use it:
+
+- **Cloud-provider Confidential VMs** (GCP Confidential VMs, Azure Confidential
+  Computing, AWS Nitro Enclaves): the hypervisor applies hardware-backed
+  protection to the entire VM. All workloads on the node run inside the TEE.
+  Attestation runs at node bootstrap time, before the node joins the cluster. No
+  RuntimeClass is required.
+- **Pod-level runtime** (Kata Containers, Confidential Containers): each pod
+  runs in a lightweight VM backed by a hardware TEE. Requires a RuntimeClass on
+  the node image and a `runtimeClassName` in the pod spec. This approach works
+  on any compatible bare metal or cloud VM.
+
+The sections below apply to both paths unless noted.
+
 ## Reference architecture
 
 Use vCluster as the tenant Kubernetes layer. Add vMetal if the
@@ -58,23 +73,29 @@ The components in this architecture each cover a distinct layer:
   required CPU, firmware, OS image, drivers, and runtime configuration.
 - **vNode** (optional) adds a runtime isolation layer for privileged or
   untrusted workloads inside the tenant environment.
-- **Kata Containers, Confidential Containers, and attestation services** provide
-  the hardware-backed confidential runtime and verification flow.
+- **A confidential runtime** — either a cloud-provider Confidential VM or a
+  pod-level runtime such as Kata Containers and Confidential Containers —
+  provides the hardware-backed TEE and attestation.
 
 ## Implementation checklist
 
-1. Select hardware that supports the target confidential compute technology.
-2. Configure firmware and host OS images for TDX, SEV-SNP, or your selected
-   hardware-backed environment.
-3. Install and configure Kata Containers, Confidential Containers, runtime
-   classes, and attestation services on the private node image.
+1. Select hardware or cloud instance types that support the target confidential
+   compute technology.
+2. Configure firmware, Shielded VM features (secure boot, vTPM, integrity
+   monitoring), and host OS images.
+3. Prepare the node image for your runtime path:
+   - **Cloud-provider VMs**: enable Confidential VM features and configure
+     bootstrap attestation.
+   - **Pod-level runtime**: install Kata Containers, Confidential Containers,
+     runtime classes, and attestation services.
 4. Register the hardware in vMetal or another node provider.
 5. Add node type properties that describe the confidential compute capability.
 6. Configure `privateNodes.autoNodes` to select those node types.
-7. Enable RuntimeClass sync so tenant clusters can use the confidential runtime.
+7. *(Pod-level path only)* Enable RuntimeClass sync so tenant clusters can
+   reference the runtime.
 8. Add vNode where tenant workloads need stronger runtime isolation.
-9. Validate scheduling, RuntimeClass selection, attestation, and workload
-   execution from inside the tenant cluster.
+9. Validate scheduling, attestation, and workload execution from inside the
+   tenant cluster.
 
 ## Build the capacity layer
 
@@ -120,19 +141,39 @@ option, not a requirement.
 
 Prepare the OS image and bootstrap flow for the confidential runtime before
 offering the node type to tenants. This typically includes firmware settings,
-kernel support, container runtime configuration, a RuntimeClass, and access
-to the attestation service used by your environment.
+Shielded VM features (secure boot, vTPM, and integrity monitoring), kernel
+support, and the confidential runtime configuration for your chosen path.
 
-:::note Attestation requirements
-The node image must include any device plugins required for quote generation,
-such as the Intel TDX attestation driver or AMD SEV-SNP device plugin. It must
-also include the Data Center Attestation Primitives libraries your attestation
-service expects. The attestation service endpoint must be reachable from the
-private nodes. If your platform enforces network policies, add an egress rule
-that permits attestation traffic before publishing the node type to tenants.
+Confidential VMs can't be live-migrated. Set `on_host_maintenance` to
+`TERMINATE` in your node configuration to prevent migration attempts from
+failing the node.
+
+Confidential node types also require an explicit zone, not just a region.
+Cloud providers enforce zone placement for Confidential VM instances.
+
+:::note Attestation
+**Cloud-provider VMs**: attestation runs as a bootstrap gate before the node
+joins the cluster. The gate script checks for hardware markers such as
+`/dev/sev-guest` for SEV-SNP or `/dev/tdx_guest` for TDX and blocks the
+kubeadm join if verification fails. No external attestation service is required
+for this mode.
+
+**Pod-level runtime**: each pod generates an attestation quote at workload
+start time. The node image must include device plugins for quote generation,
+such as the Intel TDX attestation driver or AMD SEV-SNP device plugin, and
+the Data Center Attestation Primitives libraries your attestation service
+expects. The attestation service endpoint must be reachable from the private
+nodes. If your platform enforces network policies, add an egress rule that
+permits attestation traffic before publishing the node type to tenants.
 :::
 
 ## Make RuntimeClass available to tenants
+
+:::info Pod-level runtime path only
+This section applies to Kata Containers and Confidential Containers. If you're
+using cloud-provider Confidential VMs, skip this section — all workloads on the
+node run inside the TEE without a RuntimeClass.
+:::
 
 RuntimeClass objects live in the control plane cluster. By default, they aren't
 visible inside the tenant cluster. Enable `sync.fromHost.runtimeClasses` so that
@@ -170,12 +211,16 @@ privateNodes:
 This configuration lets vCluster Platform provision matching private nodes when
 the tenant cluster needs confidential-capable worker capacity.
 
-Tenants can then schedule workloads using the RuntimeClass your node image
-exposes for Kata Containers or Confidential Containers. Private nodes join the
-tenant cluster as real nodes, so their OS-level labels are visible inside the
-cluster and the `nodeSelector` works without any additional configuration.
+Private nodes join the tenant cluster as real nodes, so their OS-level labels
+are visible inside the cluster and the `nodeSelector` works without any
+additional configuration.
 
-```yaml title="Pod spec — tenant"
+For the pod-level runtime path, tenants add a `runtimeClassName` referencing
+the RuntimeClass installed on the node image. For cloud-provider Confidential
+VMs, omit `runtimeClassName` — protection applies at the VM level and standard
+containers run inside the TEE without modification.
+
+```yaml title="Pod spec — tenant (pod-level runtime path)"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -215,13 +260,13 @@ before publishing the node type to tenant teams.
 
 ## Learn more
 
-Use these upstream resources to plan the confidential runtime and attestation
-parts of the platform.
+For the pod-level runtime path, use these resources to plan the confidential
+runtime and attestation parts of the platform. For cloud-provider Confidential
+VMs, refer to your cloud provider's documentation.
 
 | Resource | Use it for |
 |---|---|
-| [Kata Containers](https://katacontainers.io/) | Lightweight virtualized containers |
+| [Kata Containers](https://katacontainers.io/) | Pod-level virtualized container runtime |
 | [Kata Containers documentation](https://github.com/kata-containers/kata-containers/tree/main/docs) | Runtime architecture and configuration |
 | [Confidential Containers](https://confidentialcontainers.org/) | Kubernetes workloads that use hardware-backed trusted execution environments |
 | [Confidential Containers documentation](https://github.com/confidential-containers/documentation) | Operator, runtime, and attestation guidance |
-| [CNCF TAG Confidential Computing](https://tag-confidential-computing.cncf.io/) | Community resources and ecosystem background |

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -11,20 +11,26 @@ import ConfidentialComputeArchitecture from '@site/static/media/diagrams/confide
 
 <TenancySupport privateNodes="true" />
 
-This page shows how to build a confidential compute platform using vCluster with private nodes.
-There's no vCluster-specific confidential compute feature. vCluster provides
-tenant isolation and workload routing around the confidential runtime you deploy
-on the worker nodes. If your confidential compute stack runs on standard
-Kubernetes, it runs through vCluster.
+This page explains where vCluster fits in a confidential compute platform and
+shows the configuration patterns to connect it to a confidential runtime.
+vCluster has no confidential compute feature of its own. It provides tenant
+isolation and workload routing around the confidential runtime you deploy on the
+worker nodes. If your confidential compute stack runs on standard Kubernetes, it
+runs through vCluster.
 
-Confidential compute protects workload code and data in use by running it inside
-a hardware-backed trusted execution environment. Common examples are Intel TDX
+For provider-specific instance settings, node image contents, attestation
+verification, and support boundaries, follow your provider and runtime
+documentation.
+
+[Confidential compute](https://confidentialcomputing.io/) protects workload code
+and data in use by running it inside a hardware-backed trusted execution
+environment (TEE). Common examples are Intel TDX
 and AMD SEV-SNP. vCluster gives each tenant a dedicated Kubernetes control plane
 and routes workloads to confidential-capable nodes using standard Kubernetes
 mechanisms such as RuntimeClass, node selectors, and node labels. The
-hardware-backed protection covers workload data on the worker nodes. Tenants get
-hardware-backed workload protection combined with Kubernetes-level isolation from
-other tenants on the same platform.
+TEE protects workload data on the worker nodes. Tenants get that hardware-level
+protection combined with Kubernetes-level isolation from other tenants through
+vCluster.
 
 Where the TEE sits in the stack determines how you configure the node image and
 what tenants need to do to use it:
@@ -32,12 +38,13 @@ what tenants need to do to use it:
 - **Cloud-provider Confidential VMs** (GCP Confidential VMs, Azure Confidential
   Computing, AWS EC2 instances with AMD SEV-SNP): the hypervisor applies hardware-backed
   protection to the entire VM. All workloads on the node run inside the TEE.
-  Attestation runs at node bootstrap time, before the node joins the cluster. No
-  RuntimeClass is required.
+  Attestation usually runs at node bootstrap time, before the node joins the
+  cluster. No RuntimeClass is required.
 - **Pod-level runtime** (Kata Containers, Confidential Containers): each pod
-  runs in a lightweight VM backed by a hardware TEE. Requires a RuntimeClass on
-  the node image and a `runtimeClassName` in the pod spec. This approach works
-  on any compatible bare metal or cloud VM.
+  runs in a lightweight VM backed by a hardware TEE. Requires the runtime on the
+  node image, a RuntimeClass object available to the tenant cluster, and a
+  `runtimeClassName` in the pod spec. This approach works on any compatible bare
+  metal or cloud VM.
 
 The sections below apply to both paths unless noted.
 
@@ -81,8 +88,8 @@ The components in this architecture each cover a distinct layer:
 
 1. Select hardware or cloud instance types that support the target confidential
    compute technology.
-2. Configure firmware, Shielded VM features (secure boot, vTPM, integrity
-   monitoring), and host OS images.
+2. Configure provider-specific VM options, firmware, Shielded VM features
+   (secure boot, vTPM, integrity monitoring), and host OS images.
 3. Prepare the node image for your runtime path:
    - **Cloud-provider VMs**: enable Confidential VM features and configure
      bootstrap attestation.
@@ -118,14 +125,14 @@ spec:
         resources:
           cpu: "64"
           memory: 512Gi
-        # Expose confidential compute traits as node type properties.
-        properties:
-          confidential-compute: tdx
         bareMetalHosts:
           # Select only BareMetalHost resources prepared for TDX workloads.
           selector:
             matchLabels:
               confidential-compute: tdx
+        # Expose confidential compute traits as node type properties.
+        properties:
+          confidential-compute: tdx
 ```
 
 This node provider creates a `tdx-large` node type. Auto nodes can select this
@@ -142,19 +149,24 @@ offering the node type to tenants. This typically includes firmware settings,
 Shielded VM features (secure boot, vTPM, and integrity monitoring), kernel
 support, and the confidential runtime configuration for your chosen path.
 
-Confidential VMs can't be live-migrated. Set `on_host_maintenance` to
-`TERMINATE` in your node configuration to prevent migration attempts from
-failing the node.
+Configure host maintenance behavior according to the provider and confidential
+compute technology. Some Confidential VM machine types support live migration,
+while others require stop-on-maintenance behavior such as
+`on_host_maintenance: TERMINATE` or the provider-specific equivalent. Confirm
+the supported maintenance policy for the selected instance type before
+publishing the node type.
 
-Confidential node types also require an explicit zone, not just a region.
-Cloud providers enforce zone placement for Confidential VM instances.
+Cloud-provider confidential node types also require an explicit zone, not just a
+region. Cloud providers enforce zone placement for Confidential VM instances.
 
 :::note Attestation
-**Cloud-provider VMs**: attestation runs as a bootstrap gate before the node
-joins the cluster. The gate script checks for hardware markers such as
-`/dev/sev-guest` for SEV-SNP or `/dev/tdx_guest` for TDX and blocks the
-kubeadm join if verification fails. No external attestation service is required
-for this mode.
+**Cloud-provider VMs**: attestation usually runs as a bootstrap gate before the
+node joins the cluster. The gate should request and verify provider or hardware
+attestation evidence against your policy before allowing the kubeadm join.
+Checking hardware markers such as `/dev/sev-guest` for SEV-SNP or
+`/dev/tdx_guest` for TDX is only a local sanity check. It does not replace quote
+or report verification. Depending on the provider and trust model, verification
+can be local, provider-managed, or performed by an external verifier.
 
 **Pod-level runtime**: each pod generates an attestation quote at workload
 start time. The node image must include device plugins for quote generation,
@@ -194,10 +206,57 @@ Private nodes join the tenant cluster as real nodes, so their OS-level labels
 are visible inside the cluster and the `nodeSelector` works without any
 additional configuration.
 
-For the pod-level runtime path, tenants add a `runtimeClassName` referencing
-the RuntimeClass installed on the node image. For cloud-provider Confidential
-VMs, omit `runtimeClassName` — protection applies at the VM level and standard
-containers run inside the TEE without modification.
+For the pod-level runtime path, tenants add a `runtimeClassName` referencing the
+RuntimeClass installed in the control plane cluster and exposed to the tenant
+cluster. RuntimeClass syncing is disabled by default, so the platform admin must
+sync the allowed RuntimeClass objects into the tenant cluster before tenants can
+reference them.
+
+The next two examples apply only to the pod-level runtime path. If you use
+cloud-provider Confidential VMs, the private node selection above is the
+vCluster-specific configuration; finish the VM image, maintenance policy, and
+attestation setup in your provider tooling.
+
+```yaml title="vcluster.yaml — platform admin (pod-level runtime path)"
+sync:
+  fromHost:
+    runtimeClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          confidential-compute: tdx
+
+privateNodes:
+  enabled: true
+  autoNodes:
+    - provider: bare-metal
+      dynamic:
+        - name: confidential-workers
+          nodeTypeSelector:
+            - property: confidential-compute
+              operator: In
+              values:
+                - tdx
+```
+
+Label the RuntimeClass in the control plane cluster so only approved runtime
+classes are synced:
+
+```yaml title="RuntimeClass — control plane cluster"
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu-tdx
+  labels:
+    confidential-compute: tdx
+handler: kata-qemu-tdx
+```
+
+For the full selector and patches reference, see [Runtime classes](../../../../configure/vcluster-yaml/sync/from-host/runtime-classes.mdx).
+
+For cloud-provider Confidential VMs, omit `runtimeClassName`. Protection
+applies at the VM level and standard containers run inside the TEE without
+modification.
 
 ```yaml title="Pod spec — tenant (pod-level runtime path)"
 apiVersion: v1
@@ -239,9 +298,12 @@ before publishing the node type to tenant teams.
 
 ## Learn more
 
+For cloud-provider Confidential VMs, start with your provider's Confidential VM
+and attestation documentation to understand instance requirements, firmware
+options, and the bootstrap attestation flow.
+
 For the pod-level runtime path, use these resources to plan the confidential
-runtime and attestation parts of the platform. For cloud-provider Confidential
-VMs, refer to your cloud provider's documentation.
+runtime and attestation parts of the platform.
 
 | Resource | Use it for |
 |---|---|

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -3,15 +3,15 @@ title: Confidential compute
 sidebar_label: Confidential compute
 sidebar_position: 8
 description: Understand how vCluster, private nodes, vMetal, and vNode fit with confidential compute requirements.
-sidebar_class_name: private-nodes standalone
+sidebar_class_name: private-nodes
 ---
 
 import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 import ConfidentialComputeArchitecture from '@site/static/media/diagrams/confidential-compute-architecture.svg';
 
-<TenancySupport privateNodes="true" standalone="true" />
+<TenancySupport privateNodes="true" />
 
-This page shows how to build a confidential compute platform using vCluster.
+This page shows how to build a confidential compute platform using vCluster with private nodes.
 There's no vCluster-specific confidential compute feature. vCluster provides
 tenant isolation and workload routing around the confidential runtime you deploy
 on the worker nodes. If your confidential compute stack runs on standard
@@ -30,7 +30,7 @@ Where the TEE sits in the stack determines how you configure the node image and
 what tenants need to do to use it:
 
 - **Cloud-provider Confidential VMs** (GCP Confidential VMs, Azure Confidential
-  Computing, AWS Nitro Enclaves): the hypervisor applies hardware-backed
+  Computing, AWS EC2 instances with AMD SEV-SNP): the hypervisor applies hardware-backed
   protection to the entire VM. All workloads on the node run inside the TEE.
   Attestation runs at node bootstrap time, before the node joins the cluster. No
   RuntimeClass is required.
@@ -91,10 +91,8 @@ The components in this architecture each cover a distinct layer:
 4. Register the hardware in vMetal or another node provider.
 5. Add node type properties that describe the confidential compute capability.
 6. Configure `privateNodes.autoNodes` to select those node types.
-7. *(Pod-level path only)* Enable RuntimeClass sync so tenant clusters can
-   reference the runtime.
-8. Add vNode where tenant workloads need stronger runtime isolation.
-9. Validate scheduling, attestation, and workload execution from inside the
+7. Add vNode where tenant workloads need stronger runtime isolation.
+8. Validate scheduling, attestation, and workload execution from inside the
    tenant cluster.
 
 ## Build the capacity layer
@@ -166,25 +164,6 @@ expects. The attestation service endpoint must be reachable from the private
 nodes. If your platform enforces network policies, add an egress rule that
 permits attestation traffic before publishing the node type to tenants.
 :::
-
-## Make RuntimeClass available to tenants
-
-:::info Pod-level runtime path only
-This section applies to Kata Containers and Confidential Containers. If you're
-using cloud-provider Confidential VMs, skip this section — all workloads on the
-node run inside the TEE without a RuntimeClass.
-:::
-
-RuntimeClass objects live in the control plane cluster. By default, they aren't
-visible inside the tenant cluster. Enable `sync.fromHost.runtimeClasses` so that
-the RuntimeClass your node image installs is available to tenant workloads.
-
-```yaml title="vcluster.yaml — platform admin"
-sync:
-  fromHost:
-    runtimeClasses:
-      enabled: true
-```
 
 ## Route workloads to confidential nodes
 

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -50,8 +50,8 @@ operate the confidential compute runtime on the private nodes selected for
 confidential workloads.
 
 <figure>
-  <ConfidentialComputeArchitecture style={{width: '100%', height: 'auto'}} role="img" aria-label="Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime" />
-  <figcaption>Confidential compute architecture with vCluster, vMetal, vNode, and a confidential container runtime</figcaption>
+  <ConfidentialComputeArchitecture style={{width: '100%', height: 'auto'}} role="img" aria-label="Confidential compute architecture with vCluster, private nodes, optional vMetal and vNode, and separate Confidential VM and pod-level runtime paths" />
+  <figcaption>Confidential compute architecture with vCluster, private nodes, optional vMetal and vNode, and separate Confidential VM and pod-level runtime paths</figcaption>
 </figure>
 
 In this model, vCluster decides which tenant gets access to which Kubernetes

--- a/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/confidential-compute.mdx
@@ -11,33 +11,27 @@ import ConfidentialComputeArchitecture from '@site/static/media/diagrams/confide
 
 <TenancySupport privateNodes="true" standalone="true" />
 
-Confidential compute protects workload code and data while it is in use by
-running it inside a hardware-backed trusted execution environment, such as
-Intel TDX or AMD SEV-SNP. A confidential compute platform combines hardware,
-firmware, a confidential runtime, workload policy, attestation, and tenant
-Kubernetes isolation.
+This page shows how to build a confidential compute platform using vCluster.
+There's no vCluster-specific confidential compute feature. vCluster provides
+tenant isolation and workload routing around the confidential runtime you deploy
+on the worker nodes. If your confidential compute stack runs on standard
+Kubernetes, it runs through vCluster.
 
-vCluster, vNode, and vMetal fit into that build as platform layers around the
-confidential runtime:
-
-- **vCluster** provides each tenant with an isolated Kubernetes control plane
-  and a scheduling boundary for workloads.
-- **Private nodes** give the tenant dedicated worker nodes for workloads that
-  require dedicated compute.
-- **Auto nodes** connect workload demand to node provisioning through vCluster
-  Platform.
-- **vMetal** provisions and recycles physical servers that have the required
-  CPU, firmware, OS image, drivers, and runtime configuration.
-- **vNode** adds a runtime isolation layer for privileged or untrusted
-  workloads inside the tenant environment.
-- **Kata Containers, Confidential Containers, and attestation services** provide
-  the hardware-backed confidential runtime and verification flow.
+Confidential compute protects workload code and data in use by running it inside
+a hardware-backed trusted execution environment. Common examples are Intel TDX
+and AMD SEV-SNP. vCluster gives each tenant a dedicated Kubernetes control plane
+and routes workloads to confidential-capable nodes using standard Kubernetes
+mechanisms such as RuntimeClass, node selectors, and node labels. The
+hardware-backed protection covers workload data on the worker nodes. Tenants get
+hardware-backed workload protection combined with Kubernetes-level isolation from
+other tenants on the same platform.
 
 ## Reference architecture
 
-Use vCluster as the tenant Kubernetes layer, vMetal as the bare-metal lifecycle
-layer, and vNode as an additional tenant workload isolation layer. Then install
-and operate the confidential compute runtime on the private nodes selected for
+Use vCluster as the tenant Kubernetes layer. Add vMetal if the
+confidential-capable capacity comes from physical servers you manage, and add
+vNode if tenant workloads need stronger runtime isolation. Then install and
+operate the confidential compute runtime on the private nodes selected for
 confidential workloads.
 
 <figure>
@@ -46,9 +40,26 @@ confidential workloads.
 </figure>
 
 In this model, vCluster decides which tenant gets access to which Kubernetes
-environment, auto nodes selects the right capacity, vMetal prepares and joins
+environment. Auto nodes selects the right capacity, vMetal prepares and joins
 the machine, vNode strengthens the workload boundary, and the confidential
-runtime executes the workload in the hardware-backed environment.
+runtime executes the workload in the hardware-backed environment. For the
+strongest isolation guarantee, assign private nodes to a single tenant cluster
+rather than sharing nodes across tenants.
+
+The components in this architecture each cover a distinct layer:
+
+- **vCluster** provides each tenant with an isolated Kubernetes control plane
+  and a scheduling boundary for workloads.
+- **Private nodes** give the tenant dedicated worker nodes for workloads that
+  require dedicated compute.
+- **Auto nodes** connect workload demand to node provisioning through vCluster
+  Platform.
+- **vMetal** (optional) provisions and recycles physical servers that have the
+  required CPU, firmware, OS image, drivers, and runtime configuration.
+- **vNode** (optional) adds a runtime isolation layer for privileged or
+  untrusted workloads inside the tenant environment.
+- **Kata Containers, Confidential Containers, and attestation services** provide
+  the hardware-backed confidential runtime and verification flow.
 
 ## Implementation checklist
 
@@ -60,9 +71,10 @@ runtime executes the workload in the hardware-backed environment.
 4. Register the hardware in vMetal or another node provider.
 5. Add node type properties that describe the confidential compute capability.
 6. Configure `privateNodes.autoNodes` to select those node types.
-7. Add vNode where tenant workloads need stronger runtime isolation.
-8. Validate scheduling, RuntimeClass selection, attestation, and workload
-   execution from inside the tenant vCluster.
+7. Enable RuntimeClass sync so tenant clusters can use the confidential runtime.
+8. Add vNode where tenant workloads need stronger runtime isolation.
+9. Validate scheduling, RuntimeClass selection, attestation, and workload
+   execution from inside the tenant cluster.
 
 ## Build the capacity layer
 
@@ -71,7 +83,7 @@ Node type properties become selector requirements, so you can expose hardware
 features such as `tdx`, `sev-snp`, GPU model, firmware track, or image family
 to vCluster auto nodes.
 
-```yaml title="NodeProvider with confidential-capable node type"
+```yaml title="NodeProvider — platform admin"
 apiVersion: management.loft.sh/v1
 kind: NodeProvider
 metadata:
@@ -100,23 +112,46 @@ spec:
 This node provider creates a `tdx-large` node type. Auto nodes can select this
 node type when a tenant cluster requests TDX-capable capacity.
 
-Use [vMetal](https://www.vmetal.ai/docs/) when the confidential-capable
-capacity comes from physical servers. vMetal can register servers, select them
-through `BareMetalHost` labels, provision the OS image, and join the server to
-the tenant cluster as a private node.
+If the confidential-capable capacity comes from physical servers,
+[vMetal](https://www.vmetal.ai/docs/) can register servers, provision the OS
+image, and join each server to the tenant cluster as a private node. Any node
+provider that can attach a prepared worker to the cluster works. vMetal is one
+option, not a requirement.
 
 Prepare the OS image and bootstrap flow for the confidential runtime before
 offering the node type to tenants. This typically includes firmware settings,
 kernel support, container runtime configuration, a RuntimeClass, and access
 to the attestation service used by your environment.
 
+:::note Attestation requirements
+The node image must include any device plugins required for quote generation,
+such as the Intel TDX attestation driver or AMD SEV-SNP device plugin. It must
+also include the Data Center Attestation Primitives libraries your attestation
+service expects. The attestation service endpoint must be reachable from the
+private nodes. If your platform enforces network policies, add an egress rule
+that permits attestation traffic before publishing the node type to tenants.
+:::
+
+## Make RuntimeClass available to tenants
+
+RuntimeClass objects live in the control plane cluster. By default, they aren't
+visible inside the tenant cluster. Enable `sync.fromHost.runtimeClasses` so that
+the RuntimeClass your node image installs is available to tenant workloads.
+
+```yaml title="vcluster.yaml — platform admin"
+sync:
+  fromHost:
+    runtimeClasses:
+      enabled: true
+```
+
 ## Route workloads to confidential nodes
 
-Configure private nodes with auto nodes and require the confidential-capable
-node type property. vCluster Platform provisions matching nodes when the tenant
-cluster needs capacity.
+A platform admin configures the tenant cluster to use confidential nodes by
+requiring the confidential-capable node type property. vCluster Platform
+provisions matching nodes when the tenant cluster needs capacity.
 
-```yaml title="vcluster.yaml"
+```yaml title="vcluster.yaml — platform admin"
 privateNodes:
   # Enable dedicated worker nodes for this tenant cluster.
   enabled: true
@@ -135,10 +170,12 @@ privateNodes:
 This configuration lets vCluster Platform provision matching private nodes when
 the tenant cluster needs confidential-capable worker capacity.
 
-Tenant workloads can then use the RuntimeClass that your node image exposes
-for Kata Containers or Confidential Containers.
+Tenants can then schedule workloads using the RuntimeClass your node image
+exposes for Kata Containers or Confidential Containers. Private nodes join the
+tenant cluster as real nodes, so their OS-level labels are visible inside the
+cluster and the `nodeSelector` works without any additional configuration.
 
-```yaml title="Confidential workload"
+```yaml title="Pod spec — tenant"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -159,9 +196,9 @@ that match the confidential compute property.
 
 ## Add vNode for tenant isolation
 
-vNode adds a runtime isolation layer for tenant workloads. It is useful when
-tenants need privileged workloads, host-like APIs, or stronger node-level
-boundaries without giving those workloads direct access to the underlying host.
+vNode adds a runtime isolation layer for tenant workloads. It's useful when
+tenants need privileged workloads or host-like APIs without giving those
+workloads direct access to the underlying host.
 
 For confidential compute builds, use vNode as an isolation layer around tenant
 workloads and pair it with the confidential RuntimeClass exposed on prepared
@@ -170,9 +207,11 @@ isolation and hardware-backed workload execution.
 
 Review the [vNode architecture](https://www.vnode.com/docs/architecture/) and
 [vNode limitations](https://www.vnode.com/docs/limitations/) while designing
-the runtime stack. Validate vNode, Kata Containers, Confidential Containers,
-the node image, and the target hardware together before publishing the node
-type to tenant teams.
+the runtime stack. vNode operates at the OS layer using Linux user namespaces,
+while Kata Containers operates at the VM layer. Their interaction depends on
+kernel version and node configuration. Validate vNode, Kata Containers,
+Confidential Containers, the node image, and the target hardware together
+before publishing the node type to tenant teams.
 
 ## Learn more
 


### PR DESCRIPTION
# Content Description
Add confidential compute guidance for vCluster private nodes. The page explains how vCluster, vMetal, vNode, Kata Containers, Confidential Containers, and attestation fit into a confidential compute build.


## Preview Link 
https://deploy-preview-2248--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes/security/confidential-compute

## Internal Reference
Closes DOC-1441


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
