### PR TITLE
fix(config-fields): render field cards as native details to stop toggle lockup

### DIFF
--- a/src/css/content/config-fields.scss
+++ b/src/css/content/config-fields.scss
@@ -1,5 +1,11 @@
 body .markdown .config-field {
   --docusaurus-details-decoration-color: #ccc;
+  // Config-field cards render as native <details> (see src/theme/MDXComponents.js), so
+  // the arrow sizing/transition variables Docusaurus's <Details> component used to
+  // provide on its `.details` scope are redefined here. Without these, the summary
+  // disclosure arrow and the enum-values caret lose their shape.
+  --docusaurus-details-summary-arrow-size: 0.38rem;
+  --docusaurus-details-transition: transform 200ms ease;
 
   padding: 1em 1.4em;
   border: 1px solid transparent;
@@ -92,12 +98,35 @@ body .markdown .config-field {
   summary {
     padding-left: 0;
     min-height: 2.4em;
+    // Anchor the absolutely-positioned disclosure arrow (Docusaurus's component
+    // used to set this on its own `.details > summary`).
+    position: relative;
+
+    // Config-field cards render as native <details> (see src/theme/MDXComponents.js),
+    // so suppress the browser's default disclosure marker; the rotating arrow is drawn
+    // entirely by the &::before rule below (Docusaurus's component no longer provides it).
+    list-style: none;
+    cursor: pointer;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
 
     &::before {
+      content: "";
+      position: absolute;
+      top: 0.45rem;
       left: auto;
       right: 0;
       margin-top: 0.4em;
+      // CSS-only triangle, pointing right; rotated per open/closed state below.
+      border-width: var(--docusaurus-details-summary-arrow-size);
+      border-style: solid;
+      border-color: transparent transparent transparent
+        var(--docusaurus-details-decoration-color);
       transform: rotate(90deg);
+      transition: var(--docusaurus-details-transition);
+      transform-origin: calc(var(--docusaurus-details-summary-arrow-size) / 2) 50%;
     }
 
     > * {

--- a/src/css/content/config-fields.scss
+++ b/src/css/content/config-fields.scss
@@ -86,8 +86,13 @@ body .markdown .config-field {
     }
   }
 
+  // `summary + *` targeted the description block that Docusaurus's <Details>
+  // component rendered right after the summary (its collapsibleContent wrapper).
+  // Native <details> have no wrapper, so the first sibling after the summary is the
+  // first nested field card; excluding .config-field keeps that card from being
+  // shrunk and grayed like description text.
   p,
-  summary + * {
+  summary + *:not(.config-field) {
     display: inline-block;
     font-size: 0.85rem;
     color: rgb(117, 117, 117);

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -5,8 +5,42 @@ import GlossaryTerm from "@site/src/components/GlossaryTerm";
 import PageVariables from "@site/src/components/PageVariables";
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
+// Config reference pages render each field card as <details className="config-field">.
+// Docusaurus's mdx-loader rewrites every <details> to its React-controlled <Details>
+// theme component at compile time (remark/details: "MDX 2 doesn't allow to substitute
+// html elements with the provider anymore"), so the runtime mapping that matters is
+// `Details` (capital), not lowercase `details`. That controlled component owns the
+// open/closed state via a `collapsed` React state and `data-collapsed`.
+//
+// The config-reference client modules (ConfigNavigationClient and DetailsClicksClient)
+// instead drive these cards imperatively — setting `el.open`, dispatching
+// `summary.click()`, and toggling `data-collapsed` — for deep-link auto-expansion, TOC
+// highlighting, and the copy-as-YAML buttons. Those imperative writes happen outside
+// React's knowledge, so the controlled component reverts them on its next render:
+// clicking a card expands it briefly, then it snaps shut and locks up until a refresh
+// (DOC-1528). Rendering config-field cards as plain, uncontrolled native <details>
+// removes the conflict and lets the scripts own the element as they were written to.
+// All other details keep Docusaurus's component.
+const OriginalDetails = MDXComponents.Details;
+
+function isConfigField(className) {
+  return (
+    typeof className === "string" &&
+    className.split(/\s+/).includes("config-field")
+  );
+}
+
+function ConfigAwareDetails(props) {
+  if (isConfigField(props.className)) {
+    return <details {...props} />;
+  }
+  return <OriginalDetails {...props} />;
+}
+
 export default {
   ...MDXComponents,
+  details: ConfigAwareDetails,
+  Details: ConfigAwareDetails,
   GlossaryTerm: GlossaryTerm,
   PageVariables: PageVariables,
   InterpolatedCodeBlock: InterpolatedCodeBlock,


### PR DESCRIPTION
# Content Description
Expandable config reference field cards (the `<details>` cards on pages like `/platform/configure/platform-configs/overview`) would expand briefly on click, then immediately collapse and lock up until a page refresh. This renders those cards as plain native `<details>` so the existing config-reference client scripts can own them, and restores the disclosure arrow that the switch removed.

## Root cause
Docusaurus's mdx-loader rewrites every `<details>` to its React-controlled `<Details>` component at compile time. The config-reference client modules drive the cards imperatively (`el.open`, `summary.click()`, `data-collapsed`) for deep-link auto-expansion, TOC highlighting, and copy-as-YAML. Those writes happen outside React, so the controlled component reverted them on its next render. The `object[]` correlation was a red herring; all expandable cards rendered identically.

## Changes
- `src/theme/MDXComponents.js`: override the `Details`/`details` mapping so cards with the `config-field` class render as uncontrolled native `<details>`; all other details keep Docusaurus's component.
- `src/css/content/config-fields.scss`: native cards no longer inherit Docusaurus's `<Details>` CSS, so suppress the default disclosure marker, redefine the arrow size/transition variables, and draw the disclosure arrow (and enum-values caret) directly via `summary::before`.

## Verification
Tested with headless Chrome against the built site:
- Cards toggle reliably with no expand-then-collapse or lockup (verified on both `object` and `object[]` fields)
- Deep-link anchors still auto-expand parents
- Copy-as-YAML buttons still attach
- Disclosure arrow renders and rotates on open/close (closed 90deg, open -90deg), hidden on non-expandable leaf fields

## Preview Link
<!-- netlify deploy preview will be added automatically -->
https://deploy-preview-2323--vcluster-docs-site.netlify.app/docs/platform/configure/platform-configs/overview

Confirm you can fully expand **auth > github > orgs** through the entire tree (orgs should display two nested keys). Before this PR, orgs would not actually expand and resulted in the page refreshing without the ability to expand the orgs key.

## Internal Reference
Closes DOC-1528


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)