### PR TITLE
fix(redirects): point platform config ui link to platform-configs overview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -403,14 +403,14 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   from = "/docs/platform-ui-link/platform/working-with-sleep-mode/:version"
   to = "/docs/vcluster/configure/vcluster-yaml/sleep"
 
-# Config (updated: config.mdx -> introduction.mdx)
+# Config (points to the Platform Configs overview edited by the admin Config page)
 [[redirects]]
   from = "/docs/platform-ui-link/platform/config"
-  to = "/docs/platform/configure/introduction"
+  to = "/docs/platform/configure/platform-configs/overview"
 
 [[redirects]]
   from = "/docs/platform-ui-link/platform/config/:version"
-  to = "/docs/platform/:version/configure/introduction"
+  to = "/docs/platform/:version/configure/platform-configs/overview"
 
 # Database IAM
 [[redirects]]


### PR DESCRIPTION
# Content Description
Fixes the `/docs/platform-ui-link/platform/config` redirect (used by the Platform Configuration admin page) so it points to the Platform Configs overview instead of the generic `configure/introduction` page. Updates both the unversioned and versioned redirects.

## Preview Link
- https://www.vcluster.com/docs/platform/configure/platform-configs/overview

## Internal Reference
Closes DOC-1527

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
