### PR TITLE
Remove PGSSLMODE envvar note in iam_database.mdx

### DIFF
--- a/platform/administer/connector/iam_database.mdx
+++ b/platform/administer/connector/iam_database.mdx
@@ -648,26 +648,6 @@ kubectl get secrets -n vcluster-platform -l loft.sh/connector-type=shared-databa
 
 To use the secret in a tenant cluster, refer to the [Database Connectors](./database#use-tenant-cluster-with-shared-database) documentation.
 
-:::note
-AWS RDS PostgreSQL requires secure transport for IAM authentication to work. You must set the appropriate SSL mode environment variable for each tenant cluster that uses an IAM database connector.
-
-Set `PGSSLMODE` to `require` in the tenant cluster's `values.yaml`:
-
-```yaml
-controlPlane:
-  distro:
-    k8s:
-      env:
-        - name: PGSSLMODE
-          value: "require"
-  backingStore:
-    database:
-      external:
-        enabled: true
-        connector: my-rds-connector
-```
-:::
-
 ### Troubleshoot common issues
 
 #### Connection errors


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Dropping the note about PGSSLMODE env var.
From what I can tell from the code, it is completely ignored now, and [we default to "require" anyway - code](https://github.com/loft-sh/vcluster-pro/blob/0ab8a6d5bdc55bbb901b0e06670e8f689bea4d3d/pkg/database/tls.go#L18-L19).

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2288--vcluster-docs-site.netlify.app/docs/platform/next/administer/connector/iam_database

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
No Linear ticket, there was question in #7058 in Pylon

<!-- Do not change the line below -->
@netlify /docs

