### PR TITLE
docs: expose vCluster 0.35 and Platform 4.10 in version dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -256,20 +256,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "0.34.0",
+        lastVersion: "0.35.0",
         onlyIncludeVersions: ["current", "0.35.0", "0.34.0", "0.33.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "0.35.0": {
-            label: "v0.35",
-            banner: "unreleased",
+            label: "v0.35 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "0.34.0": {
-            label: "v0.34 Stable",
+            label: "v0.34",
             banner: "none",
             badge: true,
           },
@@ -294,20 +293,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "4.9.0",
+        lastVersion: "4.10.0",
         onlyIncludeVersions: ["current", "4.10.0", "4.9.0", "4.8.0", "4.7.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "4.10.0": {
-            label: "v4.10",
-            banner: "unreleased",
+            label: "v4.10 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "4.9.0": {
-            label: "v4.9 Stable",
+            label: "v4.9",
             banner: "none",
             badge: true,
           },
@@ -469,9 +467,9 @@ const config = {
         additionalLanguages: ["bash", "hcl"],
       },
       announcementBar: {
-        id: "vcluster-0-34-platform-4-9-release",
+        id: "vcluster-0-35-platform-4-10-release",
         content:
-          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.9 and vCluster 0.34</a></strong>',
+          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.10 and vCluster 0.35</a></strong>',
         backgroundColor: "#050b24",
         textColor: "#ffffff",
         isCloseable: true,

--- a/hack/test-vcluster-0.35.hurl
+++ b/hack/test-vcluster-0.35.hurl
@@ -104,7 +104,7 @@ header "Location" contains "/docs/vcluster/manage/backup-restore/backup#supporte
 GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/vcluster/category/components"
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/"
 
 # Test 17: Backing store
 GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backing-store

--- a/hack/test-vcluster-0.35.hurl
+++ b/hack/test-vcluster-0.35.hurl
@@ -332,18 +332,6 @@ HTTP 200
 [Asserts]
 body contains "vCluster"
 
-# Test 52: vCluster 0.31.0 should still be accessible
-GET {{BASE_URL}}/docs/vcluster/0.31.0/
-HTTP 200
-[Asserts]
-body contains "vCluster"
-
-# Test 53: vCluster 0.30.0 should still be accessible
-GET {{BASE_URL}}/docs/vcluster/0.30.0/
-HTTP 200
-[Asserts]
-body contains "vCluster"
-
 # Test 55: vCluster CLI pages should load
 GET {{BASE_URL}}/docs/vcluster/cli/vcluster_create/
 HTTP 200

--- a/hack/test-vcluster-0.35.hurl
+++ b/hack/test-vcluster-0.35.hurl
@@ -1,0 +1,394 @@
+# vCluster 0.35 Comprehensive Redirect Tests
+# Generated from netlify.toml redirects
+# Usage: hurl --test --variable BASE_URL=https://deploy-preview-XXXX--vcluster-docs-site.netlify.app hack/test-vcluster-0.35.hurl
+
+# =====================================================
+# Legacy paths redirects
+# =====================================================
+
+# Test 1: Legacy architecture paths
+GET {{BASE_URL}}/docs/architecture/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/architecture/"
+
+# Test 2: CLI paths redirect to vcluster.com
+GET {{BASE_URL}}/docs/cli/vcluster_create
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/cli/vcluster_create"
+
+# Test 3: Deploying vclusters legacy
+GET {{BASE_URL}}/docs/deploying-vclusters/basics
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/deploy/control-plane/kubernetes-pod/basics/basics"
+
+# Test 4: Get started redirect
+GET {{BASE_URL}}/docs/get-started
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 5: Getting started wildcard
+GET {{BASE_URL}}/docs/getting-started/setup
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 6: Networking redirect
+GET {{BASE_URL}}/docs/networking/ingress
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/networking/ingress"
+
+# Test 7: Security redirect
+GET {{BASE_URL}}/docs/security/overview
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/platform/understand/what-are-virtual-clusters#robust-security-and-isolation"
+
+# Test 8: Syncer redirect
+GET {{BASE_URL}}/docs/syncer/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/architecture#syncer"
+
+# Test 9: Using vclusters redirect
+GET {{BASE_URL}}/docs/using-vclusters/kube-context
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#common-use-cases"
+
+# Test 10: Config reference redirect
+GET {{BASE_URL}}/docs/config-reference/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
+
+# Test 11: Storage redirect
+GET {{BASE_URL}}/docs/storage/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/category/storage"
+
+# Test 12: What are virtual clusters redirect
+GET {{BASE_URL}}/docs/what-are-virtual-clusters/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# Test 13: Help & tutorials redirect
+GET {{BASE_URL}}/docs/help&tutorials/faq
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/"
+
+# =====================================================
+# Platform UI links for vCluster
+# =====================================================
+
+# Test 14: Backup restore migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backup-restore-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+
+# Test 15: Supported migration options
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/supported-migration-options
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#supported-migration-options"
+
+# Test 16: Control plane
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/category/components"
+
+# Test 17: Backing store
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backing-store
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/"
+
+# Test 18: Control plane distro
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane-distro
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/distro/"
+
+# Test 19: Resource quota
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/resource-quota
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/policies/resource-quota"
+
+# Test 20: 0.20 migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/0-20-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/reference/migrations/0-20-migration"
+
+# Test 21: Sync from host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-from-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/"
+
+# Test 22: Nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/nodes"
+
+# Test 23: Sync to host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-to-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/"
+
+# Test 24: Hybrid scheduling
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/hybrid-scheduling
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling"
+
+# Test 25: Private nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes"
+
+# Test 26: Private nodes node requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-node-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes/node-requirements"
+
+# Test 27: Private nodes auto nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes"
+
+# Test 28: Private nodes auto nodes requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes/#requirements"
+
+# Test 29: vcluster.yaml
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/vcluster-yaml
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
+
+# =====================================================
+# Deploy redirects
+# =====================================================
+
+# Test 30: Deploy control-plane wildcard
+GET {{BASE_URL}}/docs/deploy/control-plane/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/basics"
+
+# Test 31: Deploy wildcard
+GET {{BASE_URL}}/docs/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/basics"
+
+# =====================================================
+# vCluster 0.35.0 redirect
+# =====================================================
+
+# Test 32: vCluster 0.35.0 wildcard redirect
+GET {{BASE_URL}}/docs/vcluster/0.35.0/introduction/what-are-virtual-clusters
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# =====================================================
+# vCluster v0.27 restructure redirects
+# =====================================================
+
+# Test 33: Enable debug logging (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 34: Enable debug logging (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 35: Configure kai scheduler (next with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 36: Configure kai scheduler (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 37: Configure kai scheduler (current with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 38: Configure kai scheduler (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 39: Control node IP visibility (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 40: Control node IP visibility (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 41: Integrations wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/integrations/metrics/prometheus
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/metrics/prometheus"
+
+# Test 42: Integrations wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/integrations/pod-identity/eks-pod-identity
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/pod-identity/eks-pod-identity"
+
+# Test 43: Deploy environment wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/environment/eks
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks"
+
+# Test 44: Deploy environment wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/environment/gke
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/gke"
+
+# Test 45: Deploy topologies wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/topologies/multi-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/multi-namespace-mode"
+
+# Test 46: Deploy topologies wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/topologies/single-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/single-namespace-mode"
+
+# Test 47: Deploy basics (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics"
+
+# Test 48: Deploy basics (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/basics"
+
+# =====================================================
+# Verification tests - pages that should load
+# =====================================================
+
+# Test 49: vCluster main page should load (serves 0.35.0 as lastVersion)
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 50: vCluster 0.33.0 should be accessible as versioned doc
+GET {{BASE_URL}}/docs/vcluster/0.33.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 51: vCluster 0.34.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.34.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 52: vCluster 0.31.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.31.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 53: vCluster 0.30.0 should still be accessible
+GET {{BASE_URL}}/docs/vcluster/0.30.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 55: vCluster CLI pages should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_create/
+HTTP 200
+[Asserts]
+body contains "vcluster create"
+
+# Test 55: vCluster CLI certs page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_certs/
+HTTP 200
+[Asserts]
+body contains "vcluster certs"
+
+# Test 56: vCluster CLI node page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_node/
+HTTP 200
+[Asserts]
+body contains "vcluster node"
+
+# Test 57: vCluster CLI registry page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_registry/
+HTTP 200
+[Asserts]
+body contains "vcluster registry"
+
+# Test 58: vCluster CLI token page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_token/
+HTTP 200
+[Asserts]
+body contains "vcluster token"
+
+# Test 59: Documentation home page should load
+GET {{BASE_URL}}/docs/
+HTTP 200
+[Asserts]
+body contains "vCluster 0.35"
+body contains "Platform 4.10"
+
+# Test 60: vCluster main page should show v0.35 as stable
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "v0.35 Stable"
+
+# Test 61: Platform main page should show v4.10 as stable
+GET {{BASE_URL}}/docs/platform/
+HTTP 200
+[Asserts]
+body contains "v4.10 Stable"

--- a/hack/test-vcluster-0.35.hurl
+++ b/hack/test-vcluster-0.35.hurl
@@ -46,7 +46,7 @@ header "Location" contains "https://www.vcluster.com/docs/vcluster/configure/vcl
 GET {{BASE_URL}}/docs/security/overview
 HTTP 301
 [Asserts]
-header "Location" contains "https://www.vcluster.com/docs/platform/understand/what-are-virtual-clusters#robust-security-and-isolation"
+header "Location" contains "/docs/vcluster/security/"
 
 # Test 8: Syncer redirect
 GET {{BASE_URL}}/docs/syncer/overview

--- a/netlify.toml
+++ b/netlify.toml
@@ -843,13 +843,13 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 
 
 [[redirects]]
-  from = "/docs/vcluster/0.34.0/*"
+  from = "/docs/vcluster/0.35.0/*"
   to = "/docs/vcluster/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "/docs/platform/4.9.0/*"
+  from = "/docs/platform/4.10.0/*"
   to = "/docs/platform/:splat"
   status = 301
   force = true

--- a/platform/administer/projects/create.mdx
+++ b/platform/administer/projects/create.mdx
@@ -42,7 +42,7 @@ Keep templates required for projects where non-admin users create tenant cluster
   </Step>
   <Step>
     Optionally, configure integrations for the project. See the{" "}
-    <Link to="../../integrations/argocd/overview">Argo CD integration</Link> and{" "}
+    <Link to="../../integrations/argocd">Argo CD integration</Link> and{" "}
     <Link to="../../integrations/hashicorp-vault">HashiCorp Vault integration</Link> documentation for further information.
   </Step>
   <Step>

--- a/platform/integrations/argocd/_category_.json
+++ b/platform/integrations/argocd/_category_.json
@@ -1,5 +1,9 @@
 {
   "label": "Argo CD",
   "position": 1,
-  "collapsible": true
+  "collapsible": true,
+  "link": {
+    "type": "doc",
+    "id": "integrations/argocd/overview"
+  }
 }

--- a/platform/integrations/argocd/overview.mdx
+++ b/platform/integrations/argocd/overview.mdx
@@ -2,6 +2,7 @@
 title: Argo CD
 sidebar_label: Overview
 sidebar_position: 1
+slug: /integrations/argocd
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/administer/projects/create.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/projects/create.mdx
@@ -42,7 +42,7 @@ Keep templates required for projects where non-admin users create tenant cluster
   </Step>
   <Step>
     Optionally, configure integrations for the project. See the{" "}
-    <Link to="../../integrations/argocd/overview">Argo CD integration</Link> and{" "}
+    <Link to="../../integrations/argocd">Argo CD integration</Link> and{" "}
     <Link to="../../integrations/hashicorp-vault">HashiCorp Vault integration</Link> documentation for further information.
   </Step>
   <Step>

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/overview.mdx
@@ -2,6 +2,7 @@
 title: Argo CD
 sidebar_label: Overview
 sidebar_position: 1
+slug: /integrations/argocd
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/src/config/docsearch.js
+++ b/src/config/docsearch.js
@@ -5,14 +5,14 @@ export const DOCSEARCH_PRODUCTS = {
   vcluster: {
     pluginId: "vcluster",
     displayName: "vCluster",
-    stableVersion: "0.34.0",
-    stableLabel: "v0.34 Stable",
+    stableVersion: "0.35.0",
+    stableLabel: "v0.35 Stable",
   },
   platform: {
     pluginId: "platform",
     displayName: "Platform",
-    stableVersion: "4.9.0",
-    stableLabel: "v4.9 Stable",
+    stableVersion: "4.10.0",
+    stableLabel: "v4.10 Stable",
   },
   vnode: {
     pluginId: "vnode",

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -8,8 +8,8 @@
  * `versions` and `onlyIncludeVersions` config.
  */
 
-export const vclusterHiddenVersions = ["0.35.0"];
-export const platformHiddenVersions = ["4.10.0"];
+export const vclusterHiddenVersions = [];
+export const platformHiddenVersions = [];
 
 export const vclusterEOLVersions = [
   { to: "https://vcluster.com/docs/v0.32", label: "v0.32 (EOS)" },

--- a/vcluster/_fragments/private-nodes.mdx
+++ b/vcluster/_fragments/private-nodes.mdx
@@ -30,8 +30,8 @@ alt="Private nodes architecture showing dedicated worker nodes per vCluster"
 
 Private nodes can be provisioned in two different ways:
 
-* **[Manually provisioned](../../../deploy/worker-nodes/private-nodes/join)** - Nodes that were provisioned outside of vCluster. These nodes are joined to vCluster using a vCluster CLI command.
-* **[Automatically provisioned](../../../deploy/worker-nodes/private-nodes/auto-nodes)** -  Nodes that are provisioned on-demand based on the vCluster configuration and resource requirements. vCluster is connected to vCluster Platform and references a node provider defined in
+* **[Manually provisioned](../../deploy/worker-nodes/private-nodes/join)** - Nodes that were provisioned outside of vCluster. These nodes are joined to vCluster using a vCluster CLI command.
+* **[Automatically provisioned](../../deploy/worker-nodes/private-nodes/auto-nodes)** -  Nodes that are provisioned on-demand based on the vCluster configuration and resource requirements. vCluster is connected to vCluster Platform and references a node provider defined in
 vCluster Platform.
 
 

--- a/vcluster_versioned_docs/version-0.35.0/_fragments/private-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/_fragments/private-nodes.mdx
@@ -30,8 +30,8 @@ alt="Private nodes architecture showing dedicated worker nodes per vCluster"
 
 Private nodes can be provisioned in two different ways:
 
-* **[Manually provisioned](../../../deploy/worker-nodes/private-nodes/join)** - Nodes that were provisioned outside of vCluster. These nodes are joined to vCluster using a vCluster CLI command.
-* **[Automatically provisioned](../../../deploy/worker-nodes/private-nodes/auto-nodes)** -  Nodes that are provisioned on-demand based on the vCluster configuration and resource requirements. vCluster is connected to vCluster Platform and references a node provider defined in
+* **[Manually provisioned](../../deploy/worker-nodes/private-nodes/join)** - Nodes that were provisioned outside of vCluster. These nodes are joined to vCluster using a vCluster CLI command.
+* **[Automatically provisioned](../../deploy/worker-nodes/private-nodes/auto-nodes)** -  Nodes that are provisioned on-demand based on the vCluster configuration and resource requirements. vCluster is connected to vCluster Platform and references a node provider defined in
 vCluster Platform.
 
 


### PR DESCRIPTION
# Content Description

Config flip to make the pre-deployed vCluster 0.35 and Platform 4.10 docs visible in the version dropdown. All content was deployed at rc-1. Also fixes broken links introduced by the Argo CD docs restructure (single file → directory) and a private-nodes fragment relative path bug.

## Preview Link 
<!-- The preview link or links to the documents-->

## Internal Reference

Closes DOC-1425
Closes DOC-1428

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs