### PR TITLE
docs(argocd): document tenant cluster migration limitations with Argo CD

### DIFF
--- a/.github/styles/Google/Headings.yml
+++ b/.github/styles/Google/Headings.yml
@@ -64,3 +64,5 @@ exceptions:
   - OpenCost
   - Helm
   - FIPS
+  - SSO
+  - App Project

--- a/.github/styles/Google/WordList.yml
+++ b/.github/styles/Google/WordList.yml
@@ -70,6 +70,6 @@ swap:
   synch: sync
   tablename: table name
   tablet: device
-  touch: tap
+  touch(?! points?): tap
   vs\.: versus
   World Wide Web: web

--- a/platform/api/resources/project/migratevirtualclusterinstance.mdx
+++ b/platform/api/resources/project/migratevirtualclusterinstance.mdx
@@ -8,16 +8,14 @@ import SubResourceCreate from "../../_partials/resources/projects/migratevirtual
 This API can be used to move a virtual cluster from one project to another.
 
 :::warning Argo CD integration is not supported during project migration
-Moving a tenant cluster between projects while Argo CD integration is enabled deletes all Argo CD applications managed by Platform for that cluster. The workloads deployed by those applications are also removed. Applications are not recreated in the destination project.
+Migrating a tenant cluster between projects while Argo CD integration is enabled is not supported. This operation deletes all Argo CD applications managed by Platform for that cluster and removes their workloads. Applications are not recreated in the destination project. The tenant cluster may also get stuck in `Terminating`.
 
-The tenant cluster may also get stuck in `Terminating` if Argo CD integration is active at the time of migration.
-
-Before migrating, disable the Argo CD integration on the tenant cluster and confirm that all managed applications have been removed from Argo CD. Re-enable and reconfigure the integration in the destination project after the migration completes. See [Deploy applications](../../../integrations/argocd/deploy-applications.mdx) for details on managing Argo CD integration on a tenant cluster.
+Avoid this migration path when Argo CD integration is active. If migration is necessary, manually remove all Argo CD-managed applications and workloads before migrating, and reconfigure the integration in the destination project afterward. See [Deploy applications](../../../integrations/argocd/deploy-applications.mdx) for details on managing Argo CD integration.
 :::
 
-## Move vCluster to other project example
+## Move a vCluster to another project example
 
-An example Move vCluster to other project:
+Example request:
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: ProjectMigrateVirtualClusterInstance
@@ -28,11 +26,11 @@ sourceVirtualClusterInstance:
 
 ```
 
-## Move vCluster to other project reference
+## Move a vCluster to another project reference
 
 <Reference />
 
-## Move vCluster to other project (create)
+## Move a vCluster to another project (create)
 
 <SubResourceCreate />
 

--- a/platform/api/resources/project/migratevirtualclusterinstance.mdx
+++ b/platform/api/resources/project/migratevirtualclusterinstance.mdx
@@ -7,9 +7,17 @@ import SubResourceCreate from "../../_partials/resources/projects/migratevirtual
 
 This API can be used to move a virtual cluster from one project to another.
 
-## Move Virtual Cluster To Other Project example
+:::warning Argo CD integration is not supported during project migration
+Moving a tenant cluster between projects while Argo CD integration is enabled deletes all Argo CD applications managed by Platform for that cluster. The workloads deployed by those applications are also removed. Applications are not recreated in the destination project.
 
-An example Move Virtual Cluster To Other Project:
+The tenant cluster may also get stuck in `Terminating` if Argo CD integration is active at the time of migration.
+
+Before migrating, disable the Argo CD integration on the tenant cluster and confirm that all managed applications have been removed from Argo CD. Re-enable and reconfigure the integration in the destination project after the migration completes. See [Deploy applications](../../integrations/argocd/deploy-applications.mdx) for details on managing Argo CD integration on a tenant cluster.
+:::
+
+## Move vCluster to other project example
+
+An example Move vCluster to other project:
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: ProjectMigrateVirtualClusterInstance
@@ -20,11 +28,11 @@ sourceVirtualClusterInstance:
 
 ```
 
