### PR TITLE
fix(partials): stop docs-sync panic on releases without gatewayApi

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -46,13 +46,16 @@ var pathExtras = map[string]Extras{
 			"`joinNode.enabled: false` and use separate worker nodes for tenant workloads.\n" +
 			":::\n\n",
 	},
-	"sync/toHost/gatewayApi": {
-		Before: "\nSetting `enabled: true` turns on Gateway and HTTPRoute sync, imports control plane " +
-			"cluster GatewayClasses so tenant Gateways can resolve them, and serves tenant ReferenceGrants " +
-			"for validation; TLSRoutes and BackendTLSPolicies must be enabled individually.\n\n" +
-			"In auto mode grants follow route sync and are validated within the tenant cluster; " +
-			"they sync to the control plane cluster only when namespace sync is also enabled.\n\n",
-	},
+	// NOTE: do not add a pathExtras key for a field that exists only in newer
+	// vCluster versions. The receiver runs this generator against the schema of
+	// the exact released version it is processing, which includes still-maintained
+	// older release lines (for example 0.34.x). validateExtras requires every key
+	// here to resolve in that schema, so a version-conditional key hard-fails the
+	// docs-sync run for every release predating the field. The `paths` slice below
+	// tolerates a missing path (warn + skip); pathExtras does not. The
+	// `sync/toHost/gatewayApi` entry was removed for this reason: the field landed
+	// in vCluster 0.35.0, but 0.34.x patch releases still trigger regeneration.
+	// See DEVOPS-1075. gatewayApi remains in `paths` so 0.35.0+ still generate it.
 }
 
 // we only generate paths we actually need


### PR DESCRIPTION
# Content Description
Fixes the `handle-source-release` docs-sync receiver, which panicked on every vCluster 0.34.x release and blocked config-partials PRs for that maintained line. The vcluster partials generator validated `pathExtras` against the exact release schema, and `pathExtras` carried a `sync/toHost/gatewayApi` entry even though Gateway API sync only landed in vCluster 0.35.0. This drops that entry from `pathExtras` while keeping it in `paths`, so 0.35.0+ still generate the partial from the schema and 0.34.x skips it cleanly. `validateExtras` is left intact. No documentation content changes.

## Preview Link
Not applicable. This changes the Go config-partials generator only; no `.mdx` content changed.

## Internal Reference
Closes DEVOPS-1075

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs
