### PR TITLE
add documentation for NodeProfiles feature

### DIFF
--- a/platform/administer/node-profiles/_category_.json
+++ b/platform/administer/node-profiles/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Node Profiles",
+  "position": "4.5",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -7,9 +7,9 @@ description: Learn how NodeProfile applies reusable labels, taints, and annotati
 
 import NodeProfileRelationships from '@site/static/media/diagrams/node-profile-relationships.svg';
 
-Node labels, taints, and annotations drift over time. A compliance label gets added, a taint changes for a firmware update, and each affected node needs the same update. A NodeProfile prevents that drift by enforcing a defined set of labels, taints, and annotations when a node joins and continuously afterward.
+A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
 
-Define a NodeProfile, reference it from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and update the profile whenever requirements change. Every node that references it stays in sync automatically, without being re-provisioned.
+The platform doesn't just apply it once. It keeps every node that references the profile in sync as the definition changes, converging edits onto already-joined nodes without re-provisioning them.
 
 :::info Private nodes only
 NodeProfiles apply to private nodes only. They can't be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.
@@ -48,7 +48,7 @@ spec:
 
 ### Reference the profile
 
-Reference `gpu-training` from a manual join, or from an auto-node pool in `vcluster.yaml`:
+For a manual join, select `gpu-training` from the profile dropdown when generating the join command. For an auto-node pool, reference it in `vcluster.yaml`:
 
 ```yaml
 # Inside your vcluster.yaml
@@ -62,7 +62,7 @@ privateNodes:
           profile: gpu-training
 ```
 
-Every node the `gpu-burst` pool provisions joins with the `workload.vcluster.com/class=gpu` label, the `ops.vcluster.com/owner=ml-platform` annotation, and the `nvidia.com/gpu=true:NoSchedule` taint. The startup taint is removed once the node reaches `Ready`. From then on, the platform keeps the node's labels, annotations, and taints in sync with the profile automatically.
+Either way, the node joins with the `workload.vcluster.com/class=gpu` label, the `ops.vcluster.com/owner=ml-platform` annotation, and the `nvidia.com/gpu=true:NoSchedule` taint already applied. The startup taint is removed once the node reaches `Ready`. From then on, the platform keeps the node's labels, annotations, and taints in sync with the profile automatically.
 
 ### Update the profile
 
@@ -150,3 +150,5 @@ A profile resolved through the default-profile fallback chain, rather than an ex
 </figure>
 
 A manually joined node has no node provider or node type at all, but can still reference a NodeProfile. A node from an auto-node pool has both.
+
+Without a shared profile, nothing ties these nodes together, and the resulting Node objects carry no identity in common. A NodeProfile closes that gap. Every node that references the same profile carries the same `vcluster.com/node-profile=<name>` label, no matter how it joined. For example, running `kubectl get nodes` with the label selector `vcluster.com/node-profile=gpu-training` returns every GPU training node in the tenant cluster, regardless of how each one joined.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference a profile from a manual join, a static/dynamic auto-node pool, and the platform reconciles the same configuration onto every node, regardless of how it joined.
 
 Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the vCluster config, and the resulting Kubernetes Node objects carry no shared identity. 
-A named NodeProfile fixes this. Every node that references it ends up with the same `vcluster.com/node-profile=<name>` label, so listing nodes with that label returns every GPU training node in the tenant cluster no matter how it was provisioned.
+A named NodeProfile fixes this. Every node that references it reflect the same set of labels, no matter how it was provisioned.
 
 Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
 

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -6,8 +6,8 @@ sidebar_position: 1
 
 A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference a profile from a manual join, a static/dynamic auto-node pool, and the platform reconciles the same configuration onto every node, regardless of how it joined.
 
-Without a shared profile, there is no way to mark a set of nodes as, e.g., "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the vCluster config, and the resulting Kubernetes Node objects carry no shared identity. 
-A named NodeProfile fixes this. Every node that references it reflect the same set of labels, no matter how it was provisioned.
+Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the vCluster config, and the resulting Kubernetes Node objects carry no shared identity. 
+A named NodeProfile fixes this. Every node that references it ends up with the same `vcluster.com/node-profile=<name>` label, so listing nodes with that label returns every GPU training node in the tenant cluster no matter how it was provisioned.
 
 Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
 
@@ -60,9 +60,9 @@ All fields in `spec` are optional. An empty profile is valid but has no effect.
 |-------|-------------|---------------|
 | `displayName` | Human-readable name shown in the platform UI. | N/A |
 | `description` | Free-form text shown alongside the profile in selectors. | N/A |
-| `nodeLabels` | Labels reconciled onto the `Node` object. | Continuously |
-| `nodeAnnotations` | Annotations reconciled onto the `Node` object. | Continuously |
-| `taints` | Steady-state taints reconciled onto the `Node` object. | Continuously |
+| `nodeLabels` | Labels reconciled onto the Node object. | Continuously |
+| `nodeAnnotations` | Annotations reconciled onto the Node object. | Continuously |
+| `taints` | Steady-state taints reconciled onto the Node object. | Continuously |
 | `startupTaints` | Taints applied when the node joins and removed once the node reaches `Ready`. Used to hold a node from receiving traffic until join-time setup finishes. | Once, at join |
 
 ## Continuous reconciliation
@@ -73,7 +73,7 @@ Each tenant cluster runs a reconciler that watches its assigned private worker n
 - Removing a key from a profile removes it from those nodes.
 - Labels, annotations, and taints that a profile never set are left untouched, even if they were added by other means.
 
-`startupTaints` are the exception: they're applied once, at join, and removed once the node becomes Ready. They aren't part of the steady-state reconciliation loop, so editing startupTaints on a profile has no effect on nodes that already joined.
+`startupTaints` are the exception. They're applied once, at join, and removed once the node becomes Ready. They aren't part of the steady-state reconciliation loop, so editing startupTaints on a profile has no effect on nodes that already joined.
 
 Convergence happens on the reconciler's resync interval, not instantly. Expect a short delay between editing a profile and seeing the change reflected on affected nodes.
 
@@ -95,7 +95,7 @@ The profile a node joins with is baked into the join command as the `vcluster.co
 
 ## How NodeProfile relates to other node objects
 
-[Node providers](../node-providers/overview.mdx) and [Node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned: which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that — it describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
+[Node providers](../node-providers/overview.mdx) and [Node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that. It describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
 
 ```mermaid
 flowchart LR

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -7,19 +7,19 @@ description: Learn how NodeProfile applies reusable labels, taints, and annotati
 
 import NodeProfileRelationships from '@site/static/media/diagrams/node-profile-relationships.svg';
 
-Node labels, taints, and annotations drift over time. A compliance label gets added, a taint changes for a firmware update, and someone has to hand-edit every affected node and hope none get missed. A NodeProfile resolves this by enforcing a defined set of labels, taints, and annotations at join and continuously afterward, for every node that references it.
+Node labels, taints, and annotations drift over time. A compliance label gets added, a taint changes for a firmware update, and each affected node needs the same update. A NodeProfile prevents that drift by enforcing a defined set of labels, taints, and annotations when a node joins and continuously afterward.
 
-Define a NodeProfile, reference it from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and edit it whenever requirements change. Every node stays in sync automatically, without being re-provisioned.
+Define a NodeProfile, reference it from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and update the profile whenever requirements change. Every node that references it stays in sync automatically, without being re-provisioned.
 
 :::info Private nodes only
-NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.
+NodeProfiles apply to private nodes only. They can't be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.
 :::
 
 ## Use a NodeProfile
 
 ### Define a NodeProfile
 
-Say every GPU training node needs the same label, ownership annotation, and taint, no matter how it joins the cluster. Define a NodeProfile:
+Suppose every GPU training node needs the same label, ownership annotation, and taint, no matter how it joins the cluster. Define a NodeProfile:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -44,9 +44,9 @@ spec:
       effect: NoSchedule
 ```
 
-`nodeLabels` and `nodeAnnotations` are reconciled onto the Node object continuously, so they can change later without someone having to edit each node directly. The `taints` entry keeps non-GPU pods from scheduling on the node permanently. The `startupTaints` entry holds the node out of scheduling only until it reaches `Ready`, then is removed automatically.
+`nodeLabels` and `nodeAnnotations` are reconciled onto the Node object continuously, so they can change later without editing each node directly. The `taints` entry keeps non-GPU pods from scheduling on the node permanently. The `startupTaints` entry keeps the node out of scheduling only until it reaches `Ready`, then is removed automatically.
 
-### Reference the profile from a node
+### Reference the profile
 
 Reference `gpu-training` from a manual join, or from an auto-node pool in `vcluster.yaml`:
 
@@ -62,11 +62,11 @@ privateNodes:
           profile: gpu-training
 ```
 
-Every node the `gpu-burst` pool provisions joins already carrying the `workload.vcluster.com/class=gpu` label, the `ops.vcluster.com/owner=ml-platform` annotation, and the `nvidia.com/gpu=true:NoSchedule` taint. The startup taint is removed once the node reaches `Ready`. From then on, the platform keeps the node's labels, annotations, and taints in sync with the profile automatically.
+Every node the `gpu-burst` pool provisions joins with the `workload.vcluster.com/class=gpu` label, the `ops.vcluster.com/owner=ml-platform` annotation, and the `nvidia.com/gpu=true:NoSchedule` taint. The startup taint is removed once the node reaches `Ready`. From then on, the platform keeps the node's labels, annotations, and taints in sync with the profile automatically.
 
 ### Update the profile
 
-Suppose compliance now requires every GPU node to carry an audit label. Add it to the profile instead of hand-editing every node:
+If compliance later requires every GPU node to carry an audit label, add it to the profile instead of editing every node:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -92,7 +92,7 @@ spec:
       effect: NoSchedule
 ```
 
-Every node that references `gpu-training` picks up the new label automatically. No node needs to be re-provisioned, and no one has to hand-edit individual nodes.
+Every node that references `gpu-training` picks up the new label automatically. No node needs to be re-provisioned, and no one has to edit individual nodes.
 
 ## Spec fields
 
@@ -115,9 +115,9 @@ Each <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs a re
 - Removing a key from a profile removes it from those nodes.
 - Labels, annotations, and taints that a profile never set are left untouched, even if they were added by other means.
 
-The reconciler tracks which keys it owns using bookkeeping annotations on the node itself, kept separately for labels, annotations, and taints. On each reconcile, it checks that record to know what to prune if a key disappears from the profile, rather than guessing from the node's current state.
+The reconciler tracks which keys it owns using annotations on the node itself, kept separately for labels, annotations, and taints. On each reconcile, it checks that record to know what to prune if a key disappears from the profile, rather than guessing from the node's current state.
 
-A key can still collide with something the reconciler doesn't track. For example, an auto-node pool might set a taint directly, using the same key as a taint the profile also defines. When that happens, the profile's value wins. The reconciler overwrites the conflicting value on every reconcile, silently, with no error or warning.
+A key can still collide with a value the profile doesn't own. For example, an auto-node pool might set a taint directly, using the same key as a taint the profile also defines. When that happens, the profile's value wins. The reconciler overwrites the conflicting value on every reconcile without returning an error or warning.
 
 `startupTaints` are the exception. They're applied once, at join, and removed once the node becomes `Ready`. They aren't part of the steady-state reconciliation loop, so editing `startupTaints` on a profile has no effect on nodes that already joined.
 
@@ -133,13 +133,13 @@ A node resolves to exactly one profile. A profile is reusable across many nodes,
 
 If none of these resolve, the node joins without a profile, which is a valid state.
 
-A NodeProfile is a cluster-scoped object, like NodeProvider and NodeType, so nothing inherently stops a project from referencing a profile created for a different team or purpose. That's what the allowlist enforces. All three sources are validated against the project's [allowed node profiles](../projects/allowed/node-profiles.mdx), and a profile that isn't allowed is rejected, even if explicitly requested.
+A NodeProfile is a cluster-scoped object, like NodeProvider and NodeType. Without project-level restrictions, a project could reference a profile created for a different team or purpose. The allowlist prevents that. All three sources are validated against the project's [allowed node profiles](../projects/allowed/node-profiles.mdx), and a profile that isn't allowed is rejected, even if explicitly requested.
 
 ### Tamper-proof assignment
 
-An explicit profile selection, made at join time or on the auto-node pool, is baked into the join command (or `NodeClaim`) as the `vcluster.com/node-profile` label. Because this label is set through the normal node join process, the reconciler treats it as untrusted until it validates the value against the project's allowlist. Once validated, the reconciler promotes the assignment to `node-restriction.kubernetes.io/node-profile`, a [NodeRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)-protected label that a node cannot set or remove on itself. This prevents a compromised or misconfigured node from granting itself a different profile's labels and taints.
+An explicit profile selection, made at join time or on the auto-node pool, is baked into the join command or `NodeClaim` as the `vcluster.com/node-profile` label. Because this label is set through the normal node join process, the reconciler treats it as untrusted until it validates the value against the project's allowlist. Once validated, the reconciler promotes the assignment to `node-restriction.kubernetes.io/node-profile`, a [NodeRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)-protected label that a node can't set or remove on itself. This prevents a compromised or misconfigured node from granting itself a different profile's labels and taints.
 
-A profile resolved through the default-profile fallback chain, rather than an explicit selection, is not promoted this way. Defaults stay dynamic, so changing or clearing the tenant cluster's or project's default re-converges the affected nodes without requiring a new join.
+A profile resolved through the default-profile fallback chain, rather than an explicit selection, isn't promoted this way. Defaults stay dynamic, so changing or clearing the tenant cluster's or project's default re-converges the affected nodes without requiring a new join.
 
 ## How NodeProfile relates to other node objects
 

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -4,10 +4,9 @@ sidebar_label: Overview
 sidebar_position: 1
 ---
 
-A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference a profile from a manual join, a static/dynamic auto-node pool, and the platform reconciles the same configuration onto every node, regardless of how it joined.
+A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference the same profile from a manual join or a static or dynamic auto-node pool, and the platform reconciles identical configuration onto every node, regardless of how it joined.
 
-Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the vCluster config, and the resulting Kubernetes Node objects carry no shared identity. 
-A named NodeProfile fixes this. Every node that references it reflect the same set of labels, no matter how it was provisioned.
+Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> config, and the resulting Kubernetes Node objects carry no shared identity. A named NodeProfile fixes this. Every node that references it reflects the same set of labels, no matter how it was provisioned.
 
 Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
 
@@ -67,15 +66,15 @@ All fields in `spec` are optional. An empty profile is valid but has no effect.
 
 ## Continuous reconciliation
 
-Each tenant cluster runs a reconciler that watches its assigned private worker nodes and keeps them aligned with the NodeProfile they reference. The reconciler only manages the keys it owns:
+Each <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs a reconciler that watches its assigned private worker nodes and keeps them aligned with the NodeProfile they reference. The reconciler only manages the keys it owns:
 
 - Adding a label, annotation, or taint to a profile applies it to every node referencing that profile.
 - Removing a key from a profile removes it from those nodes.
 - Labels, annotations, and taints that a profile never set are left untouched, even if they were added by other means.
 
-`startupTaints` are the exception. They're applied once, at join, and removed once the node becomes Ready. They aren't part of the steady-state reconciliation loop, so editing startupTaints on a profile has no effect on nodes that already joined.
+`startupTaints` are the exception. They're applied once, at join, and removed once the node becomes `Ready`. They aren't part of the steady-state reconciliation loop, so editing `startupTaints` on a profile has no effect on nodes that already joined.
 
-Convergence is prompt, not tied to a fixed interval: the reconciler watches for profile changes and re-converges affected nodes as soon as they occur. If the tenant cluster's connection to the platform is temporarily unavailable, convergence resumes once the connection is restored.
+Convergence is prompt, not tied to a fixed interval. The reconciler watches for profile changes and re-converges affected nodes as soon as they occur. If the tenant cluster's connection to the platform is temporarily unavailable, convergence resumes once the connection is restored.
 
 ## Assignment and precedence
 
@@ -83,7 +82,7 @@ A node resolves to exactly one profile. A profile is reusable across many nodes,
 
 1. An explicit `profileRef` set on the manual join request, or a `profile` set on the auto-node pool that provisioned the node.
 2. The tenant cluster's `privateNodes.defaultProfile`.
-3. The project's default node profile, configured through [spec.defaultNodeProfile](../projects/allowed/node-profiles.mdx).
+3. The project's default node profile, configured through [`spec.defaultNodeProfile`](../projects/allowed/node-profiles.mdx).
 
 If none of these resolve, the node joins without a profile, which is a valid state.
 
@@ -97,7 +96,7 @@ A profile resolved through the default-profile fallback chain, rather than an ex
 
 ## How NodeProfile relates to other node objects
 
-[Node providers](../node-providers/overview.mdx) and [Node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that. It describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
+[Node providers](../node-providers/overview.mdx) and [node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that. It describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
 
 ```mermaid
 flowchart LR
@@ -117,8 +116,8 @@ flowchart LR
   NPROF -->|"reconciled: labels, taints, annotations"| NODE
 ```
 
-A manually joined node has no `NodeProvider` or `NodeType` at all, but can still reference a NodeProfile. A node from an auto-node pool has both.
+A manually joined node has no node provider or node type at all, but can still reference a NodeProfile. A node from an auto-node pool has both.
 
 ## Scope
 
-NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone control plane cluster, or by cloud-hosted tenant clusters.
+NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -127,7 +127,7 @@ Convergence is prompt, not tied to a fixed interval. The reconciler watches for 
 
 A node resolves to exactly one profile. A profile is reusable across many nodes, but a single node is never assigned more than one. The platform resolves the profile for a node in this order, using the first match:
 
-1. An explicit `profileRef` set on the manual join request, or a `profile` set on the auto-node pool that provisioned the node.
+1. An explicit profile set while creating manual join command, or a `profile` set on the auto-node pool that provisioned the node.
 2. The tenant cluster's `privateNodes.defaultProfile`.
 3. The project's default node profile, configured through [`spec.defaultNodeProfile`](../projects/allowed/node-profiles.mdx).
 

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -10,6 +10,10 @@ Without a shared profile, there is no way to mark a set of nodes as, for example
 
 Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
 
+:::info Private nodes only
+NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.
+:::
+
 ## Example
 
 ```yaml
@@ -117,7 +121,3 @@ flowchart LR
 ```
 
 A manually joined node has no node provider or node type at all, but can still reference a NodeProfile. A node from an auto-node pool has both.
-
-## Scope
-
-NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -5,6 +5,8 @@ sidebar_position: 1
 description: Learn how NodeProfile applies reusable labels, taints, and annotations to private nodes and keeps them continuously in sync.
 ---
 
+import NodeProfileRelationships from '@site/static/media/diagrams/node-profile-relationships.svg';
+
 A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference the same profile from a manual join or a static or dynamic auto-node pool, and the platform reconciles identical configuration onto every node, regardless of how it joined.
 
 Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> config, and the resulting Kubernetes Node objects carry no shared identity. A named NodeProfile fixes this. Every node that references it reflects the same set of labels, no matter how it was provisioned.
@@ -103,22 +105,8 @@ A profile resolved through the default-profile fallback chain, rather than an ex
 
 [Node providers](../node-providers/overview.mdx) and [node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that. It describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
 
-```mermaid
-flowchart LR
-  subgraph INFRA["Infrastructure (how a node is provisioned)"]
-    direction TB
-    NP["NodeProvider"]
-    NT["NodeType"]
-  end
-  subgraph CONFIG["Configuration (what the node looks like)"]
-    direction TB
-    NPROF["NodeProfile"]
-  end
-  NODE["Node (joined private node)"]
-
-  NP -->|"owns / generates"| NT
-  NT -->|"typeRef"| NODE
-  NPROF -->|"reconciled: labels, taints, annotations"| NODE
-```
+<figure>
+  <NodeProfileRelationships style={{width: '100%', height: 'auto'}} role="img" aria-label="NodeProfile relationship to node providers, node types, and joined private nodes" />
+</figure>
 
 A manually joined node has no node provider or node type at all, but can still reference a NodeProfile. A node from an auto-node pool has both.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview
 sidebar_label: Overview
 sidebar_position: 1
+description: Learn how NodeProfile applies reusable labels, taints, and annotations to private nodes and keeps them continuously in sync.
 ---
 
 A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference the same profile from a manual join or a static or dynamic auto-node pool, and the platform reconciles identical configuration onto every node, regardless of how it joined.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -7,17 +7,19 @@ description: Learn how NodeProfile applies reusable labels, taints, and annotati
 
 import NodeProfileRelationships from '@site/static/media/diagrams/node-profile-relationships.svg';
 
-A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference the same profile from a manual join or a static or dynamic auto-node pool, and the platform reconciles identical configuration onto every node, regardless of how it joined.
+Node labels, taints, and annotations drift over time. A compliance label gets added, a taint changes for a firmware update, and someone has to hand-edit every affected node and hope none get missed. A NodeProfile resolves this by enforcing a defined set of labels, taints, and annotations at join and continuously afterward, for every node that references it.
 
-Without a shared profile, there is no way to mark a set of nodes as, for example, "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> config, and the resulting Kubernetes Node objects carry no shared identity. A named NodeProfile fixes this. Every node that references it reflects the same set of labels, no matter how it was provisioned.
-
-Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
+Define a NodeProfile, reference it from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and edit it whenever requirements change. Every node stays in sync automatically, without being re-provisioned.
 
 :::info Private nodes only
 NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, or by cloud-hosted tenant clusters.
 :::
 
-## Example
+## Use a NodeProfile
+
+### Define a NodeProfile
+
+Say every GPU training node needs the same label, ownership annotation, and taint, no matter how it joins the cluster. Define a NodeProfile:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -42,7 +44,11 @@ spec:
       effect: NoSchedule
 ```
 
-Reference this profile from a manual join, or from an auto-node pool in `vcluster.yaml`:
+`nodeLabels` and `nodeAnnotations` are reconciled onto the Node object continuously, so they can change later without someone having to edit each node directly. The `taints` entry keeps non-GPU pods from scheduling on the node permanently. The `startupTaints` entry holds the node out of scheduling only until it reaches `Ready`, then is removed automatically.
+
+### Reference the profile from a node
+
+Reference `gpu-training` from a manual join, or from an auto-node pool in `vcluster.yaml`:
 
 ```yaml
 # Inside your vcluster.yaml
@@ -56,7 +62,37 @@ privateNodes:
           profile: gpu-training
 ```
 
