### PR TITLE
docs(ai-cloud): add ClusterMAX reference to production path intro

### DIFF
--- a/vcluster/production-guide/ai-cloud.mdx
+++ b/vcluster/production-guide/ai-cloud.mdx
@@ -18,7 +18,7 @@ Run a managed Kubernetes service on your GPU infrastructure. Each customer gets 
   <figcaption>Central control plane managing tenant clusters for customers</figcaption>
 </figure>
 
-**What makes this path different:** Customers never touch Platform. They interact with your product. Platform RBAC locks direct access to your platform engineering team.
+**What makes this path different:** Customers never touch Platform. They interact with your product. Platform RBAC locks direct access to your platform engineering team. This architecture also maps to the cluster-level isolation criteria that AI cloud buyers evaluate in frameworks like [ClusterMAX](https://www.vcluster.com/clustermax).
 
 ## Day 0: Design decisions
 

--- a/vcluster/production-guide/distributed-compute.mdx
+++ b/vcluster/production-guide/distributed-compute.mdx
@@ -18,7 +18,7 @@ One management plane for GPU compute from every source you own or contract. Whet
   <figcaption>Central control plane managing tenant workloads across distributed compute capacity sources</figcaption>
 </figure>
 
-**What makes this path different:** Every compute source, regardless of where it lives or who operates it, follows the same onboarding playbook. One ops team, one management plane, no per-provider tooling.
+**What makes this path different:** Every compute source, regardless of where it lives or who operates it, follows the same onboarding playbook. One ops team, one management plane, no per-provider tooling. This architecture also maps to the cluster-level isolation criteria that AI cloud buyers evaluate in frameworks like [ClusterMAX](https://www.vcluster.com/clustermax).
 
 ## Day 0: Design decisions
 


### PR DESCRIPTION
# Content Description

Adds a single sentence to the AI Cloud production path intro linking to the ClusterMAX framework. Replaces a forced standalone section that interrupted the Day 0/1/2 guide flow.

## Preview Link

- https://deploy-preview-2274--vcluster-docs-site.netlify.app/docs/vcluster/next/production-guide/ai-cloud
- https://deploy-preview-2274--vcluster-docs-site.netlify.app/docs/vcluster/next/production-guide/distributed-compute

## Internal Reference

Closes DOC-1506


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs