### PR TITLE
docs(platform): expand users and teams concept page

### DIFF
--- a/platform/understand/what-are-users-and-teams.mdx
+++ b/platform/understand/what-are-users-and-teams.mdx
@@ -2,12 +2,136 @@
 title: What are Users and Teams
 sidebar_label: What Are Users and Teams
 sidebar_position: 10
+description: Users and teams are the identities that own and access resources across vCluster Platform, spanning authentication, RBAC, project membership, quotas, and resource ownership.
 ---
 
-## What are Users and Teams?
+import UsersTeamsMembership from '@site/static/media/platform/diagrams/users-teams-membership.svg';
+import UsersTeamsAccessSources from '@site/static/media/platform/diagrams/users-teams-access-sources.svg';
+import ProjectMembershipOwnership from '@site/static/media/platform/diagrams/project-membership-ownership.svg';
 
-Users and teams are entities that can interact with the vCluster Platform API. A user can
-be a developer that develops applications or an administrator that manages the
-vCluster Platform. Users can be assigned to teams, which set the permissions applied
-to all the team's members. For example, you can give tenant cluster access to a team, which
-gives all members of the team tenant cluster access.
+Users and teams are the core identities in vCluster Platform. A user represents an individual or service identity that can authenticate to the platform. A team represents a group of users that should receive the same access, ownership, and platform-level configuration.
+
+They are used throughout the platform, not just during login. Users and teams can receive management roles, become project members, own resources, consume quota, receive image pull secrets, and appear as Kubernetes subjects in reconciled RBAC.
+
+<figure>
+  <UsersTeamsMembership style={{width: '100%', height: 'auto'}} role="img" aria-label="User authentication flow where team membership is resolved from explicit team users and matching SSO groups" />
+  <figcaption>For a user login or user access key, Platform resolves team membership from explicit assignment and matching SSO groups.</figcaption>
+</figure>
+
+## Users
+
+A user is the platform record for one authenticated identity that can be human or automated. Platform tracks the identifiers needed to recognize that identity at login (a stable platform name plus login-facing username and email), the subject to match against an incoming SSO token (falling back to a platform-generated `loft:user:<user-name>` subject when none is configured), and the groups associated with that identity, including any imported from SSO. Beyond identity, a user record can also grant management roles directly, hand out registry credentials for CLI-based image pulls, and be disabled to block login without deleting the user or its resources.
+
+Platform also computes each user's current effective team membership from team configuration, so admins can always see which teams a user actually belongs to right now, not just which teams were configured to include them.
+
+See the [User resource reference](../api/resources/user.mdx) for the full list of fields.
+
+[Create users →](../administer/users-permissions/managing-users/create.mdx)
+
+## Teams
+
+A team is the platform record for a shared identity boundary. Teams do not log in on their own. Instead, they become part of an authenticated user's effective identity when that user is a member.
+
+Membership comes from two places: users explicitly assigned to the team, and users whose groups match a token or SSO group name configured on the team. This lets you combine manual team assignment with identity-provider-driven membership. For example, you might add a break-glass admin user directly to a team, while the rest of the team's membership comes from an OIDC, SAML, GitHub, GitLab, Google, Microsoft, LDAP, or Dex group.
+
+Like users, teams can be granted management roles and image pull secrets directly. Those apply to whichever users are currently members of the team.
+
+See the [Team resource reference](../api/resources/team.mdx) for the full list of fields.
+
+[Create teams →](../administer/users-permissions/managing-teams/create.mdx)
+
+## How effective identity works
+
+After a user authenticates, Platform builds a Kubernetes-compatible identity for that request. The resulting identity includes:
+
+- the user's subject as the Kubernetes user name;
+- the user's direct groups;
+- `system:authenticated`;
+- platform groups such as `loft:user:<user-name>`;
+- one `loft:team:<team-name>` group for every effective team membership.
+
+This is why teams are useful beyond the UI. Platform permissions, project membership, admission policies, and tenant cluster access can all reason about users and teams as Kubernetes-style subjects and groups.
+
+[Authentication and authorization →](auth-explanation.mdx)
+
+## Permissions and roles
+
+Platform uses Kubernetes RBAC concepts to authorize users and teams. A management role defines allowed actions, and Platform applies that role to one or more users or teams through reconciled role bindings.
+
+Grant roles to teams when many people should share the same access, and grant roles directly to users only for exceptions such as platform administrators, automation users, or temporary troubleshooting access. Direct user roles and team-inherited roles are additive, so a user can receive permissions from several places at once.
+
+[Users and permissions overview →](../administer/users-permissions/overview.mdx)
+
+## Project membership
+
+Projects are where users and teams usually become operational. A project lists its members in `spec.members`, and each member is a user, a team, or all users (`User` with name `*`). Each member receives a project role that defines what they can do inside that project.
+
+When a team is a project member, all current team members receive the team's project access. Platform's project members API resolves both the direct team entry and the users who belong to that team, so project views can show the effective member set.
+
+Project ownership is related but separate. A project can have `spec.owner.user` or `spec.owner.team`, and the owner is included in the resolved project members list. Owners and members are often the same organizational unit, but they answer different questions: ownership says who the project belongs to, while membership says who can access it and with which role.
+
+<figure>
+  <ProjectMembershipOwnership style={{width: '100%', height: 'auto'}} role="img" aria-label="Project membership defines who can access a project while project ownership identifies the user or team the project belongs to" />
+  <figcaption>Project membership grants access with roles; project ownership identifies the user or team the project belongs to.</figcaption>
+</figure>
+
+[Manage project members →](../api/resources/project/members.mdx)
+
+[What are Projects →](what-are-projects.mdx)
+
+## Resource ownership
+
+Many platform resources can be owned by either a user or a team. Platform records that ownership through owner fields on the resource and through labels such as `loft.sh/user` and `loft.sh/team` on owned resources such as namespaces, space instances, tenant cluster instances, and access keys.
+
+Ownership affects how resources are displayed, who can manage them, how project quota is counted, and how sharing workflows behave. Use team ownership for shared environments and long-lived resources that should survive changes in individual staffing. Use user ownership for personal development environments, individual access keys, or short-lived work that should clearly belong to one person.
+
+[Create global secrets →](../administer/secrets/global/create.mdx)
+
+[SSH keys →](../use-platform/machines/ssh-keys.mdx)
+
+[Platform labels and annotations →](../reference/platform-annotations.mdx#user-team-management)
+
+## Quotas
+
+Project quotas can apply to the whole project or to each user or team inside the project. A project-wide quota caps the total resources that all members can consume. A per-user/team quota caps how much a single user-owned or team-owned resource bucket can consume.
+
+Ownership matters for quota accounting. Project-wide usage always counts against the project quota, and per-user/team usage is keyed from the resource's owner field. If a tenant cluster, space, or Machine is owned by a team, it counts against that team's quota bucket. If it is owned by a user, it counts against that user's quota bucket, even if the user belongs to one or more teams.
+
+[Configure project quotas →](../administer/projects/quotas.mdx)
+
+## Automation and service accounts
+
+A user does not have to represent a human. For GitOps, CI/CD, or external automation, create a dedicated user and issue an access key for that user. The access key authenticates as that user, and any access key scope can only narrow what the user is already allowed to do.
+
+Access keys can also authenticate as a team. A team access key acts as the team identity, so it receives the team's roles and project memberships rather than a particular user's direct roles. Use this when automation should belong to a shared operational identity instead of an individual user.
+
+[Access keys →](../administer/authentication/access-keys.mdx)
+
+[GitOps end-to-end guide →](../how-to/gitops-end-to-end.mdx)
+
+## SSO and account provisioning
+
+With SSO, Platform can create or update users from identity provider claims. The important design choice is usually where to manage group membership:
+
+- Manage membership in the identity provider when your organization already has authoritative groups.
+- Manage membership in Platform when teams are platform-specific or short-lived.
+- Use both when you need exceptions, such as manually adding a service user to a team whose human members come from SSO.
+
+SSO configuration can also apply cluster account templates to users when they first sign in, and can keep those templates synchronized when tokens refresh. This is useful when users or teams should automatically receive access to particular connected clusters after authentication.
+
+[SSO configuration →](../configure/platform-configs/single-sign-on.mdx)
+
+## Access troubleshooting
+
+<figure>
+  <UsersTeamsAccessSources style={{width: '100%', height: 'auto'}} role="img" aria-label="Access starts with an authenticated user or team actor, then roles, project membership, and optional access key scope are applied" />
+  <figcaption>When changing someone's access, check which actor is authenticated, then review roles, project membership, ownership, and any access key scope.</figcaption>
+</figure>
+
+When troubleshooting access, check the actor first: is the request using a normal user login, a user access key, or a team access key? Then review the user's teams, direct roles, team roles, project memberships, resource ownership, and any access key scope that might be narrowing the request.
+
+## Access modeling
+
+For most installations, start with teams as the primary unit of access. Create teams that match how work is owned: platform administrators, application teams, customer accounts, environments, or automation roles. Add those teams to projects, grant project roles to teams, and use direct user permissions only where the exception is intentional.
+
+Use user-owned resources for personal workspaces and use team-owned resources for shared services. This keeps access, ownership, and quota behavior predictable as people join, leave, or move between teams.

--- a/platform/understand/what-are-users-and-teams.mdx
+++ b/platform/understand/what-are-users-and-teams.mdx
@@ -11,7 +11,7 @@ import ProjectMembershipOwnership from '@site/static/media/platform/diagrams/pro
 
 Users and teams are the core identities in vCluster Platform. A user represents an individual or service identity that can authenticate to the platform. A team represents a group of users that should receive the same access, ownership, and platform-level configuration.
 
-They are used throughout the platform, not just during login. Users and teams can receive management roles, become project members, own resources, and consume quota. They can also receive image pull secrets and appear as Kubernetes subjects in reconciled RBAC (RBAC objects that Platform automatically creates and keeps up to date).
+They are used throughout the platform, not just during login. Users and teams can receive management roles, become project members, own resources, and consume quota. They can also receive image pull secrets and appear as Kubernetes subjects in reconciled role-based access control (RBAC) objects that Platform automatically creates and keeps up to date.
 
 ## Users
 
@@ -105,15 +105,15 @@ Ownership affects how resources are displayed, who can manage them, how project 
 
 ## Quotas
 
-Project quotas can apply to the whole project or to each user or team inside the project. A project-wide quota caps the total resources that all members can consume. A per-user/team quota caps how much resources owned by a single user or team can consume.
+Project quotas can apply to the whole project or to each user or team inside the project. A project-wide quota caps the total resources that the project can consume across all members. A per-user/team quota caps the resources that a single user or team can consume.
 
-Ownership determines which quota a resource's usage counts against. A team-owned resource counts against that team's quota, and a user-owned resource counts against that user's quota, even when the user also belongs to a team.
+Ownership determines which quota a resource's usage counts against. A team-owned resource counts against that team's quota, and a user-owned resource counts against that user's quota, even when the user also belongs to a team. Team and individual usage are tracked separately, so a team-owned resource never counts against a member's personal quota, and a member's personally owned resource never counts against the team's quota.
 
 [Configure project quotas →](../administer/projects/quotas.mdx)
 
 ## Automation and service accounts
 
-Everything so far has assumed a human is behind the user or team, but that's not required. For GitOps, CI/CD, or external automation, create a dedicated user and issue an access key for that user. The access key authenticates as that user, and any access key scope can only narrow what the user is already allowed to do.
+As the Users section noted, a user or team doesn't need a human behind it. For GitOps, CI/CD, or external automation, create a dedicated user and issue an access key for that user. The access key authenticates as that user, and any access key scope can only narrow what the user is already allowed to do.
 
 Access keys can also authenticate as a team. A team access key acts as the team identity, so it receives the team's roles and project memberships rather than a particular user's direct roles. Use this when automation should belong to a shared operational identity instead of an individual user.
 
@@ -123,12 +123,12 @@ Access keys can also authenticate as a team. A team access key acts as the team 
 
 ## Access troubleshooting
 
+When troubleshooting access, check the actor first. Is the request using a normal user login, a user access key, or a team access key? Then review the user's teams, direct roles, team roles, project memberships, resource ownership, and any access key scope that might be narrowing the request.
+
 <figure>
   <UsersTeamsAccessSources style={{width: '100%', height: 'auto'}} role="img" aria-label="Access starts with an authenticated user or team actor, then roles, project membership, and optional access key scope are applied" />
   <figcaption>When changing someone's access, check which actor is authenticated, then review roles, project membership, ownership, and any access key scope.</figcaption>
 </figure>
-
-When troubleshooting access, check the actor first. Is the request using a normal user login, a user access key, or a team access key? Then review the user's teams, direct roles, team roles, project memberships, resource ownership, and any access key scope that might be narrowing the request.
 
 ## Access modeling
 

--- a/platform/understand/what-are-users-and-teams.mdx
+++ b/platform/understand/what-are-users-and-teams.mdx
@@ -11,18 +11,13 @@ import ProjectMembershipOwnership from '@site/static/media/platform/diagrams/pro
 
 Users and teams are the core identities in vCluster Platform. A user represents an individual or service identity that can authenticate to the platform. A team represents a group of users that should receive the same access, ownership, and platform-level configuration.
 
-They are used throughout the platform, not just during login. Users and teams can receive management roles, become project members, own resources, consume quota, receive image pull secrets, and appear as Kubernetes subjects in reconciled RBAC.
-
-<figure>
-  <UsersTeamsMembership style={{width: '100%', height: 'auto'}} role="img" aria-label="User authentication flow where team membership is resolved from explicit team users and matching SSO groups" />
-  <figcaption>For a user login or user access key, Platform resolves team membership from explicit assignment and matching SSO groups.</figcaption>
-</figure>
+They are used throughout the platform, not just during login. Users and teams can receive management roles, become project members, own resources, and consume quota. They can also receive image pull secrets and appear as Kubernetes subjects in reconciled RBAC (RBAC objects that Platform automatically creates and keeps up to date).
 
 ## Users
 
-A user is the platform record for one authenticated identity that can be human or automated. Platform tracks the identifiers needed to recognize that identity at login (a stable platform name plus login-facing username and email), the subject to match against an incoming SSO token (falling back to a platform-generated `loft:user:<user-name>` subject when none is configured), and the groups associated with that identity, including any imported from SSO. Beyond identity, a user record can also grant management roles directly, hand out registry credentials for CLI-based image pulls, and be disabled to block login without deleting the user or its resources.
+A user is the platform record for one authenticated identity that can be human or automated. Platform tracks the identifiers needed to recognize that identity, including a stable platform name, an SSO-matching subject, and the groups associated with it. Beyond identity, a user record can also grant management roles directly and hand out registry credentials for CLI-based image pulls. It can also be disabled to block login without deleting the user or its resources.
 
-Platform also computes each user's current effective team membership from team configuration, so admins can always see which teams a user actually belongs to right now, not just which teams were configured to include them.
+Platform also computes each user's current effective team membership. Effective means the fully resolved result right now, not the raw configuration. This lets admins see which teams a user actually belongs to at this moment, not just which teams were configured to include them.
 
 See the [User resource reference](../api/resources/user.mdx) for the full list of fields.
 
@@ -32,13 +27,30 @@ See the [User resource reference](../api/resources/user.mdx) for the full list o
 
 A team is the platform record for a shared identity boundary. Teams do not log in on their own. Instead, they become part of an authenticated user's effective identity when that user is a member.
 
-Membership comes from two places: users explicitly assigned to the team, and users whose groups match a token or SSO group name configured on the team. This lets you combine manual team assignment with identity-provider-driven membership. For example, you might add a break-glass admin user directly to a team, while the rest of the team's membership comes from an OIDC, SAML, GitHub, GitLab, Google, Microsoft, LDAP, or Dex group.
+Membership comes from two places. Some users are explicitly assigned to the team, and others belong because their groups match a token or SSO group name configured on the team. This lets you combine manual team assignment with identity-provider-driven membership. For example, you might add a break-glass admin user (an emergency-access account for when normal login isn't available) directly to a team. The rest of the team's membership can then come from an SSO group, such as OIDC, SAML, GitHub, GitLab, Google, Microsoft, LDAP, or Dex.
 
 Like users, teams can be granted management roles and image pull secrets directly. Those apply to whichever users are currently members of the team.
 
 See the [Team resource reference](../api/resources/team.mdx) for the full list of fields.
 
 [Create teams →](../administer/users-permissions/managing-teams/create.mdx)
+
+<figure>
+  <UsersTeamsMembership style={{width: '100%', height: 'auto'}} role="img" aria-label="User authentication flow where team membership is resolved from explicit team users and matching SSO groups" />
+  <figcaption>For a user login or user access key, Platform resolves team membership from explicit assignment and matching SSO groups.</figcaption>
+</figure>
+
+## SSO and account provisioning
+
+With SSO, Platform can create or update users from identity provider claims. The important design choice is usually where to manage group membership:
+
+- Manage membership in the identity provider when your organization already has authoritative groups.
+- Manage membership in Platform when teams are platform-specific or short-lived.
+- Use both when you need exceptions, such as manually adding a service user to a team whose human members come from SSO.
+
+SSO configuration can also do more than manage membership. It can apply cluster account templates (predefined access configurations for connected clusters) to users when they first sign in. It can also keep those templates synchronized when tokens refresh. This is useful when users or teams should automatically receive access to particular connected clusters after authentication.
+
+[SSO configuration →](../configure/platform-configs/single-sign-on.mdx)
 
 ## How effective identity works
 
@@ -58,17 +70,17 @@ This is why teams are useful beyond the UI. Platform permissions, project member
 
 Platform uses Kubernetes RBAC concepts to authorize users and teams. A management role defines allowed actions, and Platform applies that role to one or more users or teams through reconciled role bindings.
 
-Grant roles to teams when many people should share the same access, and grant roles directly to users only for exceptions such as platform administrators, automation users, or temporary troubleshooting access. Direct user roles and team-inherited roles are additive, so a user can receive permissions from several places at once.
+Grant roles to teams when many people should share the same access. Grant roles directly to users only for exceptions, such as platform administrators, automation users, or temporary troubleshooting access. Direct user roles and team-inherited roles are additive, so a user can receive permissions from several places at once.
 
 [Users and permissions overview →](../administer/users-permissions/overview.mdx)
 
 ## Project membership
 
-Projects are where users and teams usually become operational. A project lists its members in `spec.members`, and each member is a user, a team, or all users (`User` with name `*`). Each member receives a project role that defines what they can do inside that project.
+Projects are where users and teams usually become operational. A project's member list can include specific users, specific teams, or all users at once. Each member receives a project role that defines what they can do inside that project.
 
-When a team is a project member, all current team members receive the team's project access. Platform's project members API resolves both the direct team entry and the users who belong to that team, so project views can show the effective member set.
+When a team is a project member, all current team members receive the team's project access. Platform's project members API resolves both the direct team entry and the users who belong to that team. This lets project views show the effective member set.
 
-Project ownership is related but separate. A project can have `spec.owner.user` or `spec.owner.team`, and the owner is included in the resolved project members list. Owners and members are often the same organizational unit, but they answer different questions: ownership says who the project belongs to, while membership says who can access it and with which role.
+Project ownership is related but separate. A project can have `spec.owner.user` or `spec.owner.team`, and the owner is included in the resolved project members list. Owners and members are often the same organizational unit, but they answer different questions. Ownership says who the project belongs to. Membership says who can access it and with which role.
 
 <figure>
   <ProjectMembershipOwnership style={{width: '100%', height: 'auto'}} role="img" aria-label="Project membership defines who can access a project while project ownership identifies the user or team the project belongs to" />
@@ -81,7 +93,7 @@ Project ownership is related but separate. A project can have `spec.owner.user` 
 
 ## Resource ownership
 
-Many platform resources can be owned by either a user or a team. Platform records that ownership through owner fields on the resource and through labels such as `loft.sh/user` and `loft.sh/team` on owned resources such as namespaces, space instances, tenant cluster instances, and access keys.
+Many platform resources can be owned by either a user or a team. Platform records that ownership through owner fields on the resource and through ownership labels applied to resources such as namespaces, space instances, tenant cluster instances, and access keys.
 
 Ownership affects how resources are displayed, who can manage them, how project quota is counted, and how sharing workflows behave. Use team ownership for shared environments and long-lived resources that should survive changes in individual staffing. Use user ownership for personal development environments, individual access keys, or short-lived work that should clearly belong to one person.
 
@@ -93,33 +105,21 @@ Ownership affects how resources are displayed, who can manage them, how project 
 
 ## Quotas
 
-Project quotas can apply to the whole project or to each user or team inside the project. A project-wide quota caps the total resources that all members can consume. A per-user/team quota caps how much a single user-owned or team-owned resource bucket can consume.
+Project quotas can apply to the whole project or to each user or team inside the project. A project-wide quota caps the total resources that all members can consume. A per-user/team quota caps how much resources owned by a single user or team can consume.
 
-Ownership matters for quota accounting. Project-wide usage always counts against the project quota, and per-user/team usage is keyed from the resource's owner field. If a tenant cluster, space, or Machine is owned by a team, it counts against that team's quota bucket. If it is owned by a user, it counts against that user's quota bucket, even if the user belongs to one or more teams.
+Ownership determines which quota a resource's usage counts against. A team-owned resource counts against that team's quota, and a user-owned resource counts against that user's quota, even when the user also belongs to a team.
 
 [Configure project quotas →](../administer/projects/quotas.mdx)
 
 ## Automation and service accounts
 
-A user does not have to represent a human. For GitOps, CI/CD, or external automation, create a dedicated user and issue an access key for that user. The access key authenticates as that user, and any access key scope can only narrow what the user is already allowed to do.
+Everything so far has assumed a human is behind the user or team, but that's not required. For GitOps, CI/CD, or external automation, create a dedicated user and issue an access key for that user. The access key authenticates as that user, and any access key scope can only narrow what the user is already allowed to do.
 
 Access keys can also authenticate as a team. A team access key acts as the team identity, so it receives the team's roles and project memberships rather than a particular user's direct roles. Use this when automation should belong to a shared operational identity instead of an individual user.
 
 [Access keys →](../administer/authentication/access-keys.mdx)
 
 [GitOps end-to-end guide →](../how-to/gitops-end-to-end.mdx)
-
-## SSO and account provisioning
-
-With SSO, Platform can create or update users from identity provider claims. The important design choice is usually where to manage group membership:
-
-- Manage membership in the identity provider when your organization already has authoritative groups.
-- Manage membership in Platform when teams are platform-specific or short-lived.
-- Use both when you need exceptions, such as manually adding a service user to a team whose human members come from SSO.
-
-SSO configuration can also apply cluster account templates to users when they first sign in, and can keep those templates synchronized when tokens refresh. This is useful when users or teams should automatically receive access to particular connected clusters after authentication.
-
-[SSO configuration →](../configure/platform-configs/single-sign-on.mdx)
 
 ## Access troubleshooting
 
@@ -128,10 +128,10 @@ SSO configuration can also apply cluster account templates to users when they fi
   <figcaption>When changing someone's access, check which actor is authenticated, then review roles, project membership, ownership, and any access key scope.</figcaption>
 </figure>
 
-When troubleshooting access, check the actor first: is the request using a normal user login, a user access key, or a team access key? Then review the user's teams, direct roles, team roles, project memberships, resource ownership, and any access key scope that might be narrowing the request.
+When troubleshooting access, check the actor first. Is the request using a normal user login, a user access key, or a team access key? Then review the user's teams, direct roles, team roles, project memberships, resource ownership, and any access key scope that might be narrowing the request.
 
 ## Access modeling
 
-For most installations, start with teams as the primary unit of access. Create teams that match how work is owned: platform administrators, application teams, customer accounts, environments, or automation roles. Add those teams to projects, grant project roles to teams, and use direct user permissions only where the exception is intentional.
+For most installations, start with teams as the primary unit of access. Create teams that match how work is owned, such as platform administrators, application teams, customer accounts, environments, or automation roles. Add those teams to projects, grant project roles to teams, and use direct user permissions only where the exception is intentional.
 
 Use user-owned resources for personal workspaces and use team-owned resources for shared services. This keeps access, ownership, and quota behavior predictable as people join, leave, or move between teams.

--- a/static/media/platform/diagrams/project-membership-ownership.svg
+++ b/static/media/platform/diagrams/project-membership-ownership.svg
@@ -1,0 +1,56 @@
+<svg viewBox="0 0 1000 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Project membership defines who can access a project while project ownership identifies the user or team the project belongs to">
+  <defs>
+    <marker id="project-arrow" viewBox="0 0 10 7" markerWidth="8" markerHeight="6" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#828592"/>
+    </marker>
+    <style>
+      text { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { font-size: 18px; font-weight: 700; fill: #050B24; }
+      .label { font-size: 14px; font-weight: 600; fill: #050B24; }
+      .small { font-size: 12px; fill: #505466; }
+      .tiny { font-size: 11px; fill: #828592; }
+      .code { font-size: 12px; font-family: "SFMono-Regular", Consolas, monospace; fill: #263147; }
+    </style>
+  </defs>
+
+  <rect width="1000" height="420" rx="18" fill="#FFFFFF"/>
+
+  <text x="500" y="42" text-anchor="middle" class="title">Project members and owners answer different questions</text>
+  <text x="500" y="66" text-anchor="middle" class="small">Members define who can access the project. The owner identifies who the project belongs to.</text>
+
+  <rect x="55" y="105" width="250" height="235" rx="16" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="180" y="138" text-anchor="middle" class="label">Project members</text>
+  <text x="180" y="160" text-anchor="middle" class="small">Many users and teams</text>
+
+  <rect x="86" y="190" width="188" height="38" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="180" y="214" text-anchor="middle" class="code">User alice: admin</text>
+
+  <rect x="86" y="242" width="188" height="38" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="180" y="266" text-anchor="middle" class="code">Team devs: edit</text>
+
+  <rect x="86" y="294" width="188" height="38" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="180" y="318" text-anchor="middle" class="code">Team qa: view</text>
+
+  <rect x="408" y="135" width="205" height="175" rx="16" fill="#F8FBFF" stroke="#6B88A6" stroke-width="1.2"/>
+  <text x="510.5" y="172" text-anchor="middle" class="label">Project</text>
+  <text x="510.5" y="196" text-anchor="middle" class="code">team-alpha</text>
+  <rect x="444" y="230" width="133" height="42" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="510.5" y="256" text-anchor="middle" class="small">Policy boundary</text>
+
+  <rect x="725" y="105" width="220" height="122" rx="16" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="835" y="138" text-anchor="middle" class="label">Project owner</text>
+  <text x="835" y="160" text-anchor="middle" class="small">One user or team</text>
+  <rect x="766" y="184" width="138" height="34" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="835" y="206" text-anchor="middle" class="code">Team devs</text>
+
+  <rect x="700" y="280" width="270" height="70" rx="10" fill="#F4F6FA"/>
+  <text x="835" y="306" text-anchor="middle" class="label">Common pattern</text>
+  <text x="835" y="328" text-anchor="middle" class="tiny">Owner and member can be the same team,</text>
+  <text x="835" y="343" text-anchor="middle" class="tiny">but they are separate fields.</text>
+
+  <line x1="305" y1="222" x2="408" y2="222" stroke="#828592" stroke-width="1.5" marker-end="url(#project-arrow)"/>
+  <text x="356.5" y="210" text-anchor="middle" class="tiny">can access</text>
+
+  <line x1="613" y1="202" x2="725" y2="166" stroke="#828592" stroke-width="1.5" marker-end="url(#project-arrow)"/>
+  <text x="671" y="170" text-anchor="middle" class="tiny">belongs to</text>
+</svg>

--- a/static/media/platform/diagrams/users-teams-access-sources.svg
+++ b/static/media/platform/diagrams/users-teams-access-sources.svg
@@ -1,0 +1,66 @@
+<svg viewBox="0 0 1000 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Access starts with an authenticated user or team actor, then roles, project membership, and optional access key scope are applied">
+  <defs>
+    <marker id="access-arrow" viewBox="0 0 10 7" markerWidth="8" markerHeight="6" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#828592"/>
+    </marker>
+    <style>
+      text { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { font-size: 18px; font-weight: 700; fill: #050B24; }
+      .label { font-size: 14px; font-weight: 600; fill: #050B24; }
+      .small { font-size: 12px; fill: #505466; }
+      .tiny { font-size: 11px; fill: #828592; }
+      .code { font-size: 12px; font-family: "SFMono-Regular", Consolas, monospace; fill: #263147; }
+    </style>
+  </defs>
+
+  <rect width="1000" height="420" rx="18" fill="#FFFFFF"/>
+
+  <text x="500" y="42" text-anchor="middle" class="title">Access starts with an actor, then roles and scopes apply</text>
+  <text x="500" y="66" text-anchor="middle" class="small">Access keys authenticate as a user or team. Optional key scope can narrow access, but does not add permissions.</text>
+
+  <rect x="45" y="115" width="180" height="86" rx="10" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="135" y="145" text-anchor="middle" class="label">User actor</text>
+  <text x="135" y="168" text-anchor="middle" class="code">login or user key</text>
+  <text x="135" y="187" text-anchor="middle" class="code">alice</text>
+
+  <rect x="45" y="275" width="180" height="86" rx="10" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="135" y="305" text-anchor="middle" class="label">Team actor</text>
+  <text x="135" y="328" text-anchor="middle" class="code">team access key</text>
+  <text x="135" y="347" text-anchor="middle" class="code">app-team</text>
+
+  <rect x="315" y="190" width="210" height="100" rx="14" fill="#F8FBFF" stroke="#6B88A6" stroke-width="1.2"/>
+  <text x="420" y="223" text-anchor="middle" class="label">Authenticated actor</text>
+  <text x="420" y="248" text-anchor="middle" class="small">Platform resolves the request</text>
+  <text x="420" y="270" text-anchor="middle" class="small">to a user or team identity</text>
+
+  <rect x="590" y="100" width="210" height="238" rx="16" fill="#F8FBFF" stroke="#6B88A6" stroke-width="1.2"/>
+  <text x="695" y="135" text-anchor="middle" class="label">Additive grants</text>
+
+  <rect x="610" y="155" width="170" height="42" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="695" y="181" text-anchor="middle" class="small">Direct user roles</text>
+
+  <rect x="610" y="215" width="170" height="42" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="695" y="241" text-anchor="middle" class="small">Team roles</text>
+
+  <rect x="610" y="275" width="170" height="42" rx="7" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="695" y="301" text-anchor="middle" class="small">Project membership</text>
+
+  <rect x="590" y="358" width="210" height="46" rx="12" fill="#F4F6FA" stroke="#828592" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="695" y="386" text-anchor="middle" class="small">Access key scope narrows</text>
+
+  <rect x="870" y="140" width="105" height="180" rx="12" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="922.5" y="176" text-anchor="middle" class="label">Result</text>
+  <text x="922.5" y="214" text-anchor="middle" class="small">Can manage</text>
+  <text x="922.5" y="252" text-anchor="middle" class="small">Can access</text>
+  <text x="922.5" y="290" text-anchor="middle" class="small">Can own</text>
+
+  <line x1="225" y1="158" x2="315" y2="218" stroke="#828592" stroke-width="1.5" marker-end="url(#access-arrow)"/>
+  <line x1="225" y1="318" x2="315" y2="262" stroke="#828592" stroke-width="1.5" marker-end="url(#access-arrow)"/>
+  <line x1="525" y1="240" x2="590" y2="240" stroke="#828592" stroke-width="1.5" marker-end="url(#access-arrow)"/>
+  <line x1="800" y1="240" x2="870" y2="240" stroke="#828592" stroke-width="1.5" marker-end="url(#access-arrow)"/>
+  <line x1="800" y1="381" x2="870" y2="292" stroke="#828592" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#access-arrow)"/>
+
+  <text x="557.5" y="226" text-anchor="middle" class="tiny">evaluate</text>
+  <text x="835" y="226" text-anchor="middle" class="tiny">allows</text>
+  <text x="865" y="366" text-anchor="middle" class="tiny">narrows</text>
+</svg>

--- a/static/media/platform/diagrams/users-teams-membership.svg
+++ b/static/media/platform/diagrams/users-teams-membership.svg
@@ -1,0 +1,61 @@
+<svg viewBox="0 0 1000 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="User authentication flow where team membership is resolved from explicit team users and matching SSO groups">
+  <defs>
+    <marker id="membership-arrow" viewBox="0 0 10 7" markerWidth="8" markerHeight="6" refX="9" refY="3.5" orient="auto">
+      <path d="M0,0 L10,3.5 L0,7 Z" fill="#828592"/>
+    </marker>
+    <style>
+      text { font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .title { font-size: 18px; font-weight: 700; fill: #050B24; }
+      .label { font-size: 14px; font-weight: 600; fill: #050B24; }
+      .small { font-size: 12px; fill: #505466; }
+      .tiny { font-size: 11px; fill: #828592; }
+      .code { font-size: 12px; font-family: "SFMono-Regular", Consolas, monospace; fill: #263147; }
+    </style>
+  </defs>
+
+  <rect width="1000" height="470" rx="18" fill="#FFFFFF"/>
+
+  <text x="500" y="42" text-anchor="middle" class="title">User authentication resolves team membership</text>
+  <text x="500" y="66" text-anchor="middle" class="small">For a user login or user access key, Platform adds team groups from direct assignment or matching SSO groups.</text>
+
+  <rect x="55" y="125" width="215" height="105" rx="10" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="162.5" y="156" text-anchor="middle" class="label">User</text>
+  <text x="162.5" y="181" text-anchor="middle" class="code">metadata.name: alice</text>
+  <text x="162.5" y="204" text-anchor="middle" class="code">spec.groups: devs</text>
+
+  <rect x="55" y="280" width="215" height="105" rx="10" fill="#FFF8F3" stroke="#FF6600" stroke-width="1.6"/>
+  <text x="162.5" y="311" text-anchor="middle" class="label">SSO token</text>
+  <text x="162.5" y="336" text-anchor="middle" class="code">subject: alice@example.com</text>
+  <text x="162.5" y="359" text-anchor="middle" class="code">groups: devs</text>
+
+  <rect x="392" y="110" width="245" height="290" rx="16" fill="#F8FBFF" stroke="#6B88A6" stroke-width="1.2"/>
+  <text x="514.5" y="145" text-anchor="middle" class="label">Team</text>
+  <text x="514.5" y="169" text-anchor="middle" class="code">metadata.name: app-team</text>
+
+  <rect x="425" y="205" width="179" height="62" rx="8" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="514.5" y="230" text-anchor="middle" class="label">Direct members</text>
+  <text x="514.5" y="251" text-anchor="middle" class="code">spec.users: alice</text>
+
+  <rect x="425" y="302" width="179" height="62" rx="8" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1"/>
+  <text x="514.5" y="327" text-anchor="middle" class="label">Group members</text>
+  <text x="514.5" y="348" text-anchor="middle" class="code">spec.groups: devs</text>
+
+  <rect x="755" y="165" width="190" height="140" rx="12" fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.2"/>
+  <text x="850" y="208" text-anchor="middle" class="label">Effective identity</text>
+  <text x="850" y="235" text-anchor="middle" class="code">user: alice@example.com</text>
+  <text x="850" y="258" text-anchor="middle" class="code">group: loft:user:alice</text>
+  <text x="850" y="281" text-anchor="middle" class="code">group: loft:team:app-team</text>
+
+  <line x1="162.5" y1="280" x2="162.5" y2="230" stroke="#828592" stroke-width="1.5" marker-end="url(#membership-arrow)"/>
+  <text x="222" y="258" text-anchor="middle" class="tiny">syncs groups</text>
+
+  <line x1="270" y1="177" x2="392" y2="225" stroke="#828592" stroke-width="1.5" marker-end="url(#membership-arrow)"/>
+
+  <line x1="270" y1="204" x2="392" y2="333" stroke="#828592" stroke-width="1.5" marker-end="url(#membership-arrow)"/>
+
+  <line x1="637" y1="235" x2="755" y2="235" stroke="#828592" stroke-width="1.5" marker-end="url(#membership-arrow)"/>
+  <text x="696" y="222" text-anchor="middle" class="tiny">adds team group</text>
+
+  <rect x="340" y="420" width="350" height="30" rx="15" fill="#F4F6FA"/>
+  <text x="514.5" y="440" text-anchor="middle" class="tiny">Platform records the resolved team list on user status.</text>
+</svg>


### PR DESCRIPTION
# Content Description
Expands the "What are Users and Teams" concept page: identity resolution, permissions and roles, project membership vs. ownership, resource ownership, quotas, automation/service accounts, SSO provisioning, access troubleshooting, and access modeling guidance. Adds three diagrams (team membership resolution, access evaluation, project membership vs. ownership).

## Preview Link 
<!-- Netlify will post the deploy preview link on this PR -->
https://deploy-preview-2352--vcluster-docs-site.netlify.app/docs/platform/next/understand/what-are-users-and-teams

## Internal Reference
Closes DOC-1591

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs