### PR TITLE
docs(doc-1444): document storage quota enforcement per tenant cluster

### DIFF
--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -34,7 +34,9 @@ Helm
 HostPath Mapper
 HorizontalPodAutoscaler
 [iI]ngress
+figcaption
 JavaScript
+[kK]yverno
 [jJ]ob
 apiserver
 kubeadm
@@ -58,6 +60,7 @@ OSImage[s]?
 [oOpen] [sSource]
 PersistentVolume
 PersistentVolumeClaim
+PVC
 PXE
 [pP]od
 PodDisruptionBudget

--- a/platform/administer/projects/quotas.mdx
+++ b/platform/administer/projects/quotas.mdx
@@ -132,3 +132,9 @@ Error: metadata.name: Forbidden: cannot create nodeclaim, because per-user nodec
 In order to avoid these errors in practice, quotas may be increased. Decreasing quotas, on the other hand, will not
 result in resources being automatically deleted. If you decrease quotas, resources will most likely exceed limits unless specifically cleaned up.
 :::
+
+## Enforce limits inside a tenant cluster
+
+Project quotas track aggregate usage across the project. They don't enforce per-namespace storage caps or per-PVC size limits inside individual tenant clusters. To close that gap, deploy ResourceQuota objects or Kyverno policies through a tenant cluster template.
+
+[Enforce storage quotas per tenant cluster →](../../how-to/enforce-storage-quotas.mdx)

--- a/platform/how-to/enforce-storage-quotas.mdx
+++ b/platform/how-to/enforce-storage-quotas.mdx
@@ -1,0 +1,156 @@
+---
+title: Enforce storage quotas per tenant cluster
+sidebar_label: Storage quota enforcement
+sidebar_position: 7
+description: Enforce per-cluster storage limits inside vCluster Platform tenant clusters using ResourceQuota objects or Kyverno policies applied at provisioning time through templates.
+---
+
+import StorageQuotaEnforcementDiagram from '@site/static/media/diagrams/storage-quota-enforcement.svg';
+
+vCluster Platform [project quotas](../administer/projects/quotas.mdx) track aggregate storage consumption across all tenant clusters in a project. They reject new resources when the project total would be exceeded, but don't distribute limits evenly across namespaces or enforce per-PVC caps inside individual tenant clusters.
+
+This guide covers two patterns for enforcing storage limits within a tenant cluster. Both can be applied automatically at provisioning time through templates so that every new tenant cluster starts with the right guardrails in place.
+
+<figure>
+  <StorageQuotaEnforcementDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Storage quota enforcement flow for tenant PVC creation" />
+  <figcaption>Storage quota enforcement flow for tenant PVC creation</figcaption>
+</figure>
+
+Project quotas provide the outer platform-level guardrail. ResourceQuota and Kyverno provide tenant-cluster admission controls that enforce limits before a PVC is created.
+
+Use ResourceQuota for namespace-level aggregate limits. Use Kyverno when you need per-PVC size limits or storage class allowlists. Use both when tenants need bounded total usage and per-object guardrails.
+
+## Pattern 1: ResourceQuota inside the tenant cluster
+
+A Kubernetes ResourceQuota object enforces aggregate limits on PVC count and total storage requests within a namespace. It's namespace-scoped, so cluster-wide tenant enforcement requires one per namespace. Adding one to a tenant cluster template deploys it inside every tenant cluster created from that template.
+
+### Add a ResourceQuota to a tenant cluster template
+
+In the `objects` field of a VirtualClusterTemplate, include a ResourceQuota for each namespace you want to constrain. vCluster Platform applies the objects inside the tenant cluster at provisioning time.
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: VirtualClusterTemplate
+metadata:
+  name: standard-tenant
+spec:
+  template:
+    helmRelease:
+      chart:
+        version: "0.25.0"
+    objects: |-
+      apiVersion: v1
+      kind: ResourceQuota
+      metadata:
+        name: storage-quota
+        namespace: default
+      spec:
+        hard:
+          requests.storage: "100Gi"
+          count/persistentvolumeclaims: "20"
+```
+
+To limit storage from a specific storage class, use the scoped resource name:
+
+```yaml
+spec:
+  hard:
+    ceph-rbd.storageclass.storage.k8s.io/requests.storage: "50Gi"
+```
+
+Repeat the ResourceQuota block for each namespace that requires enforcement.
+
+:::note Namespace templates
+For per-namespace enforcement that applies when a namespace is created inside a tenant cluster, use a Space template with a ResourceQuota in the `objects` field instead. See [Create a template](../administer/templates/create-templates.mdx).
+:::
+
+When a tenant or namespace admin creates a PVC that would push usage past the configured limit, the API server rejects the request with an error:
+
+```
+Error from server (Forbidden): persistentvolumeclaims "my-pvc" is forbidden:
+exceeded quota: storage-quota, requested: requests.storage=20Gi,
+used: requests.storage=90Gi, limited: requests.storage=100Gi
+```
+
+## Pattern 2: Kyverno policies
+
+ResourceQuota handles aggregate limits per namespace, but it can't cap the size of an individual PVC or restrict which storage classes tenants may use. [Kyverno](https://kyverno.io) fills those gaps.
+
+Install Kyverno inside the tenant cluster as an [App](../administer/templates/create-templates.mdx) in the tenant cluster template, then add the ClusterPolicy manifests to the `objects` field. Kyverno's admission webhook must be running before tenants create PVCs for the policies to take effect.
+
+The examples below use `kyverno.io/v1`. Adjust the API version and validation syntax for the Kyverno version installed in your tenant clusters.
+
+### Restrict individual PVC size
+
+The following ClusterPolicy rejects any PVC whose storage request exceeds 50Gi:
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-pvc-size
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: max-pvc-storage-request
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolumeClaim
+      validate:
+        message: "PVC storage requests must not exceed 50Gi."
+        deny:
+          conditions:
+            any:
+              - key: "{{ request.object.spec.resources.requests.storage }}"
+                operator: GreaterThan
+                value: "50Gi"
+```
+
+### Restrict allowed storage classes
+
+The following ClusterPolicy limits PVCs to an approved set of storage classes, preventing tenants from requesting storage from arbitrary provisioners such as Ceph RBD:
+
+```yaml
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-storage-class
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: allowed-storage-classes
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolumeClaim
+      validate:
+        message: "Only 'standard' and 'fast-ssd' storage classes are permitted."
+        pattern:
+          spec:
+            storageClassName: "standard | fast-ssd"
+```
+
+Add these manifests to the `objects` field of the tenant cluster template alongside any ResourceQuota objects. Kyverno must already be running inside the tenant cluster to enforce the policies.
+
+## Comparison
+
+| Capability | ResourceQuota | Kyverno |
+|---|---|---|
+| Aggregate storage limit per namespace | Yes | No |
+| PVC count limit per namespace | Yes | No |
+| Storage class-scoped aggregate limit | Yes | No |
+| Per-PVC maximum size | No | Yes |
+| Restrict allowed storage classes | No | Yes |
+| Applied automatically using templates | Yes | Yes (requires Kyverno App) |
+
+Use ResourceQuota for aggregate enforcement and Kyverno for per-object rules and storage class governance. The two approaches work together and can be included in the same template.
+
+## Related
+
+- [Manage Quotas](../administer/projects/quotas.mdx): project-level quota configuration including aggregate `requests.storage` and `count/persistentvolumeclaims` limits
+- [Create a template](../administer/templates/create-templates.mdx): add objects and Apps to a tenant cluster template

--- a/platform/how-to/enforce-storage-quotas.mdx
+++ b/platform/how-to/enforce-storage-quotas.mdx
@@ -7,22 +7,15 @@ description: Enforce per-cluster storage limits inside vCluster Platform tenant 
 
 import StorageQuotaEnforcementDiagram from '@site/static/media/diagrams/storage-quota-enforcement.svg';
 
-vCluster Platform [project quotas](../administer/projects/quotas.mdx) track aggregate storage consumption across all tenant clusters in a project. They reject new resources when the project total would be exceeded, but don't distribute limits evenly across namespaces or enforce per-PVC caps inside individual tenant clusters.
+vCluster Platform [project quotas](../administer/projects/quotas.mdx) cap aggregate storage consumption across all tenant clusters in a project, but they don't distribute limits across namespaces or enforce per-PVC caps inside individual tenant clusters. Per-cluster enforcement fills that gap. A ResourceQuota or Kyverno policy applied inside the tenant cluster controls how much storage any single namespace can consume and how individual PVCs may be sized.
 
-This guide covers two patterns for enforcing storage limits within a tenant cluster. Both can be applied automatically at provisioning time through templates so that every new tenant cluster starts with the right guardrails in place.
-
-<figure>
-  <StorageQuotaEnforcementDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Storage quota enforcement flow for tenant PVC creation" />
-  <figcaption>Storage quota enforcement flow for tenant PVC creation</figcaption>
-</figure>
-
-Project quotas provide the outer platform-level guardrail. ResourceQuota and Kyverno provide tenant-cluster admission controls that enforce limits before a PVC is created.
+This guide covers two patterns for per-cluster enforcement. Both can be applied automatically at provisioning time through templates so that every new tenant cluster starts with the right guardrails in place.
 
 Use ResourceQuota for namespace-level aggregate limits. Use Kyverno when you need per-PVC size limits or storage class allowlists. Use both when tenants need bounded total usage and per-object guardrails.
 
 ## Pattern 1: ResourceQuota inside the tenant cluster
 
-A Kubernetes ResourceQuota object enforces aggregate limits on PVC count and total storage requests within a namespace. It's namespace-scoped, so cluster-wide tenant enforcement requires one per namespace. Adding one to a tenant cluster template deploys it inside every tenant cluster created from that template.
+A Kubernetes ResourceQuota object enforces aggregate limits on PVC count and total storage requests. It's namespace-scoped, so enforcing limits across all namespaces in the tenant cluster requires one ResourceQuota per namespace. Adding one to a tenant cluster template deploys it inside every tenant cluster created from that template.
 
 ### Add a ResourceQuota to a tenant cluster template
 
@@ -50,7 +43,13 @@ spec:
           count/persistentvolumeclaims: "20"
 ```
 
-To limit storage from a specific storage class, use the scoped resource name:
+These two constraints are independent aggregate limits. `requests.storage` caps the combined total storage across all PVCs in the namespace, not the size of any individual PVC. In this example, the namespace cannot have PVCs that total more than 100Gi of space. `count/persistentvolumeclaims` caps the number of PVCs regardless of their size. In this example, the namespace cannot have more than 20 PVCs, even if their total combined storage is less than 100Gi.
+
+With this example, a tenant could create 20 PVCs of 5Gi each (100Gi combined, both limits reached simultaneously), or 2 PVCs of 50Gi each (100Gi combined, only the storage limit reached). What is not possible is more than 20 PVCs or any number of PVCs totaling more than 100Gi.
+
+### Scope to a storage class
+
+To limit storage from a specific storage class, add a scoped resource name under the same `spec.hard` key:
 
 ```yaml
 spec:
@@ -58,11 +57,15 @@ spec:
     ceph-rbd.storageclass.storage.k8s.io/requests.storage: "50Gi"
 ```
 
+### Apply across namespaces
+
 Repeat the ResourceQuota block for each namespace that requires enforcement.
 
 :::note Namespace templates
 For per-namespace enforcement that applies when a namespace is created inside a tenant cluster, use a Space template with a ResourceQuota in the `objects` field instead. See [Create a template](../administer/templates/create-templates.mdx).
 :::
+
+### Enforcement errors
 
 When a tenant or namespace admin creates a PVC that would push usage past the configured limit, the API server rejects the request with an error:
 
@@ -72,13 +75,13 @@ exceeded quota: storage-quota, requested: requests.storage=20Gi,
 used: requests.storage=90Gi, limited: requests.storage=100Gi
 ```
 
+The count limit produces a similar error, replacing `requests.storage` with `count/persistentvolumeclaims` in the output.
+
 ## Pattern 2: Kyverno policies
 
-ResourceQuota handles aggregate limits per namespace, but it can't cap the size of an individual PVC or restrict which storage classes tenants may use. [Kyverno](https://kyverno.io) fills those gaps.
+ResourceQuota enforces aggregate limits but cannot cap individual PVC sizes or restrict which storage classes tenants may use. [Kyverno](https://kyverno.io) fills those gaps.
 
-Install Kyverno inside the tenant cluster as an [App](../administer/templates/create-templates.mdx) in the tenant cluster template, then add the ClusterPolicy manifests to the `objects` field. Kyverno's admission webhook must be running before tenants create PVCs for the policies to take effect.
-
-The examples below use `kyverno.io/v1`. Adjust the API version and validation syntax for the Kyverno version installed in your tenant clusters.
+Install Kyverno inside the tenant cluster as an [App](../administer/templates/create-templates.mdx) in the tenant cluster template. The examples below use `kyverno.io/v1`. Adjust the API version and validation syntax for the Kyverno version installed in your tenant clusters.
 
 ### Restrict individual PVC size
 
@@ -135,7 +138,73 @@ spec:
             storageClassName: "standard | fast-ssd"
 ```
 
-Add these manifests to the `objects` field of the tenant cluster template alongside any ResourceQuota objects. Kyverno must already be running inside the tenant cluster to enforce the policies.
+### Embed Kyverno policies in a tenant cluster template
+
+Add ClusterPolicy manifests to the `objects` field of a VirtualClusterTemplate to deploy them inside every tenant cluster created from that template. Multiple manifests are separated by `---`.
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: VirtualClusterTemplate
+metadata:
+  name: standard-tenant
+spec:
+  template:
+    helmRelease:
+      chart:
+        version: "0.25.0"
+    objects: |-
+      apiVersion: kyverno.io/v1
+      kind: ClusterPolicy
+      metadata:
+        name: restrict-pvc-size
+      spec:
+        validationFailureAction: Enforce
+        background: false
+        rules:
+          - name: max-pvc-storage-request
+            match:
+              any:
+                - resources:
+                    kinds:
+                      - PersistentVolumeClaim
+            validate:
+              message: "PVC storage requests must not exceed 50Gi."
+              deny:
+                conditions:
+                  any:
+                    - key: "{{ request.object.spec.resources.requests.storage }}"
+                      operator: GreaterThan
+                      value: "50Gi"
+      ---
+      apiVersion: kyverno.io/v1
+      kind: ClusterPolicy
+      metadata:
+        name: restrict-storage-class
+      spec:
+        validationFailureAction: Enforce
+        background: false
+        rules:
+          - name: allowed-storage-classes
+            match:
+              any:
+                - resources:
+                    kinds:
+                      - PersistentVolumeClaim
+            validate:
+              message: "Only 'standard' and 'fast-ssd' storage classes are permitted."
+              pattern:
+                spec:
+                  storageClassName: "standard | fast-ssd"
+```
+
+## Template application order
+
+The platform applies `objects` before `apps`. ClusterPolicy manifests in the `objects` field are applied before the Kyverno App finishes installing its CRDs and admission webhook, so the apply will fail if Kyverno is not already present. To avoid this, either pre-install Kyverno in the tenant cluster before using this template, or package the ClusterPolicy manifests as a dedicated App listed after the Kyverno App rather than using the `objects` field.
+
+<figure>
+  <StorageQuotaEnforcementDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Storage quota enforcement flow for tenant PVC creation" />
+  <figcaption>Storage quota enforcement flow for tenant PVC creation</figcaption>
+</figure>
 
 ## Comparison
 

--- a/platform/understand/what-are-projects.mdx
+++ b/platform/understand/what-are-projects.mdx
@@ -32,6 +32,10 @@ Projects define which templates members can use when creating tenant clusters. A
 
 Projects can define resource quotas that cap total compute and storage consumption across all tenant clusters and spaces in the project. Quotas prevent any single project from consuming disproportionate infrastructure resources.
 
+[Configure project quotas →](../administer/projects/quotas.mdx)
+
+[Enforce storage limits inside a tenant cluster →](../how-to/enforce-storage-quotas.mdx)
+
 ## Secrets
 
 Projects can store secrets that are shared across resources within the project. These are useful for distributing credentials, tokens, or configuration that multiple tenant clusters need access to.

--- a/platform/use-platform/namespaces/key-features/isolation.mdx
+++ b/platform/use-platform/namespaces/key-features/isolation.mdx
@@ -124,3 +124,5 @@ The `objects` field accepts a yaml string with Kubernetes resources separated by
 Not all CNIs will support all network policies. Make sure you understand what capabilities your
 CNI supports when investigating namespace isolation.
 :::
+
+To enforce storage limits inside a tenant cluster, including per-PVC size caps and storage class restrictions, see [Enforce storage quotas per tenant cluster](../../../how-to/enforce-storage-quotas.mdx).

--- a/static/media/diagrams/storage-quota-enforcement.svg
+++ b/static/media/diagrams/storage-quota-enforcement.svg
@@ -1,0 +1,68 @@
+<svg viewBox="0 0 1080 390" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style><![CDATA[
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <marker id="storage-quota-arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+
+    <marker id="storage-quota-arrow-muted" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#828592"/>
+    </marker>
+  </defs>
+
+  <rect x="30" y="30" width="1040" height="330" rx="8" fill="#F8F9FB" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="50" y="58" font-size="12" font-weight="500" fill="#828592">PVC admission and quota enforcement</text>
+
+  <rect x="65" y="129" width="160" height="64" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="145" y="154" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">Tenant creates</text>
+  <text x="145" y="173" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">PVC</text>
+
+  <rect x="260" y="78" width="540" height="210" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="280" y="106" font-size="12" font-weight="500" fill="#828592">Tenant cluster</text>
+
+  <rect x="300" y="130" width="145" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="372.5" y="152" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">Kyverno</text>
+  <text x="372.5" y="170" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ClusterPolicy</text>
+  <text x="372.5" y="185" font-size="10" fill="#828592" text-anchor="middle">Pattern 2</text>
+
+  <rect x="505" y="130" width="125" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="567.5" y="157" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ResourceQuota</text>
+  <text x="567.5" y="177" font-size="10" fill="#828592" text-anchor="middle">Pattern 1</text>
+
+  <rect x="690" y="130" width="70" height="62" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="725" y="157" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">PVC</text>
+  <text x="725" y="176" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">created</text>
+
+  <rect x="322.5" y="230" width="100" height="40" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="372.5" y="255" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Rejected</text>
+
+  <rect x="517.5" y="230" width="100" height="40" rx="8" fill="#F4F6F8" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="567.5" y="255" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Rejected</text>
+
+  <rect x="910" y="130" width="145" height="62" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="982.5" y="153" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">Project quota</text>
+  <text x="982.5" y="173" font-size="11" fill="#828592" text-anchor="middle">platform level</text>
+
+  <line x1="225" y1="161" x2="298" y2="161" stroke="#050B24" stroke-width="1.5" marker-end="url(#storage-quota-arrow)"/>
+
+  <line x1="445" y1="161" x2="503" y2="161" stroke="#050B24" stroke-width="1.5" marker-end="url(#storage-quota-arrow)"/>
+  <text x="474" y="149" font-size="11" fill="#828592" text-anchor="middle">passes</text>
+
+  <line x1="630" y1="161" x2="688" y2="161" stroke="#050B24" stroke-width="1.5" marker-end="url(#storage-quota-arrow)"/>
+  <text x="659" y="149" font-size="11" fill="#828592" text-anchor="middle">passes</text>
+
+  <line x1="372.5" y1="192" x2="372.5" y2="228" stroke="#050B24" stroke-width="1.5" marker-end="url(#storage-quota-arrow)"/>
+  <text x="408" y="214" font-size="11" fill="#828592">rejects</text>
+
+  <line x1="567.5" y1="192" x2="567.5" y2="228" stroke="#050B24" stroke-width="1.5" marker-end="url(#storage-quota-arrow)"/>
+  <text x="603" y="214" font-size="11" fill="#828592">rejects</text>
+
+  <line x1="760" y1="161" x2="908" y2="161" stroke="#828592" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#storage-quota-arrow-muted)"/>
+  <text x="855" y="133" font-size="11" fill="#828592" text-anchor="middle">
+    <tspan x="855" dy="0">usage</tspan>
+    <tspan x="855" dy="13">tracked</tspan>
+  </text>
+</svg>

--- a/static/media/diagrams/storage-quota-enforcement.svg
+++ b/static/media/diagrams/storage-quota-enforcement.svg
@@ -24,13 +24,13 @@
   <text x="280" y="106" font-size="12" font-weight="500" fill="#828592">Tenant cluster</text>
 
   <rect x="300" y="130" width="145" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="372.5" y="152" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">Kyverno</text>
-  <text x="372.5" y="170" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ClusterPolicy</text>
-  <text x="372.5" y="185" font-size="10" fill="#828592" text-anchor="middle">Pattern 2</text>
+  <text x="372.5" y="157" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ResourceQuota</text>
+  <text x="372.5" y="177" font-size="10" fill="#828592" text-anchor="middle">Pattern 1</text>
 
   <rect x="505" y="130" width="125" height="62" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
-  <text x="567.5" y="157" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ResourceQuota</text>
-  <text x="567.5" y="177" font-size="10" fill="#828592" text-anchor="middle">Pattern 1</text>
+  <text x="567.5" y="152" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">Kyverno</text>
+  <text x="567.5" y="170" font-size="13" font-weight="500" fill="#050B24" text-anchor="middle">ClusterPolicy</text>
+  <text x="567.5" y="185" font-size="10" fill="#828592" text-anchor="middle">Pattern 2</text>
 
   <rect x="690" y="130" width="70" height="62" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
   <text x="725" y="157" font-size="13" font-weight="600" fill="#050B24" text-anchor="middle">PVC</text>


### PR DESCRIPTION
# Content Description
Adds a new how-to guide documenting how to enforce storage quotas inside individual tenant clusters. vCluster Platform project quotas track aggregate storage usage but don't enforce per-namespace limits or per-PVC caps within individual tenant clusters. The guide covers ResourceQuota objects and Kyverno ClusterPolicy examples, an SVG admission-flow diagram, and cross-links from quotas.mdx, what-are-projects.mdx, and namespaces/isolation.mdx.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2254--vcluster-docs-site.netlify.app/docs/platform/next/how-to/enforce-storage-quotas

## Internal Reference
Closes DOC-1444

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs