### PR TITLE
docs(private-nodes): document air-gapped containerd registry mirrors for joined nodes

### DIFF
--- a/vcluster/deploy/worker-nodes/private-nodes/security/air-gapped.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/security/air-gapped.mdx
@@ -191,6 +191,54 @@ controlPlane:
 
 </details>
 
+### Redirect workload image pulls on joined nodes {#workload-image-mirrors}
+
+The `defaultImageRegistry` setting above only affects the images vCluster deploys for its own control plane components. Workloads scheduled onto joined Private Nodes pull their images through each node's containerd runtime, which reaches out to public registries such as `docker.io` and `ghcr.io` by default. In an air-gapped environment, those pulls fail.
+
+To redirect them to your private registry, configure containerd registry mirrors through `privateNodes.joinNode.containerd.registry`. As each node joins, vCluster renders these settings into a containerd `hosts.toml` file on the node, following the containerd [registry host model](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+
+:::note Joined nodes only
+This mechanism applies to real Private Nodes joined through kubeadm, such as bare-metal servers or cloud VMs. It does not apply to vind, whose Docker driver ignores this setting and serves images through a host-cache registry proxy instead. For vind, see [Deploy vind in an air-gapped environment](../../../control-plane/docker-container/air-gapped.mdx).
+:::
+
+Add the following to your `vcluster.yaml`. Each key under `mirrors` is the registry you want to redirect, and each `hosts[].server` entry is the mirror endpoint that containerd contacts in its place. If you omit `capabilities`, containerd defaults to `pull` and `resolve`.
+
+<InterpolatedCodeBlock
+  code={"privateNodes:\n" +
+    "  joinNode:\n" +
+    "    containerd:\n" +
+    "      registry:\n" +
+    "        mirrors:\n" +
+    '          # Redirect Docker Hub pulls to your internal registry\n' +
+    '          "docker.io":\n' +
+    "            hosts:\n" +
+    "              - server: [[VAR:MIRROR_ENDPOINT:https://registry.internal]]\n" +
+    '                capabilities: ["pull", "resolve"]\n' +
+    '          # Redirect GitHub Container Registry pulls to your internal registry\n' +
+    '          "ghcr.io":\n' +
+    "            hosts:\n" +
+    "              - server: [[VAR:MIRROR_ENDPOINT:https://registry.internal]]\n" +
+    '                capabilities: ["pull", "resolve"]'}
+  language="yaml"
+  title="Configure containerd registry mirrors"
+/>
+
+If your private registry requires authentication, add an `auth` section keyed by the registry host. vCluster writes these credentials into the node's containerd configuration.
+
+<InterpolatedCodeBlock
+  code={"privateNodes:\n" +
+    "  joinNode:\n" +
+    "    containerd:\n" +
+    "      registry:\n" +
+    "        auth:\n" +
+    '          # Credentials for your internal registry\n' +
+    '          "[[VAR:REGISTRY_HOST:registry.internal]]":\n' +
+    "            username: [[VAR:USERNAME:my-user]]\n" +
+    "            password: [[VAR:PASSWORD:my-password]]"}
+  language="yaml"
+  title="Authenticate to the mirror registry"
+/>
+
 After your private registry is populated with the required images, you can proceed with adding Private Nodes.
 
 ### Installation


### PR DESCRIPTION
# Content Description
Documents `privateNodes.joinNode.containerd.registry.mirrors` and `.auth` on the Private Nodes air-gapped page for redirecting workload image pulls on kubeadm-joined nodes to an internal registry, and clarifies the distinction from vind's registry-proxy mechanism.

## Preview Link
[Air-gapped: Redirect workload image pulls on joined nodes](https://deploy-preview-2350--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes/security/air-gapped#workload-image-mirrors)

## Internal Reference
Closes DOC-1590

@netlify /docs