-## Move Virtual Cluster To Other Project reference
+## Move vCluster to other project reference
 
 <Reference />
 
-## Move Virtual Cluster To Other Project (Create)
+## Move vCluster to other project (create)
 
 <SubResourceCreate />
 

--- a/platform/api/resources/project/migratevirtualclusterinstance.mdx
+++ b/platform/api/resources/project/migratevirtualclusterinstance.mdx
@@ -12,7 +12,7 @@ Moving a tenant cluster between projects while Argo CD integration is enabled de
 
 The tenant cluster may also get stuck in `Terminating` if Argo CD integration is active at the time of migration.
 
-Before migrating, disable the Argo CD integration on the tenant cluster and confirm that all managed applications have been removed from Argo CD. Re-enable and reconfigure the integration in the destination project after the migration completes. See [Deploy applications](../../integrations/argocd/deploy-applications.mdx) for details on managing Argo CD integration on a tenant cluster.
+Before migrating, disable the Argo CD integration on the tenant cluster and confirm that all managed applications have been removed from Argo CD. Re-enable and reconfigure the integration in the destination project after the migration completes. See [Deploy applications](../../../integrations/argocd/deploy-applications.mdx) for details on managing Argo CD integration on a tenant cluster.
 :::
 
 ## Move vCluster to other project example

--- a/platform/integrations/argocd/legacy.mdx
+++ b/platform/integrations/argocd/legacy.mdx
@@ -40,7 +40,7 @@ Argo CD Integration has three major components or levels, with each level adding
 integration touch points.
 
 1. Sync tenant clusters to Argo CD
-2. Enable SSO Integration (sign in to Argo CD via vCluster Platform)
+2. Enable SSO Integration (sign in to Argo CD using vCluster Platform)
 3. Create Argo CD [App Project](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/)
    per vCluster Platform Project
 
@@ -52,9 +52,9 @@ in the Argo CD UI. When the tenant clusters are deleted, vCluster Platform will 
 deleted cluster from Argo CD.
 
 The second integration level is enabling SSO integration. This is a project level setting that
-will configure Argo CD to allow users to authenticate via vCluster Platform. After enabling this setting
-users who browse to the Argo CD instance will see a button to login via vCluster Platform. All members of the
-project will be able to log in via vCluster Platform and gain access to Argo CD.
+will configure Argo CD to allow users to authenticate using vCluster Platform. After enabling this setting
+users who browse to the Argo CD instance will see a button to login using vCluster Platform. All members of the
+project will be able to log in using vCluster Platform and gain access to Argo CD.
 
 The final integration level is the App Project/Argo CD Project integration. This tier configures
 an App Project in Argo CD that corresponds to the vCluster Platform project. This option allows for
@@ -67,7 +67,7 @@ with a single Argo CD instance, or with different Argo CD instances depending on
 
 ## Project Integration
 
-### Enable Argo CD Integration Per Project
+### Enable Argo CD integration per project
 
 :::warning Integration Errors
 If there are any errors establishing Argo CD integration, an `Argo CD Error` message will appear
@@ -161,19 +161,14 @@ under the 'Project Settings' button.
   </TabItem>
 </Tabs>
 
-:::warning Disabling Argo CD Integration
-Upon disabling of Argo integration at the project, all tenant clusters will be removed from Argo
-CD, so be careful when disabling Argo CD at the project level.
-:::
-
-### Enable Argo CD SSO Integration
+### Enable Argo CD SSO integration
 
 Projects may also enable SSO integration with Argo CD, which allows all members
-of the vCluster Platform project to log in to Argo CD via vCluster Platform.
+of the vCluster Platform project to log in to Argo CD using vCluster Platform.
 
 :::info Pre-Requisites
 The `loftHost` vCluster Platform configuration must be set to enable this integration. The `loftHost` can be
