### PR TITLE
docs: password changes invalidate sessions and access keys

### DIFF
--- a/platform/administer/authentication/access-keys.mdx
+++ b/platform/administer/authentication/access-keys.mdx
@@ -58,6 +58,7 @@ Access key management requires careful attention to security. Rotate keys regula
 
 Apply the principle of least privilege by using the most restrictive scope possible for each access key. When a process no longer requires an access key, delete it promptly to reduce your security exposure.
 
+Changing or resetting a user's password deletes all of that user's existing access keys, including ones used by automation. If you rotate a password, plan to generate and distribute new access keys for any integrations that relied on the old ones. See [Change your password](../../use-platform/change-your-password.mdx) and [Reset a user's password](../users-permissions/managing-users/reset-password.mdx) for the exact effects of each method.
 
 ## Create an access key
 
@@ -104,7 +105,8 @@ Apply the principle of least privilege by using the most restrictive scope possi
 ## Use access keys
 
 ### Log in using CLI
-You can use an access key to login to vCluster Platform via the vCluster CLI:
+
+You can use an access key to login to vCluster Platform using the vCluster CLI:
 
 ```
 vcluster platform login my-vcluster-platform-url.com --access-key ACCESS_KEY

--- a/platform/administer/authentication/reset-admin-password.mdx
+++ b/platform/administer/authentication/reset-admin-password.mdx
@@ -4,30 +4,33 @@ sidebar_label: Reset Admin Password
 sidebar_position: 3
 ---
 
-:::note
-If you don't see any authentication methods on the login page, you most likely don't have access to your SSO authentication anymore.
-To reenable password login you need to edit the vCluster Platform configuration.
+If you're locked out of vCluster Platform, you can reset the admin password directly from the command line.
 
-Run the following command to get a new hashed configuration with password login enabled:
-```bash
- kubectl get secrets/loft-manager-config  -o jsonpath="{.data.config}" | base64 -d | yq "del(.auth.password.disabled)" | base64
-```
+If you still have UI access, use [Reset a user's password](../users-permissions/managing-users/reset-password.mdx) instead. It works for the admin account too.
 
-Then, copy the output, `kubectl edit get secrets/loft-manager-config` and replace `.data.config` with the new config.
-Make sure to restart your vCluster Platform pods afterwards for the new configuration to take effect.
+:::note No authentication methods on the login page
+If you don't see any authentication methods on the login page at all, password login was likely disabled and you lost access to SSO. Re-enable password login first, then come back to reset the password. See [Recovery](../../how-to/disable-local-admin.mdx#recovery).
 :::
 
 ## vCluster CLI
 
-If you are still authenticated via the vCluster CLI you can easily reset the admin password:
+If you are still authenticated using the vCluster CLI you can easily reset the admin password:
 
 ```bash
 vcluster platform reset password --user=admin
 ```
 
+:::warning Existing sessions and access keys are invalidated
+Resetting a password through the CLI deletes all of that user's existing access keys, including browser sessions, other CLI sessions, and any API tokens the user generated. Anyone using the old password or an existing access key for this user must log in again. This does not apply to the [Kubectl](#kubectl) method below, which patches the password secret directly and leaves existing sessions and access keys untouched.
+:::
+
 ## Kubectl
 
-In order to find the kubernetes secret where the password hash for the admin account, run the following command:
+If you don't have CLI access, you can reset the password by patching the underlying Kubernetes secret directly.
+
+### Find the password secret
+
+Run the following command to look up the admin user's password reference:
 
 ```
 $ kubectl get user admin -o yaml
@@ -39,30 +42,24 @@ spec:
   passwordRef:
     key: password
     secretName: loft-user-secret-admin
-    secretNamespace: loft
+    secretNamespace: vcluster-platform
 ...
 ```
 
-The important part of the yaml is the password ref, which holds the reference for the secret where the password is stored.
+Note the `secretName` and `secretNamespace` under `passwordRef`. Older installs may use the `loft` namespace instead of `vcluster-platform`. You'll use both values in the next step.
 
-## Reset the password
+### Set a new password
 
-The next step is to create a sha256 hash of your new password:
+Replace `SECRET_NAME`, `SECRET_NAMESPACE`, and `my-new-password` below with the values from the previous step and your new password, then run:
 
-```
-echo -n my-new-password | sha256sum
-```
+```bash
+SECRET_NAME=loft-user-secret-admin
+SECRET_NAMESPACE=vcluster-platform
+NEW_PASSWORD_HASH=$(echo -n "my-new-password" | sha256sum | awk '{print $1}')
 
-which should print something like:
-
-```
-d7ff0c3cf3be79e0ecd30971c163b6be693fcb26578f18f1b9a3926eaf7b339d  -
-```
-
-Now copy the hash without the `-` and patch the secret with the new password hash:
-
-```
-kubectl get secret loft-user-secret-admin -n loft -o json | jq --arg password "$(echo d7ff0c3cf3be79e0ecd30971c163b6be693fcb26578f18f1b9a3926eaf7b339d | base64)" '.data["password"]=$password' | kubectl apply -f -
+kubectl get secret "$SECRET_NAME" -n "$SECRET_NAMESPACE" -o json \
+  | jq --arg password "$(printf '%s' "$NEW_PASSWORD_HASH" | base64)" '.data["password"]=$password' \
+  | kubectl apply -f -
 ```
 
-After that you should be able to login with the user `admin` and your new password into vCluster Platform
+After that you should be able to log in to vCluster Platform with the user `admin` and your new password.

--- a/platform/administer/users-permissions/managing-users/reset-password.mdx
+++ b/platform/administer/users-permissions/managing-users/reset-password.mdx
@@ -1,0 +1,67 @@
+---
+title: Reset a user's password
+sidebar_label: Reset Password
+sidebar_position: 4
+description: Generate a password reset link for another user and understand when their existing sessions and access keys actually get invalidated.
+---
+
+import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
+import Button from "@site/src/components/Button";
+import Label from "@site/src/components/Label";
+
+As an administrator, you can reset another user's password from the Users management screen. This generates a one-time reset link rather than setting a new password directly, so the user's existing sessions stay active until the link is used.
+
+## Generate a reset link
+
+<Flow id="reset-password">
+  <Step>
+    Click <NavStep>Users</NavStep> in the left sidebar.
+  </Step>
+  <Step>
+    Click the user whose password you want to reset.
+  </Step>
+  <Step>
+    Click <Button>Reset Password</Button>.
+  </Step>
+  <Step>
+    Click <Button>Reset Password</Button> again to confirm in the dialog that
+    appears.
+  </Step>
+  <Step>
+    In the <Label>Reset Password Link</Label> popup, click{" "}
+    <Button>Copy & Close</Button> to copy the link.
+  </Step>
+  <Step>
+    Send the copied link to the user. The link is only shown once. If you
+    close the popup without copying it, repeat this flow to generate a new
+    one.
+  </Step>
+</Flow>
+
+You can also start this flow from the row actions menu next to a user in the Users list.
+
+## Effect on the user's sessions and access keys
+
+Clicking <Button>Reset Password</Button> only generates the link. It doesn't change the user's password, and it doesn't affect their existing sessions or access keys.
+
+The password only changes when the link is opened and a new password is submitted, whether that's by the user themselves or by you on their behalf. At that point:
+
+- All of that user's existing [access keys](../../authentication/access-keys.mdx) are deleted, including browser sessions on other devices, CLI sessions, and any API tokens they generated.
+- If the user is logged in elsewhere at that moment, that session ends immediately, and they need to log in again with the new password.
+
+## Change the password immediately
+
+A reset link only takes effect once it's used. To force an immediate password change and session invalidation without waiting on the user, reset the password directly from the CLI instead:
+
+```bash
+vcluster platform reset password --user=<username>
+```
+
+This works for any user, including the admin account, and deletes that user's existing access keys right away, the same as the reset link does once it's redeemed.
+
+
+## Related
+
+- [Access keys](../../authentication/access-keys.mdx)
+- [Change your password](../../../use-platform/change-your-password.mdx), for users resetting their own password

--- a/platform/how-to/disable-local-admin.mdx
+++ b/platform/how-to/disable-local-admin.mdx
@@ -23,7 +23,7 @@ Before disabling the local admin account:
 - You have kubectl access to the cluster running vCluster Platform
 
 :::warning Verify SSO access first
-Ensure you can log in via SSO with global admin permissions before disabling the local admin. Locking yourself out requires recovery steps.
+Ensure you can log in using SSO with global admin permissions before disabling the local admin. Locking yourself out requires recovery steps.
 :::
 
 ## Disable the admin account
@@ -91,9 +91,7 @@ If SSO becomes unavailable and you need to regain access:
 
    Replace `.data.config` with the new value and restart the vCluster Platform pods.
 
-<!-- vale off -->
 2. Reset the admin password using kubectl. See [Reset Admin Password](../administer/authentication/reset-admin-password.mdx) for detailed instructions.
-<!-- vale on -->
 
 3. Unlock the admin user:
    - Log in with the reset password

--- a/platform/use-platform/change-your-password.mdx
+++ b/platform/use-platform/change-your-password.mdx
@@ -1,0 +1,54 @@
+---
+title: Change your password
+sidebar_label: Change your password
+sidebar_position: 3.5
+description: Change your own vCluster Platform password and understand the effect on your other sessions and access keys.
+---
+
+import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
+import Button from "@site/src/components/Button";
+import Label from "@site/src/components/Label";
+
+If you log in to vCluster Platform with a username and password, you can change your password from your Profile page.
+
+<Flow id="change-your-password">
+  <Step>
+    Click your avatar and name at the bottom of the left sidebar.
+  </Step>
+  <Step>
+    Click <NavStep>Profile</NavStep> in the menu that appears.
+  </Step>
+  <Step>
+    In the Basics section, click <Button>Change Password</Button>. If you
+    haven't set a password before, this button reads{" "}
+    <Button>Set Password</Button> instead, and you won't be asked for your
+    current password.
+  </Step>
+  <Step>
+    Enter your current password in the <Label>Current Password</Label> field.
+  </Step>
+  <Step>
+    Enter your new password in the <Label>New Password</Label> field, then
+    enter it again in the <Label>Repeat New Password</Label> field.
+  </Step>
+  <Step>
+    Click <Button>Save</Button>.
+  </Step>
+</Flow>
+
+## Effect on your other sessions and access keys
+
+Changing your password invalidates all of your existing [access keys](../administer/authentication/access-keys.mdx), including:
+
+- Browser sessions on other devices or browsers
+- CLI sessions started with `vcluster platform login`
+- Any access keys you generated for API or automation use
+
+The browser tab where you change your password stays logged in. The platform automatically re-authenticates you with the new password after the change succeeds, so you won't be logged out there.
+
+Every other session or access key stops working immediately. To restore access, log in again with your new password, or generate new access keys for any automation that relied on the old ones.
+
+:::info
+An administrator resetting your password on your behalf has the same effect once the new password is set. See [Reset a user's password](../administer/users-permissions/managing-users/reset-password.mdx).
+:::


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Documents the knock-on effect of password rotation: it invalidates existing sessions and access keys. Adds a self-service "change your password" page and an admin-facing "reset a user's password" page, fixes a critical hash bug and stale namespace examples in the admin recovery flow, and cross-links access keys to both.

## Preview Link 
<!-- The preview link or links to the documents-->
- [Reset admin password](https://deploy-preview-2351--vcluster-docs-site.netlify.app/docs/platform/next/administer/authentication/reset-admin-password)
- [Reset user's password](https://deploy-preview-2351--vcluster-docs-site.netlify.app/docs/platform/next/administer/users-permissions/managing-users/reset-password)
- [Change your password](https://deploy-preview-2351--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/change-your-password)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1589


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs