### PR TITLE
feat: add UI permalinks for Argo CD integration and migration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -574,6 +574,24 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   from = "/docs/platform-ui-link/platform/node-claims/:version"
   to = "/docs/platform/:version/administer/node-providers/overview#node-claims"
 
+# Argo CD integration
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/argocd-integration"
+  to = "/docs/platform/integrations/argocd/connect-argocd"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/argocd-integration/:version"
+  to = "/docs/platform/:version/integrations/argocd/connect-argocd"
+
+# Argo CD migration (legacy integration)
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/argocd-migration"
+  to = "/docs/platform/integrations/argocd/legacy"
+
+[[redirects]]
+  from = "/docs/platform-ui-link/platform/argocd-migration/:version"
+  to = "/docs/platform/:version/integrations/argocd/legacy"
+
 # Volume snapshots
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/volume-snapshots/:version"


### PR DESCRIPTION
Adds Platform UI permalink redirects for the Argo CD integration:

- `/docs/platform-ui-link/platform/argocd-integration` → `/docs/platform/integrations/argocd`
- `/docs/platform-ui-link/platform/argocd-migration` → `/docs/platform/integrations/argocd`

(plus the versioned `/:version` variants)

Both currently point at the existing Argo CD page. Once #2071 lands (splitting the page into `integrations/argocd/`), a follow-up will retarget them to `connect-argocd` and `legacy` respectively (TODOs left in `netlify.toml`).