### PR TITLE
feat(ci): open a docs follow-up when loft-sh/plans changes affect sidebar labels

### DIFF
--- a/.github/workflows/check-plans-sidebar-labels.yml
+++ b/.github/workflows/check-plans-sidebar-labels.yml
@@ -16,6 +16,8 @@ on:
   schedule:
     # Weekly on Mondays at 09:27 UTC. Off-hour offset to avoid the top-of-hour
     # stampede with the feature-table sync (09:00) and EOS/EOL sync (09:13).
+    # The script looks back ~2 weeks (DEFAULT_SINCE_DAYS), so a skipped or
+    # delayed weekly run does not drop plans commits that landed in the gap.
     - cron: '27 9 * * 1'
   workflow_dispatch:
   repository_dispatch:
@@ -47,8 +49,20 @@ jobs:
         run: npm ci
 
       - name: Check plans sidebar labels
+        id: check
         # GH_ACCESS_TOKEN reads the private loft-sh/plans repo and files the
         # review issue in this repo (mirrors sync-upstream-features.yml).
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: node scripts/check-plans-sidebar-labels.js --open-issue
+
+      - name: Fail if the plans fetch failed
+        # A failed read of loft-sh/plans reports drift=false, which on a
+        # scheduled run is indistinguishable from a genuinely quiet week. The
+        # script emits plans_fetch_failed=true on that path; turn the job red so
+        # a revoked GH_ACCESS_TOKEN or lost repo access is visible instead of
+        # silently skipping the sidebar-label review. See DOC-1523.
+        if: steps.check.outputs.plans_fetch_failed == 'true'
+        run: |
+          echo "::error::Could not read loft-sh/plans commits; the sidebar-label review was skipped. Check that GH_ACCESS_TOKEN still has read access to loft-sh/plans."
+          exit 1

--- a/.github/workflows/check-plans-sidebar-labels.yml
+++ b/.github/workflows/check-plans-sidebar-labels.yml
@@ -1,0 +1,54 @@
+name: Check plans sidebar labels
+
+# When loft-sh/plans changes, the left-nav Enterprise/Free sidebar labels and
+# the ProAdmonition partial can drift: unlike the Feature Table they are hand
+# maintained, with no machine mapping from a plan tier to the exact pages that
+# need a label flipped. So this opens (or updates) a single review issue
+# carrying a best-effort suspect list and the full label inventory for a human
+# to act on. Mechanical drift gets an auto-PR (check-eos-eol-labels.yml);
+# judgement drift gets a review issue. See DOC-1523.
+#
+# All logic lives in scripts/check-plans-sidebar-labels.js (unit tested); this
+# workflow is a single invocation. The script treats workflow_dispatch and
+# repository_dispatch as a forced run via GITHUB_EVENT_NAME.
+
+on:
+  schedule:
+    # Weekly on Mondays at 09:27 UTC. Off-hour offset to avoid the top-of-hour
+    # stampede with the feature-table sync (09:00) and EOS/EOL sync (09:13).
+    - cron: '27 9 * * 1'
+  workflow_dispatch:
+  repository_dispatch:
+    # loft-sh/plans can POST a dispatch of this type to trigger a review on push.
+    types: [plans-updated]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-plans-sidebar-labels
+  cancel-in-progress: false
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check plans sidebar labels
+        # GH_ACCESS_TOKEN reads the private loft-sh/plans repo and files the
+        # review issue in this repo (mirrors sync-upstream-features.yml).
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: node scripts/check-plans-sidebar-labels.js --open-issue

--- a/.github/workflows/check-plans-sidebar-labels.yml
+++ b/.github/workflows/check-plans-sidebar-labels.yml
@@ -44,7 +44,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Check plans sidebar labels
         # GH_ACCESS_TOKEN reads the private loft-sh/plans repo and files the

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sync-latest-versions": "node scripts/check-latest-versions.js --update",
     "check-eos-eol-labels": "node scripts/check-eos-eol-labels.js",
     "sync-eos-eol-labels": "node scripts/check-eos-eol-labels.js --update",
+    "check-plans-sidebar-labels": "node scripts/check-plans-sidebar-labels.js --dry-run --force",
     "validate-mdx-links": "python3 scripts/find-spa-broken-links.py",
     "check-redirects": "bash hack/check-redirects.sh pr",
     "fix-redirects": "bash hack/check-redirects.sh --fix",

--- a/scripts/check-plans-sidebar-labels.js
+++ b/scripts/check-plans-sidebar-labels.js
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+
+/**
+ * check-plans-sidebar-labels.js
+ *
+ * Opens (or updates) a docs follow-up issue when loft-sh/plans changes, so a
+ * human reviews whether the left-nav Enterprise/Free sidebar labels and the
+ * ProAdmonition partial still match the plan tiers.
+ *
+ * Why an issue and not an auto-PR:
+ *   The Feature Table sync (scripts/sync-upstream-features.js) already mirrors
+ *   plan tiers into src/data/products.yaml mechanically. Sidebar labels are
+ *   different: they live in per-page `sidebar_class_name: pro|free` frontmatter
+ *   and in editorially-placed <ProAdmonition /> includes. There is no reliable
+ *   machine mapping from a plan-tier change to the exact pages that need a label
+ *   flipped (a page can document several features, a docs_url can point at a
+ *   section anchor, a ProAdmonition is placed by hand). So this opens a review
+ *   issue carrying a best-effort suspect list, not a pre-written diff. Mechanical
+ *   drift gets an auto-PR (see check-eos-eol-labels.js); judgement drift gets a
+ *   review issue. DOC-1513 (custom resources wrongly marked Enterprise) is the
+ *   exact drift this catches.
+ *
+ * What it does:
+ *   1. Detects recent loft-sh/plans commits (the trigger).
+ *   2. Cross-checks every feature in src/data/features.yaml that maps cleanly to
+ *      a whole docs page: a Free-tier feature whose page still carries a `pro`
+ *      label or a ProAdmonition is flagged (over-labeled); an Enterprise-only
+ *      feature whose page carries a `free` label is flagged (under-labeled).
+ *   3. Inventories every page currently carrying a pro/free label or a
+ *      ProAdmonition, so the reviewer has the full surface to check.
+ *   4. Opens or updates a single tracking issue (deduped by label).
+ *
+ * Usage:
+ *   node scripts/check-plans-sidebar-labels.js              # report only (no side effects)
+ *   node scripts/check-plans-sidebar-labels.js --dry-run    # print the issue body
+ *   node scripts/check-plans-sidebar-labels.js --open-issue # open/update the tracking issue
+ *   node scripts/check-plans-sidebar-labels.js --force      # act even without recent plans commits
+ *   node scripts/check-plans-sidebar-labels.js --since-days 14
+ *
+ * GITHUB_EVENT_NAME=workflow_dispatch|repository_dispatch is treated as --force
+ * (a human or upstream repo explicitly asked for the review).
+ *
+ * Outputs (when GITHUB_OUTPUT is set):
+ *   drift=true|false
+ *   issue=<url-or-number>   (--open-issue only, when an issue was opened/updated)
+ *
+ * Functions are exported for the test suite. Main execution is gated by
+ * require.main === module so the file can be required as a library.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+const PRODUCTS_YAML = path.join(ROOT, 'src/data/products.yaml');
+const FEATURES_YAML = path.join(ROOT, 'src/data/features.yaml');
+
+// Live ("next") docs trees. Versioned docs are backported by CI and are not
+// reviewed here.
+const DOC_ROOTS = ['vcluster', 'platform'];
+
+const PLANS_REPO = 'loft-sh/plans';
+const PRODUCTS_PATH = 'src/data/products.yaml';
+const PRO_ADMONITION_PARTIAL = 'vcluster/_partials/admonitions/pro-admonition.mdx';
+const SIDEBAR_CSS = 'src/css/sidebar.scss';
+
+const ISSUE_TITLE = 'Review sidebar Enterprise/Free labels after loft-sh/plans change';
+const ISSUE_LABEL = 'plans-sidebar-review';
+
+function defaultExec(cmd, args) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+function loadYaml(file) {
+  // Strip the leading comment header before parsing, mirroring
+  // sync-upstream-features.js.
+  const content = fs.readFileSync(file, 'utf8').replace(/^#[^\n]*\n/gm, '');
+  return yaml.load(content) || {};
+}
+
+/**
+ * Feature IDs assigned to the Free tier in products.yaml. Everything not in
+ * this set is Enterprise-only (Dev/Prod/Scale all have enterprise: true).
+ */
+function freeFeatureSet(products) {
+  const free = products?.products?.free?.features || [];
+  return new Set(free);
+}
+
+function parseFrontmatter(content) {
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : '';
+}
+
+/**
+ * Tokenize the space-separated `sidebar_class_name` frontmatter value. Pages
+ * combine label classes with layout classes, e.g. "pro host-nodes".
+ */
+function sidebarClasses(content) {
+  const fm = parseFrontmatter(content);
+  const m = fm.match(/^sidebar_class_name:\s*(.+)$/m);
+  if (!m) return [];
+  return m[1]
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function usesProAdmonition(content) {
+  return /pro-admonition\.mdx/.test(content) || /<ProAdmonition\b/.test(content);
+}
+
+/**
+ * Map a feature's docs_url to a source file, or null when it cannot be mapped
+ * to a whole page. Anchored URLs (#section) are skipped on purpose: they point
+ * at one feature within a shared page, so the page-level label cannot be
+ * attributed to that feature alone.
+ */
+function resolveDocPath(docsUrl, { exists } = {}) {
+  const fileExists = exists || ((f) => fs.existsSync(path.join(ROOT, f)));
+  if (!docsUrl || !docsUrl.startsWith('/docs/')) return null;
+  if (docsUrl.includes('#')) return null;
+  const rel = docsUrl.replace(/^\/docs\//, '').replace(/\/$/, '');
+  if (!rel) return null;
+  const candidates = [`${rel}.mdx`, `${rel}.md`, `${rel}/README.mdx`, `${rel}/README.md`];
+  for (const c of candidates) {
+    if (fileExists(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * Conservative cross-check of feature tier (from products.yaml) against the
+ * label on the feature's docs page. Only whole-page, cleanly-resolved features
+ * are considered, and only explicit contradictions are flagged. A missing
+ * `pro` label is never flagged: absence is the default and would be pure noise.
+ */
+function crossCheck({ products, features, readFile, exists } = {}) {
+  const read = readFile || ((f) => fs.readFileSync(path.join(ROOT, f), 'utf8'));
+  const free = freeFeatureSet(products);
+  const feats = (features && features.features) || {};
+  const mismatches = [];
+
+  for (const [id, meta] of Object.entries(feats)) {
+    const file = resolveDocPath(meta && meta.docs_url, { exists });
+    if (!file) continue;
+
+    let content;
+    try {
+      content = read(file);
+    } catch {
+      continue;
+    }
+
+    const classes = sidebarClasses(content);
+    const hasPro = classes.includes('pro');
+    const hasFree = classes.includes('free');
+    const proAdm = usesProAdmonition(content);
+    const isFree = free.has(id);
+
+    if (isFree && (hasPro || proAdm)) {
+      const markers = [];
+      if (hasPro) markers.push('`sidebar_class_name: pro`');
+      if (proAdm) markers.push('ProAdmonition');
+      mismatches.push({
+        id,
+        name: (meta && meta.name) || id,
+        tier: 'Free',
+        kind: 'over-labeled',
+        file,
+        docsUrl: meta.docs_url,
+        detail: `Free tier but page has ${markers.join(' + ')}`,
+      });
+    } else if (!isFree && hasFree) {
+      mismatches.push({
+        id,
+        name: (meta && meta.name) || id,
+        tier: 'Enterprise',
+        kind: 'under-labeled',
+        file,
+        docsUrl: meta.docs_url,
+        detail: 'Enterprise-only but page has `sidebar_class_name: free`',
+      });
+    }
+  }
+
+  mismatches.sort((a, b) => a.file.localeCompare(b.file));
+  return mismatches;
+}
+
+/**
+ * Inventory every live-docs page that currently carries a pro/free label or a
+ * ProAdmonition. This is the full surface a reviewer should sweep.
+ */
+function buildInventory({ root, listFiles, readFile } = {}) {
+  const baseRoot = root || ROOT;
+  const read = readFile || ((f) => fs.readFileSync(path.join(baseRoot, f), 'utf8'));
+  const list =
+    listFiles ||
+    ((dir) => {
+      const abs = path.join(baseRoot, dir);
+      if (!fs.existsSync(abs)) return [];
+      return fs
+        .readdirSync(abs, { recursive: true })
+        .filter((e) => /\.(mdx|md)$/.test(e))
+        .map((e) => path.join(dir, e));
+    });
+
+  const inv = { pro: [], free: [], proAdmonition: [] };
+  for (const dir of DOC_ROOTS) {
+    for (const rel of list(dir)) {
+      let content;
+      try {
+        content = read(rel);
+      } catch {
+        continue;
+      }
+      const classes = sidebarClasses(content);
+      if (classes.includes('pro')) inv.pro.push(rel);
+      if (classes.includes('free')) inv.free.push(rel);
+      if (usesProAdmonition(content)) inv.proAdmonition.push(rel);
+    }
+  }
+  inv.pro.sort();
+  inv.free.sort();
+  inv.proAdmonition.sort();
+  return inv;
+}
+
+/**
+ * Recent commits on the loft-sh/plans default branch. Returns [] (and logs)
+ * when the repo cannot be read, so a forced run still produces a review issue.
+ */
+function fetchPlansCommits({ sinceDays = 7, now = new Date(), repo = PLANS_REPO, exec = defaultExec } = {}) {
+  const since = new Date(now.getTime() - sinceDays * 86400 * 1000).toISOString();
+  const raw = exec('gh', [
+    'api',
+    `repos/${repo}/commits?since=${encodeURIComponent(since)}&per_page=100`,
+  ]);
+  const arr = JSON.parse(raw || '[]');
+  return arr.map((c) => ({
+    sha: (c.sha || '').slice(0, 7),
+    message: ((c.commit && c.commit.message) || '').split('\n')[0],
+    date: (c.commit && c.commit.author && c.commit.author.date) || '',
+    url: c.html_url || '',
+  }));
+}
+
+function renderIssueBody({ commits, mismatches, inventory, sinceDays, force }) {
+  const lines = [];
+  lines.push(
+    'A change in [loft-sh/plans](https://github.com/loft-sh/plans) may have shifted which features are Free vs Enterprise.'
+  );
+  lines.push(
+    'The Feature Table is synced automatically, but the left-nav `Enterprise`/`Free` sidebar labels and the `ProAdmonition` partial are maintained by hand and can drift. Review them and update any that no longer match the plans.'
+  );
+  lines.push('');
+
+  lines.push('## Triggering plans activity');
+  lines.push('');
+  if (commits && commits.length) {
+    lines.push(`Commits on \`${PLANS_REPO}\` in the last ${sinceDays} day(s):`);
+    lines.push('');
+    for (const c of commits.slice(0, 30)) {
+      const date = c.date ? c.date.slice(0, 10) : '';
+      const link = c.url ? `[\`${c.sha}\`](${c.url})` : `\`${c.sha}\``;
+      lines.push(`- ${link} ${date} ${c.message}`);
+    }
+    if (commits.length > 30) lines.push(`- ...and ${commits.length - 30} more`);
+  } else if (force) {
+    lines.push('Manually triggered review (no recent plans commits were read).');
+  } else {
+    lines.push(`No commits read on \`${PLANS_REPO}\` in the last ${sinceDays} day(s).`);
+  }
+  lines.push('');
+
+  lines.push('## Suspected mismatches (best effort)');
+  lines.push('');
+  lines.push(
+    'Computed by comparing each feature tier in `' +
+      PRODUCTS_PATH +
+      '` against the sidebar label on the feature page it maps to. Only whole-page, cleanly-resolved features are listed, so this is a starting point, not the full set. Confirm each before changing it.'
+  );
+  lines.push('');
+  if (mismatches && mismatches.length) {
+    lines.push('| Feature | Tier | Page | Issue |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const m of mismatches) {
+      lines.push(`| ${m.name} (\`${m.id}\`) | ${m.tier} | \`${m.file}\` | ${m.detail} |`);
+    }
+  } else {
+    lines.push('None detected automatically. Review the inventory below by hand.');
+  }
+  lines.push('');
+
+  lines.push('## Label inventory');
+  lines.push('');
+  lines.push(
+    `Every live-docs page currently carrying a label or a ProAdmonition. Sources: \`sidebar_class_name\` frontmatter (rendered as badges by \`${SIDEBAR_CSS}\`) and \`${PRO_ADMONITION_PARTIAL}\`.`
+  );
+  lines.push('');
+  const section = (heading, files) => {
+    lines.push(`<details><summary>${heading} (${files.length})</summary>`);
+    lines.push('');
+    for (const f of files) lines.push(`- \`${f}\``);
+    if (!files.length) lines.push('- _none_');
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  };
+  section('Pages with the Enterprise (`pro`) sidebar label', inventory.pro);
+  section('Pages with the `free` sidebar label', inventory.free);
+  section('Pages using the ProAdmonition partial', inventory.proAdmonition);
+
+  lines.push('## How to resolve');
+  lines.push('');
+  lines.push('1. Check the suspected mismatches above and confirm each against the current plans.');
+  lines.push(
+    '2. Flip `sidebar_class_name: pro` <-> `free` (or remove it) in the page frontmatter where the tier changed.'
+  );
+  lines.push(
+    `3. Add or remove the \`<ProAdmonition />\` include (from \`${PRO_ADMONITION_PARTIAL}\`) to match.`
+  );
+  lines.push('4. Open a PR with the label changes and link it here.');
+  lines.push('5. Close this issue once the labels match the plans.');
+  lines.push('');
+  lines.push('## Related');
+  lines.push('');
+  lines.push('- [DOC-1513](https://linear.app/loft/issue/DOC-1513): custom resources wrongly marked as Enterprise, the drift class this catches.');
+  lines.push('- Feature Table sync: `.github/workflows/sync-upstream-features.yml`.');
+  lines.push('');
+  lines.push('<sub>Opened automatically by `.github/workflows/check-plans-sidebar-labels.yml`. Closes DOC-1523.</sub>');
+
+  return lines.join('\n') + '\n';
+}
+
+function findOpenIssue({ label, exec = defaultExec }) {
+  const raw = exec('gh', [
+    'issue',
+    'list',
+    '--state',
+    'open',
+    '--label',
+    label,
+    '--json',
+    'number',
+    '--limit',
+    '50',
+  ]);
+  const arr = JSON.parse(raw || '[]');
+  return arr.length ? arr[0].number : null;
+}
+
+function ensureLabel({ label, exec = defaultExec }) {
+  // --force makes this create-or-update and idempotent across runs. The orange
+  // is the vCluster brand primary.
+  try {
+    exec('gh', [
+      'label',
+      'create',
+      label,
+      '--description',
+      'Review docs sidebar Enterprise/Free labels after a loft-sh/plans change',
+      '--color',
+      'FF6600',
+      '--force',
+    ]);
+  } catch {
+    // Non-fatal: issue creation can still attach an existing label.
+  }
+}
+
+/**
+ * Open a fresh tracking issue, or update the one already open. A single open
+ * issue at a time keeps weekly plans churn from spamming the tracker; the next
+ * change after a reviewer closes it opens a new one.
+ */
+function openOrUpdateTrackingIssue({ title, body, label, exec = defaultExec }) {
+  ensureLabel({ label, exec });
+  const existing = findOpenIssue({ label, exec });
+  if (existing) {
+    exec('gh', ['issue', 'edit', String(existing), '--body', body]);
+    exec('gh', [
+      'issue',
+      'comment',
+      String(existing),
+      '--body',
+      'Re-checked after new loft-sh/plans activity. Body updated with the latest suspected mismatches and inventory.',
+    ]);
+    return { number: existing, action: 'updated' };
+  }
+  const out = exec('gh', ['issue', 'create', '--title', title, '--body', body, '--label', label]);
+  const url = (out || '').trim().split('\n').pop();
+  return { url, action: 'created' };
+}
+
+function appendGithubOutput(entries) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, entries.join('\n') + '\n');
+}
+
+function parseArgs(argv) {
+  const opts = { openIssue: false, dryRun: false, force: false, sinceDays: 7 };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--open-issue') opts.openIssue = true;
+    else if (argv[i] === '--dry-run') opts.dryRun = true;
+    else if (argv[i] === '--force') opts.force = true;
+    else if (argv[i] === '--since-days') {
+      const v = argv[i + 1];
+      if (!v || !/^\d+$/.test(v)) throw new Error('--since-days requires a positive integer');
+      opts.sinceDays = parseInt(v, 10);
+      i++;
+    }
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const eventName = process.env.GITHUB_EVENT_NAME || '';
+  const force = opts.force || eventName === 'workflow_dispatch' || eventName === 'repository_dispatch';
+
+  const products = loadYaml(PRODUCTS_YAML);
+  const features = loadYaml(FEATURES_YAML);
+
+  const mismatches = crossCheck({ products, features });
+  const inventory = buildInventory({});
+
+  let commits = [];
+  try {
+    commits = fetchPlansCommits({ sinceDays: opts.sinceDays });
+  } catch (e) {
+    console.error(`Could not read ${PLANS_REPO} commits: ${e.message}`);
+  }
+
+  const plansChanged = commits.length > 0;
+  const shouldAct = force || plansChanged;
+
+  const body = renderIssueBody({
+    commits,
+    mismatches,
+    inventory,
+    sinceDays: opts.sinceDays,
+    force,
+  });
+
+  if (opts.dryRun) {
+    console.log(body);
+  }
+
+  console.error(
+    `plans commits (last ${opts.sinceDays}d): ${commits.length}; suspected mismatches: ${mismatches.length}; ` +
+      `labeled pages: pro=${inventory.pro.length} free=${inventory.free.length} proAdmonition=${inventory.proAdmonition.length}`
+  );
+
+  if (!shouldAct) {
+    console.log(`No ${PLANS_REPO} commits in the last ${opts.sinceDays} day(s); no review needed.`);
+    appendGithubOutput(['drift=false']);
+    return 0;
+  }
+
+  if (opts.openIssue) {
+    const res = openOrUpdateTrackingIssue({ title: ISSUE_TITLE, body, label: ISSUE_LABEL });
+    const ref = res.url || `#${res.number}`;
+    console.log(`Tracking issue ${res.action}: ${ref}`);
+    appendGithubOutput(['drift=true', `issue=${ref}`]);
+  } else {
+    console.log(
+      `Plans changed or run forced. ${mismatches.length} suspected mismatch(es). Re-run with --open-issue to file the review issue.`
+    );
+    appendGithubOutput(['drift=true']);
+  }
+  return 0;
+}
+
+module.exports = {
+  freeFeatureSet,
+  parseFrontmatter,
+  sidebarClasses,
+  usesProAdmonition,
+  resolveDocPath,
+  crossCheck,
+  buildInventory,
+  fetchPlansCommits,
+  renderIssueBody,
+  findOpenIssue,
+  openOrUpdateTrackingIssue,
+  parseArgs,
+  ISSUE_TITLE,
+  ISSUE_LABEL,
+};
+
+if (require.main === module) {
+  try {
+    process.exit(main());
+  } catch (err) {
+    console.error(err.stack || err.message);
+    process.exit(2);
+  }
+}

--- a/scripts/check-plans-sidebar-labels.js
+++ b/scripts/check-plans-sidebar-labels.js
@@ -70,6 +70,13 @@ const PRODUCTS_DISPLAY_PATH = 'src/data/products.yaml';
 const PRO_ADMONITION_PARTIAL = 'vcluster/_partials/admonitions/pro-admonition.mdx';
 const SIDEBAR_CSS = 'src/css/sidebar.scss';
 
+// Default lookback window for loft-sh/plans commits. Deliberately ~2x the weekly
+// cron cadence so a skipped, delayed, or briefly-disabled scheduled run does not
+// drop commits that landed in the gap (a 7-day window ending after a missed run
+// leaves those days unreviewed forever). Overlap is safe: the tracker is a single
+// label-deduped issue, so re-seeing a commit updates it rather than spamming.
+const DEFAULT_SINCE_DAYS = 14;
+
 const ISSUE_TITLE = 'Review sidebar Enterprise/Free labels after loft-sh/plans change';
 const ISSUE_LABEL = 'plans-sidebar-review';
 
@@ -238,7 +245,7 @@ function buildInventory({ root, listFiles, readFile } = {}) {
  * Recent commits on the loft-sh/plans default branch. Returns [] (and logs)
  * when the repo cannot be read, so a forced run still produces a review issue.
  */
-function fetchPlansCommits({ sinceDays = 7, now = new Date(), repo = PLANS_REPO, exec = defaultExec } = {}) {
+function fetchPlansCommits({ sinceDays = DEFAULT_SINCE_DAYS, now = new Date(), repo = PLANS_REPO, exec = defaultExec } = {}) {
   const since = new Date(now.getTime() - sinceDays * 86400 * 1000).toISOString();
   const raw = exec('gh', [
     'api',
@@ -407,7 +414,7 @@ function appendGithubOutput(entries) {
 }
 
 function parseArgs(argv) {
-  const opts = { openIssue: false, dryRun: false, force: false, sinceDays: 7 };
+  const opts = { openIssue: false, dryRun: false, force: false, sinceDays: DEFAULT_SINCE_DAYS };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--open-issue') opts.openIssue = true;
     else if (argv[i] === '--dry-run') opts.dryRun = true;

--- a/scripts/check-plans-sidebar-labels.js
+++ b/scripts/check-plans-sidebar-labels.js
@@ -43,6 +43,8 @@
  * Outputs (when GITHUB_OUTPUT is set):
  *   drift=true|false
  *   issue=<url-or-number>   (--open-issue only, when an issue was opened/updated)
+ *   plans_fetch_failed=true (only when the loft-sh/plans commit read threw, so a
+ *                            failed fetch is not mistaken for a quiet week)
  *
  * Functions are exported for the test suite. Main execution is gated by
  * require.main === module so the file can be required as a library.
@@ -62,7 +64,9 @@ const FEATURES_YAML = path.join(ROOT, 'src/data/features.yaml');
 const DOC_ROOTS = ['vcluster', 'platform'];
 
 const PLANS_REPO = 'loft-sh/plans';
-const PRODUCTS_PATH = 'src/data/products.yaml';
+// Prose display string for the issue body (PRODUCTS_YAML above is the absolute
+// read path). Kept separate so the rendered issue shows a repo-relative path.
+const PRODUCTS_DISPLAY_PATH = 'src/data/products.yaml';
 const PRO_ADMONITION_PARTIAL = 'vcluster/_partials/admonitions/pro-admonition.mdx';
 const SIDEBAR_CSS = 'src/css/sidebar.scss';
 
@@ -281,7 +285,7 @@ function renderIssueBody({ commits, mismatches, inventory, sinceDays, force }) {
   lines.push('');
   lines.push(
     'Computed by comparing each feature tier in `' +
-      PRODUCTS_PATH +
+      PRODUCTS_DISPLAY_PATH +
       '` against the sidebar label on the feature page it maps to. Only whole-page, cleanly-resolved features are listed, so this is a starting point, not the full set. Confirm each before changing it.'
   );
   lines.push('');
@@ -430,11 +434,16 @@ function main() {
   const inventory = buildInventory({});
 
   let commits = [];
+  let fetchFailed = false;
   try {
     commits = fetchPlansCommits({ sinceDays: opts.sinceDays });
   } catch (e) {
     console.error(`Could not read ${PLANS_REPO} commits: ${e.message}`);
+    fetchFailed = true;
   }
+  // Surface a failed fetch to the caller so it can't masquerade as a clean
+  // no-activity week (drift=false with zero commits).
+  const failFlag = fetchFailed ? ['plans_fetch_failed=true'] : [];
 
   const plansChanged = commits.length > 0;
   const shouldAct = force || plansChanged;
@@ -458,7 +467,7 @@ function main() {
 
   if (!shouldAct) {
     console.log(`No ${PLANS_REPO} commits in the last ${opts.sinceDays} day(s); no review needed.`);
-    appendGithubOutput(['drift=false']);
+    appendGithubOutput(['drift=false', ...failFlag]);
     return 0;
   }
 
@@ -466,12 +475,12 @@ function main() {
     const res = openOrUpdateTrackingIssue({ title: ISSUE_TITLE, body, label: ISSUE_LABEL });
     const ref = res.url || `#${res.number}`;
     console.log(`Tracking issue ${res.action}: ${ref}`);
-    appendGithubOutput(['drift=true', `issue=${ref}`]);
+    appendGithubOutput(['drift=true', `issue=${ref}`, ...failFlag]);
   } else {
     console.log(
       `Plans changed or run forced. ${mismatches.length} suspected mismatch(es). Re-run with --open-issue to file the review issue.`
     );
-    appendGithubOutput(['drift=true']);
+    appendGithubOutput(['drift=true', ...failFlag]);
   }
   return 0;
 }

--- a/tests/check-plans-sidebar-labels.test.js
+++ b/tests/check-plans-sidebar-labels.test.js
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for scripts/check-plans-sidebar-labels.js.
+ *
+ * Uses Node's built-in test runner (node --test); no extra dependencies.
+ * Run: node --test tests/check-plans-sidebar-labels.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  freeFeatureSet,
+  parseFrontmatter,
+  sidebarClasses,
+  usesProAdmonition,
+  resolveDocPath,
+  crossCheck,
+  buildInventory,
+  fetchPlansCommits,
+  renderIssueBody,
+  findOpenIssue,
+  openOrUpdateTrackingIssue,
+  parseArgs,
+} = require('../scripts/check-plans-sidebar-labels.js');
+
+const PRODUCTS = {
+  products: {
+    free: { name: 'Free', enterprise: false, features: ['custom-resources', 'sleep-mode'] },
+    dev: { name: 'Dev', enterprise: true, features: ['sso', 'sleep-mode'] },
+    prod: { name: 'Prod', enterprise: true, features: ['sso'] },
+    scale: { name: 'Scale', enterprise: true, features: ['sso'] },
+  },
+};
+
+const FEATURES = {
+  features: {
+    'custom-resources': { name: 'Custom Resources', docs_url: '/docs/vcluster/custom-resources' },
+    'sleep-mode': { name: 'Sleep Mode', docs_url: '/docs/vcluster/sleep#enable' }, // anchored -> skipped
+    sso: { name: 'Single Sign-On', docs_url: '/docs/platform/sso' },
+    orphan: { name: 'Orphan', docs_url: '/docs/vcluster/does-not-exist' },
+    nourl: { name: 'No URL' },
+  },
+};
+
+// Virtual filesystem keyed by repo-relative path.
+const FILES = {
+  // Free feature, but page still marked Enterprise -> over-labeled (DOC-1513 case).
+  'vcluster/custom-resources.mdx': '---\ntitle: Custom Resources\nsidebar_class_name: pro host-nodes\n---\nbody',
+  // Enterprise feature, but page marked free -> under-labeled.
+  'platform/sso.mdx': '---\ntitle: SSO\nsidebar_class_name: free\n---\nbody',
+  // Anchored docs_url for sleep-mode; should never be read.
+  'vcluster/sleep.mdx': '---\ntitle: Sleep\nsidebar_class_name: pro\n---\nbody',
+};
+
+function fakeExists(f) {
+  return Object.prototype.hasOwnProperty.call(FILES, f);
+}
+function fakeRead(f) {
+  if (!fakeExists(f)) throw new Error(`ENOENT ${f}`);
+  return FILES[f];
+}
+
+test('freeFeatureSet returns only the Free tier features', () => {
+  const s = freeFeatureSet(PRODUCTS);
+  assert.ok(s.has('custom-resources'));
+  assert.ok(s.has('sleep-mode'));
+  assert.ok(!s.has('sso'));
+  assert.equal(s.size, 2);
+});
+
+test('freeFeatureSet tolerates missing structure', () => {
+  assert.equal(freeFeatureSet({}).size, 0);
+  assert.equal(freeFeatureSet({ products: {} }).size, 0);
+});
+
+test('parseFrontmatter extracts the block and handles no-frontmatter', () => {
+  assert.match(parseFrontmatter('---\na: 1\nb: 2\n---\nrest'), /a: 1/);
+  assert.equal(parseFrontmatter('no frontmatter here'), '');
+});
+
+test('sidebarClasses tokenizes space-separated classes', () => {
+  assert.deepEqual(sidebarClasses('---\nsidebar_class_name: pro host-nodes\n---\n'), ['pro', 'host-nodes']);
+  assert.deepEqual(sidebarClasses('---\nsidebar_class_name: free\n---\n'), ['free']);
+});
+
+test('sidebarClasses strips quotes and trailing whitespace', () => {
+  assert.deepEqual(sidebarClasses('---\nsidebar_class_name: "pro host-nodes"\n---\n'), ['pro', 'host-nodes']);
+  assert.deepEqual(sidebarClasses('---\nsidebar_class_name: private-nodes \n---\n'), ['private-nodes']);
+});
+
+test('sidebarClasses returns [] when absent', () => {
+  assert.deepEqual(sidebarClasses('---\ntitle: X\n---\n'), []);
+});
+
+test('usesProAdmonition detects import path and JSX tag', () => {
+  assert.ok(usesProAdmonition("import P from '../_partials/admonitions/pro-admonition.mdx'"));
+  assert.ok(usesProAdmonition('<ProAdmonition />'));
+  assert.ok(!usesProAdmonition('just some text'));
+});
+
+test('resolveDocPath maps a whole-page docs_url to a file', () => {
+  assert.equal(
+    resolveDocPath('/docs/vcluster/custom-resources', { exists: fakeExists }),
+    'vcluster/custom-resources.mdx'
+  );
+});
+
+test('resolveDocPath skips anchored URLs', () => {
+  assert.equal(resolveDocPath('/docs/vcluster/sleep#enable', { exists: fakeExists }), null);
+});
+
+test('resolveDocPath returns null for unknown or non-docs URLs', () => {
+  assert.equal(resolveDocPath('/docs/vcluster/does-not-exist', { exists: fakeExists }), null);
+  assert.equal(resolveDocPath('https://example.com', { exists: fakeExists }), null);
+  assert.equal(resolveDocPath(undefined, { exists: fakeExists }), null);
+});
+
+test('crossCheck flags over-labeled Free feature and under-labeled Enterprise feature', () => {
+  const m = crossCheck({ products: PRODUCTS, features: FEATURES, readFile: fakeRead, exists: fakeExists });
+  const byId = Object.fromEntries(m.map((x) => [x.id, x]));
+
+  assert.ok(byId['custom-resources'], 'expected custom-resources flagged');
+  assert.equal(byId['custom-resources'].kind, 'over-labeled');
+  assert.equal(byId['custom-resources'].tier, 'Free');
+
+  assert.ok(byId['sso'], 'expected sso flagged');
+  assert.equal(byId['sso'].kind, 'under-labeled');
+  assert.equal(byId['sso'].tier, 'Enterprise');
+
+  // sleep-mode is anchored (skipped), orphan/nourl do not resolve.
+  assert.ok(!byId['sleep-mode']);
+  assert.ok(!byId['orphan']);
+  assert.ok(!byId['nourl']);
+  assert.equal(m.length, 2);
+});
+
+test('crossCheck flags ProAdmonition on a Free-tier page', () => {
+  const files = {
+    'vcluster/cr.mdx': '---\ntitle: CR\n---\nimport P from "../_partials/admonitions/pro-admonition.mdx"\n<ProAdmonition />',
+  };
+  const products = { products: { free: { features: ['cr'] }, dev: { features: [] } } };
+  const features = { features: { cr: { name: 'CR', docs_url: '/docs/vcluster/cr' } } };
+  const m = crossCheck({
+    products,
+    features,
+    readFile: (f) => files[f],
+    exists: (f) => Object.prototype.hasOwnProperty.call(files, f),
+  });
+  assert.equal(m.length, 1);
+  assert.equal(m[0].kind, 'over-labeled');
+  assert.match(m[0].detail, /ProAdmonition/);
+});
+
+test('crossCheck does not flag correctly-labeled pages', () => {
+  const files = {
+    'vcluster/free-ok.mdx': '---\nsidebar_class_name: free\n---\n',
+    'platform/pro-ok.mdx': '---\nsidebar_class_name: pro\n---\n',
+  };
+  const products = { products: { free: { features: ['a'] }, dev: { features: ['b'] } } };
+  const features = {
+    features: {
+      a: { name: 'A', docs_url: '/docs/vcluster/free-ok' }, // free feature + free label = ok
+      b: { name: 'B', docs_url: '/docs/platform/pro-ok' }, // enterprise feature + pro label = ok
+    },
+  };
+  const m = crossCheck({
+    products,
+    features,
+    readFile: (f) => files[f],
+    exists: (f) => Object.prototype.hasOwnProperty.call(files, f),
+  });
+  assert.equal(m.length, 0);
+});
+
+test('buildInventory categorizes pages by label and ProAdmonition', () => {
+  const files = {
+    'vcluster/a.mdx': '---\nsidebar_class_name: pro\n---\n',
+    'vcluster/b.mdx': '---\nsidebar_class_name: free host-nodes\n---\n',
+    'platform/c.md': '---\ntitle: c\n---\n<ProAdmonition />',
+    'platform/d.mdx': '---\ntitle: d\n---\nno labels',
+  };
+  const listFiles = (dir) => Object.keys(files).filter((f) => f.startsWith(dir + '/'));
+  const inv = buildInventory({ listFiles, readFile: (f) => files[f] });
+  assert.deepEqual(inv.pro, ['vcluster/a.mdx']);
+  assert.deepEqual(inv.free, ['vcluster/b.mdx']);
+  assert.deepEqual(inv.proAdmonition, ['platform/c.md']);
+});
+
+test('fetchPlansCommits parses gh api JSON and trims sha + message', () => {
+  const fakeExec = () =>
+    JSON.stringify([
+      {
+        sha: 'abcdef1234567890',
+        html_url: 'https://github.com/loft-sh/plans/commit/abcdef1',
+        commit: { message: 'move custom-resources to free\n\nbody', author: { date: '2026-06-28T10:00:00Z' } },
+      },
+    ]);
+  const commits = fetchPlansCommits({ sinceDays: 7, now: new Date('2026-06-29T00:00:00Z'), exec: fakeExec });
+  assert.equal(commits.length, 1);
+  assert.equal(commits[0].sha, 'abcdef1');
+  assert.equal(commits[0].message, 'move custom-resources to free');
+  assert.equal(commits[0].date, '2026-06-28T10:00:00Z');
+});
+
+test('fetchPlansCommits returns [] on empty response', () => {
+  assert.deepEqual(fetchPlansCommits({ exec: () => '[]' }), []);
+});
+
+test('renderIssueBody includes commits, mismatch table, inventory, and DOC-1513', () => {
+  const body = renderIssueBody({
+    commits: [{ sha: 'abc1234', message: 'tier change', date: '2026-06-28T00:00:00Z', url: 'https://x/abc' }],
+    mismatches: [
+      { id: 'custom-resources', name: 'Custom Resources', tier: 'Free', file: 'vcluster/custom-resources.mdx', detail: 'Free tier but page has `sidebar_class_name: pro`' },
+    ],
+    inventory: { pro: ['vcluster/custom-resources.mdx'], free: [], proAdmonition: [] },
+    sinceDays: 7,
+    force: false,
+  });
+  assert.match(body, /abc1234/);
+  assert.match(body, /Custom Resources/);
+  assert.match(body, /Suspected mismatches/);
+  assert.match(body, /Label inventory/);
+  assert.match(body, /DOC-1513/);
+  assert.match(body, /Closes DOC-1523/);
+});
+
+test('renderIssueBody handles no mismatches and forced (no commits) run', () => {
+  const body = renderIssueBody({
+    commits: [],
+    mismatches: [],
+    inventory: { pro: [], free: [], proAdmonition: [] },
+    sinceDays: 7,
+    force: true,
+  });
+  assert.match(body, /Manually triggered review/);
+  assert.match(body, /None detected automatically/);
+});
+
+test('findOpenIssue returns the first open issue number or null', () => {
+  assert.equal(findOpenIssue({ label: 'x', exec: () => '[{"number":42}]' }), 42);
+  assert.equal(findOpenIssue({ label: 'x', exec: () => '[]' }), null);
+});
+
+test('openOrUpdateTrackingIssue creates when none open', () => {
+  const calls = [];
+  const exec = (_cmd, args) => {
+    calls.push(args.join(' '));
+    if (args[0] === 'issue' && args[1] === 'list') return '[]';
+    if (args[0] === 'issue' && args[1] === 'create') return 'https://github.com/loft-sh/vcluster-docs/issues/7\n';
+    return '';
+  };
+  const res = openOrUpdateTrackingIssue({ title: 'T', body: 'B', label: 'plans-sidebar-review', exec });
+  assert.equal(res.action, 'created');
+  assert.equal(res.url, 'https://github.com/loft-sh/vcluster-docs/issues/7');
+  assert.ok(calls.some((c) => c.startsWith('issue create')));
+});
+
+test('openOrUpdateTrackingIssue updates and comments when one is open', () => {
+  const calls = [];
+  const exec = (_cmd, args) => {
+    calls.push(args.join(' '));
+    if (args[0] === 'issue' && args[1] === 'list') return '[{"number":99}]';
+    return '';
+  };
+  const res = openOrUpdateTrackingIssue({ title: 'T', body: 'B', label: 'plans-sidebar-review', exec });
+  assert.equal(res.action, 'updated');
+  assert.equal(res.number, 99);
+  assert.ok(calls.some((c) => c.startsWith('issue edit 99')));
+  assert.ok(calls.some((c) => c.startsWith('issue comment 99')));
+});
+
+test('parseArgs reads flags and --since-days', () => {
+  const o = parseArgs(['--open-issue', '--dry-run', '--force', '--since-days', '14']);
+  assert.equal(o.openIssue, true);
+  assert.equal(o.dryRun, true);
+  assert.equal(o.force, true);
+  assert.equal(o.sinceDays, 14);
+});
+
+test('parseArgs rejects a bad --since-days', () => {
+  assert.throws(() => parseArgs(['--since-days', 'x']), /positive integer/);
+});
+
+test('parseArgs defaults', () => {
+  const o = parseArgs([]);
+  assert.equal(o.openIssue, false);
+  assert.equal(o.dryRun, false);
+  assert.equal(o.force, false);
+  assert.equal(o.sinceDays, 7);
+});

--- a/tests/check-plans-sidebar-labels.test.js
+++ b/tests/check-plans-sidebar-labels.test.js
@@ -286,5 +286,7 @@ test('parseArgs defaults', () => {
   assert.equal(o.openIssue, false);
   assert.equal(o.dryRun, false);
   assert.equal(o.force, false);
-  assert.equal(o.sinceDays, 7);
+  // 14, not 7: the lookback deliberately overlaps ~2x the weekly cron so a
+  // skipped or delayed run does not drop commits in the gap.
+  assert.equal(o.sinceDays, 14);
 });


### PR DESCRIPTION
# Content Description

Adds a weekly CI workflow that opens (or updates) a docs follow-up issue whenever `loft-sh/plans` changes, prompting a review of the left-nav Enterprise/Free sidebar labels and the `ProAdmonition` partial.

## Summary

The Feature Table already syncs plan tiers into `src/data/products.yaml` automatically, but the sidebar labels (`sidebar_class_name: pro|free`, rendered as ENTERPRISE/FREE badges by `src/css/sidebar.scss`) and the `ProAdmonition` partial are maintained by hand. When `loft-sh/plans` moves a feature between Free and Enterprise, nothing prompts a review of those surfaces, so the docs drift. DOC-1513 (custom resources wrongly marked Enterprise) is the exact failure this leaves uncaught.

This opens a review issue rather than an auto-PR. Unlike the mechanical EOS/EOL date drift (which keeps its auto-PR path in `check-eos-eol-labels`), the plan-tier to page-label mapping needs human judgement: a page can document several features, a `docs_url` can point at a section anchor, and a `ProAdmonition` is placed editorially. The issue carries a best-effort suspect list plus the full label inventory, so the reviewer gets a concrete starting point instead of an empty checklist.

## Key Changes

- `scripts/check-plans-sidebar-labels.js`: detects recent `loft-sh/plans` commits, cross-checks each feature tier in `products.yaml` against the label on its docs page (flags a Free feature whose page still carries `pro`/`ProAdmonition`, and an Enterprise-only feature whose page carries `free`), builds the full label inventory, and opens or updates a single deduped tracking issue.
- `.github/workflows/check-plans-sidebar-labels.yml`: weekly schedule + `workflow_dispatch` + `repository_dispatch` (`plans-updated`, so `loft-sh/plans` can trigger on push). Single script invocation, pinned action SHAs, `persist-credentials: false`.
- `tests/check-plans-sidebar-labels.test.js`: 24 unit tests (Node built-in runner, no new dependencies) covering frontmatter parsing, the cross-check in both directions, the inventory, commit parsing, issue-body rendering, and the open-or-update logic with an injected `gh` exec.
- `package.json`: a `check-plans-sidebar-labels` script for local dry-runs.

Validated locally against real repo data: the cross-check surfaces a genuine suspect (`external-database-kerberos` is Free in plans but its page carries `sidebar_class_name: pro` + a `ProAdmonition`).

## Preview Link

No documentation pages changed (CI tooling, script, and tests only), so there is no deploy preview for this PR.

## Dependencies

None. Reuses the existing `GH_ACCESS_TOKEN` secret, the same token the Feature Table sync uses to read the private `loft-sh/plans` repo.

## TODO

- [ ] Optional follow-up: add a `repository_dispatch` sender in `loft-sh/plans` to trigger the review on push. The workflow already runs weekly without it.

## Internal Reference

Closes DOC-1523
References DOC-1513


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