-Every node the `gpu-burst` pool provisions joins with the `gpu-training` profile's labels and taints already applied, and stays in sync with the profile from then on.
+Every node the `gpu-burst` pool provisions joins already carrying the `workload.vcluster.com/class=gpu` label, the `ops.vcluster.com/owner=ml-platform` annotation, and the `nvidia.com/gpu=true:NoSchedule` taint. The startup taint is removed once the node reaches `Ready`. From then on, the platform keeps the node's labels, annotations, and taints in sync with the profile automatically.
+
+### Update the profile
+
+Suppose compliance now requires every GPU node to carry an audit label. Add it to the profile instead of hand-editing every node:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  name: gpu-training
+spec:
+  displayName: GPU Training
+  description: |
+    GPU worker defaults for training workloads.
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+    compliance.vcluster.com/audited: "true" # added
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  taints:
+    - key: nvidia.com/gpu
+      value: "true"
+      effect: NoSchedule
+  startupTaints:
+    - key: node.vcluster.com/bootstrap
+      value: "true"
+      effect: NoSchedule
+```
+
+Every node that references `gpu-training` picks up the new label automatically. No node needs to be re-provisioned, and no one has to hand-edit individual nodes.
 
 ## Spec fields
 
@@ -79,6 +115,10 @@ Each <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs a re
 - Removing a key from a profile removes it from those nodes.
 - Labels, annotations, and taints that a profile never set are left untouched, even if they were added by other means.
 
+The reconciler tracks which keys it owns using bookkeeping annotations on the node itself, kept separately for labels, annotations, and taints. On each reconcile, it checks that record to know what to prune if a key disappears from the profile, rather than guessing from the node's current state.
+
+A key can still collide with something the reconciler doesn't track. For example, an auto-node pool might set a taint directly, using the same key as a taint the profile also defines. When that happens, the profile's value wins. The reconciler overwrites the conflicting value on every reconcile, silently, with no error or warning.
+
 `startupTaints` are the exception. They're applied once, at join, and removed once the node becomes `Ready`. They aren't part of the steady-state reconciliation loop, so editing `startupTaints` on a profile has no effect on nodes that already joined.
 
 Convergence is prompt, not tied to a fixed interval. The reconciler watches for profile changes and re-converges affected nodes as soon as they occur. If the tenant cluster's connection to the platform is temporarily unavailable, convergence resumes once the connection is restored.
@@ -93,7 +133,7 @@ A node resolves to exactly one profile. A profile is reusable across many nodes,
 
 If none of these resolve, the node joins without a profile, which is a valid state.
 
-All three sources are validated against the project's [allowed node profiles](../projects/allowed/node-profiles.mdx). A profile that isn't allowed in the project is rejected, even if explicitly requested.
+A NodeProfile is a cluster-scoped object, like NodeProvider and NodeType, so nothing inherently stops a project from referencing a profile created for a different team or purpose. That's what the allowlist enforces. All three sources are validated against the project's [allowed node profiles](../projects/allowed/node-profiles.mdx), and a profile that isn't allowed is rejected, even if explicitly requested.
 
 ### Tamper-proof assignment
 
@@ -103,7 +143,7 @@ A profile resolved through the default-profile fallback chain, rather than an ex
 
 ## How NodeProfile relates to other node objects
 
-[Node providers](../node-providers/overview.mdx) and [node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that. It describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
+[Node providers](../node-providers/overview.mdx) and [node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned, which infrastructure it comes from and what hardware it has. NodeProfile describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
 
 <figure>
   <NodeProfileRelationships style={{width: '100%', height: 'auto'}} role="img" aria-label="NodeProfile relationship to node providers, node types, and joined private nodes" />

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -1,0 +1,122 @@
+---
+title: Overview
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+A NodeProfile is a reusable, cluster-scoped collection of node runtime settings (labels, taints, and annotations) that the platform continuously applies to every private node assigned to it. Reference a profile from a manual join, a static/dynamic auto-node pool, and the platform reconciles the same configuration onto every node, regardless of how it joined.
+
+Without a shared profile, there is no way to mark a set of nodes as, e.g., "this is a GPU training node" across every provisioning path. Manual joins have no provider, auto-node pools live in the vCluster config, and the resulting Kubernetes Node objects carry no shared identity. 
+A named NodeProfile fixes this. Every node that references it reflect the same set of labels, no matter how it was provisioned.
+
+Profiles are also continuously reconciled, not just applied once at join. Editing a profile converges the change onto every node that already references it, without requiring the node to be re-provisioned.
+
+## Example
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  name: gpu-training
+spec:
+  displayName: GPU Training
+  description: |
+    GPU worker defaults for training workloads.
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  taints:
+    - key: nvidia.com/gpu
+      value: "true"
+      effect: NoSchedule
+  startupTaints:
+    - key: node.vcluster.com/bootstrap
+      value: "true"
+      effect: NoSchedule
+```
+
+Reference this profile from a manual join, or from an auto-node pool in `vcluster.yaml`:
+
+```yaml
+# Inside your vcluster.yaml
+privateNodes:
+  enabled: true
+  autoNodes:
+    - provider: my-node-provider
+      static:
+        - name: gpu-burst
+          quantity: 2
+          profile: gpu-training
+```
+
+Every node the `gpu-burst` pool provisions joins with the `gpu-training` profile's labels and taints already applied, and stays in sync with the profile from then on.
+
+## Spec fields
+
+All fields in `spec` are optional. An empty profile is valid but has no effect.
+
+| Field | Description | When applied |
+|-------|-------------|---------------|
+| `displayName` | Human-readable name shown in the platform UI. | N/A |
+| `description` | Free-form text shown alongside the profile in selectors. | N/A |
+| `nodeLabels` | Labels reconciled onto the `Node` object. | Continuously |
+| `nodeAnnotations` | Annotations reconciled onto the `Node` object. | Continuously |
+| `taints` | Steady-state taints reconciled onto the `Node` object. | Continuously |
+| `startupTaints` | Taints applied when the node joins and removed once the node reaches `Ready`. Used to hold a node from receiving traffic until join-time setup finishes. | Once, at join |
+
+## Continuous reconciliation
+
+Each tenant cluster runs a reconciler that watches its assigned private worker nodes and keeps them aligned with the NodeProfile they reference. The reconciler only manages the keys it owns:
+
+- Adding a label, annotation, or taint to a profile applies it to every node referencing that profile.
+- Removing a key from a profile removes it from those nodes.
+- Labels, annotations, and taints that a profile never set are left untouched, even if they were added by other means.
+
+`startupTaints` are the exception: they're applied once, at join, and removed once the node becomes Ready. They aren't part of the steady-state reconciliation loop, so editing startupTaints on a profile has no effect on nodes that already joined.
+
+Convergence happens on the reconciler's resync interval, not instantly. Expect a short delay between editing a profile and seeing the change reflected on affected nodes.
+
+## Assignment and precedence
+
+A node resolves to exactly one profile. A profile is reusable across many nodes, but a single node is never assigned more than one. The platform resolves the profile for a node in this order, using the first match:
+
+1. An explicit `profileRef` set on the manual join request, or a `profile` set on the auto-node pool that provisioned the node.
+2. The tenant cluster's `privateNodes.defaultProfile`.
+3. The project's default node profile, configured through [spec.defaultNodeProfile](../projects/allowed/node-profiles.mdx).
+
+If none of these resolve, the node joins without a profile, which is a valid state.
+
+All three sources are validated against the project's [allowed node profiles](../projects/allowed/node-profiles.mdx). A profile that isn't allowed in the project is rejected, even if explicitly requested.
+
+### Tamper-proof assignment
+
+The profile a node joins with is baked into the join command as the `vcluster.com/node-profile` label. Because this label is set through the normal node join process, the reconciler treats it as untrusted until it validates the value against the project's allowlist. Once validated, the reconciler promotes the assignment to `node-restriction.kubernetes.io/node-profile`, a [NodeRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)-protected label that a node cannot set or remove on itself. This prevents a compromised or misconfigured node from granting itself a different profile's labels and taints.
+
+## How NodeProfile relates to other node objects
+
+[Node providers](../node-providers/overview.mdx) and [Node types](../node-providers/overview.mdx#node-types) describe how a node is provisioned: which infrastructure it comes from and what hardware it has. NodeProfile is orthogonal to that — it describes what the node looks like once it's part of the tenant cluster, independent of where it came from.
+
+```mermaid
+flowchart LR
+  subgraph INFRA["Infrastructure (how a node is provisioned)"]
+    direction TB
+    NP["NodeProvider"]
+    NT["NodeType"]
+  end
+  subgraph CONFIG["Configuration (what the node looks like)"]
+    direction TB
+    NPROF["NodeProfile"]
+  end
+  NODE["Node (joined private node)"]
+
+  NP -->|"owns / generates"| NT
+  NT -->|"typeRef"| NODE
+  NPROF -->|"reconciled: labels, taints, annotations"| NODE
+```
+
+A manually joined node has no `NodeProvider` or `NodeType` at all, but can still reference a NodeProfile. A node from an auto-node pool has both.
+
+## Scope
+
+NodeProfile applies to private nodes only. It cannot be used by tenant clusters whose control plane runs on a shared or standalone control plane cluster, or by cloud-hosted tenant clusters.

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -75,7 +75,7 @@ Each tenant cluster runs a reconciler that watches its assigned private worker n
 
 `startupTaints` are the exception. They're applied once, at join, and removed once the node becomes Ready. They aren't part of the steady-state reconciliation loop, so editing startupTaints on a profile has no effect on nodes that already joined.
 
-Convergence happens on the reconciler's resync interval, not instantly. Expect a short delay between editing a profile and seeing the change reflected on affected nodes.
+Convergence is prompt, not tied to a fixed interval: the reconciler watches for profile changes and re-converges affected nodes as soon as they occur. If the tenant cluster's connection to the platform is temporarily unavailable, convergence resumes once the connection is restored.
 
 ## Assignment and precedence
 
@@ -91,7 +91,9 @@ All three sources are validated against the project's [allowed node profiles](..
 
 ### Tamper-proof assignment
 
-The profile a node joins with is baked into the join command as the `vcluster.com/node-profile` label. Because this label is set through the normal node join process, the reconciler treats it as untrusted until it validates the value against the project's allowlist. Once validated, the reconciler promotes the assignment to `node-restriction.kubernetes.io/node-profile`, a [NodeRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)-protected label that a node cannot set or remove on itself. This prevents a compromised or misconfigured node from granting itself a different profile's labels and taints.
+An explicit profile selection, made at join time or on the auto-node pool, is baked into the join command (or `NodeClaim`) as the `vcluster.com/node-profile` label. Because this label is set through the normal node join process, the reconciler treats it as untrusted until it validates the value against the project's allowlist. Once validated, the reconciler promotes the assignment to `node-restriction.kubernetes.io/node-profile`, a [NodeRestriction](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction)-protected label that a node cannot set or remove on itself. This prevents a compromised or misconfigured node from granting itself a different profile's labels and taints.
+
+A profile resolved through the default-profile fallback chain, rather than an explicit selection, is not promoted this way. Defaults stay dynamic, so changing or clearing the tenant cluster's or project's default re-converges the affected nodes without requiring a new join.
 
 ## How NodeProfile relates to other node objects
 

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -5,31 +5,11 @@ sidebar_position: 4
 description: Control which node profiles a project's private nodes can use, and set a default profile for nodes that don't select one.
 ---
 
-Allowed node profiles control which [node profiles](../../node-profiles/overview.mdx) a project's private nodes may use, and which profile a node falls back to when none is selected. Use this to restrict tenants to a curated set of profiles, and to guarantee that nodes joining without an explicit profile still receive a baseline configuration.
+A project can restrict which [node profiles](../../node-profiles/overview.mdx) its private nodes may use, and separately set a default profile for nodes that don't select one explicitly. Use these settings to keep tenants on a curated set of profiles and to apply a baseline configuration to nodes that join without an explicit profile.
 
-## Behavior
+## Define allowed and default profiles
 
-The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or an owner-prefix wildcard ending in `.*`. For example, `platform.*` matches any profile whose name starts with `platform.`, such as `platform.gpu-training`.
-
-| Value | Effect |
-|-------|--------|
-| Unset (field omitted) | All node profiles are allowed. This is the default. |
-| Empty list (`allowedNodeProfiles: []`) | No node profiles are allowed. Any explicit `profileRef` or `profile` is rejected. `defaultNodeProfile` must also be unset. Setting both `defaultNodeProfile` and an empty `allowedNodeProfiles` list in the same project is rejected. |
-| One or more entries | Only allows node profiles matching any specified entry. |
-
-Matching rules:
-
-- Names are case sensitive.
-- A wildcard entry must end in `.*`. Only that literal suffix triggers prefix matching. A pattern like `gpu-*` (no dot) is treated as an exact name and won't match anything else.
-- The platform rejects a manual join, `NodeClaim`, or auto-node pool that explicitly references a disallowed node profile.
-
-`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>'s `privateNodes.defaultProfile` also isn't set. It must always be present in `allowedNodeProfiles`. That means it can't be set while `allowedNodeProfiles` is an empty list, since nothing matches an empty allowlist.
-
-Changing `allowedNodeProfiles` or `defaultNodeProfile` requires permission to update the project's corresponding subresource.
-
-## Configure allowed node profiles
-
-Edit the project and set `spec.allowedNodeProfiles` and, optionally, `spec.defaultNodeProfile`:
+Suppose the `ml-platform` project should only allow the `gpu-training` and `general-compute` profiles, and should default to `general-compute` when a node doesn't select a profile explicitly. Edit the project YAML and set `spec.allowedNodeProfiles` and, optionally, `spec.defaultNodeProfile`:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -43,17 +23,47 @@ spec:
   defaultNodeProfile: general-compute
 ```
 
-Nodes in this project can use either `gpu-training` or `general-compute`. A node that joins without an explicit profile, and whose tenant cluster has no `privateNodes.defaultProfile`, falls back to `general-compute`.
+With this spec, nodes in this project can use either `gpu-training` or `general-compute`. A node that joins without an explicit profile, and whose <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> has no `privateNodes.defaultProfile`, falls back to the project's `general-compute` default.
 
-To disallow all node profiles in a project:
+If a project shouldn't use node profiles at all, disallow them:
 
 ```yaml
 spec:
   allowedNodeProfiles: []
 ```
 
-If the project has `defaultNodeProfile` set, clear it in the same update. The platform rejects an empty `allowedNodeProfiles` list while `defaultNodeProfile` is still set, since the default itself would no longer be allowed.
+:::warning Also clear the default
+An empty `allowedNodeProfiles` list is rejected while `defaultNodeProfile` is still set, because the default itself would no longer be allowed. Clear `defaultNodeProfile` in the same update.
+:::
+
+## Behavior
+
+The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Changing either field requires permission to update the corresponding project subresource.
+
+### Allowed node profiles
+
+The value of `allowedNodeProfiles` determines which profiles a project's nodes may use:
+
+| Value | Effect |
+|-------|--------|
+| Unset (field omitted) | All node profiles are allowed. This is the default. |
+| Empty list (`allowedNodeProfiles: []`) | No node profiles are allowed. Any explicit `profileRef` or `profile` is rejected. `defaultNodeProfile` must also be unset. |
+| One or more entries | Only allows node profiles matching any specified entry. |
+
+Each entry in `allowedNodeProfiles` has a `name`, which can be either an exact `NodeProfile` name or an owner-prefix wildcard ending in `.*`.
+
+Matching rules:
+
+- Names are case sensitive.
+- A wildcard entry must end in `.*`. Only that literal suffix triggers prefix matching, so `platform.*` matches any profile whose name starts with `platform.`, such as `platform.gpu-training`. A pattern like `gpu-*` is treated as an exact name.
+- The platform rejects a manual join, `NodeClaim`, or auto-node pool that explicitly references a disallowed profile.
+
+### Default node profile
+
+`defaultNodeProfile` sets the project fallback profile. A node uses this value only when it doesn't select a profile explicitly and the tenant cluster's `privateNodes.defaultProfile` is also unset.
+
+The default must always be allowed by `allowedNodeProfiles`. That means `defaultNodeProfile` can't be set while `allowedNodeProfiles` is an empty list, because nothing matches an empty allowlist.
 
 ## Precedence
 
-A profile is resolved in the order described in [Assignment and precedence](../../node-profiles/overview.mdx#assignment-and-precedence): an explicit selection first, then the tenant cluster's default, then the project's default. Whichever source wins, the result is validated against `allowedNodeProfiles` before it's applied.
+A profile is resolved in the order described in [Assignment and precedence](../../node-profiles/overview.mdx#assignment-and-precedence). An explicit selection wins first, then the tenant cluster's default, then the project's default. Whichever source wins, the result is validated against `allowedNodeProfiles` before the profile is applied.

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -2,6 +2,7 @@
 title: Manage Node Profiles
 sidebar_label: Node Profiles
 sidebar_position: 4
+description: Control which node profiles a project's private nodes can use, and set a default profile for nodes that don't select one.
 ---
 
 Allowed node profiles control which [node profiles](../../node-profiles/overview.mdx) a project's private nodes may use, and which profile a node falls back to when none is selected. Use this to restrict tenants to a curated set of profiles, and to guarantee that nodes joining without an explicit profile still receive a baseline configuration.

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -8,7 +8,7 @@ Allowed node profiles control which [node profiles](../../node-profiles/overview
 
 ## Behavior
 
-The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or an owner-prefix wildcard ending in `.*` (for example, `platform.*` matches any profile whose name starts with `platform.`, such as `platform.gpu-training`).
+The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or an owner-prefix wildcard ending in `.*`. For example, `platform.*` matches any profile whose name starts with `platform.`, such as `platform.gpu-training`.
 
 | Value | Effect |
 |-------|--------|
@@ -22,7 +22,7 @@ Matching rules:
 - A wildcard entry must end in `.*`. Only that literal suffix triggers prefix matching. A pattern like `gpu-*` (no dot) is treated as an exact name and won't match anything else.
 - The platform rejects a manual join, `NodeClaim`, or auto-node pool that explicitly references a disallowed node profile.
 
-`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the tenant cluster's `privateNodes.defaultProfile` also isn't set. It must always be present in `allowedNodeProfiles`, so it can't be set at all while `allowedNodeProfiles` is an empty list, since nothing matches an empty allowlist.
+`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>'s `privateNodes.defaultProfile` also isn't set. It must always be present in `allowedNodeProfiles`. That means it can't be set while `allowedNodeProfiles` is an empty list, since nothing matches an empty allowlist.
 
 Changing `allowedNodeProfiles` or `defaultNodeProfile` requires permission to update the project's corresponding subresource.
 

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -8,20 +8,21 @@ Allowed node profiles control which [node profiles](../../node-profiles/overview
 
 ## Behavior
 
-The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or a wildcard.
+The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or an owner-prefix wildcard ending in `.*` (for example, `platform.*` matches any profile whose name starts with `platform.`, such as `platform.gpu-training`).
 
 | Value | Effect |
 |-------|--------|
 | Unset (field omitted) | All node profiles are allowed. This is the default. |
-| Empty list (`allowedNodeProfiles: []`) | No node profiles are allowed. Any explicit `profileRef` or `profile` is rejected, and `defaultNodeProfile` has no effect. |
+| Empty list (`allowedNodeProfiles: []`) | No node profiles are allowed. Any explicit `profileRef` or `profile` is rejected. `defaultNodeProfile` must also be unset. Setting both `defaultNodeProfile` and an empty `allowedNodeProfiles` list in the same project is rejected. |
 | One or more entries | Only allows node profiles matching any specified entry. |
 
 Matching rules:
 
 - Names are case sensitive.
+- A wildcard entry must end in `.*`. Only that literal suffix triggers prefix matching. A pattern like `gpu-*` (no dot) is treated as an exact name and won't match anything else.
 - The platform rejects a manual join, `NodeClaim`, or auto-node pool that explicitly references a disallowed node profile.
 
-`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the tenant cluster's `privateNodes.defaultProfile` also isn't set. It must itself be present in `allowedNodeProfiles` when that field is set to a non-empty list.
+`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the tenant cluster's `privateNodes.defaultProfile` also isn't set. It must always be present in `allowedNodeProfiles`, so it can't be set at all while `allowedNodeProfiles` is an empty list, since nothing matches an empty allowlist.
 
 Changing `allowedNodeProfiles` or `defaultNodeProfile` requires permission to update the project's corresponding subresource.
 
@@ -49,6 +50,8 @@ To disallow all node profiles in a project:
 spec:
   allowedNodeProfiles: []
 ```
+
+If the project has `defaultNodeProfile` set, clear it in the same update. The platform rejects an empty `allowedNodeProfiles` list while `defaultNodeProfile` is still set, since the default itself would no longer be allowed.
 
 ## Precedence
 

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -55,10 +55,4 @@ If the project has `defaultNodeProfile` set, clear it in the same update. The pl
 
 ## Precedence
 
-A node's profile is resolved in this order, using the first match:
-
-1. An explicit `profileRef` on the join request or `NodeClaim`, or `profile` on the auto-node pool.
-2. The tenant cluster's `privateNodes.defaultProfile`.
-3. The project's `defaultNodeProfile`.
-
-Every source is validated against `allowedNodeProfiles`, regardless of where it was set. See [Assignment and precedence](../../node-profiles/overview.mdx#assignment-and-precedence) for the full resolution and reconciliation behavior.
+A profile is resolved in the order described in [Assignment and precedence](../../node-profiles/overview.mdx#assignment-and-precedence): an explicit selection first, then the tenant cluster's default, then the project's default. Whichever source wins, the result is validated against `allowedNodeProfiles` before it's applied.

--- a/platform/administer/projects/allowed/node-profiles.mdx
+++ b/platform/administer/projects/allowed/node-profiles.mdx
@@ -1,0 +1,61 @@
+---
+title: Manage Node Profiles
+sidebar_label: Node Profiles
+sidebar_position: 4
+---
+
+Allowed node profiles control which [node profiles](../../node-profiles/overview.mdx) a project's private nodes may use, and which profile a node falls back to when none is selected. Use this to restrict tenants to a curated set of profiles, and to guarantee that nodes joining without an explicit profile still receive a baseline configuration.
+
+## Behavior
+
+The project fields are `spec.allowedNodeProfiles` and `spec.defaultNodeProfile`. Each entry in `allowedNodeProfiles` has a `name` that is either an exact `NodeProfile` name (for example, `gpu-training`) or a wildcard.
+
+| Value | Effect |
+|-------|--------|
+| Unset (field omitted) | All node profiles are allowed. This is the default. |
+| Empty list (`allowedNodeProfiles: []`) | No node profiles are allowed. Any explicit `profileRef` or `profile` is rejected, and `defaultNodeProfile` has no effect. |
+| One or more entries | Only allows node profiles matching any specified entry. |
+
+Matching rules:
+
+- Names are case sensitive.
+- The platform rejects a manual join, `NodeClaim`, or auto-node pool that explicitly references a disallowed node profile.
+
+`defaultNodeProfile` sets the profile a node receives when it doesn't select one explicitly and the tenant cluster's `privateNodes.defaultProfile` also isn't set. It must itself be present in `allowedNodeProfiles` when that field is set to a non-empty list.
+
+Changing `allowedNodeProfiles` or `defaultNodeProfile` requires permission to update the project's corresponding subresource.
+
+## Configure allowed node profiles
+
+Edit the project and set `spec.allowedNodeProfiles` and, optionally, `spec.defaultNodeProfile`:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: Project
+metadata:
+  name: ml-platform
+spec:
+  allowedNodeProfiles:
+    - name: gpu-training
+    - name: general-compute
+  defaultNodeProfile: general-compute
+```
+
+Nodes in this project can use either `gpu-training` or `general-compute`. A node that joins without an explicit profile, and whose tenant cluster has no `privateNodes.defaultProfile`, falls back to `general-compute`.
+
+To disallow all node profiles in a project:
+
+```yaml
+spec:
+  allowedNodeProfiles: []
+```
+
+## Precedence
+
+A node's profile is resolved in this order, using the first match:
+
+1. An explicit `profileRef` on the join request or `NodeClaim`, or `profile` on the auto-node pool.
+2. The tenant cluster's `privateNodes.defaultProfile`.
+3. The project's `defaultNodeProfile`.
+
+Every source is validated against `allowedNodeProfiles`, regardless of where it was set. See [Assignment and precedence](../../node-profiles/overview.mdx#assignment-and-precedence) for the full resolution and reconciliation behavior.

--- a/static/media/diagrams/node-profile-relationships.svg
+++ b/static/media/diagrams/node-profile-relationships.svg
@@ -1,0 +1,74 @@
+<svg viewBox="0 0 760 390" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="NodeProfile relationship to node providers, node types, and joined private nodes">
+  <defs>
+    <style><![CDATA[
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+
+    <marker id="arr" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#050B24"/>
+    </marker>
+  </defs>
+
+  <!-- Infrastructure group -->
+  <rect x="35" y="45" width="330" height="210"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="55" y="78"
+        font-size="12" font-weight="500" fill="#828592">Infrastructure</text>
+  <text x="55" y="96"
+        font-size="11" fill="#828592">how a node is provisioned</text>
+
+  <rect x="120" y="110" width="160" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="200" y="133"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">NodeProvider</text>
+
+  <rect x="130" y="195" width="140" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="200" y="218"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">NodeType</text>
+
+  <!-- Configuration group -->
+  <rect x="425" y="45" width="300" height="210"
+        rx="8" fill="#EDEFF3" stroke="#E6E7E9" stroke-width="1.5"/>
+  <text x="445" y="78"
+        font-size="12" font-weight="500" fill="#828592">Configuration</text>
+  <text x="445" y="96"
+        font-size="11" fill="#828592">what the node looks like</text>
+
+  <rect x="500" y="150" width="150" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="575" y="173"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">NodeProfile</text>
+
+  <!-- Joined node -->
+  <rect x="320" y="310" width="120" height="46"
+        rx="8" fill="white" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="380" y="329"
+        font-size="13" font-weight="500" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Node</text>
+  <text x="380" y="345"
+        font-size="11" fill="#828592"
+        text-anchor="middle" dominant-baseline="middle">private worker</text>
+
+  <!-- Relationships -->
+  <line x1="200" y1="156" x2="200" y2="193"
+        stroke="#050B24" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="222" y="179"
+        font-size="11" fill="#828592">owns / generates</text>
+
+  <path d="M 200 241 C 200 280, 320 278, 350 309"
+        stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
+  <text x="175" y="284"
+        font-size="11" fill="#828592" text-anchor="middle">typeRef</text>
+
+  <path d="M 575 196 C 575 278, 440 278, 410 309"
+        stroke="#050B24" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
+  <text x="625" y="276"
+        font-size="11" fill="#828592" text-anchor="middle">reconciles</text>
+  <text x="625" y="294"
+        font-size="11" fill="#828592" text-anchor="middle">labels, taints, annotations</text>
+</svg>

--- a/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
@@ -18,6 +18,17 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 For step-by-step instructions on deploying vCluster with private nodes and joining worker nodes, see the [Deploy private nodes guide](../../../deploy/worker-nodes/private-nodes/overview.mdx).
 
+## Default node profile
+
+Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/next/administer/node-profiles/overview) name to apply it to any node that joins the tenant cluster without an explicit profile:
+
+```yaml title="Set a default node profile"
+privateNodes:
+  enabled: true
+  defaultProfile: general-compute
+```
+
+This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
@@ -16,11 +16,11 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 ## Deploy vCluster by manually joining private nodes
 
-For step-by-step instructions on deploying vCluster with private nodes and joining worker nodes, see the [Deploy private nodes guide](../../../deploy/worker-nodes/private-nodes/overview.mdx).
+For step-by-step instructions on deploying <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> with private nodes and joining worker nodes, see the [Deploy private nodes guide](../../../deploy/worker-nodes/private-nodes/overview.mdx).
 
 ## Default node profile
 
-Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/next/administer/node-profiles/overview) name to apply it to any node that joins the tenant cluster without an explicit profile:
+Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/next/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
 
 ```yaml title="Set a default node profile"
 privateNodes:

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -224,6 +224,28 @@ privateNodes:
 ```
 
 
+### Node profiles
+
+Each static or dynamic node pool can reference a [node profile](/docs/platform/next/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
+
+```yaml title="Example of a node pool referencing a node profile"
+privateNodes:
+  enabled: true
+  autoNodes:
+    - provider: my-provider
+      static:
+        - name: gpu-burst
+          quantity: 2
+          profile: gpu-training
+      dynamic:
+        - name: gpu-dynamic
+          profile: gpu-training
+```
+
+If a pool doesn't set `profile`, nodes it provisions fall back to the tenant cluster's `defaultProfile` or the project's default node profile, if either is configured. A node resolves to at most one profile.
+
+`profile` is independent of `taints` and `nodeLabels` set directly on the pool. Both apply, but a profile is reconciled continuously and shared across every provisioning path, while `taints` and `nodeLabels` on the pool are specific to that pool.
+
 ## Config reference
 
 <PrivateNodesAutoNodes />

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -18,7 +18,7 @@ import PrivateNodesAutoNodes from '../../../_partials/config/privateNodes/autoNo
 
 ### Prerequisites
 
-- vCluster control plane has to be running and in `Ready` state and connected to vCluster Platform
+- <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane has to be running and in `Ready` state and connected to vCluster Platform
 - A [node provider](/platform/administer/node-providers/overview) is configured in vCluster Platform.
 
 ### Node pools
@@ -242,7 +242,7 @@ privateNodes:
           profile: gpu-training
 ```
 
-If a pool doesn't set `profile`, nodes it provisions fall back to the tenant cluster's `defaultProfile` or the project's default node profile, if either is configured. A node resolves to at most one profile.
+If a pool doesn't set `profile`, nodes it provisions fall back to the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>'s `defaultProfile` or the project's default node profile, if either is configured. A node resolves to at most one profile.
 
 `profile` is independent of `taints` and `nodeLabels` set directly on the pool. Both apply, but a profile is reconciled continuously and shared across every provisioning path, while `taints` and `nodeLabels` on the pool are specific to that pool.
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -50,7 +50,7 @@ privateNodes:
 Changing fields within `privateNodes.autoNodes` will not restart the vCluster even on a `helm upgrade`
 :::
 
-It's also possible to mix different providers within the same vCluster. You can specify the provider via the `provider` field that should reference a node provider created in the platform.
+It's also possible to mix different providers within the same vCluster. You can specify the provider using the `provider` field that should reference a node provider created in the platform.
 :::warning
 Once the node pool is created using the configured provider in vCluster, you can not edit the provider later.
 :::
@@ -58,7 +58,7 @@ Once the node pool is created using the configured provider in vCluster, you can
 ### Node type selector
 
 Node type selector on a node pool can be used to include or exclude certain node types.
- These allow you to select properties on node types via [Kubernetes set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement). 
+ These allow you to select properties on node types using [Kubernetes set-based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement). 
 
 ```yaml title="Examples of how to set node type selector"
 privateNodes:
@@ -130,7 +130,7 @@ privateNodes:
 Disruption configures how Karpenter should disrupt nodes and the config corresponds to the [Karpenter disruption config](https://karpenter.sh/docs/concepts/disruption/).
 By default, Karpenter will disrupt nodes if they are empty or underutilized after 30 seconds of inactivity.
 
-You can define more advanced ways of disruptions via schedules or budgets according to the [Karpenter config](https://karpenter.sh/docs/concepts/disruption/#nodepool-disruption-budgets).
+You can define more advanced ways of disruptions using schedules or budgets according to the [Karpenter config](https://karpenter.sh/docs/concepts/disruption/#nodepool-disruption-budgets).
 
 ```yaml title="Example of creating advanced disruption configuration"
 privateNodes:
@@ -174,7 +174,7 @@ privateNodes:
 ```
 
 :::warning Too small limits
-When limits are too low (e.g. CPU is 1 and the smallest node type has CPU of 2) **nodes will not provision**. Make sure to use appropriate limits. When using `limits.nodes` consider that this might be the biggest nodes, so its usually a good idea to use a combination of `limits.cpu` and `limits.nodes`.
+When limits are too low (for example, CPU is 1 and the smallest node type has CPU of 2) **nodes will not provision**. Make sure to use appropriate limits. When using `limits.nodes` consider that this might be the biggest nodes, so its usually a good idea to use a combination of `limits.cpu` and `limits.nodes`.
 :::
 
 ### Static node pools
@@ -198,7 +198,7 @@ You can change the quantity of static node pools without restarting vCluster and
 
 ### Taints and node labels
 
-You can define taints and node labels for each node pool via the `taints` and `nodeLabels` fields which are useful to control scheduling on these nodes.
+You can define taints and node labels for each node pool using the `taints` and `nodeLabels` fields which are useful to control scheduling on these nodes.
 
 ```yaml title="Example of node pools with taints and node labels"
 privateNodes:

--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -86,6 +86,16 @@ This node has joined the cluster:
 Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 ```
 
+## Join with a node profile
+
+If the tenant cluster is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join, instead of joining it bare and configuring it by hand afterward.
+
+1. Open the tenant cluster instance in the platform UI and select **Attach Node Directly**.
+2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
+3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
+
+The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
+
 ## Available flags to use in the script to join nodes
 
 The output of creating the token outputs a script to join the worker node to the vCluster. There are several flags available that can be added to the script.

--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -90,7 +90,7 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 If the tenant cluster is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join, instead of joining it bare and configuring it by hand afterward.
 
-1. Open the tenant cluster instance in the platform UI and select **Attach Node Directly**.
+1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
 2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 

--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -13,8 +13,8 @@ import TabItem from '@theme/TabItem'
 
 ## Prerequisites
 
-- vCluster CLI installed on your local machine
-- vCluster control plane has to be running and in `Ready` state
+- <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> CLI installed on your local machine
+- vCluster <GlossaryTerm term="control-plane">control plane</GlossaryTerm> has to be running and in `Ready` state
 - A node that satisfies the [node requirements](./node-requirements.mdx)
 
 ## Create token
@@ -88,7 +88,7 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the tenant cluster is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join, instead of joining it bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
 
 1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
 2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
@@ -102,7 +102,7 @@ The output of creating the token outputs a script to join the worker node to the
 
 | Flag | Description | Default |
 | ---- | ----------- | ------- |
-| `--kubernetes-version` | Version of kubernetes node components | optional, defaults to the version of vCluster k8s |
+| `--kubernetes-version` | Version of kubernetes node components | optional, defaults to the version of vCluster <GlossaryTerm term="k8s">k8s</GlossaryTerm> |
 | `--repository-url` | Specific vCluster version to install | optional, defaults to `/usr/local/bin` |
 | `--binaries-dir` | allows to customize target directory where k8s node components binaries are installed | optional, defaults to `/usr/local/bin |
 | `--cni-binaries-dir` | allows to customize target directory where CNI binaries are installed | optional, defaults to `/opt/cni/bin` |

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -74,6 +74,16 @@ vcluster node upgrade my-node
 Alternatively, you can manually upgrade by following the [official Kubeadm Kubernetes guide](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes/).
 
 
+## Node profiles
+
+A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the tenant cluster. Editing the profile on the platform converges the change onto every node referencing it:
+
+- Adding a label, annotation, or taint applies it to the node.
+- Removing one prunes it from the node.
+- `startupTaints` are the exception. They're only applied when the node joins and removed once it reaches `Ready`, so editing `startupTaints` has no effect on nodes that already joined.
+
+Convergence happens on the reconciler's resync interval, so expect a short delay between editing a profile and seeing it reflected with `kubectl get node <node-name> -o yaml`.
+
 ## Reuse a node
 
 A node can be re-used for another tenant cluster by using the `--force-join` flag. Before joining the node to a new vCluster, it

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -55,7 +55,7 @@ The upgrade Pod runs directly on the node and completes the following steps:
 2. Replaces the `kubeadm` binary.
 3. Runs `kubeadm upgrade node`.
 4. Cordons the node.
-5. Replaces other binaries such as `containerd`, `kubelet`, etc.
+5. Replaces other binaries such as `containerd`, `kubelet`, and so on.
 6. Restarts `containerd` and `kubelet` if necessary.
 7. Uncordons the node.
 

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -76,7 +76,7 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>: edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/next/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
+A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/next/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
 
 Convergence is prompt rather than tied to a polling interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -82,7 +82,7 @@ A node that joined with a [node profile](/docs/platform/next/administer/node-pro
 - Removing one prunes it from the node.
 - `startupTaints` are the exception. They're only applied when the node joins and removed once it reaches `Ready`, so editing `startupTaints` has no effect on nodes that already joined.
 
-Convergence happens on the reconciler's resync interval, so expect a short delay between editing a profile and seeing it reflected with `kubectl get node <node-name> -o yaml`.
+Convergence is prompt: the reconciler watches for profile changes rather than polling on a fixed interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 
 ## Reuse a node
 

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -14,10 +14,10 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 ### Upgrade vCluster control plane
 
 :::warning Kubernetes Version Skew Policy applies
-Do not upgrade multiple minor versions at the same time for the control plane as outlined in the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). Instead always upgrade a single minor version, wait until the cluster becomes healthy and then upgrade to the next minor version. For example: `v1.26` -> `v1.27` -> `v1.28`.
+Do not upgrade multiple minor versions at the same time for the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> as outlined in the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). Instead always upgrade a single minor version, wait until the cluster becomes healthy and then upgrade to the next minor version. For example: `v1.26` -> `v1.27` -> `v1.28`.
 :::
 
-To upgrade the vCluster control plane, update the Kubernetes `init` container version in your `vcluster.yaml` file.
+To upgrade the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane, update the Kubernetes `init` container version in your `vcluster.yaml` file.
 After the change, vCluster upgrades the control plane automatically. If automatic worker node upgrades are configured, those nodes are also upgraded.
 
 To change the Kubernetes version, add the following to your `vcluster.yaml`:
@@ -76,13 +76,13 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the tenant cluster. Editing the profile on the platform converges the change onto every node referencing it:
+A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Editing the profile on the platform converges the change onto every node referencing it:
 
 - Adding a label, annotation, or taint applies it to the node.
 - Removing one prunes it from the node.
 - `startupTaints` are the exception. They're only applied when the node joins and removed once it reaches `Ready`, so editing `startupTaints` has no effect on nodes that already joined.
 
-Convergence is prompt: the reconciler watches for profile changes rather than polling on a fixed interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
+Convergence is prompt. The reconciler watches for profile changes rather than polling on a fixed interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 
 ## Reuse a node
 

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -76,13 +76,9 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Editing the profile on the platform converges the change onto every node referencing it:
+A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>: edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/next/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
 
-- Adding a label, annotation, or taint applies it to the node.
-- Removing one prunes it from the node.
-- `startupTaints` are the exception. They're only applied when the node joins and removed once it reaches `Ready`, so editing `startupTaints` has no effect on nodes that already joined.
-
-Convergence is prompt. The reconciler watches for profile changes rather than polling on a fixed interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
+Convergence is prompt rather than tied to a polling interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 
 ## Reuse a node
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->
- Platform
  - https://deploy-preview-2360--vcluster-docs-site.netlify.app/docs/platform/next/administer/projects/allowed/node-profiles
  - https://deploy-preview-2360--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-profiles/overview


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGNODE-390


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

