### PR TITLE
docs(ENGNODE-336): add information about wildcard in proxy config

### DIFF
--- a/vcluster/configure/vcluster-yaml/experimental/_code/proxy-wildcard-config.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/proxy-wildcard-config.yaml
@@ -1,6 +1,6 @@
 # Wildcard Resource Proxy configuration
 # Proxies all resource kinds from the example.com/v1 API group to a target tenant cluster.
-# Use this when new Kinds are added to the API group frequently, avoiding config updates.
+# Use this when new kinds are added to the API group frequently, avoiding config updates.
 experimental:
   proxy:
     customResources:

--- a/vcluster/configure/vcluster-yaml/experimental/_code/proxy-wildcard-config.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/proxy-wildcard-config.yaml
@@ -1,0 +1,10 @@
+# Wildcard Resource Proxy configuration
+# Proxies all resource kinds from the example.com/v1 API group to a target tenant cluster.
+# Use this when new Kinds are added to the API group frequently, avoiding config updates.
+experimental:
+  proxy:
+    customResources:
+      "*.example.com/v1":
+        enabled: true
+        targetVirtualCluster:
+          name: "target"

--- a/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
@@ -160,7 +160,7 @@ The resource key follows the format `resource.apiGroup/version`:
 - `otherresources.test.io/v2` - proxies OtherResource resources from the `test.io` API group, version `v2`
 - `additionalresources.acme.org/v1alpha1` - proxies AdditionalResource resources from the `acme.org` API group, version `v1alpha1`
 
-#### Wildcard Kind matching {#wildcard-kind-matching}
+#### Wildcard kind matching {#wildcard-kind-matching}
 
 You can use `*` as the resource name to match all resource kinds in an API group and version:
 
@@ -170,7 +170,7 @@ You can use `*` as the resource name to match all resource kinds in an API group
 This is useful when a CRD API group has multiple kinds that all target the same cluster, so your `vcluster.yaml` does not need updating whenever a new kind is added to the group.
 
 :::note Wildcard and explicit entries are mutually exclusive
-A wildcard key (e.g. `*.example.com/v1`) and an explicit key (e.g. `myresources.example.com/v1`) cannot both be configured for the same group and version. vCluster rejects that combination at startup.
+A wildcard key (for example `*.example.com/v1`) and an explicit key (for example `myresources.example.com/v1`) cannot both be enabled for the same group and version. vCluster rejects that combination at startup. A disabled explicit entry (`enabled: false`) does not conflict with a wildcard for the same group and version.
 :::
 
 ## Example: Basic proxy setup {#basic-setup}
@@ -401,7 +401,7 @@ In this configuration:
 - `target-a` stores MyResource and SecondaryResource resources from `example.com/v1`
 - `target-b` stores OtherResource and AdditionalResource resources from `test.io/v2`
 
-## Example: Wildcard Kind proxy {#wildcard-kind}
+## Example: Wildcard kind proxy {#wildcard-kind}
 
 When an API group contains several resource kinds that all belong to the same target, use a wildcard key so you don't have to update the config each time a new kind is added.
 
@@ -721,6 +721,8 @@ vcluster connect <target> -- kubectl auth can-i create myresources.example.com \
 ### Target unavailable errors {#target-unavailable}
 
 Ensure the target tenant cluster is running and healthy. vCluster automatically attempts to reconnect when the target becomes available.
+
+For a wildcard proxy, `kubectl api-resources` and other discovery-based commands return no resource kinds for that group and version while the target is unavailable. This keeps the client's API service healthy but means kind discovery goes empty during an outage. Discovery resumes as soon as the target reconnects. Explicit (non-wildcard) entries are not affected. They continue to advertise their configured resource names during an outage.
 
 ## Config reference {#config-reference}
 

--- a/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
@@ -15,6 +15,7 @@ import ProxyMultiTargetConfig from '!!raw-loader!@site/vcluster/configure/vclust
 import ProxyAccessModesConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/proxy-access-modes-config.yaml'
 import ProxyCrossProjectConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/proxy-cross-project-config.yaml'
 import ProxyPlatformRbac from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/proxy-platform-rbac.yaml'
+import ProxyWildcardConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/proxy-wildcard-config.yaml'
 
 <ProAdmonition/>
 
@@ -158,6 +159,19 @@ The resource key follows the format `resource.apiGroup/version`:
 - `myresources.example.com/v1` - proxies MyResource resources from the `example.com` API group, version `v1`
 - `otherresources.test.io/v2` - proxies OtherResource resources from the `test.io` API group, version `v2`
 - `additionalresources.acme.org/v1alpha1` - proxies AdditionalResource resources from the `acme.org` API group, version `v1alpha1`
+
+#### Wildcard Kind matching {#wildcard-kind-matching}
+
+You can use `*` as the resource name to match all resource kinds in an API group and version:
+
+- `*.example.com/v1` - proxies **all** resource kinds from the `example.com` API group, version `v1`
+- `*.test.io/v2` - proxies all resource kinds from the `test.io` API group, version `v2`
+
+This is useful when a CRD API group has multiple kinds that all target the same cluster, so your `vcluster.yaml` does not need updating whenever a new kind is added to the group.
+
+:::note Wildcard and explicit entries are mutually exclusive
+A wildcard key (e.g. `*.example.com/v1`) and an explicit key (e.g. `myresources.example.com/v1`) cannot both be configured for the same group and version. vCluster rejects that combination at startup.
+:::
 
 ## Example: Basic proxy setup {#basic-setup}
 
@@ -386,6 +400,14 @@ flowchart LR
 In this configuration:
 - `target-a` stores MyResource and SecondaryResource resources from `example.com/v1`
 - `target-b` stores OtherResource and AdditionalResource resources from `test.io/v2`
+
+## Example: Wildcard Kind proxy {#wildcard-kind}
+
+When an API group contains several resource kinds that all belong to the same target, use a wildcard key so you don't have to update the config each time a new kind is added.
+
+<CodeBlock language="yaml" title="client-wildcard.yaml">{ProxyWildcardConfig}</CodeBlock>
+
+Any resource kind served by the `example.com/v1` API group in the target tenant cluster is automatically proxied. You do not need to enumerate individual resource names.
 
 ## Example: Cross-project proxy {#cross-project}
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Add information about wildcard(*) in API proxy config.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2358--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/experimental/proxy#wildcard-kind-matching

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Product change implemented in ENGNODE-336, no docs ticket.

<!-- Do not change the line below -->
@netlify /docs

