### PR TITLE
chore: Add additional platform redirects for contextual docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -257,6 +257,60 @@ command = """
   from = "/docs/platform-ui-link/platform/what-are-secrets/:version"
   to = "/docs/platform/:version/understand/what-are-secrets"
 
+# Understanding Users and Teams
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-users-and-teams"
+  to = "/docs/platform/understand/what-are-users-and-teams"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-users-and-teams/:version"
+  to = "/docs/platform/:version/understand/what-are-users-and-teams"
+
+# Understanding Projects
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-projects"
+  to = "/docs/platform/understand/what-are-projects"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-projects/:version"
+  to = "/docs/platform/:version/understand/what-are-projects"
+
+# Understanding Apps
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-apps"
+  to = "/docs/platform/understand/what-are-apps"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-apps/:version"
+  to = "/docs/platform/:version/understand/what-are-apps"
+
+# Understanding Namespaces
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-namespaces"
+  to = "/docs/platform/understand/what-are-namespaces"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-namespaces/:version"
+  to = "/docs/platform/:version/understand/what-are-namespaces"
+
+# Understanding Clusters
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-clusters"
+  to = "/docs/platform/understand/what-are-clusters"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-clusters/:version"
+  to = "/docs/platform/:version/understand/what-are-clusters"
+
+# Understanding Templates
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-templates"
+  to = "/docs/platform/understand/what-are-templates"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/what-are-templates/:version"
+  to = "/docs/platform/:version/understand/what-are-templates"
+
 # Team
 [[redirects]]
   from = "/docs/platform-ui-link/platform/crd/team"


### PR DESCRIPTION

# Content Description

Added a bunch of new platform redirects used in the Contextual Docs project


## Preview Link 

## Internal Reference
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

