### PR TITLE
docs(doc-1515): document kyverno bring-up ordering and translated-name gotchas

### DIFF
--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -64,6 +64,16 @@ Missing `caBundle` with `failurePolicy: Fail` can make vCluster unrecoverable. T
 
 ## Kyverno example
 
+:::warning Apply Enforce-mode policies after the tenant is ready
+A Kyverno `ClusterPolicy` running on the control plane cluster in `Enforce` mode validates the resources that vCluster syncs from the tenant. This includes vCluster's own system pods, which don't carry an `app.kubernetes.io/name` label. A label-requiring policy applied before the tenant is provisioned rejects those pods, and the VirtualClusterInstance ends in `Failed`.
+
+To avoid this, do one of the following:
+
+- Apply Enforce-mode policies only after the tenant cluster reaches `Ready`.
+- Start the policy in `Audit` mode.
+- Scope the policy to exclude vCluster system namespaces and service accounts.
+:::
+
 This example ensures that all new ConfigMap resources are sent to a mutating webhook on the control plane cluster.
 
 ```yaml
@@ -105,7 +115,11 @@ centralAdmission:
 
 Any time a ConfigMap is created, the vCluster API server forwards the admission request to a proxy, which in turn calls the actual admission hook running in the control plane cluster in the `kyverno` namespace.
 
-The service providing the webhooks should not rely on the real names of the objects if they are synced on the control plane cluster (for example, pods). The requests that reach the host admission service holds the objects from the tenant cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined below).
+The service providing the webhooks should not rely on the real names of the objects if they are synced on the control plane cluster (for example, pods). The requests that reach the host admission service hold the objects from the tenant cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined above).
+
+:::warning Policies that key off name or namespace
+When vCluster syncs a tenant pod to the control plane cluster, the admission webhook fires against the translated name (`<pod>-x-<namespace>-x-<tenant>`) and the host namespace. It doesn't see the tenant's view. Policies that use `metadata.name` or the namespace for uniqueness or matching see these translated values and produce wrong results. A uniqueness or collision check (for example, no two Ingresses sharing the same host and path) sees distinct translated names and silently passes resources that actually collide. A naming-convention or length check sees the appended `-x-<namespace>-x-<tenant>` suffix and rejects tenant resources that are valid in the tenant's own view. Namespace-scoped match and exclude rules see the host namespace rather than the tenant namespace, so they apply to the wrong set of objects. Read the original tenant identifiers from the `request.options.vCluster.name` and `request.options.vCluster.namespace.metadata.name` fields documented above.
+:::
 
 The hook services do not require authentication as the proxy does not have access to the `AdmissionConfiguration` object or the files it references. Most policy engines (such as jsPolicy, Kyverno, or Gatekeeper) do not set authentication by default, so it should work with most installations.
 

--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -20,11 +20,9 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <ProAdmonition/>
 
-:::important
-You must enable `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers to use the Central Admission Control feature. For more information, see the Kubernetes [admission controllers reference](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
-:::
-
 Centralized admission control is an advanced feature for cluster admins that have custom rules that they need to apply to the tenant cluster. Cluster admins can enforce [Kubernetes admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that reference the control plane cluster or external policy services from within the tenant cluster. Examples of validating and mutating webhook based policy engines include OPA, Kyverno, and jsPolicy.
+
+This feature requires the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers to be enabled. For more information, see the Kubernetes [admission controllers reference](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
 
 :::warning
 - Central admission control is read-only after tenant cluster creation. Admins cannot bypass or alter hooks after vCluster deployment.
@@ -39,15 +37,11 @@ Central admission webhooks are different from the other policies:
 - vCluster rewrites these definitions to point to a proxy for a control plane cluster service that handles webhook requests. The host might also have webhook configurations that use this service.
 - A user can still install a webhook service or webhook configuration into the tenant cluster outside of this config, but it would run inside the tenant cluster like any other workload.
 
-:::info Namespace rewriting
-vCluster rewrites the namespace of the object (if the object is namespace scoped) to the host namespace where vCluster is running in. This is not visible to the end-user, but the admission controller is able to use things like namespace selector like usual. Some admission controllers like gatekeeper wouldn't work otherwise as they rely on the namespace to always be there in the underlying cluster. To access the virtual namespace in a webhook, you can access the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request) that holds the full virtual namespace object.
-:::
+## Access tenant identifiers in webhooks
 
-:::info Translated name of pods
-In some circumstances it might be necessary to have the translated name of a pod, which is used when this pod is created on the control plane cluster, available in a webhook running inside a tenant cluster.
-Therefore, vCluster puts the translated pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
-As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for pods.
-:::
+vCluster rewrites the namespace of a namespace-scoped object to the host namespace where vCluster runs. This is not visible to the user, but the admission controller can use mechanisms like the namespace selector as usual. Some admission controllers such as Gatekeeper rely on the namespace always being present in the underlying cluster and wouldn't work otherwise. To access the tenant namespace in a webhook, read the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request), which holds the full tenant namespace object.
+
+In some cases a webhook running inside the tenant cluster needs the translated name of a pod. This is the name used when the pod is created on the control plane cluster. vCluster puts the translated pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request). The final name is only available during the validation phase, so this only works with `validatingWebhooks` that have rules configured for pods.
 
 ## Certificate configuration
 
@@ -64,6 +58,8 @@ Missing `caBundle` with `failurePolicy: Fail` can make vCluster unrecoverable. T
 
 ## Kyverno example
 
+This example ensures that all new ConfigMap resources are sent to a mutating webhook on the control plane cluster.
+
 :::warning Apply Enforce-mode policies after the tenant is ready
 A Kyverno `ClusterPolicy` running on the control plane cluster in `Enforce` mode validates the resources that vCluster syncs from the tenant. This includes vCluster's own system pods, which don't carry an `app.kubernetes.io/name` label. A label-requiring policy applied before the tenant is provisioned rejects those pods, and the VirtualClusterInstance ends in `Failed`.
 
@@ -73,8 +69,6 @@ To avoid this, do one of the following:
 - Start the policy in `Audit` mode.
 - Scope the policy to exclude vCluster system namespaces and service accounts.
 :::
-
-This example ensures that all new ConfigMap resources are sent to a mutating webhook on the control plane cluster.
 
 ```yaml
 centralAdmission:
@@ -118,7 +112,13 @@ Any time a ConfigMap is created, the vCluster API server forwards the admission 
 The service providing the webhooks should not rely on the real names of the objects if they are synced on the control plane cluster (for example, pods). The requests that reach the host admission service hold the objects from the tenant cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined above).
 
 :::warning Policies that key off name or namespace
-When vCluster syncs a tenant pod to the control plane cluster, the admission webhook fires against the translated name (`<pod>-x-<namespace>-x-<tenant>`) and the host namespace. It doesn't see the tenant's view. Policies that use `metadata.name` or the namespace for uniqueness or matching see these translated values and produce wrong results. A uniqueness or collision check (for example, no two Ingresses sharing the same host and path) sees distinct translated names and silently passes resources that actually collide. A naming-convention or length check sees the appended `-x-<namespace>-x-<tenant>` suffix and rejects tenant resources that are valid in the tenant's own view. Namespace-scoped match and exclude rules see the host namespace rather than the tenant namespace, so they apply to the wrong set of objects. Read the original tenant identifiers from the `request.options.vCluster.name` and `request.options.vCluster.namespace.metadata.name` fields documented above.
+The admission webhook fires against the translated name (`<pod>-x-<namespace>-x-<tenant>`) and the host namespace, not the tenant's view. Policies that key off `metadata.name` or the namespace produce wrong results:
+
+- A uniqueness or collision check silently passes resources that actually collide.
+- A naming or length check rejects tenant resources that are valid in the tenant's own view.
+- Namespace-scoped match and exclude rules apply to the wrong set of objects.
+
+To read the original tenant identifiers, see [Access tenant identifiers in webhooks](#access-tenant-identifiers-in-webhooks).
 :::
 
 The hook services do not require authentication as the proxy does not have access to the `AdmissionConfiguration` object or the files it references. Most policy engines (such as jsPolicy, Kyverno, or Gatekeeper) do not set authentication by default, so it should work with most installations.


### PR DESCRIPTION
# Content Description
Adds two lab-verified gotcha callouts to the Kyverno example on the central admission control page. One warns that an Enforce-mode ClusterPolicy on the control plane cluster rejects vCluster system pods (no `app.kubernetes.io/name` label) when applied before a tenant is provisioned, landing the VirtualClusterInstance in `Failed`. The other warns that the admission webhook fires against the translated name, so policies that key off `metadata.name` or namespace misbehave unless they read the `request.options.vCluster.*` fields.

Did a full audit of the nine admonitions on the page. Folded some into prose and combined others to reduce the count and make sure the separation calls out where true attention is needed. Reduced to five page admonitions.

Also checked `platform/how-to/enforce-storage-quotas.mdx` and left it unchanged: that page runs Kyverno inside the tenant cluster (native names, not translated) and its example policies match `PersistentVolumeClaim` only, so neither gotcha applies. It already documents its own objects-before-apps ordering caveat.

**Engineering priority**: LOW (this adds user warnings, little risk to customer production deployments)
**Requested reviewer/team**: support team
**Deadline**: Docs will merge this if no identified issues on **June 25, 2026**

## Preview Link
<!-- Netlify preview is generated on this PR; link added automatically -->
https://deploy-preview-2313--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/policies/admission-control

## Internal Reference
Closes DOC-1515


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)