### PR TITLE
fix(release): wait for checksum db before platform pin bump

### DIFF
--- a/hack/release/wait-for-platform-modules.bats
+++ b/hack/release/wait-for-platform-modules.bats
@@ -8,8 +8,8 @@
 # Shim behaviour is driven by env vars:
 #   GH_MODE   ok | fail            (tag present | never published)
 #   GO_MODE   ok | fail | flaky:N  (resolves | never | fails N times then ok)
-# The go shim logs each `go list` invocation to $SHIM_STATE/go.log so tests
-# can assert on the queried module path and that -mod=mod was passed.
+# The go shim logs each `go mod download` invocation to $SHIM_STATE/go.log so
+# tests can assert on the queried module path and that -mod=mod was passed.
 
 setup() {
     SCRIPT="${BATS_TEST_DIRNAME}/wait-for-platform-modules.sh"
@@ -44,8 +44,8 @@ SH
 _make_go() {
     cat >"$BIN/go" <<'SH'
 #!/usr/bin/env bash
-# Only intercept `go list -m ...`; anything else is a no-op success.
-[ "$1" = "list" ] || exit 0
+# Only intercept `go mod download ...`; anything else is a no-op success.
+[ "$1" = "mod" ] && [ "$2" = "download" ] || exit 0
 echo "GOFLAGS=${GOFLAGS} args=$*" >>"$SHIM_STATE/go.log"
 mode="${GO_MODE:-ok}"
 case "$mode" in
@@ -64,23 +64,23 @@ SH
     chmod +x "$BIN/go"
 }
 
-@test "both phases pass when tag is present and proxy resolves" {
+@test "both phases pass when tag is present and the module downloads" {
     VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"loft-sh/agentapi: tag v4.10.1 present"* ]]
     [[ "$output" == *"loft-sh/api: tag v4.10.1 present"* ]]
-    [[ "$output" == *"github.com/loft-sh/agentapi/v4: resolves at v4.10.1 through the proxy"* ]]
-    [[ "$output" == *"github.com/loft-sh/api/v4: resolves at v4.10.1 through the proxy"* ]]
+    [[ "$output" == *"github.com/loft-sh/agentapi/v4: v4.10.1 downloads and checksum-verifies"* ]]
+    [[ "$output" == *"github.com/loft-sh/api/v4: v4.10.1 downloads and checksum-verifies"* ]]
 }
 
-@test "phase 2 queries the proxy with -mod=mod for both modules" {
+@test "phase 2 downloads with -mod=mod for both modules" {
     VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    grep -q "GOFLAGS=-mod=mod args=list -m github.com/loft-sh/agentapi/v4@v4.10.1" "$SHIM_STATE/go.log"
-    grep -q "GOFLAGS=-mod=mod args=list -m github.com/loft-sh/api/v4@v4.10.1" "$SHIM_STATE/go.log"
+    grep -q "GOFLAGS=-mod=mod args=mod download github.com/loft-sh/agentapi/v4@v4.10.1" "$SHIM_STATE/go.log"
+    grep -q "GOFLAGS=-mod=mod args=mod download github.com/loft-sh/api/v4@v4.10.1" "$SHIM_STATE/go.log"
 }
 
-@test "tag never published → fails with upstream-pipeline error, never reaches proxy check" {
+@test "tag never published → fails with upstream-pipeline error, never reaches download check" {
     GH_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"tag v4.10.1 not present after 5 attempts"* ]]
@@ -88,33 +88,33 @@ SH
     [ ! -f "$SHIM_STATE/go.log" ]
 }
 
-@test "proxy never resolves → fails with propagation error after the tag check passes" {
+@test "download never verifies → fails with propagation error after the tag check passes" {
     GO_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"tag v4.10.1 present"* ]]
-    [[ "$output" == *"did not resolve through the module proxy after 5 attempts"* ]]
-    [[ "$output" == *"proxy propagation stalled"* ]]
+    [[ "$output" == *"was not downloadable and checksum-verified after 5 attempts"* ]]
+    [[ "$output" == *"propagation stalled"* ]]
 }
 
-@test "proxy lags then resolves within the attempt budget → succeeds" {
-    # Each module fails twice then resolves; MAX_ATTEMPTS=5 leaves headroom.
+@test "download lags then verifies within the attempt budget → succeeds" {
+    # Each module fails twice then downloads; MAX_ATTEMPTS=5 leaves headroom.
     GO_MODE=flaky:2 VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"waiting for proxy to resolve v4.10.1"* ]]
-    [[ "$output" == *"resolves at v4.10.1 through the proxy"* ]]
+    [[ "$output" == *"waiting for v4.10.1 to download and checksum-verify"* ]]
+    [[ "$output" == *"v4.10.1 downloads and checksum-verifies"* ]]
 }
 
 @test "major version is derived from VERSION (v5 needs no code change)" {
     VERSION=v5.2.0 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    grep -q "args=list -m github.com/loft-sh/agentapi/v5@v5.2.0" "$SHIM_STATE/go.log"
-    grep -q "args=list -m github.com/loft-sh/api/v5@v5.2.0" "$SHIM_STATE/go.log"
+    grep -q "args=mod download github.com/loft-sh/agentapi/v5@v5.2.0" "$SHIM_STATE/go.log"
+    grep -q "args=mod download github.com/loft-sh/api/v5@v5.2.0" "$SHIM_STATE/go.log"
 }
 
 @test "pre-release versions are accepted and queried verbatim" {
     VERSION=v4.10.1-rc.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    grep -q "args=list -m github.com/loft-sh/agentapi/v4@v4.10.1-rc.1" "$SHIM_STATE/go.log"
+    grep -q "args=mod download github.com/loft-sh/agentapi/v4@v4.10.1-rc.1" "$SHIM_STATE/go.log"
 }
 
 @test "missing VERSION env var → exits non-zero" {

--- a/hack/release/wait-for-platform-modules.sh
+++ b/hack/release/wait-for-platform-modules.sh
@@ -15,19 +15,30 @@
 #      loft-sh/{agentapi,api} a short time later. The bump step must not
 #      run before those tags exist. (DEVOPS-904.)
 #
-#   2. Module-proxy resolution (go list -m <module>@<version>). The bump
-#      step runs `go mod tidy`, which resolves api/agentapi through GOPROXY
-#      (proxy.golang.org; these modules are NOT in GOPRIVATE, which is
-#      narrowed to vcluster-pro*). The proxy caches a version only after it
-#      first fetches it from the origin, which lags tag creation. DEVOPS-1008:
-#      on platform v4.10.1 the tag check passed but `go mod tidy` still
-#      failed with `unknown revision v4.10.1` because the proxy had not
-#      cached agentapi/v4@v4.10.1 yet. Gating on tag presence first keeps the
-#      proxy request from racing ahead of the origin tag; the `go list` step
-#      then both verifies and warms the proxy, so the bump never runs ahead
-#      of propagation.
+#   2. Checksum-verified download (go mod download <module>@<version>).
+#      The bump step runs `go mod tidy`, which both resolves api/agentapi
+#      through GOPROXY (proxy.golang.org) AND verifies each module against
+#      GOSUMDB (sum.golang.org); these modules are NOT in GOPRIVATE, which
+#      is narrowed to vcluster-pro*, so the checksum database is consulted.
+#      Both Google services cache a version only after fetching it from the
+#      origin, and they lag tag creation independently:
+#        - DEVOPS-1008 (platform v4.10.1): the tag check passed but the
+#          proxy had not cached agentapi/v4@v4.10.1, so `go mod tidy` failed
+#          with `unknown revision`. A `go list -m` probe (proxy only) closed
+#          that gap.
+#        - DEVOPS-1041 (platform v4.10.2): the proxy HAD cached the version
+#          (the `go list -m` probe passed) but sum.golang.org had not, so
+#          `go mod tidy` failed verifying the module: 404 from
+#          `sum.golang.org/lookup/...` ("unknown revision v4.10.2"). The
+#          proxy and the checksum DB propagate on separate timelines, so a
+#          proxy-only probe is not sufficient.
+#      `go mod download` exercises BOTH services exactly as the bump step
+#      does, so the wait does not pass until the release is genuinely
+#      consumable. Gating on tag presence first keeps these requests from
+#      racing ahead of the origin tag; the download then verifies and warms
+#      the module cache, so the bump never runs ahead of propagation.
 #
-# `go list -m <module>@<version>` needs -mod=mod: this repo carries a
+# `go mod download <module>@<version>` needs -mod=mod: this repo carries a
 # vendor/ tree, so the default -mod=vendor cannot satisfy a version query.
 #
 # Inputs (env):
@@ -66,19 +77,21 @@ for repo in loft-sh/agentapi loft-sh/api; do
     echo "::notice::${repo}: tag ${VERSION} present (attempt ${attempt})"
 done
 
-# Phase 2: module-proxy resolution. This is what the bump step's `go mod
-# tidy` actually requires; checking it here keeps the bump from racing
-# proxy propagation.
+# Phase 2: checksum-verified download. `go mod download` resolves through
+# the proxy AND verifies against the checksum database (sum.golang.org) for
+# these public modules, which is exactly what the bump step's `go mod tidy`
+# requires; gating on it here keeps the bump from racing either service's
+# propagation.
 for mod in "github.com/loft-sh/agentapi/${major}" "github.com/loft-sh/api/${major}"; do
     attempt=0
-    until GOFLAGS=-mod=mod go list -m "${mod}@${VERSION}" >/dev/null 2>&1; do
+    until GOFLAGS=-mod=mod go mod download "${mod}@${VERSION}" >/dev/null 2>&1; do
         attempt=$((attempt + 1))
         if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            echo "::error::${mod}@${VERSION} did not resolve through the module proxy after ${MAX_ATTEMPTS} attempts; proxy propagation stalled" >&2
+            echo "::error::${mod}@${VERSION} was not downloadable and checksum-verified after ${MAX_ATTEMPTS} attempts; proxy or checksum database (sum.golang.org) propagation stalled" >&2
             exit 1
         fi
-        echo "${mod}: waiting for proxy to resolve ${VERSION} (attempt ${attempt}/${MAX_ATTEMPTS})"
+        echo "${mod}: waiting for ${VERSION} to download and checksum-verify (attempt ${attempt}/${MAX_ATTEMPTS})"
         sleep "$SLEEP_SECONDS"
     done
-    echo "::notice::${mod}: resolves at ${VERSION} through the proxy (attempt ${attempt})"
+    echo "::notice::${mod}: ${VERSION} downloads and checksum-verifies (attempt ${attempt})"
 done


### PR DESCRIPTION
# Content Description

CI / release-pipeline fix, no docs content changes.

The `handle-source-release` receiver bumps the loft-sh/api + loft-sh/agentapi pins on every platform release, then runs `go mod tidy`. The pre-bump wait (`hack/release/wait-for-platform-modules.sh`) gated phase 2 only on module-proxy resolution via `go list -m`. But `go mod tidy` additionally checksum-verifies each public module against the checksum database (sum.golang.org), and proxy.golang.org and sum.golang.org propagate a freshly published tag on independent timelines.

Platform v4.10.2 hit that gap ([run 28407236864](https://github.com/loft-sh/vcluster-docs/actions/runs/28407236864)): the wait's `go list -m` probe passed because the proxy had cached the version, but `go mod tidy` then 404'd verifying the module against sum.golang.org (`unknown revision v4.10.2`), so no docs-sync PR opened. A plain re-run is now green, confirming a propagation race rather than a missing GOPRIVATE/GONOSUMDB entry.

This switches the phase 2 probe from `go list -m` to `go mod download`, which resolves through the proxy AND checksum-verifies against sum.golang.org, exactly as the bump step's `go mod tidy` does. The wait no longer passes until the release is genuinely consumable. Checksum verification stays on for these public modules; only the wait is corrected. DEVOPS-1008 closed the proxy-lag side of this; this closes the checksum-db-lag side the same way.

Verification: `bats hack/release/wait-for-platform-modules.bats` (8/8 green) and `shellcheck` clean. The `hack/release` bats suite is not wired into PR CI, so it was run locally.

## Preview Link

N/A (no docs content changed)

## Internal Reference

Closes DEVOPS-1041

@netlify /docs