### PR TITLE
docs(doc-1576): add patching reference page for sync resources

### DIFF
--- a/static/media/diagrams/sync-patching-flow.svg
+++ b/static/media/diagrams/sync-patching-flow.svg
@@ -1,0 +1,55 @@
+<svg viewBox="0 0 1080 380" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style><![CDATA[
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <marker id="sync-patching-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0 0, 10 4, 0 8" fill="#050B24"/>
+    </marker>
+
+    <marker id="sync-patching-arrow-muted" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto">
+      <polygon points="0 0, 10 4, 0 8" fill="#828592"/>
+    </marker>
+  </defs>
+
+  <rect x="30" y="30" width="1020" height="320" rx="8" fill="#F8F9FB" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="54" y="62" font-size="12" font-weight="500" fill="#828592">Sync patch translation flow</text>
+
+  <rect x="70" y="116" width="245" height="132" rx="8" fill="white" stroke="#326CE3" stroke-width="1.5"/>
+  <text x="192.5" y="174" font-size="17" font-weight="650" fill="#050B24" text-anchor="middle">Tenant cluster</text>
+  <text x="192.5" y="197" font-size="11" fill="#828592" text-anchor="middle">Tenant-facing values</text>
+
+  <rect x="418" y="92" width="244" height="180" rx="8" fill="#FFF7F2" stroke="#FF6600" stroke-width="2"/>
+  <text x="540" y="124" font-size="15" font-weight="650" fill="#050B24" text-anchor="middle">Patch</text>
+  <text x="540" y="145" font-size="11" fill="#828592" text-anchor="middle">Runs JavaScript on matched paths</text>
+
+  <rect x="453" y="170" width="174" height="36" rx="8" fill="white" stroke="#FF6600" stroke-width="1.5"/>
+  <text x="540" y="192" font-size="12" font-weight="650" fill="#050B24" text-anchor="middle">expression</text>
+
+  <rect x="453" y="218" width="174" height="36" rx="8" fill="white" stroke="#FF6600" stroke-width="1.5"/>
+  <text x="540" y="240" font-size="12" font-weight="650" fill="#050B24" text-anchor="middle">reverseExpression</text>
+
+  <rect x="765" y="116" width="245" height="132" rx="8" fill="white" stroke="#326CE3" stroke-width="1.5"/>
+  <text x="887.5" y="174" font-size="17" font-weight="650" fill="#050B24" text-anchor="middle">Control plane cluster</text>
+  <text x="887.5" y="197" font-size="11" fill="#828592" text-anchor="middle">Control plane cluster values</text>
+
+  <line x1="315" y1="188" x2="418" y2="188" stroke="#050B24" stroke-width="1.5" marker-end="url(#sync-patching-arrow)"/>
+  <line x1="662" y1="188" x2="765" y2="188" stroke="#050B24" stroke-width="1.5" marker-end="url(#sync-patching-arrow)"/>
+  <text x="366" y="160" font-size="10.5" fill="#828592" text-anchor="middle">
+    <tspan x="366" dy="0">tenant to</tspan>
+    <tspan x="366" dy="13">control plane</tspan>
+  </text>
+  <text x="713" y="173" font-size="11" fill="#828592" text-anchor="middle">rewritten value</text>
+
+  <line x1="765" y1="236" x2="662" y2="236" stroke="#828592" stroke-width="1.5" marker-end="url(#sync-patching-arrow-muted)"/>
+  <line x1="418" y1="236" x2="315" y2="236" stroke="#828592" stroke-width="1.5" marker-end="url(#sync-patching-arrow-muted)"/>
+  <text x="713" y="255" font-size="10.5" fill="#828592" text-anchor="middle">
+    <tspan x="713" dy="0">control plane</tspan>
+    <tspan x="713" dy="13">to tenant</tspan>
+  </text>
+  <text x="366" y="255" font-size="11" fill="#828592" text-anchor="middle">transformed value</text>
+
+  <rect x="392" y="294" width="296" height="32" rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="540" y="315" font-size="12" font-weight="500" fill="#050B24" text-anchor="middle">Patch paths decide which fields are transformed</text>
+</svg>

--- a/vcluster/configure/vcluster-yaml/sync/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/README.mdx
@@ -25,6 +25,10 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 ## Resources available to sync from control plane cluster to tenant cluster
 <SyncFromHostResources/>
 
+## Patching synced resources
+
+Use [patching](./patching/README.mdx) to transform fields, references, and custom resource labels while resources sync between the tenant cluster and the control plane cluster.
+
 ## Config reference
 
 <Sync/>

--- a/vcluster/configure/vcluster-yaml/sync/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/README.mdx
@@ -25,7 +25,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 ## Resources available to sync from control plane cluster to tenant cluster
 <SyncFromHostResources/>
 
-## Patching synced resources
+## Patch synced resources
 
 Use [patching](./patching/README.mdx) to transform fields, references, and custom resource labels while resources sync between the tenant cluster and the control plane cluster.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -131,13 +131,7 @@ sync:
 
 ## Patches
 
-You can specify `reverseExpression` in the `sync.fromHost.configMaps.patches` .
-
-They are applied on the host object and appear in the virtual object.
-
-`expressions` have no effect.
-
-So, for the following `vcluster.yaml` :
+Use `sync.fromHost.configMaps.patches` to transform ConfigMap fields while syncing from the control plane cluster to the tenant cluster. For from-host sync, use `reverseExpression` for values that should appear in the tenant cluster. See [Patching synced resources](../patching/README.mdx) for syntax and directionality.
 
 ```yaml title="configure ConfigMap sync from host with patches"
 sync:
@@ -152,10 +146,6 @@ sync:
           # optional reverseExpression to reverse the change from the host cluster
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
-
-1. Your ConfigMap in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the tenant cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
-
 
 <FromHostConfigMapExample />
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -190,15 +190,7 @@ sync:
 
 ### Patches
 
-You can use patches to transform data as it syncs from the control plane cluster to the tenant cluster.
-
-When syncing custom resources from the control plane cluster to the tenant cluster, you can use `reverseExpression` to modify the data during the sync process. The control plane cluster remains unchanged, but the tenant cluster gets the modified data.
-
-:::note
-`expressions` (used for virtual-to-host syncing) have no effect when syncing from host to virtual.
-:::
-
-The following `vcluster.yaml` shows how patches are used:
+Use `sync.fromHost.customResources.<resource>.patches` to transform custom resource fields while syncing from the control plane cluster to the tenant cluster. For from-host sync, use `reverseExpression` for values that should appear in the tenant cluster. See [Patching synced resources](../patching/README.mdx) for syntax, directionality, and custom resource labels patches.
 
 ```yaml title="configure custom resource sync from host with patches"
 sync:
@@ -215,12 +207,6 @@ sync:
             # optional reverseExpression to reverse the change from the host cluster
             reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
-
-In the example:
-
-- The custom resource in the host namespace `default` named `my-object` is synced to the namespace `barfoo2` in the tenant cluster and named `object-my`.
-
-- If the `default/my-object` host object has an annotation with a value that starts with `www.` (for example: `my-address: www.loft.sh`), then the synced object in the tenant cluster `barfoo2/object-my` has the annotation `my-address: loft.sh`.
 
 <NamespacedCustomResourcesExample/>
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -7,7 +7,6 @@ sidebar_class_name: host-nodes
 ---
 
 import SyncNodes from '../../../../_partials/config/sync/fromHost/nodes.mdx'
-import Patches from '../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -129,7 +128,7 @@ sync:
 
 ### Patches
 
-<Patches resource="nodes" path="status.nodeInfo.operatingSystem" direction="fromHost"  />
+Use `sync.fromHost.nodes.patches` to transform node fields while syncing nodes from the control plane cluster to the tenant cluster. See [Patching synced resources](../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -130,13 +130,7 @@ sync:
 
 ## Patches
 
-You can specify `reverseExpression` in the `sync.fromHost.secrets.patches` .
-
-They are applied on the host object and appear in the virtual object.
-
-`expressions` have no effect.
-
-So, for the following `vcluster.yaml` :
+Use `sync.fromHost.secrets.patches` to transform Secret fields while syncing from the control plane cluster to the tenant cluster. For from-host sync, use `reverseExpression` for values that should appear in the tenant cluster. See [Patching synced resources](../patching/README.mdx) for syntax and directionality.
 
 ```yaml title="configure Secret sync from host with patches"
 sync:
@@ -151,10 +145,6 @@ sync:
           # optional reverseExpression to reverse the change from the host cluster
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
-
-1. Your Secret in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the tenant cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
-
 
 <FromHostSecretExample />
 

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -9,29 +9,32 @@ slug: /configure/vcluster-yaml/sync/patching
 
 import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
 import FeatureTable from '@site/src/components/FeatureTable';
+import SyncPatchingFlow from '@site/static/media/diagrams/sync-patching-flow.svg';
 
-<FeatureTable names="vcp-distro-sync-patches,vcp-distro-translate-patches" />
+<FeatureTable names="vcp-distro-sync-patches" />
 
 <TenancySupport hostNodes="true" />
 
-Use patches when a resource needs different field values on each side of the sync boundary. For example, you can rewrite image references to a private registry, or rewrite fields that contain the name of another synced object that vCluster translates. Without a patch, vCluster copies field values unchanged.
+Use patches when a resource needs different field values on each side of the sync boundary. For example, you can rewrite image references to a private registry, or rewrite fields that contain the name of another synced object that vCluster translates. Without a patch, vCluster applies its built-in translations and otherwise leaves synced fields unchanged.
 
 Patches are translation rules. When a resource changes, vCluster rewrites the fields that match your patch configuration and writes the result to the target cluster.
 
-```mermaid
-sequenceDiagram
-    participant T as Tenant cluster
-    participant P as Patch
-    participant H as Control plane cluster
+Patch lists live under the resource's sync direction. Use `sync.toHost.<resource>.patches` for resources synced from the tenant cluster to the control plane cluster, and `sync.fromHost.<resource>.patches` for resources synced from the control plane cluster into the tenant cluster.
 
-    T->>P: image: docker.io/nginx:latest
-    Note over P: expression
-    P-->>H: image: registry.internal/nginx:latest
-
-    H->>P: image: registry.internal/nginx:latest
-    Note over P: reverseExpression
-    P-->>T: image: docker.io/nginx:latest
+```yaml
+sync:
+  toHost:
+    pods:
+      patches: []
+  fromHost:
+    configMaps:
+      patches: []
 ```
+
+<figure>
+  <SyncPatchingFlow style={{width: '100%', height: 'auto'}} role="img" aria-label="Sync patch flow showing expression rewriting tenant values for the control plane cluster and reverseExpression restoring values for the tenant cluster" />
+  <figcaption>Sync patches rewrite matched fields as changes move between the tenant and control plane clusters</figcaption>
+</figure>
 
 ## Path syntax
 
@@ -283,15 +286,26 @@ These resources sync tenant cluster state to the control plane cluster. Use `exp
 
 ### From the control plane cluster
 
-These resources sync control plane cluster state into the tenant cluster. Unlike toHost resources, the keyword that transforms values as they arrive in the tenant cluster is not consistent across fromHost resources. Check the third column before writing your patch.
+These resources sync control plane cluster state into the tenant cluster. Most use `expression` to transform values arriving in the tenant cluster. ConfigMaps, Secrets, and custom resources use `reverseExpression` instead — they go through a different sync framework internally.
 
 | Resource | Config key | Use for control plane→tenant |
 | --- | --- | --- |
 | [ConfigMaps](../from-host/configmaps.mdx) | `sync.fromHost.configMaps.patches` | `reverseExpression` |
 | [Secrets](../from-host/secrets.mdx) | `sync.fromHost.secrets.patches` | `reverseExpression` |
-| [Nodes](../from-host/nodes.mdx) | `sync.fromHost.nodes.patches` | `expression` |
-| [Gateways](../to-host/networking/gateway-api.mdx) | `sync.fromHost.gateways.patches` | `expression` |
 | [Custom resources](../from-host/custom-resources.mdx) | `sync.fromHost.customResources.<resource>.patches` | `reverseExpression` |
+| [CSI Drivers](../from-host/csi-drivers.mdx) | `sync.fromHost.csiDrivers.patches` | `expression` |
+| [CSI Nodes](../from-host/csi-nodes.mdx) | `sync.fromHost.csiNodes.patches` | `expression` |
+| [CSI Storage Capacities](../from-host/csi-storage-capacities.mdx) | `sync.fromHost.csiStorageCapacities.patches` | `expression` |
+| [Device Classes](../from-host/device-classes.mdx) | `sync.fromHost.deviceClasses.patches` | `expression` |
+| [Events](../from-host/events.mdx) | `sync.fromHost.events.patches` | `expression` |
+| [Gateway Classes](../from-host/gateway-classes.mdx) | `sync.fromHost.gatewayClasses.patches` | `expression` |
+| [Gateways](../from-host/gateways.mdx) | `sync.fromHost.gateways.patches` | `expression` |
+| [Ingress Classes](../from-host/ingress-classes.mdx) | `sync.fromHost.ingressClasses.patches` | `expression` |
+| [Nodes](../from-host/nodes.mdx) | `sync.fromHost.nodes.patches` | `expression` |
+| [Priority Classes](../from-host/priority-classes.mdx) | `sync.fromHost.priorityClasses.patches` | `expression` |
+| [Runtime Classes](../from-host/runtime-classes.mdx) | `sync.fromHost.runtimeClasses.patches` | `expression` |
+| [Storage Classes](../from-host/storage-classes.mdx) | `sync.fromHost.storageClasses.patches` | `expression` |
+| Volume Snapshot Classes | `sync.fromHost.volumeSnapshotClasses.patches` | `expression` |
 
 ## Troubleshooting
 

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -79,7 +79,7 @@ Expression patches run JavaScript against each matched value. The expression rec
 For `sync.toHost`, `expression` transforms changes from the tenant cluster to the control plane cluster. `reverseExpression` transforms changes from the control plane cluster back to the tenant cluster.
 If you omit `expression`, vCluster drops that field from the patch when syncing to the control plane cluster. If you omit `reverseExpression`, it drops the field when syncing back to the tenant cluster. Write only one to create a one-way transform.
 
-For `sync.fromHost`, the transform only happens in one direction, from the control plane cluster to the tenant cluster. Whether to use `expression` or `reverseExpression` depends on the resource. See the [Supported resources](#from-the-control-plane-cluster) table for which to use. If you configure the wrong keyword for a resource, vCluster silently skips the expression and syncs the field unchanged.
+For `sync.fromHost`, the transform only happens in one direction, from the control plane cluster to the tenant cluster. For most fromHost resources, `expression` transforms values as they arrive from the control plane cluster. ConfigMaps, Secrets, and custom resources are exceptions that use `reverseExpression` for this direction. See the [Supported resources](#from-the-control-plane-cluster) table for which keyword each resource requires. If you configure the wrong keyword for a resource, vCluster silently skips the expression and syncs the field unchanged.
 
 ```yaml title="Rewrite container images to a private registry"
 sync:
@@ -276,7 +276,7 @@ These resources sync tenant cluster state to the control plane cluster. Use `exp
 
 ### From the control plane cluster
 
-These resources sync control plane cluster state into the tenant cluster. Most use `expression` to transform values arriving in the tenant cluster. ConfigMaps, Secrets, and custom resources use `reverseExpression` instead — they go through a different sync framework internally.
+These resources sync control plane cluster state into the tenant cluster. For most resources, `expression` transforms values as they arrive from the control plane cluster, which matches the natural reading of the keyword for this direction. ConfigMaps, Secrets, and custom resources are the exception: their sync implementations share the same direction model as `sync.toHost`, where `reverseExpression` means the control plane→tenant direction. Use the third column to confirm which keyword applies to each resource rather than reasoning from the keyword names alone.
 
 | Resource | Config key | Use for control plane→tenant |
 | --- | --- | --- |

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -56,7 +56,7 @@ patches:
 
 Choose the mode based on what the field contains:
 
-| When you need to transform ... | Use |
+| To transform | Use |
 | --- | --- |
 | A field value | `expression` / `reverseExpression` |
 | A field referencing another Kubernetes object | `reference` |
@@ -297,7 +297,7 @@ These resources sync control plane cluster state into the tenant cluster. For mo
 | [Storage Classes](../from-host/storage-classes.mdx) | `sync.fromHost.storageClasses.patches` | `expression` |
 | Volume Snapshot Classes | `sync.fromHost.volumeSnapshotClasses.patches` | `expression` |
 
-## Troubleshooting
+## Troubleshoot
 
 | Symptom | What to check |
 | --- | --- |

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -1,0 +1,306 @@
+---
+title: Patching
+sidebar_label: Patching
+sidebar_position: 0
+description: Configure sync patches for resources synced between tenant and control plane clusters.
+sidebar_class_name: free host-nodes
+slug: /configure/vcluster-yaml/sync/patching
+---
+
+import TenancySupport from '../../../../_fragments/tenancy-support.mdx';
+import FeatureTable from '@site/src/components/FeatureTable';
+
+<FeatureTable names="vcp-distro-sync-patches,vcp-distro-translate-patches" />
+
+<TenancySupport hostNodes="true" />
+
+Use patches when a resource needs different field values on each side of the sync boundary. For example, you can rewrite image references to a private registry, or rewrite fields that contain the name of another synced object that vCluster translates. Without a patch, vCluster copies field values unchanged.
+
+Patches are translation rules. When a resource changes, vCluster rewrites the fields that match your patch configuration and writes the result to the target cluster.
+
+```mermaid
+sequenceDiagram
+    participant T as Tenant cluster
+    participant P as Patch
+    participant H as Control plane cluster
+
+    T->>P: image: docker.io/nginx:latest
+    Note over P: expression
+    P-->>H: image: registry.internal/nginx:latest
+
+    H->>P: image: registry.internal/nginx:latest
+    Note over P: reverseExpression
+    P-->>T: image: docker.io/nginx:latest
+```
+
+## Path syntax
+
+A path identifies the field in the Kubernetes object the patch targets. Patch paths use a dot notation.
+
+### Bracket notation
+
+Use bracket notation for map keys that contain `.`, `[`, or `]`.
+
+```yaml
+patches:
+  - path: metadata.annotations["example.com/key"]
+    expression: '"patched-" + value'
+```
+
+### All entries
+
+Use `[*]` to match all elements of an array or all keys of a map. `*` does not match patterns or globs. Rather, it selects every entry at that position in the path. vCluster runs the patch once for each.
+
+You can use `[*]` multiple times in a single path. `spec.containers[*].volumeMounts[*].mountPath` applies the patch to every `mountPath` across every container.
+
+```yaml
+patches:
+  - path: spec.containers[*].env[*].value
+    expression: 'value.replace("internal.svc", "internal.svc.cluster.local")'
+```
+
+## Patch modes
+
+Choose the mode based on what the field contains:
+
+| When you need to transform ... | Use |
+| --- | --- |
+| A field value | `expression` / `reverseExpression` |
+| A field referencing another Kubernetes object | `reference` |
+| Labels on a custom resource | `labels` |
+
+You can use `expression` and `reverseExpression` together in one entry.
+
+## Validation rules
+
+- Each patch requires a `path`.
+- Each patch uses exactly one mode. `expression` and `reverseExpression` can coexist in one entry, but neither can be combined with `reference` or `labels`.
+- A resource's patch list cannot contain duplicate paths.
+- `metadata.name` and `metadata.namespace` are not valid patch paths.
+- Reference patches require a vCluster mapper for the referenced resource type.
+
+## Expression patches
+
+Expression patches run JavaScript against each matched value. The expression receives `value` as the current field value and its return value replaces it.
+
+For `sync.toHost`, `expression` transforms changes from the tenant cluster to the control plane cluster. `reverseExpression` transforms changes from the control plane cluster back to the tenant cluster.
+If you omit `expression`, vCluster drops that field from the patch when syncing to the control plane cluster. If you omit `reverseExpression`, it drops the field when syncing back to the tenant cluster. Write only one to create a one-way transform.
+
+For `sync.fromHost`, the transform only happens in one direction, from the control plane cluster to the tenant cluster. Whether to use `expression` or `reverseExpression` depends on the resource. See the [Supported resources](#from-the-control-plane-cluster) table for which to use. If you configure the wrong keyword for a resource, vCluster silently skips the expression and syncs the field unchanged.
+
+```yaml title="Rewrite container images to a private registry"
+sync:
+  toHost:
+    pods:
+      enabled: true
+      patches:
+        - path: spec.containers[*].image
+          expression: 'value.replace("docker.io/", "registry.internal/")'
+```
+
+In this example, any container image from `docker.io` in the tenant cluster is rewritten when the Pod syncs to the control plane cluster. A Pod with `image: docker.io/nginx:latest` runs as `image: registry.internal/nginx:latest` on the control plane cluster.
+
+```yaml title="Prefix service port names when syncing to the control plane cluster"
+sync:
+  toHost:
+    services:
+      enabled: true
+      patches:
+        - path: spec.ports[*].name
+          expression: '"tenant-" + value'
+          reverseExpression: 'value.replace(/^tenant-/, "")'
+```
+
+In this example, a port named `http` in the tenant cluster becomes `tenant-http` on the control plane cluster. When a change flows back from the control plane cluster, the prefix is stripped and the port is `http` again in the tenant cluster.
+
+```yaml title="Remove a prefix from imported ConfigMap annotations"
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      mappings:
+        byName:
+          "default/my-cm": "tenant/my-cm"
+      patches:
+        - path: metadata.annotations[*]
+          reverseExpression: 'value.startsWith("www.") ? value.slice(4) : value'
+```
+
+In this example, the ConfigMap `my-cm` from the `default` namespace on the control plane cluster is synced into the `tenant` namespace in the tenant cluster. For every annotation value, if the value starts with `www.`, that prefix is stripped in the tenant cluster. An annotation value of `www.example.com` on the control plane cluster appears as `example.com` in the tenant cluster. The control plane cluster object is unchanged.
+
+### JavaScript runtime
+
+Expressions can use these variables:
+
+| Variable | Description |
+| --- | --- |
+| `value` | The matched value. |
+| `valueExists` | `true` when the matched path exists in the patch. |
+| `context.vcluster.name` | Tenant cluster name. |
+| `context.vcluster.namespace` | Tenant cluster namespace in the control plane cluster. |
+| `context.vcluster.config` | Effective `vcluster.yaml` configuration. |
+| `context.hostObject` | Control plane cluster object, or `null` when unavailable. |
+| `context.virtualObject` | Tenant cluster object, or `null` when unavailable. |
+| `context.path` | The concrete matched path, useful with wildcards. |
+
+Expressions can use these helper functions:
+
+| Function | Description |
+| --- | --- |
+| `btoa(value)` | Base64-encode a string. |
+| `atob(value)` | Base64-decode a string. |
+| `virtualToHostDNS(value)` | Rewrite a tenant service DNS name to the control plane cluster service DNS name. |
+
+`virtualToHostDNS` supports service DNS names in the form `<name>.<namespace>.svc` or `<name>.<namespace>.svc.<cluster-domain>`.
+
+### Empty paths
+
+Empty paths are an advanced use case. Use them when you need to read multiple fields to decide what to change, or when you need to set multiple fields in a single expression.
+
+With a normal path, `value` is the single field the patch targets. With an empty path, `value` is the entire set of fields being changed in this sync operation. This is only the changed fields, not the full object. The expression must return the modified change set.
+
+```yaml
+patches:
+  - path: ""
+    expression: |
+      (value => {
+        value.metadata ??= {};
+        value.metadata.annotations ??= {};
+        value.metadata.annotations["patched-by"] = "vcluster";
+        return value;
+      })(value)
+```
+
+If the incoming change set is `{"spec": {"replicas": 3}}`, the expression receives that object, adds the annotation, and returns `{"spec": {"replicas": 3}, "metadata": {"annotations": {"patched-by": "vcluster"}}}`. Both changes are then applied together.
+
+## Reference patches
+
+Reference patches tell vCluster that a field contains the name of another synced object. When syncing, vCluster rewrites the name to its translated value in the target cluster.
+
+vCluster renames synced objects on the control plane cluster to avoid collisions across tenant clusters. A Secret named `my-secret` in the `default` namespace becomes `default-x-my-secret-x-my-vcluster` on the control plane cluster. Any field that holds that name must be rewritten to match, or the reference breaks.
+
+### Simple reference patch
+
+Use a simple reference patch when the field value is a plain string holding only the object name.
+
+```yaml title="Treat an annotation value as a Secret name"
+sync:
+  toHost:
+    pods:
+      enabled: true
+      patches:
+        - path: metadata.annotations["example.com/secret-name"]
+          reference:
+            apiVersion: v1
+            kind: Secret
+```
+
+If a Pod in the tenant cluster has the annotation `example.com/secret-name: my-secret`, vCluster rewrites it when syncing the Pod to the control plane cluster. On the control plane cluster, the annotation becomes `example.com/secret-name: default-x-my-secret-x-my-vcluster`. Without the patch, the annotation stays as `my-secret`, which would not match the actual Secret name on the control plane cluster.
+
+### Structured reference patch
+
+Use a structured reference patch when the field value is a nested object that contains the name as a sub-field, such as a Kubernetes `ObjectReference` or `LocalObjectReference`.
+
+```yaml title="Rewrite a structured Secret reference"
+sync:
+  toHost:
+    customResources:
+      widgets.example.com:
+        enabled: true
+        patches:
+          - path: spec.secretRef
+            reference:
+              apiVersion: v1
+              kind: Secret
+              namePath: name
+              namespacePath: namespace
+```
+
+In the tenant cluster, `spec.secretRef` holds an object like:
+
+```yaml
+name: my-secret
+namespace: default
+```
+
+`namePath: name` and `namespacePath: namespace` are paths relative to that object, pointing to the sub-fields vCluster should rewrite. On the control plane cluster, those values become the translated Secret name and namespace:
+
+```yaml
+name: default-x-my-secret-x-my-vcluster
+namespace: my-vcluster-ns
+```
+
+The values you set for `namePath` and `namespacePath` depend on how the resource defines its reference. If the sub-field were named `secretName` instead of `name`, you would write `namePath: secretName`.
+
+`namePath` is required when you set `namespacePath`, `kindPath`, or `apiVersionPath`.
+
+## Labels patches
+
+Use `labels` patches only with custom resource sync. They are not supported on built-in resources.
+
+vCluster translates pod label keys when syncing to the control plane cluster to prevent collisions across tenant clusters. If a custom resource has a field containing label selectors, such as `spec.selector.matchLabels`, those keys must be translated the same way or the selector will not match any pods on the control plane cluster. Setting `labels: {}` on a path tells vCluster to apply that translation to the field. The `labels` key takes an empty object — there are no configuration options inside it.
+
+```yaml title="Translate selector labels on a custom resource"
+sync:
+  toHost:
+    customResources:
+      widgets.example.com:
+        enabled: true
+        patches:
+          - path: spec.selector.matchLabels
+            labels: {}
+```
+
+If `spec.selector.matchLabels` held `{app: my-app}` in the tenant cluster, vCluster rewrites the key to its translated form on the control plane cluster so the selector continues to match the correct pods.
+
+## Supported resources
+
+### To the control plane cluster
+
+These resources sync tenant cluster state to the control plane cluster. Use `expression` for changes flowing outbound and `reverseExpression` for changes flowing back.
+
+| Resource | Config key |
+| --- | --- |
+| [Pods](../to-host/core/pods/README.mdx) | `sync.toHost.pods.patches` |
+| [ConfigMaps](../to-host/core/config-maps.mdx) | `sync.toHost.configMaps.patches` |
+| [Secrets](../to-host/core/secrets.mdx) | `sync.toHost.secrets.patches` |
+| [Services](../to-host/networking/services.mdx) | `sync.toHost.services.patches` |
+| [Endpoints](../to-host/networking/endpoints.mdx) | `sync.toHost.endpoints.patches` |
+| [EndpointSlices](../to-host/networking/endpointslices.mdx) | `sync.toHost.endpointSlices.patches` |
+| [Ingresses](../to-host/networking/ingresses.mdx) | `sync.toHost.ingresses.patches` |
+| [NetworkPolicies](../to-host/networking/network-policies.mdx) | `sync.toHost.networkPolicies.patches` |
+| [Gateway API: HTTPRoutes](../to-host/networking/gateway-api.mdx) | `sync.toHost.gatewayApi.httpRoutes.patches` |
+| [Gateway API: TLSRoutes](../to-host/networking/gateway-api.mdx) | `sync.toHost.gatewayApi.tlsRoutes.patches` |
+| [Gateway API: BackendTLSPolicies](../to-host/networking/gateway-api.mdx) | `sync.toHost.gatewayApi.backendTLSPolicies.patches` |
+| [Gateway API: ReferenceGrants](../to-host/networking/gateway-api.mdx) | `sync.toHost.gatewayApi.referenceGrants.patches` |
+| [PersistentVolumeClaims](../to-host/storage/persistent-volume-claims.mdx) | `sync.toHost.persistentVolumeClaims.patches` |
+| [PersistentVolumes](../to-host/storage/persistent-volumes.mdx) | `sync.toHost.persistentVolumes.patches` |
+| [StorageClasses](../to-host/storage/storage-classes.mdx) | `sync.toHost.storageClasses.patches` |
+| [ResourceClaims](../to-host/DRA/resourceclaims.mdx) | `sync.toHost.resourceClaims.patches` |
+| [ResourceClaimTemplates](../to-host/DRA/resourceclaimtemplates.mdx) | `sync.toHost.resourceClaimTemplates.patches` |
+| [PodDisruptionBudgets](../to-host/advanced/pod-disruption-budgets.mdx) | `sync.toHost.podDisruptionBudgets.patches` |
+| [Custom resources](../to-host/advanced/custom-resources.mdx) | `sync.toHost.customResources.<resource>.patches` |
+
+### From the control plane cluster
+
+These resources sync control plane cluster state into the tenant cluster. Unlike toHost resources, the keyword that transforms values as they arrive in the tenant cluster is not consistent across fromHost resources. Check the third column before writing your patch.
+
+| Resource | Config key | Use for control plane→tenant |
+| --- | --- | --- |
+| [ConfigMaps](../from-host/configmaps.mdx) | `sync.fromHost.configMaps.patches` | `reverseExpression` |
+| [Secrets](../from-host/secrets.mdx) | `sync.fromHost.secrets.patches` | `reverseExpression` |
+| [Nodes](../from-host/nodes.mdx) | `sync.fromHost.nodes.patches` | `expression` |
+| [Gateways](../to-host/networking/gateway-api.mdx) | `sync.fromHost.gateways.patches` | `expression` |
+| [Custom resources](../from-host/custom-resources.mdx) | `sync.fromHost.customResources.<resource>.patches` | `reverseExpression` |
+
+## Troubleshooting
+
+| Symptom | What to check |
+| --- | --- |
+| Pro feature license error | Confirm the tenant cluster uses the Pro image and has a license from vCluster Platform. See [Resolve Pro feature license errors](../../../../troubleshoot/pro-feature-license-error.mdx). |
+| Patch appears to do nothing | Confirm the path exists in the merge patch for the update. Patches run on changed fields only, not the full object. On create, vCluster converts the object to a patch, so more fields are available. |
+| `sync.fromHost` patch appears to do nothing | Confirm you are using the correct expression keyword for the resource. vCluster silently skips the wrong keyword with no error. See the [Supported resources](#from-the-control-plane-cluster) table. |
+| A field stops syncing in one direction | Check whether you have an `expression` or `reverseExpression` entry for that direction. Omitting the expression for a direction causes vCluster to drop that field from the patch. |
+| An object is stuck in a failing sync loop | An expression error is likely. Check vCluster pod logs for messages containing `apply patches host object` or `apply patches virtual object`. No event or status condition is set on the object. |
+| A field is being deleted instead of transformed | The expression may be returning `null` or `undefined`. vCluster deletes the field when an expression returns either value. |
+| Reference patch fails with a missing mapper error | The referenced resource type must be synced or otherwise known to vCluster. |

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -21,16 +21,6 @@ Patches are translation rules. When a resource changes, vCluster rewrites the fi
 
 Patch lists live under the resource's sync direction. Use `sync.toHost.<resource>.patches` for resources synced from the tenant cluster to the control plane cluster, and `sync.fromHost.<resource>.patches` for resources synced from the control plane cluster into the tenant cluster.
 
-```yaml
-sync:
-  toHost:
-    pods:
-      patches: []
-  fromHost:
-    configMaps:
-      patches: []
-```
-
 <figure>
   <SyncPatchingFlow style={{width: '100%', height: 'auto'}} role="img" aria-label="Sync patch flow showing expression rewriting tenant values for the control plane cluster and reverseExpression restoring values for the tenant cluster" />
   <figcaption>Sync patches rewrite matched fields as changes move between the tenant and control plane clusters</figcaption>

--- a/vcluster/configure/vcluster-yaml/sync/patching/_category_.json
+++ b/vcluster/configure/vcluster-yaml/sync/patching/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "patching",
+  "position": 3,
+  "className": "host-nodes"
+}

--- a/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing resource claims to host
 ---
 
 import ResourceClaims from '../../../../../_partials/config/sync/toHost/resourceclaims.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 import FeatureTable from '@site/src/components/FeatureTable';
 
@@ -42,7 +41,7 @@ sync:
 
 ## Patches
 
-<Patches resource="resourceClaims" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.resourceClaims.patches` to transform ResourceClaim fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaimtemplates.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/DRA/resourceclaimtemplates.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing resource claim templates to host
 ---
 
 import ResourceClaimTemplates from '../../../../../_partials/config/sync/toHost/resourceclaimtemplates.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 import FeatureTable from '@site/src/components/FeatureTable';
 
@@ -42,7 +41,7 @@ sync:
 
 ## Patches
 
-<Patches resource="resourceClaimTemplates" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.resourceClaimTemplates.patches` to transform ResourceClaimTemplate fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -54,17 +54,9 @@ sync:
 
 ## Patches
 
-You can modify the sync behavior with patches that target specific paths. Currently, there are two different kinds of patches supported.
+Use `sync.toHost.customResources.<resource>.patches` to transform custom resource fields while syncing to the control plane cluster. Custom resources support expression patches, reference patches, and labels patches. See [Patching synced resources](../../patching/README.mdx) for the full syntax and directionality rules.
 
-:::info Wildcard patches
-You can use `*` in paths to select all entries of an array or object, for example `spec.containers[*].name` or `spec.containers[*].volumeMounts[*]`. vCluster calls the patch multiple times.
-:::
-
-### Reference patches
-
-You can use a reference patch to make a specific field in one resource point to another resource that vCluster should rewrite. If the referenced resource exists in the control plane cluster, vCluster automatically imports it into the tenant cluster.
-
-This is useful when working with resources that reference other resources like `Secrets`:
+Reference patches are useful when a custom resource field points to another synced resource, such as a Secret:
 
 ```yaml
 sync:
@@ -79,37 +71,7 @@ sync:
             kind: Secret
 ```
 
-vCluster translates the path `spec.secretName` as it points to a Secret. If the Secret is created in the control plane cluster, vCluster automatically imports it into the tenant cluster.
-
-<!-- vale off -->
-### JavaScript expression patches {#javascript-expression-patches}
-<!-- vale on -->
-
-These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the tenant cluster into the control plane cluster or when syncing from the control plane cluster into the tenant cluster. To add a prefix to field values you can:
-
-```yaml
-sync:
-  toHost:
-    customResources:
-      customobjects.example.io:
-        enabled: true
-        patches:
-        - path: spec.names[*]
-          # specifies the sync direction here again, because you can also react on change for fromHost with an expression
-          expression: '"prefix-"+value'
-          # optional reverseExpression, if omitted patches from host are discarded for that path
-          # reverseExpression: 'value.slice("prefix-".length)'
-```
-
-There is also a variable called `context` besides `value` that can be used to access vCluster specific data:
-- `context.vcluster.name`: Name of the tenant cluster
-- `context.vcluster.namespace`: Namespace of the tenant cluster
-- `context.vcluster.config`: Config of the tenant cluster, basically `vcluster.yaml` merged with the defaults
-- `context.hostObject`: Host object (can be null if not available)
-- `context.virtualObject`: Virtual object (can be null if not available)
-- `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
-
-For example, to add a prefix to values in a custom resource field, you can use the following patch:
+Expression patches are useful when the tenant and control plane cluster need different field values:
 
 ```yaml
 sync:
@@ -119,58 +81,8 @@ sync:
         enabled: true
         patches:
         - path: spec.hosts[*]
-          # specifies the sync direction here again, because you can also react on change for fromHost
           expression: "value.startsWith('prod-') ? value : `prod-${value}`"
-          # specifies how to sync back changes to the virtual cluster. If omitted does not sync back changes.
           reverseExpression: "value.startsWith('prod-') ? value.slice(5) : value"
-```
-
-The patch creates a new custom object within the vCluster:
-
-```yaml
-apiVersion: example.io/v1
-kind: CustomObject
-metadata:
-  name: name-within-vcluster
-spec:
-  hosts:
-    - server.example.com
-```
-
-vCluster syncs the control plane cluster and applies your patch, creating this modified resource:
-
-```yaml
-apiVersion: example.io/v1
-kind: CustomObject
-metadata:
-  name: synced-name
-spec:
-  hosts:
-    - prod-server.example.com # the patch added prod- prefix to this field
-```
-
-If you directly edit the resource in the control plane cluster and change the value:
-
-```yaml
-apiVersion: example.io/v1
-kind: CustomObject
-metadata:
-  name: synced-name
-spec:
-  hosts:
-    - prod-other-server.example.com # changed from prod-server.example.com
-```
-
-vCluster detects the change, applies the reverse patch, and updates the resource in your tenant cluster:
-
-```yaml
-apiVersion: example.io/v1
-kind: CustomObject
-metadata:
-  name: name-within-vcluster
-spec:
-  hosts:
-    - other-server.example.com # the patch removed the prod- prefix
 ```
 
 ## Configure Istio waypoint Gateway via custom resources

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing pod disruption budgets to host
 
 
 import PodDisruptionBudget from '../../../../../_partials/config/sync/toHost/podDisruptionBudgets.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -33,7 +32,7 @@ sync:
 
 ## Patches
 
-<Patches resource="podDisruptionBudgets" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.podDisruptionBudgets.patches` to transform PodDisruptionBudget fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing config maps to host
 
 import SyncAllResource from '../../../../../_partials/config/sync/toHost/configMaps.mdx'
 import DisableResourceWarning from  '../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -50,7 +49,7 @@ sync:
 
 ## Patches
 
-<Patches resource="configMaps" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.configMaps.patches` to transform ConfigMap fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
@@ -7,7 +7,6 @@ slug: /configure/vcluster-yaml/sync/to-host/core/pods
 ---
 
 import DisableResourceWarning from '../../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
-import Patches from '../../../../../../_fragments/patches.mdx'
 import SyncPods from '../../../../../../_partials/config/sync/toHost/pods.mdx'
 import TenancySupport from '../../../../../../_fragments/tenancy-support.mdx';
 
@@ -80,7 +79,7 @@ sync:
 
 ## Patches
 
-<Patches resource="pods" path="spec.containers[*].name" direction="toHost"  />
+Use `sync.toHost.pods.patches` to transform Pod fields, such as `spec.containers[*].name`, while syncing to the control plane cluster. See [Patching synced resources](../../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Use secrets for ServiceAccount tokens
 
@@ -104,4 +103,3 @@ For more information on the new object structure, see the [configuration referen
 <DisableResourceWarning/>
 
 <SyncPods/>
-

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing secrets to host
 
 import SyncAllResource from '../../../../../_partials/config/sync/toHost/secrets.mdx'
 import DisableResourceWarning from  '../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -46,7 +45,7 @@ sync:
 
 ## Patches
 
-<Patches resource="secrets" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.secrets.patches` to transform Secret fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing endpoints to host
 ---
 
 import Endpoints from '../../../../../_partials/config/sync/toHost/endpoints.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -32,7 +31,7 @@ sync:
 
 ## Patches
 
-<Patches resource="endpoints" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.endpoints.patches` to transform Endpoints fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpointslices.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpointslices.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing endpoint slices to host
 ---
 
 import EndpointSlices from '../../../../../_partials/config/sync/toHost/endpointSlices.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -34,7 +33,7 @@ sync:
 
 ## Patches
 
-<Patches resource="endpointSlices" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.endpointSlices.patches` to transform EndpointSlice fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/gateway-api.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/gateway-api.mdx
@@ -1166,7 +1166,7 @@ The address is whatever the Gateway controller assigned (LoadBalancer IP, NodePo
 
 ## Patches
 
-Patch lists are resource-specific. For these examples, use `sync.fromHost.gateways.patches` for imported control plane `Gateway` resources and `sync.toHost.gatewayApi.httpRoutes.patches`, `tlsRoutes.patches`, `backendTLSPolicies.patches`, or `referenceGrants.patches` for tenant-created resources. Each list accepts the same expression and reference patch shapes.
+Patch lists are resource-specific. For these examples, use `sync.fromHost.gateways.patches` for imported control plane `Gateway` resources and `sync.toHost.gatewayApi.httpRoutes.patches`, `tlsRoutes.patches`, `backendTLSPolicies.patches`, or `referenceGrants.patches` for tenant-created resources. Each list accepts the same expression and reference patch shapes. See [Patching synced resources](../../patching/README.mdx) for full syntax and directionality.
 
 ```yaml title="Patch imported Gateway hostnames during sync"
 sync:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing ingresses to host
 ---
 
 import Ingress from '../../../../../_partials/config/sync/toHost/ingresses.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -39,7 +38,7 @@ sync:
 
 ## Patches
 
-<Patches resource="ingresses" path="spec.rules[*].host" direction="toHost"  />
+Use `sync.toHost.ingresses.patches` to transform Ingress fields, such as `spec.rules[*].host`, while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
@@ -7,7 +7,6 @@ description: Configuration for syncing network policies to host
 ---
 
 import EnableSwitch from '../../../../../_partials/config/sync/toHost/networkPolicies.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -37,7 +36,7 @@ NetworkPolicy resources inside tenant clusters rely on the control plane cluster
 
 ## Patches
 
-<Patches resource="networkPolicies" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.networkPolicies.patches` to transform NetworkPolicy fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing services to host
 
 import Services from '../../../../../_partials/config/sync/toHost/services.mdx'
 import DisableResourceWarning from  '../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -25,7 +24,7 @@ Sync all [Service](https://kubernetes.io/docs/concepts/services-networking/servi
 
 ## Patches
 
-<Patches resource="services" path="spec.ports[*].name" direction="toHost" />
+Use `sync.toHost.services.patches` to transform Service fields, such as `spec.ports[*].name`, while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing persistent volume claims to host
 
 
 import EnableSwitch from '../../../../../_partials/config/sync/toHost/persistentVolumeClaims.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -33,7 +32,7 @@ sync:
 
 ## Patches
 
-<Patches resource="persistentVolumeClaims" path="spec.storageClassName" direction="toHost"  />
+Use `sync.toHost.persistentVolumeClaims.patches` to transform PersistentVolumeClaim fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing persistent volumes to host
 
 
 import EnableSwitch from '../../../../../_partials/config/sync/toHost/persistentVolumes.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -35,7 +34,7 @@ sync:
 
 ## Patches
 
-<Patches resource="persistentVolumes" path="metadata.annotations[*]" direction="toHost"  />
+Use `sync.toHost.persistentVolumes.patches` to transform PersistentVolume fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
@@ -8,7 +8,6 @@ description: Configuration for syncing storage classes to host
 
 
 import EnableSwitch from '../../../../../_partials/config/sync/toHost/storageClasses.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
 import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
@@ -33,7 +32,7 @@ sync:
 
 ## Patches
 
-<Patches resource="storageClasses" path="metadata.annotations[*]" direction="toHost" />
+Use `sync.toHost.storageClasses.patches` to transform StorageClass fields while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.
 
 ## Config reference
 


### PR DESCRIPTION
# Content Description

New `/configure/vcluster-yaml/sync/patching` reference page documenting sync patch configuration. Covers path syntax (dot notation, bracket notation, wildcards, empty paths), patch modes (expression, reference, labels), directionality for toHost and fromHost resources, validation rules, and a troubleshooting table. Includes an SVG diagram showing the expression/reverseExpression flow.

Also fixes broken patching links across 22 existing resource pages — all were missing the `README.mdx` suffix, causing silent 404s on click.

## Preview Link
<!-- The preview link or links to the documents-->
https://deploy-preview-2335--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/patching


## Internal Reference

Closes DOC-1576

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs