### PR TITLE
fix(sidebar): correct and add feature tier labels

### DIFF
--- a/.claude/skills/feature-label-audit/SKILL.md
+++ b/.claude/skills/feature-label-audit/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: feature-label-audit
+description: Audit and fix sidebar feature tier labels in vCluster docs. Use when verifying that sidebar badges (FREE/ENTERPRISE) match plan assignments in the plans repo, or when adding missing labels to newly documented features.
+context: fork
+---
+
+# Feature Label Audit
+
+Sidebar badges in the docs are driven by CSS classes set via frontmatter or category config. They must match the feature assignments in `~/git/vcluster/plans/`.
+
+## How the Labels Work
+
+### Setting a label
+
+On an `.mdx` page (frontmatter):
+```yaml
+sidebar_class_name: pro        # ENTERPRISE badge
+sidebar_class_name: free       # FREE badge
+sidebar_class_name: pro host-nodes  # multiple classes — only one label class allowed
+```
+
+On a category (`_category_.json`):
+```json
+{ "className": "pro" }
+{ "className": "free" }
+```
+
+The category className labels the collapsible section header only — it does **not** propagate to pages inside the category. Individual pages need their own `sidebar_class_name`.
+
+### What the badges render
+
+Defined in `src/css/sidebar.scss`:
+- `.pro` → orange "ENTERPRISE" pill
+- `.free` → dark "FREE" pill
+
+## The Plans Repo
+
+Plans live at `~/git/vcluster/plans/`:
+
+| File | Tier |
+|------|------|
+| `free.yaml` | Free |
+| `dev.yaml` | Dev (superset of free) |
+| `prod.yaml` | Prod (superset of dev) |
+| `scale.yaml` | Scale/Enterprise (superset of prod) |
+| `internal.yaml` | Internal (superset of all) |
+
+**Rule:** A feature in `free.yaml` → label `free`. A feature absent from `free.yaml` but present in any paid plan → label `pro`.
+
+## Finding the Feature Key
+
+The feature key is exposed on the page via the `FeatureTable` component:
+
+```mdx
+<FeatureTable names="vault-integration" />
+<FeatureTable names="ha-mode,regional-cluster-endpoints" />
+```
+
+The `names` attribute is the feature key to look up in the plans YAML files.
+
+Pages with `<ProAdmonition/>` but no `FeatureTable` require checking the code (see below).
+
+## Audit Workflow
+
+### 1. Find all labeled pages
+
+```bash
+# Pages with sidebar_class_name
+grep -rn "sidebar_class_name.*pro\|sidebar_class_name.*free" platform vcluster --include="*.mdx"
+
+# Categories with className
+grep -rn "\"className\"" platform vcluster --include="_category_.json"
+```
+
+### 2. Find pages with feature references but no label (missing labels)
+
+```bash
+# Pages with FeatureTable or ProAdmonition but no sidebar_class_name
+grep -rln "FeatureTable\|ProAdmonition" platform vcluster --include="*.mdx" \
+  | grep -v "_partials\|_fragments\|versioned_docs" \
+  | while read f; do
+      grep -q "sidebar_class_name" "$f" || echo "UNLABELED: $f"
+    done
+```
+
+### 3. Extract feature keys from unlabeled pages
+
+```bash
+grep -o 'names="[^"]*"' <file.mdx>
+```
+
+### 4. Check the plan tier
+
+```bash
+grep "<feature-key>" ~/git/vcluster/plans/free.yaml   # in free = label free
+grep "<feature-key>" ~/git/vcluster/plans/dev.yaml    # not in free but in dev+ = label pro
+```
+
+If the feature key appears in `free.yaml` → `free`. If absent from `free.yaml` → `pro`.
+
+### 5. Apply the label
+
+Add `sidebar_class_name: pro` (or `free`) as the last field before the closing `---` in the frontmatter.
+
+## Verifying ProAdmonition Usage
+
+`<ProAdmonition/>` shows an "Enterprise-Only Feature" callout inline. It should only appear when the surrounding content is genuinely enterprise-gated.
+
+Common issues:
+- **Imported but never used** — dead import, just remove the `import` line.
+- **Used in a sub-section of a free feature** — remove the admonition from that section.
+- **Used for a feature with no plan key** — check the vCluster OSS/Pro Go code for a license gate. Search in `~/git/vcluster/vcluster-pro/` for the feature name near `license.GetLicense()` or `currentLicense.Enabled(...)`.
+
+## Skip These
+
+- Air-gapped install pages inside a `pro`-labeled category — the category header carries the badge; individual pages don't need one.
+- API reference pages — no label needed.
+- Overview/index pages that span multiple tiers — no label needed.
+- `vcluster/introduction/oss-vs-free.mdx` — intro page.
+
+## What to Check in Code
+
+When a `ProAdmonition` has no matching `FeatureTable`, verify the gate in the Go code:
+
+```bash
+# Check if feature is in OSS or Pro repo
+grep -r "migrate\|<feature-name>" ~/git/vcluster/vcluster-pro/pkg/ | grep -i "license\|Enabled\|feature"
+
+# OSS stub pattern confirms pro-only:
+# var Foo = func(...) { return nil, NewFeatureError(...) }
+grep -r "NewFeatureError" ~/git/vcluster/vcluster/pkg/pro/
+```
+
+If the implementation lives only in `vcluster-pro/` with a license check → the `ProAdmonition` is correct and the page needs `sidebar_class_name: pro`.

--- a/.claude/skills/feature-label-audit/SKILL.md
+++ b/.claude/skills/feature-label-audit/SKILL.md
@@ -1,10 +1,35 @@
 ---
 name: feature-label-audit
-description: Audit and fix sidebar feature tier labels in vCluster docs. Use when verifying that sidebar badges (FREE/ENTERPRISE) match plan assignments in the plans repo, or when adding missing labels to newly documented features.
+description: Audit and fix the vCluster docs feature table that the FeatureTable component renders from src/data/features.yaml. Covers three facets - sidebar tier badges (FREE/ENTERPRISE) versus plan assignments in the plans repo, feature docs_url link targets, and which FeatureTable rows each page imports. Use when verifying badges, checking that feature links resolve to the right page, or confirming a page surfaces the correct rows.
 context: fork
 ---
 
-# Feature Label Audit
+# Feature Table Audit
+
+The feature comparison table (rendered by the `FeatureTable` component from `src/data/features.yaml`) drives three things in the docs, each its own audit facet:
+
+1. **Sidebar tier badges** (FREE / ENTERPRISE pills) that must match plan assignments in `~/git/vcluster/plans/`.
+2. **Feature `docs_url` link targets** that each row links to.
+3. **`<FeatureTable names="...">` row imports** that decide which rows a given page surfaces.
+
+This skill covers all three. Labels and the plans repo come first, then the link-target and row-import audits.
+
+## The feature table source (`src/data/features.yaml`)
+
+`src/data/features.yaml` is the single source the `FeatureTable` component reads. Each entry is keyed by a feature ID and carries the row label, description, category, optional `pricing`, and `docs_url`:
+
+```yaml
+ha-mode:
+  name: "High-Availability Mode"   # label shown in the table
+  description: "..."
+  category: "Deployment Modes"
+  docs_url: "/docs/platform/maintenance/reliability-scaling/high-availability"
+  pricing: "add-on"                # optional
+```
+
+Feature keys are synced from `loft-sh/admin-apis`, and tiers from `loft-sh/plans` (see the header comment in the file), so do not hand-edit keys. The `docs_url` value and which pages import which rows are docs-owned, and are what facets 2 and 3 audit.
+
+## Sidebar tier badges
 
 Sidebar badges in the docs are driven by CSS classes set via frontmatter or category config. They must match the feature assignments in `~/git/vcluster/plans/`.
 
@@ -132,3 +157,47 @@ grep -r "NewFeatureError" ~/git/vcluster/vcluster/pkg/pro/
 ```
 
 If the implementation lives only in `vcluster-pro/` with a license check → the `ProAdmonition` is correct and the page needs `sidebar_class_name: pro`.
+
+## Audit: `docs_url` link targets
+
+Every `docs_url` in `features.yaml` should resolve to a real page whose topic matches the feature.
+
+**URL to file mapping** (site baseUrl is `/docs`):
+- `/docs/vcluster/PATH` maps to `vcluster/PATH.mdx` or `vcluster/PATH/README.mdx`
+- `/docs/platform/PATH` maps to `platform/PATH.mdx` or `platform/PATH/README.mdx`
+
+**Three gotchas that make a link look fine but break:**
+- **`slug:` overrides.** A page can set `slug:` in frontmatter, so the file path is not the served URL. If the literal path file is missing, grep for a `slug:` that resolves to the URL before calling the link broken (this is how `air-gapped` and `standalone` resolve).
+- **Anchors.** `#foo` must match a heading (slugified: lowercase, spaces to hyphens) or an explicit `{#id}`. A valid page with a dead anchor still loads, it just lands at the top.
+- **Moved pages.** A page relocating under a new parent (for example into `configure/platform-configs/`) silently breaks the old `docs_url`; nothing redirects.
+
+Existence, slug, and anchor checks:
+```bash
+ls vcluster/PATH.mdx platform/PATH.mdx 2>/dev/null            # literal path
+grep -rl "^slug:.*PATH" platform vcluster --include="*.mdx"   # slug fallback
+grep -n "{#anchor-id}\|^#\+ Heading Text" path/to/page.mdx    # anchor
+```
+
+**Orphaned partials.** Some config reference partials (for example `_partials/config/experimental/genericSync.mdx`) carry valid `{#id}` anchors but are imported into no page, so a `docs_url` pointing at that anchor never resolves. Confirm something imports the partial:
+```bash
+grep -rln "experimental/genericSync" platform vcluster --include="*.mdx" | grep -v versioned
+```
+If nothing imports it, the fix is to create the page (mirroring a sibling page that imports its partial), not to tweak the link.
+
+## Audit: `<FeatureTable names="...">` row imports
+
+A page's `<FeatureTable>` renders the row(s) named in `names`. The classic bug is a page importing the wrong row (the HA page once imported `platform-external-db` instead of `ha-mode`).
+
+List every usage:
+```bash
+grep -rn "<FeatureTable" platform vcluster --include="*.mdx" | grep -v versioned
+```
+`names="all"` on the comparison pages (`oss-vs-free.mdx`, `what-are-virtual-clusters.mdx`) is intentional and renders the whole table.
+
+**The check** is a loose bidirectional consistency with each row's canonical `docs_url`: for `<FeatureTable names="X">` on page P, look up X's `docs_url`. If it points somewhere other than P, P is surfacing a row that belongs elsewhere. Treat that as a smell, then judge:
+
+- Row's `docs_url` is a clearly unrelated page (deletion page showing the Auto Sleep row) → wrong row, fix `names` or drop the table.
+- Two pages import the same row → fine if both genuinely discuss the feature; just pick which page owns the canonical `docs_url`.
+- A row's `docs_url` points at page P but no page imports it → the row surfaces nowhere; decide whether P should show it.
+
+**The invariant:** a page may surface any row it genuinely discusses, but every row must still have one sensible canonical `docs_url`.

--- a/.claude/skills/feature-table-audit/SKILL.md
+++ b/.claude/skills/feature-table-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: feature-label-audit
+name: feature-table-audit
 description: Audit and fix the vCluster docs feature table that the FeatureTable component renders from src/data/features.yaml. Covers three facets - sidebar tier badges (FREE/ENTERPRISE) versus plan assignments in the plans repo, feature docs_url link targets, and which FeatureTable rows each page imports. Use when verifying badges, checking that feature links resolve to the right page, or confirming a page surfaces the correct rows.
 context: fork
 ---
@@ -27,7 +27,9 @@ ha-mode:
   pricing: "add-on"                # optional
 ```
 
-Feature keys are synced from `loft-sh/admin-apis`, and tiers from `loft-sh/plans` (see the header comment in the file), so do not hand-edit keys. The `docs_url` value and which pages import which rows are docs-owned, and are what facets 2 and 3 audit.
+Feature keys are synced from `loft-sh/admin-apis`, and tiers from `loft-sh/plans` (see the header comment in the file), so do not hand-edit keys. The `docs_url` value is the docs-owned lever you audit, and it drives both the link target (facet 2) and the canonical FeatureTable placement (facet 3).
+
+**Critical:** `docs_url` is the source of truth for *where a feature's `<FeatureTable>` lives*. `scripts/sync-feature-tables.js` maps each feature's `docs_url` (anchor stripped) to a file and inserts/updates the `<FeatureTable>` on that page. `npm run validate-feature-tables` runs it with `--dry-run` and the `validate-feature-tables` CI check fails if anything is out of sync. So after editing any `docs_url`, run `npm run sync-feature-tables` and commit the regenerated pages, or CI will fail.
 
 ## Sidebar tier badges
 
@@ -186,18 +188,19 @@ If nothing imports it, the fix is to create the page (mirroring a sibling page t
 
 ## Audit: `<FeatureTable names="...">` row imports
 
-A page's `<FeatureTable>` renders the row(s) named in `names`. The classic bug is a page importing the wrong row (the HA page once imported `platform-external-db` instead of `ha-mode`).
+A page's `<FeatureTable>` renders the row(s) named in `names`. There are two kinds of placement, and they are governed differently:
 
-List every usage:
+**Canonical placements are generated, not hand-audited.** For every feature with a `docs_url`, `sync-feature-tables.js` ensures the page that `docs_url` resolves to contains a `<FeatureTable>` listing that feature (multiple features sharing a `docs_url` are merged into one `names="a,b"` table). You do not place these by hand. To move or fix a canonical table, change the feature's `docs_url` and run `npm run sync-feature-tables`. To preview, run `npm run validate-feature-tables` (the same `--dry-run` the CI runs); it prints `[INSERT]` / `[UPDATE]` for anything stale and exits non-zero.
+
+The script only manages pages that are some feature's `docs_url` target. It does **not** remove `<FeatureTable>` from other pages, and resolves `docs_url` only by literal file path; targets that work via `slug:` or a directory `README.mdx` (e.g. `standalone` → `binary/`, `argo-integration`, `air-gapped-mode`) log `[WARN] No file found` and are skipped, not failed. External URLs (vnode) are skipped too.
+
+**Extra placements are the manual part.** A page may also surface a row it merely discusses, even though it is not that feature's `docs_url` target (e.g. the vcluster sleep page showing `vcp-distro-sleep-mode`). The generator leaves these alone and CI does not check them, so they need human judgment:
+
 ```bash
 grep -rn "<FeatureTable" platform vcluster --include="*.mdx" | grep -v versioned
 ```
-`names="all"` on the comparison pages (`oss-vs-free.mdx`, `what-are-virtual-clusters.mdx`) is intentional and renders the whole table.
+(`names="all"` on `oss-vs-free.mdx` and `what-are-virtual-clusters.mdx` is intentional and renders the whole table.)
 
-**The check** is a loose bidirectional consistency with each row's canonical `docs_url`: for `<FeatureTable names="X">` on page P, look up X's `docs_url`. If it points somewhere other than P, P is surfacing a row that belongs elsewhere. Treat that as a smell, then judge:
+For each, check the named row against the page topic. The classic bug is a wrong row — the HA page once imported `platform-external-db` instead of `ha-mode`, and a deletion page imported the Auto Sleep row. Fix by correcting `names` or dropping the table.
 
-- Row's `docs_url` is a clearly unrelated page (deletion page showing the Auto Sleep row) → wrong row, fix `names` or drop the table.
-- Two pages import the same row → fine if both genuinely discuss the feature; just pick which page owns the canonical `docs_url`.
-- A row's `docs_url` points at page P but no page imports it → the row surfaces nowhere; decide whether P should show it.
-
-**The invariant:** a page may surface any row it genuinely discusses, but every row must still have one sensible canonical `docs_url`.
+**The invariant:** a page may surface any row it genuinely discusses, but every row must have one sensible canonical `docs_url`, and the canonical table placement follows from that `docs_url` automatically.

--- a/platform/administer/authentication/oidc-provider.mdx
+++ b/platform/administer/authentication/oidc-provider.mdx
@@ -2,6 +2,7 @@
 title: Use the vCluster Platform as an OIDC provider
 sidebar_label: vCluster Platform as OIDC provider
 sidebar_position: 2
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform/administer/bare-metal/overview.mdx
+++ b/platform/administer/bare-metal/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform/administer/clusters/advanced/multi-region/overview.mdx
+++ b/platform/administer/clusters/advanced/multi-region/overview.mdx
@@ -4,6 +4,7 @@ sidebar_position: 1
 title: Overview
 description: Deploy vCluster Platform across multiple AWS regions with shared database, latency-based DNS failover, and regional ALB ingress.
 toc_max_heading_level: 3
+sidebar_class_name: pro
 ---
 
 import VersionBadge from '@site/src/components/VersionBadge';

--- a/platform/administer/clusters/advanced/regional-cluster-endpoints.mdx
+++ b/platform/administer/clusters/advanced/regional-cluster-endpoints.mdx
@@ -2,6 +2,7 @@
 title: Regional Cluster Endpoints
 sidebar_label: Regional Cluster Endpoints
 sidebar_position: 12
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform/administer/clusters/connect-cluster.mdx
+++ b/platform/administer/clusters/connect-cluster.mdx
@@ -2,6 +2,7 @@
 title: Connect a Cluster
 sidebar_label: Connect a Cluster
 sidebar_position: 2
+sidebar_class_name: free
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform/administer/connector/database.mdx
+++ b/platform/administer/connector/database.mdx
@@ -3,6 +3,7 @@ title: Database Connector
 sidebar_label: Database
 sidebar_position: 1
 description: Learn how to use Database Connectors with the platform to manage backing stores for multiple tenant clusters.
+sidebar_class_name: pro
 ---
 
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';

--- a/platform/administer/node-providers/bcm.mdx
+++ b/platform/administer/node-providers/bcm.mdx
@@ -2,6 +2,7 @@
 title: Nvidia Base Command Manager
 sidebar_label: Nvidia Base Command Manager
 sidebar_position: 4
+sidebar_class_name: pro
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -2,6 +2,7 @@
 title: KubeVirt
 sidebar_label: KubeVirt
 sidebar_position: 3
+sidebar_class_name: free
 ---
 
 

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -2,6 +2,7 @@
 title: Metal3
 sidebar_label: Metal3
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform/administer/node-providers/terraform.mdx
+++ b/platform/administer/node-providers/terraform.mdx
@@ -2,6 +2,7 @@
 title: Terraform
 sidebar_label: Terraform
 sidebar_position: 2
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform/administer/projects/quotas.mdx
+++ b/platform/administer/projects/quotas.mdx
@@ -2,6 +2,7 @@
 title: Manage Quotas
 sidebar_label: Quotas
 sidebar_position: 3
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform/administer/templates/versioning.mdx
+++ b/platform/administer/templates/versioning.mdx
@@ -2,6 +2,7 @@
 title: Versioning Templates
 sidebar_label: Versioning
 sidebar_position: 4
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, {Step} from "@site/src/components/Flow";

--- a/platform/install/environments/aws.mdx
+++ b/platform/install/environments/aws.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 import Flow, { Step } from '@site/src/components/Flow';

--- a/platform/install/environments/azure.mdx
+++ b/platform/install/environments/azure.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 

--- a/platform/integrations/argocd/legacy.mdx
+++ b/platform/integrations/argocd/legacy.mdx
@@ -2,6 +2,7 @@
 title: Argo CD (legacy)
 sidebar_label: Argo CD (legacy)
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/integrations/argocd/overview.mdx
+++ b/platform/integrations/argocd/overview.mdx
@@ -3,6 +3,7 @@ title: Argo CD
 sidebar_label: Overview
 sidebar_position: 1
 slug: /integrations/argocd
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform/integrations/hashicorp-vault.mdx
+++ b/platform/integrations/hashicorp-vault.mdx
@@ -2,6 +2,7 @@
 title: HashiCorp Vault Secret Sync
 sidebar_label: HashiCorp Vault
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Button from "@site/src/components/Button";

--- a/platform/maintenance/monitoring/central-hostpath-mapper.mdx
+++ b/platform/maintenance/monitoring/central-hostpath-mapper.mdx
@@ -2,6 +2,7 @@
 title: Central HostPath Mapper
 sidebar_label: Central HostPath Mapper
 sidebar_position: 6
+sidebar_class_name: free
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/reliability-scaling/high-availability.mdx
+++ b/platform/maintenance/reliability-scaling/high-availability.mdx
@@ -3,6 +3,7 @@ title: High Availability Installation
 sidebar_label: High Availability
 sidebar_position: 5
 description: Learn how to configure and run the vCluster Platform in high availability mode with multiple replicas.
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform/use-platform/machines/overview.mdx
+++ b/platform/use-platform/machines/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform/use-platform/namespaces/key-features/sleep-mode.mdx
+++ b/platform/use-platform/namespaces/key-features/sleep-mode.mdx
@@ -2,6 +2,7 @@
 title: Auto Sleep & Auto Delete
 sidebar_label: Auto Sleep & Auto Delete
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform/use-platform/secrets/secret-sync.mdx
+++ b/platform/use-platform/secrets/secret-sync.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sync Secrets
 sidebar_position: 4
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform_versioned_docs/version-4.10.0/administer/authentication/oidc-provider.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/authentication/oidc-provider.mdx
@@ -2,6 +2,7 @@
 title: Use the vCluster Platform as an OIDC provider
 sidebar_label: vCluster Platform as OIDC provider
 sidebar_position: 2
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform_versioned_docs/version-4.10.0/administer/bare-metal/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/bare-metal/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/multi-region/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/multi-region/overview.mdx
@@ -4,6 +4,7 @@ sidebar_position: 1
 title: Overview
 description: Deploy vCluster Platform across multiple AWS regions with shared database, latency-based DNS failover, and regional ALB ingress.
 toc_max_heading_level: 3
+sidebar_class_name: pro
 ---
 
 import VersionBadge from '@site/src/components/VersionBadge';

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/regional-cluster-endpoints.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/regional-cluster-endpoints.mdx
@@ -2,6 +2,7 @@
 title: Regional Cluster Endpoints
 sidebar_label: Regional Cluster Endpoints
 sidebar_position: 12
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/connect-cluster.mdx
@@ -2,6 +2,7 @@
 title: Connect a Cluster
 sidebar_label: Connect a Cluster
 sidebar_position: 2
+sidebar_class_name: free
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform_versioned_docs/version-4.10.0/administer/connector/database.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/connector/database.mdx
@@ -3,6 +3,7 @@ title: Database Connector
 sidebar_label: Database
 sidebar_position: 1
 description: Learn how to use Database Connectors with the platform to manage backing stores for multiple tenant clusters.
+sidebar_class_name: pro
 ---
 
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/bcm.mdx
@@ -2,6 +2,7 @@
 title: Nvidia Base Command Manager
 sidebar_label: Nvidia Base Command Manager
 sidebar_position: 4
+sidebar_class_name: pro
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/kubevirt.mdx
@@ -2,6 +2,7 @@
 title: KubeVirt
 sidebar_label: KubeVirt
 sidebar_position: 3
+sidebar_class_name: free
 ---
 
 

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/metal3.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/metal3.mdx
@@ -2,6 +2,7 @@
 title: Metal3
 sidebar_label: Metal3
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/terraform.mdx
@@ -2,6 +2,7 @@
 title: Terraform
 sidebar_label: Terraform
 sidebar_position: 2
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform_versioned_docs/version-4.10.0/administer/projects/quotas.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/projects/quotas.mdx
@@ -2,6 +2,7 @@
 title: Manage Quotas
 sidebar_label: Quotas
 sidebar_position: 3
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.10.0/administer/templates/versioning.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/templates/versioning.mdx
@@ -2,6 +2,7 @@
 title: Versioning Templates
 sidebar_label: Versioning
 sidebar_position: 4
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.10.0/administer/virtual-machines/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/virtual-machines/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, {Step} from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.10.0/install/environments/aws.mdx
+++ b/platform_versioned_docs/version-4.10.0/install/environments/aws.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 import Flow, { Step } from '@site/src/components/Flow';

--- a/platform_versioned_docs/version-4.10.0/install/environments/azure.mdx
+++ b/platform_versioned_docs/version-4.10.0/install/environments/azure.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 

--- a/platform_versioned_docs/version-4.10.0/install/environments/gcp.mdx
+++ b/platform_versioned_docs/version-4.10.0/install/environments/gcp.mdx
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '@site/vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx';
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/legacy.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/legacy.mdx
@@ -2,6 +2,7 @@
 title: Argo CD (legacy)
 sidebar_label: Argo CD (legacy)
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/overview.mdx
@@ -3,6 +3,7 @@ title: Argo CD
 sidebar_label: Overview
 sidebar_position: 1
 slug: /integrations/argocd
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/integrations/hashicorp-vault.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/hashicorp-vault.mdx
@@ -2,6 +2,7 @@
 title: HashiCorp Vault Secret Sync
 sidebar_label: HashiCorp Vault
 sidebar_position: 5
+sidebar_class_name: pro
 ---
 
 import Button from "@site/src/components/Button";

--- a/platform_versioned_docs/version-4.10.0/maintenance/monitoring/central-hostpath-mapper.mdx
+++ b/platform_versioned_docs/version-4.10.0/maintenance/monitoring/central-hostpath-mapper.mdx
@@ -2,6 +2,7 @@
 title: Central HostPath Mapper
 sidebar_label: Central HostPath Mapper
 sidebar_position: 6
+sidebar_class_name: free
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform_versioned_docs/version-4.10.0/maintenance/reliability-scaling/high-availability.mdx
+++ b/platform_versioned_docs/version-4.10.0/maintenance/reliability-scaling/high-availability.mdx
@@ -3,6 +3,7 @@ title: High Availability Installation
 sidebar_label: High Availability
 sidebar_position: 5
 description: Learn how to configure and run the vCluster Platform in high availability mode with multiple replicas.
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/use-platform/machines/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/machines/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import FeatureTable from '@site/src/components/FeatureTable';

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/sleep-mode.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/sleep-mode.mdx
@@ -2,6 +2,7 @@
 title: Auto Sleep & Auto Delete
 sidebar_label: Auto Sleep & Auto Delete
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';

--- a/platform_versioned_docs/version-4.10.0/use-platform/secrets/secret-sync.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/secrets/secret-sync.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sync Secrets
 sidebar_position: 4
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -2,12 +2,11 @@
 title: CoreDNS
 sidebar_label: coredns
 sidebar_position: 3
-sidebar_class_name: pro host-nodes
+sidebar_class_name: host-nodes
 description: Configure CoreDNS.
 ---
 
 import CoreDNS from '../../../../_partials/config/controlPlane/coredns.mdx'
-import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Flow, { Step } from "@site/src/components/Flow";
@@ -55,8 +54,6 @@ Configuration changes applied directly to CoreDNS are not persistent. They get o
 
 ### Deploy embedded CoreDNS
 <TenancySupport hostNodes="true" />
-
-<ProAdmonition/>
 
 The embedded CoreDNS feature allows you to run CoreDNS as part of the syncer, which saves the resources of an external CoreDNS pod. This consolidates all tenant cluster components into a single pod and optimizes resource allocation. It also enables advanced DNS features like custom hostname mapping, cross-vCluster service resolution, and communication with control plane cluster services.
 
@@ -132,10 +129,7 @@ controlPlane:
 
 <TenancySupport hostNodes="true" />
 
-<ProAdmonition/>
-
-
-```yaml title="Embedded CoreDNS enterprise configuration"
+```yaml title="Embedded CoreDNS configuration"
 controlPlane:
   coredns:
     enabled: true

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -3,12 +3,11 @@ title: Custom resources
 sidebar_label: customResources
 sidebar_position: 1
 toc_max_heading_level: 3
-sidebar_class_name: pro host-nodes
+sidebar_class_name: host-nodes
 description: Configuration for syncing custom resources from host
 ---
 
 import CustomResourceDefinitions from '../../../../_partials/config/sync/fromHost/customResources.mdx'
-import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import NamespacedCustomResourcesExample from '../../../../_fragments/sync-from-host-namespaced-custom-resources-example.mdx'
 import VersionedCrdSyncing from '../../../../_fragments/sync/versioned-crd-syncing.mdx'
 import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
@@ -16,8 +15,6 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 
 <TenancySupport hostNodes="true" />
-
-<ProAdmonition/>
 
 # Sync custom resources from the control plane cluster to the tenant cluster
 

--- a/vcluster/key-features/sleep.mdx
+++ b/vcluster/key-features/sleep.mdx
@@ -2,6 +2,7 @@
 title: Auto Sleep
 sidebar_label: Auto Sleep
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/vcluster/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster/manage/migrate-etcd-backing-store.mdx
@@ -3,6 +3,7 @@ title: Migrate etcd backing store
 sidebar_label: Migrate etcd backing store
 sidebar_position: 7
 description: Migrate your vCluster from deployed etcd to embedded etcd without data loss.
+sidebar_class_name: pro
 ---
 
 import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'

--- a/vcluster/third-party-integrations/rancher/install-rancher-integration.mdx
+++ b/vcluster/third-party-integrations/rancher/install-rancher-integration.mdx
@@ -2,12 +2,12 @@
 title: Install the Rancher integration in vCluster
 sidebar_label: Rancher Integration
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem'
 import Flow, { Step } from '@site/src/components/Flow'
-import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 
 
 
@@ -191,8 +191,6 @@ To upgrade the extension to a newer version, follow the [Rancher extension updat
 ## Remove virtual node resources
 
 Since tenant clusters share physical nodes with the downstream cluster they run on, Rancher may count tenant cluster nodes toward your resource usage. To prevent this, use sync patches to zero out the CPU capacity reported by the tenant cluster's nodes.
-
-<ProAdmonition/>
 
 Add the following to your `vcluster.yaml` to zero out node CPU capacity:
 

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -2,12 +2,11 @@
 title: CoreDNS
 sidebar_label: coredns
 sidebar_position: 3
-sidebar_class_name: pro host-nodes
+sidebar_class_name: host-nodes
 description: Configure CoreDNS.
 ---
 
 import CoreDNS from '../../../../_partials/config/controlPlane/coredns.mdx'
-import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Flow, { Step } from "@site/src/components/Flow";
@@ -56,7 +55,6 @@ Configuration changes applied directly to CoreDNS are not persistent. They get o
 ### Deploy embedded CoreDNS
 <TenancySupport hostNodes="true" />
 
-<ProAdmonition/>
 
 The embedded CoreDNS feature allows you to run CoreDNS as part of the syncer, which saves the resources of an external CoreDNS pod. This consolidates all tenant cluster components into a single pod and optimizes resource allocation. It also enables advanced DNS features like custom hostname mapping, cross-vCluster service resolution, and communication with control plane cluster services.
 
@@ -132,10 +130,9 @@ controlPlane:
 
 <TenancySupport hostNodes="true" />
 
-<ProAdmonition/>
 
 
-```yaml title="Embedded CoreDNS enterprise configuration"
+```yaml title="Embedded CoreDNS configuration"
 controlPlane:
   coredns:
     enabled: true

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -3,12 +3,11 @@ title: Custom resources
 sidebar_label: customResources
 sidebar_position: 1
 toc_max_heading_level: 3
-sidebar_class_name: pro host-nodes
+sidebar_class_name: host-nodes
 description: Configuration for syncing custom resources from host
 ---
 
 import CustomResourceDefinitions from '../../../../_partials/config/sync/fromHost/customResources.mdx'
-import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import NamespacedCustomResourcesExample from '../../../../_fragments/sync-from-host-namespaced-custom-resources-example.mdx'
 import VersionedCrdSyncing from '../../../../_fragments/sync/versioned-crd-syncing.mdx'
 import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
@@ -17,7 +16,6 @@ import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-<ProAdmonition/>
 
 # Sync custom resources from the control plane cluster to the tenant cluster
 

--- a/vcluster_versioned_docs/version-0.35.0/key-features/sleep.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/key-features/sleep.mdx
@@ -2,6 +2,7 @@
 title: Auto Sleep
 sidebar_label: Auto Sleep
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/vcluster_versioned_docs/version-0.35.0/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/manage/migrate-etcd-backing-store.mdx
@@ -3,6 +3,7 @@ title: Migrate etcd backing store
 sidebar_label: Migrate etcd backing store
 sidebar_position: 7
 description: Migrate your vCluster from deployed etcd to embedded etcd without data loss.
+sidebar_class_name: pro
 ---
 
 import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'

--- a/vcluster_versioned_docs/version-0.35.0/third-party-integrations/rancher/install-rancher-integration.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/third-party-integrations/rancher/install-rancher-integration.mdx
@@ -2,12 +2,12 @@
 title: Install the Rancher integration in vCluster
 sidebar_label: Rancher Integration
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem'
 import Flow, { Step } from '@site/src/components/Flow'
-import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 
 
 
@@ -192,7 +192,6 @@ To upgrade the extension to a newer version, follow the [Rancher extension updat
 
 Since tenant clusters share physical nodes with the downstream cluster they run on, Rancher may count tenant cluster nodes toward your resource usage. To prevent this, use sync patches to zero out the CPU capacity reported by the tenant cluster's nodes.
 
-<ProAdmonition/>
 
 Add the following to your `vcluster.yaml` to zero out node CPU capacity:
 


### PR DESCRIPTION
# Content Description

Audit of `sidebar_class_name` frontmatter and `_category_.json` className values against the feature assignments in the plans repo (`~/git/vcluster/plans/*.yaml`). Corrects two mislabeled pages and adds missing ENTERPRISE/FREE sidebar badges to 27 pages that had none.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2310--vcluster-docs-site.netlify.app/docs/platform/next/


## Internal Reference
Closes DOC-1513


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs