### PR TITLE
docs(istio): recommend kubernetes gateway api for new gateways

### DIFF
--- a/vcluster/_fragments/integrations/istio.mdx
+++ b/vcluster/_fragments/integrations/istio.mdx
@@ -63,7 +63,7 @@ Istio [intends to make the Kubernetes Gateway API the default API for traffic ma
 For new setups that expose tenant workloads outside the cluster, consider Kubernetes `Gateway` resources instead of Istio `Gateway` (`networking.istio.io`) resources:
 
 - To let tenants create their own `Gateway` and `HTTPRoute` resources, enable [Gateway API sync](../../configure/vcluster-yaml/sync/to-host/networking/gateway-api.mdx).
-- To let tenants attach `HTTPRoute` resources to a shared Gateway owned by the platform team in the control plane cluster, see [Imported Gateways and GatewayClasses](../../configure/vcluster-yaml/sync/from-host/gateways.mdx).
+- To let tenants attach `HTTPRoute` resources to a shared Gateway in the control plane cluster, see [Imported Gateways and GatewayClasses](../../configure/vcluster-yaml/sync/from-host/gateways.mdx).
 
 The integration continues to sync Istio `Gateway` resources, so existing configurations keep working.
 `VirtualService` and `DestinationRule` resources are still required for the mesh-internal routing shown in this guide.

--- a/vcluster/_fragments/integrations/istio.mdx
+++ b/vcluster/_fragments/integrations/istio.mdx
@@ -58,6 +58,17 @@ This configuration:
 Only `DestinationRules`, `Gateways`, and `VirtualServices` from `networking.istio.io/v1` API Version are synced to the control plane clusters. Other kinds are not yet supported.
 :::
 
+:::note Prefer the Kubernetes Gateway API for new gateways
+Istio [intends to make the Kubernetes Gateway API the default API for traffic management](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/).
+For new setups that expose tenant workloads outside the cluster, consider Kubernetes `Gateway` resources instead of Istio `Gateway` (`networking.istio.io`) resources:
+
+- To let tenants create their own `Gateway` and `HTTPRoute` resources, enable [Gateway API sync](../../configure/vcluster-yaml/sync/to-host/networking/gateway-api.mdx).
+- To let tenants attach `HTTPRoute` resources to a shared Gateway owned by the platform team in the control plane cluster, see [Imported Gateways and GatewayClasses](../../configure/vcluster-yaml/sync/from-host/gateways.mdx).
+
+The integration continues to sync Istio `Gateway` resources, so existing configurations keep working.
+`VirtualService` and `DestinationRule` resources are still required for the mesh-internal routing shown in this guide.
+:::
+
 ### Network policies
 
 If you are using [network policies](../../configure/vcluster-yaml/policies/network-policy.mdx), consult the [Ambient and Kubernetes NetworkPolicy](https://istio.io/latest/docs/ambient/usage/networkpolicy/) documentation.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGNODE-575


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

