### PR TITLE
fix(release): gate platform pin bump on module-proxy resolution

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -133,32 +133,21 @@ jobs:
 
       # loft-enterprise's release pipeline cuts its own tag + release first
       # (which triggers our dispatch), then creates matching upstream tags
-      # in loft-sh/{agentapi,api} in subsequent steps. Without a wait, the
-      # bump step's `go mod tidy` below races the upstream tag creation
-      # and fails with `unknown revision <version>`. Empirically the gap
-      # was ~30s-2min on v4.7.3-rc.1 (2026-05-27). Polling on the GitHub
-      # API directly (not `go list`) sidesteps Go's module proxy cache,
-      # which can lag tag creation. 10s × 60 = 10 min ceiling.
-      - name: Wait for agentapi + api tags to be published
+      # in loft-sh/{agentapi,api} and lets them propagate to the Go module
+      # proxy. The bump step's `go mod tidy` below resolves both modules
+      # through GOPROXY, so it must not run until the proxy can serve the
+      # released version, not merely until the GitHub tag exists. The wait
+      # checks tag presence first (a clear "upstream never published"
+      # signal) then module-proxy resolution (the propagation race that
+      # broke platform v4.10.1 under DEVOPS-1008, where the tag existed but
+      # `go mod tidy` still reported `unknown revision`). Logic + bats
+      # coverage live in the script. 10s x 60 = 10 min ceiling per check.
+      - name: Wait for agentapi + api to resolve through the module proxy
         if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: |
-          set -eo pipefail
-          for repo in loft-sh/agentapi loft-sh/api; do
-            attempt=0
-            until gh api "repos/${repo}/git/refs/tags/${VERSION}" >/dev/null 2>&1; do
-              attempt=$((attempt + 1))
-              if [ "$attempt" -ge 60 ]; then
-                echo "::error::${repo}: tag ${VERSION} not present after 10 minutes; upstream pipeline never published it" >&2
-                exit 1
-              fi
-              echo "${repo}: waiting for tag ${VERSION} (attempt ${attempt}/60)"
-              sleep 10
-            done
-            echo "::notice::${repo}: tag ${VERSION} present (attempt ${attempt:-0})"
-          done
+        run: bash hack/release/wait-for-platform-modules.sh
 
       # The platform partials generator reflects against the loft-sh/api +
       # loft-sh/agentapi types pinned in this repo's go.mod. Without bumping

--- a/hack/release/wait-for-platform-modules.bats
+++ b/hack/release/wait-for-platform-modules.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+#
+# Tests for wait-for-platform-modules.sh. `gh` and `go` are shimmed onto
+# PATH so the poll loop is exercised deterministically without network or a
+# real release. SLEEP_SECONDS=0 keeps the suite fast; MAX_ATTEMPTS is small
+# so timeout paths finish quickly.
+#
+# Shim behaviour is driven by env vars:
+#   GH_MODE   ok | fail            (tag present | never published)
+#   GO_MODE   ok | fail | flaky:N  (resolves | never | fails N times then ok)
+# The go shim logs each `go list` invocation to $SHIM_STATE/go.log so tests
+# can assert on the queried module path and that -mod=mod was passed.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/wait-for-platform-modules.sh"
+    BIN="$(mktemp -d)"
+    SHIM_STATE="$(mktemp -d)"
+    export SHIM_STATE
+    export PATH="$BIN:$PATH"
+    export SLEEP_SECONDS=0
+    export MAX_ATTEMPTS=5
+    export GH_TOKEN=test-token
+    export GH_MODE=ok
+    export GO_MODE=ok
+    _make_gh
+    _make_go
+}
+
+teardown() {
+    rm -rf "$BIN" "$SHIM_STATE"
+}
+
+_make_gh() {
+    cat >"$BIN/gh" <<'SH'
+#!/usr/bin/env bash
+case "${GH_MODE:-ok}" in
+  fail) exit 1 ;;
+  *)    exit 0 ;;
+esac
+SH
+    chmod +x "$BIN/gh"
+}
+
+_make_go() {
+    cat >"$BIN/go" <<'SH'
+#!/usr/bin/env bash
+# Only intercept `go list -m ...`; anything else is a no-op success.
+[ "$1" = "list" ] || exit 0
+echo "GOFLAGS=${GOFLAGS} args=$*" >>"$SHIM_STATE/go.log"
+mode="${GO_MODE:-ok}"
+case "$mode" in
+  fail) exit 1 ;;
+  flaky:*)
+    n="${mode#flaky:}"
+    key="$(printf '%s' "${@: -1}" | tr -c 'A-Za-z0-9' '_')"
+    f="$SHIM_STATE/go_${key}"
+    c=0; [ -f "$f" ] && c="$(cat "$f")"
+    c=$((c + 1)); printf '%s' "$c" >"$f"
+    if [ "$c" -gt "$n" ]; then exit 0; else exit 1; fi
+    ;;
+  *) exit 0 ;;
+esac
+SH
+    chmod +x "$BIN/go"
+}
+
+@test "both phases pass when tag is present and proxy resolves" {
+    VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"loft-sh/agentapi: tag v4.10.1 present"* ]]
+    [[ "$output" == *"loft-sh/api: tag v4.10.1 present"* ]]
+    [[ "$output" == *"github.com/loft-sh/agentapi/v4: resolves at v4.10.1 through the proxy"* ]]
+    [[ "$output" == *"github.com/loft-sh/api/v4: resolves at v4.10.1 through the proxy"* ]]
+}
+
+@test "phase 2 queries the proxy with -mod=mod for both modules" {
+    VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "GOFLAGS=-mod=mod args=list -m github.com/loft-sh/agentapi/v4@v4.10.1" "$SHIM_STATE/go.log"
+    grep -q "GOFLAGS=-mod=mod args=list -m github.com/loft-sh/api/v4@v4.10.1" "$SHIM_STATE/go.log"
+}
+
+@test "tag never published → fails with upstream-pipeline error, never reaches proxy check" {
+    GH_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tag v4.10.1 not present after 5 attempts"* ]]
+    [[ "$output" == *"upstream pipeline never published it"* ]]
+    [ ! -f "$SHIM_STATE/go.log" ]
+}
+
+@test "proxy never resolves → fails with propagation error after the tag check passes" {
+    GO_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tag v4.10.1 present"* ]]
+    [[ "$output" == *"did not resolve through the module proxy after 5 attempts"* ]]
+    [[ "$output" == *"proxy propagation stalled"* ]]
+}
+
+@test "proxy lags then resolves within the attempt budget → succeeds" {
+    # Each module fails twice then resolves; MAX_ATTEMPTS=5 leaves headroom.
+    GO_MODE=flaky:2 VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"waiting for proxy to resolve v4.10.1"* ]]
+    [[ "$output" == *"resolves at v4.10.1 through the proxy"* ]]
+}
+
+@test "major version is derived from VERSION (v5 needs no code change)" {
+    VERSION=v5.2.0 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "args=list -m github.com/loft-sh/agentapi/v5@v5.2.0" "$SHIM_STATE/go.log"
+    grep -q "args=list -m github.com/loft-sh/api/v5@v5.2.0" "$SHIM_STATE/go.log"
+}
+
+@test "pre-release versions are accepted and queried verbatim" {
+    VERSION=v4.10.1-rc.1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "args=list -m github.com/loft-sh/agentapi/v4@v4.10.1-rc.1" "$SHIM_STATE/go.log"
+}
+
+@test "missing VERSION env var → exits non-zero" {
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"VERSION env var required"* ]]
+}

--- a/hack/release/wait-for-platform-modules.sh
+++ b/hack/release/wait-for-platform-modules.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# wait-for-platform-modules.sh: block until the released loft-sh/api and
+# loft-sh/agentapi module versions are actually consumable by the
+# platform-pin bump step, not merely present as GitHub tags.
+#
+# Run by handle-source-release.yml before the bump step, only for
+# platform-released events.
+#
+# Two checks, in order:
+#
+#   1. GitHub tag presence (gh api). loft-enterprise's release pipeline
+#      publishes its own release first (which fires the repository_dispatch
+#      that triggers the receiver), THEN creates the matching tags in
+#      loft-sh/{agentapi,api} a short time later. The bump step must not
+#      run before those tags exist. (DEVOPS-904.)
+#
+#   2. Module-proxy resolution (go list -m <module>@<version>). The bump
+#      step runs `go mod tidy`, which resolves api/agentapi through GOPROXY
+#      (proxy.golang.org; these modules are NOT in GOPRIVATE, which is
+#      narrowed to vcluster-pro*). The proxy caches a version only after it
+#      first fetches it from the origin, which lags tag creation. DEVOPS-1008:
+#      on platform v4.10.1 the tag check passed but `go mod tidy` still
+#      failed with `unknown revision v4.10.1` because the proxy had not
+#      cached agentapi/v4@v4.10.1 yet. Gating on tag presence first keeps the
+#      proxy request from racing ahead of the origin tag; the `go list` step
+#      then both verifies and warms the proxy, so the bump never runs ahead
+#      of propagation.
+#
+# `go list -m <module>@<version>` needs -mod=mod: this repo carries a
+# vendor/ tree, so the default -mod=vendor cannot satisfy a version query.
+#
+# Inputs (env):
+#   VERSION        Released platform version, vX.Y.Z[-pre] (required).
+#   GH_TOKEN       Token for gh api tag lookups (required at runtime; the
+#                  bats suite shims gh, so it is not needed there).
+#   MAX_ATTEMPTS   Poll attempts per check. Default 60.
+#   SLEEP_SECONDS  Delay between attempts. Default 10. (10s x 60 = 10 min
+#                  ceiling per check.)
+#
+# The major-version segment is derived from VERSION, so a future v5 cutover
+# needs no change here.
+
+set -eo pipefail
+
+: "${VERSION:?VERSION env var required}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-60}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
+
+stripped="${VERSION#v}"
+major="v${stripped%%.*}"
+
+# Phase 1: GitHub tag presence. Surfaces "upstream never published" as a
+# distinct, actionable error instead of a confusing downstream go mod error.
+for repo in loft-sh/agentapi loft-sh/api; do
+    attempt=0
+    until gh api "repos/${repo}/git/refs/tags/${VERSION}" >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::${repo}: tag ${VERSION} not present after ${MAX_ATTEMPTS} attempts; upstream pipeline never published it" >&2
+            exit 1
+        fi
+        echo "${repo}: waiting for tag ${VERSION} (attempt ${attempt}/${MAX_ATTEMPTS})"
+        sleep "$SLEEP_SECONDS"
+    done
+    echo "::notice::${repo}: tag ${VERSION} present (attempt ${attempt})"
+done
+
+# Phase 2: module-proxy resolution. This is what the bump step's `go mod
+# tidy` actually requires; checking it here keeps the bump from racing
+# proxy propagation.
+for mod in "github.com/loft-sh/agentapi/${major}" "github.com/loft-sh/api/${major}"; do
+    attempt=0
+    until GOFLAGS=-mod=mod go list -m "${mod}@${VERSION}" >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "::error::${mod}@${VERSION} did not resolve through the module proxy after ${MAX_ATTEMPTS} attempts; proxy propagation stalled" >&2
+            exit 1
+        fi
+        echo "${mod}: waiting for proxy to resolve ${VERSION} (attempt ${attempt}/${MAX_ATTEMPTS})"
+        sleep "$SLEEP_SECONDS"
+    done
+    echo "::notice::${mod}: resolves at ${VERSION} through the proxy (attempt ${attempt})"
+done


### PR DESCRIPTION
# Content Description

Fixes the `handle-source-release` receiver so a freshly released platform version no longer fails the `loft-sh/api` + `loft-sh/agentapi` pin bump when the Go module proxy has not yet cached the new version.

## Summary

On the `platform-released` v4.10.1 event, the receiver's tag-wait gate confirmed the GitHub tags existed, but the bump step's `go mod tidy` still failed with `unknown revision v4.10.1` for `agentapi/v4`. `go mod tidy` resolves these modules through `GOPROXY` (`proxy.golang.org`; they are not in `GOPRIVATE`), and the proxy caches a version only after it first fetches it from the origin, which lags tag creation. The tag gate checked the wrong thing, so the bump ran ahead of proxy propagation and the v4.10.1 docs-sync PR never opened.

## Key Changes

- New `hack/release/wait-for-platform-modules.sh`: waits for tag presence first (a clear "upstream never published" signal), then waits for module-proxy resolution via `go list -m <module>@<version>`, the exact operation the bump step depends on. Uses `-mod=mod` because the repo carries a `vendor/` tree and the default `-mod=vendor` cannot satisfy a version query. The major version is derived from the released version, so a future v5 cutover needs no code change.
- `hack/release/wait-for-platform-modules.bats`: 8 tests covering both phases passing, tag-never-published, proxy-never-resolves, proxy-lags-then-resolves, major-version derivation, pre-release versions, and missing input. `gh`/`go` are shimmed on PATH for deterministic, network-free runs.
- `.github/workflows/handle-source-release.yml`: the inline tag-only gate is replaced by a single step that runs the tested script, moving logic out of untestable YAML in line with the existing `classify-version.sh` / `run-generator.sh` convention.

## Testing

- `bats hack/release/*.bats`: 37 pass (29 existing + 8 new).
- `shellcheck hack/release/wait-for-platform-modules.sh`: clean.
- `actionlint .github/workflows/handle-source-release.yml`: clean.
- Confirmed the root cause: at the time of the failing run `agentapi/v4@v4.10.1` did not resolve through the proxy while `api/v4@v4.10.1` did; both resolve now that propagation has completed.

## Notes

- Re-running the `handle-source-release` workflow (workflow_dispatch, `platform-released`, `v4.10.1`) will open the docs-sync PR now that propagation is complete and the gate is correct.
- zizmor flags `actions/checkout@v4` and `actions/setup-go@v5` as unpinned in this workflow. Those are pre-existing on `main` and unrelated to this fix; left out of scope to keep the change focused.

## Preview Link

N/A: CI/workflow change only, no documentation pages modified.

## Internal Reference

Closes DEVOPS-1008

<!-- Do not change the line below -->
@netlify /docs