-configured via with the Helm values, or in the `Admin` section of the UI on the `Config` pane.
+configured using the Helm values, or in the `Admin` section of the UI on the `Config` pane.
 :::
 
 <Tabs
@@ -268,12 +263,18 @@ configured via with the Helm values, or in the `Admin` section of the UI on the 
   </TabItem>
 </Tabs>
 
-### Enable Argo CD App Project Integration
+### Enable Argo CD App Project integration
 
 App Project integration, can be enabled by editing a project manifest and setting the
 `argoCD.project.enabled` field of the project spec to 'true'. Additionally, users may
 provide metadata fields to apply the Argo CD App Project object, Argo CD RBAC roles to apply,
 and an array of permissible source repositories that may be accessed within the project.
+
+:::warning Moving tenant clusters between projects
+Because Argo CD applications are project-scoped, moving a tenant cluster to another project deletes all Argo CD applications managed by Platform for that cluster. The workloads deployed by those applications are also removed and are not recreated in the destination project. The tenant cluster may also get stuck in `Terminating`.
+
+Before migrating, disable the Argo CD integration on the tenant cluster and confirm all managed applications have been removed. See [Move vCluster to other project](../../api/resources/project/migratevirtualclusterinstance.mdx) for details.
+:::
 
 ## Tenant cluster integration
 
@@ -340,3 +341,7 @@ The Argo CD integration can be disabled on a per tenant cluster or per project l
 used to enable it. Disabling the integration at the tenant cluster level simply removes it as a registered cluster
 in Argo CD. Disabling the integration at the project level removes all tenant clusters from Argo CD, so be careful
 when disabled Argo at this level.
+
+:::warning Disabling at the project level deletes all managed applications
+When Argo CD integration is disabled at the project level, all Argo CD applications managed by Platform for tenant clusters in that project are deleted. The workloads deployed by those applications are also removed.
+:::

--- a/platform/integrations/argocd/legacy.mdx
+++ b/platform/integrations/argocd/legacy.mdx
@@ -271,9 +271,9 @@ provide metadata fields to apply the Argo CD App Project object, Argo CD RBAC ro
 and an array of permissible source repositories that may be accessed within the project.
 
 :::warning Moving tenant clusters between projects
-Because Argo CD applications are project-scoped, moving a tenant cluster to another project deletes all Argo CD applications managed by Platform for that cluster. The workloads deployed by those applications are also removed and are not recreated in the destination project. The tenant cluster may also get stuck in `Terminating`.
+Migrating a tenant cluster between projects while Argo CD integration is enabled is not supported. Because Argo CD applications are project-scoped, this operation deletes all Argo CD applications managed by Platform for that cluster and removes their workloads. Applications are not recreated in the destination project. The tenant cluster may also get stuck in `Terminating`.
 
-Before migrating, disable the Argo CD integration on the tenant cluster and confirm all managed applications have been removed. See [Move vCluster to other project](../../api/resources/project/migratevirtualclusterinstance.mdx) for details.
+Avoid this migration path when Argo CD integration is active. See [Move a vCluster to another project](../../api/resources/project/migratevirtualclusterinstance.mdx) for details.
 :::
 
 ## Tenant cluster integration


### PR DESCRIPTION
# Content Description

Adds warnings documenting the known limitation that migrating a tenant cluster between projects while Argo CD integration is enabled deletes all managed Argo CD applications and their workloads. Apps are not recreated in the destination project, and the cluster may get stuck in `Terminating`. Also fixes pre-existing Vale warnings across both modified files, adds `SSO` and `App Project` to the Headings exceptions list, and scopes the `touch → tap` WordList rule to exclude "touch points."

## Preview Link

<!-- The preview link or links to the documents-->
- https://deploy-preview-2291--vcluster-docs-site.netlify.app/docs/platform/next/integrations/argocd/legacy#enable-argo-cd-app-project-integration
- https://deploy-preview-2291--vcluster-docs-site.netlify.app/docs/platform/next/api/resources/project/migratevirtualclusterinstance

## Internal Reference

Closes DOC-1511

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs