### PR TITLE
docs: fix outdated API group, namespace prefix, and CLI command in platform guides

### DIFF
--- a/platform/administer/templates/external-credentials.mdx
+++ b/platform/administer/templates/external-credentials.mdx
@@ -97,7 +97,7 @@ spec:
 ```
 
 :::tip
-Remember to set the label `loft.sh/project-secret` on the Kubernetes secret, in order for Loft to pick it up correctly. Also make sure the secret is created in the correct project namespace in the form of `loft-p-`.
+Remember to set the label `loft.sh/project-secret` on the Kubernetes secret, in order for Loft to pick it up correctly. Also make sure the secret is created in the correct project namespace in the form of `p-`.
 :::
 
 Then just reference the created secret within the app itself:

--- a/platform/how-to/gitops-end-to-end.mdx
+++ b/platform/how-to/gitops-end-to-end.mdx
@@ -239,11 +239,11 @@ With the platform, cluster, and project in place, deploy tenant clusters through
 Create a VirtualClusterInstance resource that the platform manages. This gives you full platform features like sleep mode, auto-delete, and template enforcement.
 
 <InterpolatedCodeBlock
-  code={`apiVersion: storage.loft.sh/v1
+  code={`apiVersion: management.loft.sh/v1
 kind: VirtualClusterInstance
 metadata:
   name: [[VAR:VCLUSTER_NAME:dev-vcluster]]
-  namespace: loft-p-[[VAR:PROJECT_NAME:team-alpha]]
+  namespace: p-[[VAR:PROJECT_NAME:team-alpha]]
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -271,7 +271,7 @@ spec:
 />
 
 :::tip
-The namespace follows the pattern `loft-p-<project-name>`. The platform uses this convention to associate tenant clusters with projects.
+The namespace follows the pattern `p-<project-name>`. The platform uses this convention to associate tenant clusters with projects.
 :::
 
 When the `VirtualClusterInstance` reconciles, Platform registers the tenant cluster with Argo CD using the connector credentials. You can then declare Argo CD Applications in the tenant cluster configuration. See [Deploy applications](../integrations/argocd/deploy-applications.mdx).

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -42,7 +42,7 @@ If you are manually creating the vCluster namespace as part of your GitOps workf
   metadata:
     labels:
       loft.sh/vcluster-instance-name: dev-reliability     # Identifies the specific vCluster instance name
-      loft.sh/vcluster-instance-namespace: loft-p-default # Specifies the parent namespace in Loft
+      loft.sh/vcluster-instance-namespace: p-default # Specifies the parent namespace in Loft
       loft.sh/vcluster-instance-project: default          # Defines the Loft project this vCluster belongs to
   ```
 

--- a/platform/integrations/argocd/deploy-applications.mdx
+++ b/platform/integrations/argocd/deploy-applications.mdx
@@ -53,7 +53,7 @@ An `ArgoCDApplicationTemplate` is a reusable Argo CD ApplicationSpec. Create one
   <TabItem value="yaml">
 
 ```yaml
-apiVersion: storage.loft.sh/v1
+apiVersion: management.loft.sh/v1
 kind: ArgoCDApplicationTemplate
 metadata:
   name: app-template
@@ -354,7 +354,7 @@ Create an `ArgoCDApplication` object in the project namespace. Use `spec.destina
   <TabItem value="template">
 
 ```yaml
-apiVersion: storage.loft.sh/v1
+apiVersion: management.loft.sh/v1
 kind: ArgoCDApplication
 metadata:
   name: shared-infra
@@ -372,7 +372,7 @@ spec:
   <TabItem value="inline">
 
 ```yaml
-apiVersion: storage.loft.sh/v1
+apiVersion: management.loft.sh/v1
 kind: ArgoCDApplication
 metadata:
   name: cluster-monitoring

--- a/platform/reference/platform-annotations.mdx
+++ b/platform/reference/platform-annotations.mdx
@@ -311,7 +311,7 @@ Identifies the vCluster Platform project that owns this resource.
 
 **Type:** Annotation
 
-**Example:** `loft.sh/project-namespace: "loft-p-team-alpha"`
+**Example:** `loft.sh/project-namespace: "p-team-alpha"`
 
 **Used on:** Various resources
 
@@ -375,7 +375,7 @@ The name of the SpaceInstance that created this namespace.
 
 **Type:** Label
 
-**Example:** `loft.sh/space-instance-namespace: "loft-p-default"`
+**Example:** `loft.sh/space-instance-namespace: "p-default"`
 
 **Used on:** Namespace
 
@@ -487,7 +487,7 @@ The name of the VirtualClusterInstance that created this vCluster.
 
 **Type:** Label
 
-**Example:** `loft.sh/vcluster-instance-namespace: "loft-p-default"`
+**Example:** `loft.sh/vcluster-instance-namespace: "p-default"`
 
 **Used on:** Namespace, Pod
 
@@ -523,7 +523,7 @@ The name of the tenant cluster an object is associated with.
 
 **Type:** Label
 
-**Example:** `platform.vcluster.com/vcluster-instance-namespace: "loft-p-default"`
+**Example:** `platform.vcluster.com/vcluster-instance-namespace: "p-default"`
 
 **Used on:** Resources associated with vCluster instances
 

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -148,7 +148,7 @@ The platform access key can only be provided as a Kubernetes Secret. You can fin
 Create a Helm chart that deploys the VirtualClusterInstance directly, allowing the Platform to manage the vCluster from creation. This approach is ideal when you want Helm to deploy the CRD but let the Platform handle the actual vCluster.
 
 ```yaml title="templates/virtualclusterinstance.yaml"
-apiVersion: storage.loft.sh/v1
+apiVersion: management.loft.sh/v1
 kind: VirtualClusterInstance
 metadata:
   name: {{ .Values.name }}
@@ -176,7 +176,7 @@ The Platform must create and manage the namespace when `external: false`. Pre-ex
 For [GitOps deployments](/docs/platform/install/gitops), create the [VirtualClusterInstance](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx) directly in your Git repository. Tools like [Argo CD](/docs/platform/integrations/argocd) or Flux will apply the CRD, and the Platform will manage the tenant cluster:
 
 ```yaml title="gitops/vcluster-instance.yaml"
-apiVersion: storage.loft.sh/v1
+apiVersion: management.loft.sh/v1
 kind: VirtualClusterInstance
 metadata:
   name: gitops-vcluster
@@ -273,7 +273,7 @@ kubectl get virtualclusterinstances.storage.loft.sh [[VAR:NAME:vc-name]] \\
 vcluster list --driver=platform
 
 # Access Platform UI
-vcluster platform ui`}
+vcluster ui`}
   language="bash"
 />
 


### PR DESCRIPTION
# Content Description

Fixes three categories of outdated content found by a support engineer (DOC-1510): wrong API group (`storage.loft.sh/v1` → `management.loft.sh/v1`) on `VirtualClusterInstance`, `ArgoCDApplicationTemplate`, and `ArgoCDApplication` resources; wrong namespace prefix (`loft-p-` → `p-`) in examples and prose; and a non-existent CLI command (`vcluster platform ui` → `vcluster platform start`).

## Preview Link 
- https://deploy-preview-2292--vcluster-docs-site.netlify.app/docs/platform/next/how-to/gitops-end-to-end
- https://deploy-preview-2292--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/virtual-clusters/add-virtual-clusters

A few other pages as well that search identified. These were the two called out in the original ticket.


## Internal Reference

Closes DOC-1510


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs