### PR TITLE
docs(coredns): document port 1053 requirement for networkpolicies and corefile overrides

### DIFF
--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -14,6 +14,7 @@ ClusterRole
 ClusterRoleBinding
 ConfigMap
 CoreDNS
+Corefile
 CPU
 CRD
 CronJob

--- a/vcluster/configure/vcluster-yaml/policies/network-policy.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/network-policy.mdx
@@ -39,7 +39,7 @@ policies:
 This creates Kubernetes NetworkPolicies resources in the host namespace that:
 - Allow traffic between pods within the tenant cluster
 - Block traffic from other namespaces
-- Permit DNS and API server communication
+- Permit DNS (port 1053) and API server communication
 
 :::note
 The Kubernetes NetworkPolicies resources are managed by vCluster. Manual changes to these resources will be overwritten.
@@ -193,6 +193,19 @@ spec:
 ### Example configurations {#examples}
 
 #### Custom ingress and egress rules {#custom-rules}
+
+:::warning DNS port in tenant clusters
+Tenant cluster DNS runs on port 1053, not the standard port 53. Custom egress rules that allow DNS traffic must target port 1053 or DNS resolution silently fails. UDP packets are dropped with no error in pod logs.
+
+```yaml
+ports:
+  - port: 1053
+    protocol: UDP
+  - port: 1053
+    protocol: TCP
+```
+:::
+
 Control inbound and outbound traffic with specific ports and IP addresses for vCluster control plane and workloads:
 ```yaml title="vcluster.yaml"
 policies:
@@ -233,7 +246,7 @@ policies:
 ```
 
 :::note
-`ingress` and `egress` config sections accept the same content type as [PodNetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/#podnetworkpolicy-resource)
+`ingress` and `egress` config sections follow the same schema as [PodNetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/#podnetworkpolicy-resource)
 :::
 
 #### Add custom labels {#custom-labels}
@@ -250,16 +263,6 @@ policies:
     annotations:
       description: "Network isolation for production vCluster"
 ```
-
-:::warning DNS Port in vCluster
-vCluster uses port 1053 for DNS queries, not the standard port 53. When creating custom NetworkPolicies for pods inside vCluster, ensure DNS rules target port 1053:
-
-```yaml
-ports:
-  - port: 1053
-    protocol: UDP
-```
-:::
 
 ## Project-scoped isolation with Platform {#project-scoped-isolation}
 

--- a/vcluster/learn-how-to/control-plane/container/configure-custom-coredns.mdx
+++ b/vcluster/learn-how-to/control-plane/container/configure-custom-coredns.mdx
@@ -10,8 +10,6 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-<!-- vale off -->
-
 Customizing CoreDNS enables tailored DNS management for specific requirements, such as handling custom zones, forwarding DNS queries, and integrating with external DNS providers. This guide explains how to configure and use custom CoreDNS setups in a vCluster.
 
 ## Common CoreDNS customizations
@@ -29,6 +27,10 @@ For more advanced configurations, see to the [CoreDNS documentation](https://cor
 ## Define CoreDNS configuration 
 
 Create or modify the `vcluster.yaml` file to include a custom CoreDNS configuration using the `overwriteManifests` field:
+
+:::note
+All Corefile server blocks must bind on port **1053**, not the standard DNS port 53. The tenant cluster's CoreDNS process listens on port 1053 to avoid privilege requirements. A custom Corefile that binds on port 53 does not match the listener and silently breaks DNS resolution. UDP packets are dropped with no error in pod logs.
+:::
 
 ```yaml
 controlPlane:


### PR DESCRIPTION
# Content Description
Document the port 1053 requirement for CoreDNS in two operator-facing scenarios: custom NetworkPolicies that allow DNS egress, and custom Corefile overrides via `overwriteConfig`/`overwriteManifests`.

## Preview Link
<!-- The preview link or links to the documents-->

## Internal Reference
Closes DOC-1521

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs