### PR TITLE
Call out the 1.5 min version requirement for GatewayAPI

### DIFF
--- a/vcluster/key-features/gateway-api.mdx
+++ b/vcluster/key-features/gateway-api.mdx
@@ -42,7 +42,7 @@ For a step-by-step adoption path, see [Migrate from ingress-nginx to Gateway API
 
 Before adopting Gateway API, verify:
 
-- Gateway API CRDs are installed on the Control Plane Cluster.
+- Version [v1.5.0 or later](https://gateway-api.sigs.k8s.io/docs/implementations/versions/v1.5/) Gateway API CRDs are installed on the Control Plane Cluster.
 - A Gateway API-compatible controller is installed and healthy.
 - At least one `GatewayClass` is available for the controller you plan to use.
 - DNS and certificates are planned for the Gateway listener hostnames.

--- a/vcluster_versioned_docs/version-0.35.0/key-features/gateway-api.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/key-features/gateway-api.mdx
@@ -42,7 +42,7 @@ For a step-by-step adoption path, see [Migrate from ingress-nginx to Gateway API
 
 Before adopting Gateway API, verify:
 
-- Gateway API CRDs are installed on the Control Plane Cluster.
+- Version [v1.5.0 or later](https://gateway-api.sigs.k8s.io/docs/implementations/versions/v1.5/) Gateway API CRDs are installed on the Control Plane Cluster.
 - A Gateway API-compatible controller is installed and healthy.
 - At least one `GatewayClass` is available for the controller you plan to use.
 - DNS and certificates are planned for the Gateway listener hostnames.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->
[Top bullet point of the Prerequisites](https://deploy-preview-2278--vcluster-docs-site.netlify.app/docs/vcluster/next/key-features/gateway-api/#prerequisites)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1507


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

