### PR TITLE
docs: document platform audit payload storage and omission annotations

### DIFF
--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -121,7 +121,7 @@ See the [complete policy reference](../../api/resources/config.mdx#audit-policy)
 
 ## Request and response payload storage
 
-The audit level of the policy rule that matches a request decides which payloads the platform stores inside the audit event. Rules with the `Request` level store the request payload. Rules with the `RequestResponse` level store the request and the response payload.
+Which payloads the platform stores inside an audit event follows the matched rule's audit granularity, described in [Optional: Audit policy](#optional-audit-policy). `Request` stores the request payload. `RequestResponse` also stores the response payload.
 
 With the preconfigured audit levels this means:
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -157,7 +157,7 @@ The following reasons can appear as annotation values:
 | `truncated` | The payload exceeded the capture limit and only a partial copy was captured. |
 | `too-large` | The payload exceeded the capture limit after decompression or conversion to JSON. |
 | `decode-failed` | The payload could not be decompressed or decoded. |
-| `unsupported-encoding` | The payload used a content encoding or content type that the platform cannot convert to JSON. |
+| `unsupported-encoding` | The payload used a content encoding or media type that the platform cannot convert to JSON. |
 | `invalid-json` | The payload was not valid JSON and not in any recognized format. |
 
 ## Persist audit logs

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -100,7 +100,7 @@ The platform stores payloads for resource requests only. Long-running requests, 
 The platform always stores payloads as JSON:
 
 - Payloads that arrive as plain JSON are stored unchanged.
-- Gzip-compressed response bodies are stored in their decompressed form.
+- Gzip-compressed request and response bodies are stored in their decompressed form.
 - Payloads sent in the Kubernetes Protobuf format are converted to their JSON equivalent for known Kubernetes API types. The stored payload matches what a JSON client would have sent.
 
 ### Payload size limit

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -129,7 +129,7 @@ With the preconfigured audit levels this means:
 - Level 3 stores request payloads for all requests.
 - Level 4 stores request and response payloads for all requests.
 
-Payloads are stored for resource requests only. Long-running requests, such as log streaming, and creates of sensitive resources, such as shared secrets and access keys, keep metadata-only events on every level.
+Payloads are stored for resource requests only. Long-running requests, such as log streaming, never store payloads. Creates of sensitive resources, such as shared secrets and access keys, keep metadata-only events on every level.
 
 The platform always stores payloads as JSON:
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -65,8 +65,8 @@ See the [complete list of fields](../../api/resources/config.mdx#audit) under th
 
 The platform provides audit levels, which are preconfigured audit policies for the most common use cases. These levels range from 1 to 4 where 1 logs the fewest requests, while 4 logs the most:
 
-- **Level 1**: Logs modifying requests such as creation / modification or deletion of any objects
-- **Level 2**: Like Level 1 but also logs the metadata of reading requests, such as listing pods inside a tenant cluster or space. It won't log the response or request payload and instead only the metadata such as request origin, target, and so on.
+- **Level 1**: Logs modifying requests such as creation / modification or deletion of any objects. Creation requests also log the request payload.
+- **Level 2**: Like Level 1 but also logs the metadata of reading requests, such as listing pods inside a tenant cluster or space. Reading requests won't log the response or request payload and instead only the metadata, such as request origin and target.
 - **Level 3**: Like Level 2 but instead of only logging the request metadata also logs the complete request payload sent to the platform
 - **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -70,7 +70,7 @@ The platform provides audit levels, which are preconfigured audit policies for t
 - **Level 3**: Like Level 2 but instead of only logging the request metadata also logs the complete request payload sent to the platform
 - **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester
 
-Captured payloads are normalized before they are stored: payloads that are already plain JSON are stored unchanged, all others, such as compressed or protobuf-encoded ones, are converted to plain JSON. A size limit also applies. See [Request and response payload storage](#request-and-response-payload-storage).
+Captured payloads are normalized before they are stored. Payloads that are already plain JSON are stored unchanged. Other payloads are converted to plain JSON, or omitted with an annotation when conversion is not possible. A size limit also applies. See [Request and response payload storage](#request-and-response-payload-storage).
 
 For all of these levels, certain internal read-only APIs are not logged since those might pollute the log and drastically increase log size. To log these, create a custom audit policy as described below.
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -134,12 +134,12 @@ Payloads are stored for resource requests only. Long-running requests, such as l
 The platform always stores payloads as JSON:
 
 - Payloads that arrive as plain JSON are stored unchanged.
-- The platform stores compressed response bodies in their decompressed form.
-- The platform converts payloads sent in the Kubernetes Protobuf format to their JSON equivalent. The stored payload matches what a JSON client would have sent.
+- The platform stores gzip-compressed response bodies in their decompressed form.
+- The platform converts payloads sent in the Kubernetes Protobuf format to their JSON equivalent for known Kubernetes API types. The stored payload matches what a JSON client would have sent.
 
 ### Payload size limit
 
-The platform captures at most 2 MB per request or response payload. Payloads above this limit are not stored.
+The platform captures at most 2 MiB per request or response payload. Payloads above this limit are not stored.
 
 ### Omitted payloads
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -70,6 +70,8 @@ The platform provides audit levels, which are preconfigured audit policies for t
 - **Level 3**: Like Level 2 but instead of only logging the request metadata also logs the complete request payload sent to the platform
 - **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester
 
+Captured payloads are normalized before they are stored: payloads that are already plain JSON are stored unchanged, all others, such as compressed or protobuf-encoded ones, are converted to plain JSON. A size limit also applies. See [Request and response payload storage](#request-and-response-payload-storage).
+
 For all of these levels, certain internal read-only APIs are not logged since those might pollute the log and drastically increase log size. To log these, create a custom audit policy as described below.
 
 Configure the audit level through the platform config, which can be modified either through the platform UI or Helm:
@@ -116,6 +118,47 @@ config:
 ```
 
 See the [complete policy reference](../../api/resources/config.mdx#audit-policy).
+
+## Request and response payload storage
+
+The audit level of the policy rule that matches a request decides which payloads the platform stores inside the audit event. Rules with the `Request` level store the request payload. Rules with the `RequestResponse` level store the request and the response payload.
+
+With the preconfigured audit levels this means:
+
+- Levels 1 and 2 store request payloads for create requests.
+- Level 3 stores request payloads for all requests.
+- Level 4 stores request and response payloads for all requests.
+
+Payloads are stored for resource requests only. Long-running requests, such as log streaming, and creates of sensitive resources, such as shared secrets and access keys, keep metadata-only events on every level.
+
+The platform always stores payloads as JSON:
+
+- Payloads that arrive as plain JSON are stored unchanged.
+- The platform stores compressed response bodies in their decompressed form.
+- The platform converts payloads sent in the Kubernetes Protobuf format to their JSON equivalent. The stored payload matches what a JSON client would have sent.
+
+### Payload size limit
+
+The platform captures at most 2 MB per request or response payload. Payloads above this limit are not stored.
+
+### Omitted payloads
+
+When a payload cannot be stored, the platform keeps the audit event with all of its metadata. Only the payload is left out. The event then carries an annotation that names the omission reason:
+
+| Annotation | Description |
+|------------|-------------|
+| `audit.platform.vcluster.com/request-object-omitted` | The request payload was omitted. The value names the reason. |
+| `audit.platform.vcluster.com/response-object-omitted` | The response payload was omitted. The value names the reason. |
+
+The following reasons can appear as annotation values:
+
+| Reason | Description |
+|--------|-------------|
+| `truncated` | The payload exceeded the capture limit and only a partial copy was captured. |
+| `too-large` | The payload exceeded the capture limit after decompression or conversion to JSON. |
+| `decode-failed` | The payload could not be decompressed or decoded. |
+| `unsupported-encoding` | The payload used a content encoding or content type that the platform cannot convert to JSON. |
+| `invalid-json` | The payload was not valid JSON and not in any recognized format. |
 
 ## Persist audit logs
 

--- a/platform/configure/platform-configs/audit.mdx
+++ b/platform/configure/platform-configs/audit.mdx
@@ -65,14 +65,14 @@ See the [complete list of fields](../../api/resources/config.mdx#audit) under th
 
 The platform provides audit levels, which are preconfigured audit policies for the most common use cases. These levels range from 1 to 4 where 1 logs the fewest requests, while 4 logs the most:
 
-- **Level 1**: Logs modifying requests such as creation / modification or deletion of any objects. Creation requests also log the request payload.
+- **Level 1**: Logs modifying requests such as creation, modification, or deletion of any objects. Creation requests also log the request payload.
 - **Level 2**: Like Level 1 but also logs the metadata of reading requests, such as listing pods inside a tenant cluster or space. Reading requests won't log the response or request payload and instead only the metadata, such as request origin and target.
-- **Level 3**: Like Level 2 but instead of only logging the request metadata also logs the complete request payload sent to the platform
-- **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester
+- **Level 3**: Like Level 2 but instead of only logging the request metadata, also logs the complete request payload sent to the platform.
+- **Level 4**: Like Level 3 but instead of only logging metadata and request payload, also logs the response the platform has sent to the requester.
 
-Captured payloads are normalized before they are stored. Payloads that are already plain JSON are stored unchanged. Other payloads are converted to plain JSON, or omitted with an annotation when conversion is not possible. A size limit also applies. See [Request and response payload storage](#request-and-response-payload-storage).
+Captured payloads are normalized to JSON and size-limited before storage. Unconvertible or oversized payloads are omitted with an annotation. See [Request and response payload storage](#request-and-response-payload-storage).
 
-For all of these levels, certain internal read-only APIs are not logged since those might pollute the log and drastically increase log size. To log these, create a custom audit policy as described below.
+For all of these levels, certain internal read-only APIs aren't logged since those might pollute the log and drastically increase log size. To log these, create a custom audit policy as described below.
 
 Configure the audit level through the platform config, which can be modified either through the platform UI or Helm:
 
@@ -91,18 +91,47 @@ Configure the audit level through the platform config, which can be modified eit
   </TabItem>
 </Tabs>
 
+## Request and response payload storage
+
+Audit levels and custom policies both determine payload storage through one of four granularity settings. `Request` stores the request payload. `RequestResponse` also stores the response payload. See [Audit policy](#audit-policy) for the full list.
+
+The platform stores payloads for resource requests only. Long-running requests, such as log streaming, never store payloads. Creates of sensitive resources, such as shared secrets and access keys, keep metadata-only events on every level.
+
+The platform always stores payloads as JSON:
+
+- Payloads that arrive as plain JSON are stored unchanged.
+- Gzip-compressed response bodies are stored in their decompressed form.
+- Payloads sent in the Kubernetes Protobuf format are converted to their JSON equivalent for known Kubernetes API types. The stored payload matches what a JSON client would have sent.
+
+### Payload size limit
+
+The platform captures at most 2 MiB per request or response payload. It doesn't store payloads above this limit.
+
+### Omitted payloads
+
+When the platform can't store a payload, it keeps the audit event with all of its metadata but leaves out the payload. The event then carries an annotation that names the omission reason:
+
+- `audit.platform.vcluster.com/request-object-omitted` for the request payload
+- `audit.platform.vcluster.com/response-object-omitted` for the response payload
+
+The following reasons can appear as annotation values:
+
+| Reason | Description |
+|--------|-------------|
+| `truncated` | The payload exceeded the capture limit, so the platform captured only a partial copy. |
+| `too-large` | The payload exceeded the capture limit after decompression or conversion to JSON. |
+| `decode-failed` | The platform couldn't decompress or decode the payload. |
+| `unsupported-encoding` | The payload used a content encoding or media type that the platform can't convert to JSON. |
+| `invalid-json` | The payload wasn't valid JSON and not in any recognized format. |
+
 ## Audit policy
 
-:::warning
-It is recommended to use audit levels instead of audit policy directly, because a policy is much more complex to define.
-:::
-
-As an alternative to audit levels, policy allows you to define exact rules about what events should be recorded and what data they should include. When an event is processed, it's compared against the list of rules in order. The first matching rule sets the audit granularity of the event. The defined audit granularity options are:
+Audit policy is a more complex alternative to audit levels, letting you define exact rules about what events should be recorded and what data they should include. When an event is processed, it's compared against the list of rules in order. The first matching rule sets the audit granularity of the event. The defined audit granularity options are:
 
 - `None`: Don't log events that match this rule.
 - `Metadata`: Log request metadata (requesting user, timestamp, resource, verb, and so on) but not request or response body.
-- `Request`: Log event metadata and request body but not response body. This does not apply for non-resource requests.
-- `RequestResponse`: Log event metadata, request and response bodies. This does not apply for non-resource requests.
+- `Request`: Log event metadata and request body but not response body. This doesn't apply for non-resource requests.
+- `RequestResponse`: Log event metadata, request and response bodies. This doesn't apply for non-resource requests.
 
 An example policy that catches all requests:
 
@@ -119,53 +148,12 @@ config:
 
 See the [complete policy reference](../../api/resources/config.mdx#audit-policy).
 
-## Request and response payload storage
-
-Which payloads the platform stores inside an audit event follows the matched rule's audit granularity, described in [Optional: Audit policy](#optional-audit-policy). `Request` stores the request payload. `RequestResponse` also stores the response payload.
-
-With the preconfigured audit levels this means:
-
-- Levels 1 and 2 store request payloads for create requests.
-- Level 3 stores request payloads for all requests.
-- Level 4 stores request and response payloads for all requests.
-
-Payloads are stored for resource requests only. Long-running requests, such as log streaming, never store payloads. Creates of sensitive resources, such as shared secrets and access keys, keep metadata-only events on every level.
-
-The platform always stores payloads as JSON:
-
-- Payloads that arrive as plain JSON are stored unchanged.
-- The platform stores gzip-compressed response bodies in their decompressed form.
-- The platform converts payloads sent in the Kubernetes Protobuf format to their JSON equivalent for known Kubernetes API types. The stored payload matches what a JSON client would have sent.
-
-### Payload size limit
-
-The platform captures at most 2 MiB per request or response payload. Payloads above this limit are not stored.
-
-### Omitted payloads
-
-When a payload cannot be stored, the platform keeps the audit event with all of its metadata. Only the payload is left out. The event then carries an annotation that names the omission reason:
-
-| Annotation | Description |
-|------------|-------------|
-| `audit.platform.vcluster.com/request-object-omitted` | The request payload was omitted. The value names the reason. |
-| `audit.platform.vcluster.com/response-object-omitted` | The response payload was omitted. The value names the reason. |
-
-The following reasons can appear as annotation values:
-
-| Reason | Description |
-|--------|-------------|
-| `truncated` | The payload exceeded the capture limit and only a partial copy was captured. |
-| `too-large` | The payload exceeded the capture limit after decompression or conversion to JSON. |
-| `decode-failed` | The payload could not be decompressed or decoded. |
-| `unsupported-encoding` | The payload used a content encoding or media type that the platform cannot convert to JSON. |
-| `invalid-json` | The payload was not valid JSON and not in any recognized format. |
-
 ## Persist audit logs
 
-There are two ways to persist platform audit logs: deploying the platform with a persistent volume claim (PVC) or connecting the platform to a persistent database.
+Persist platform audit logs in one of two ways: deploy the platform with a persistent volume claim (PVC), or connect the platform to a persistent database.
 
 :::info HA only supported with persistent database
-If you are running the platform in high availability (HA mode), the only way to persist audit logs is to use a persistent database. The PVC approach does not work.
+If you are running the platform in high availability (HA mode), the only way to persist audit logs is to use a persistent database. The PVC approach doesn't work.
 :::
 
 ### Deploy the platform with a PVC to save audit logs
@@ -225,9 +213,7 @@ restarting the platform clears the database. See [Use a persistent database as p
 
 ### Enable audit sidecar
 
-To easily export the audit events to third party systems, enable the audit log
-sidecar that prints all the audit events to `stdout` in a separate container which can then be easily watched and exported.
-Enabling the sidecar is only possible through Helm values.
+To export audit events to third-party systems, enable the audit log sidecar. It prints all audit events to `stdout` in a separate container, so you can watch and export them from there. You can only enable the sidecar through Helm values.
 
 Create a `values.yaml` with the following contents:
 
@@ -256,8 +242,6 @@ kubectl logs -n vcluster-platform -l app=loft -c audit -f
 
 ## Audit logging for Regional Cluster Endpoints
 
-Regional Cluster Endpoints allow direct communication between users and clusters, bypassing the central platform instance. When this feature is enabled, the platform audit configuration is synced to each agent. Each platform agent propagates audit events it receives back to the central platform instance, which then logs it as a regular audit event. These "propagated" events can be identified by the `annotations.audit.loft.sh/sent-by-agent` identifier in an audit event.
+[Regional Cluster Endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) allow direct communication between users and clusters, bypassing the central platform instance. When this feature is enabled, the platform audit configuration is synced to each agent. Each platform agent propagates audit events it receives back to the central platform instance, which then logs it as a regular audit event. These "propagated" events can be identified by the `annotations.audit.loft.sh/sent-by-agent` identifier in an audit event.
 
-:::info Disable agent sync back
-Disable event sync back from the agent to the central platform instance using the audit config option `disableAgentSyncBack`.
-:::
+To disable this behavior, set the audit config option `disableAgentSyncBack`.

--- a/platform/maintenance/logging/overview.mdx
+++ b/platform/maintenance/logging/overview.mdx
@@ -33,8 +33,8 @@ Four audit levels control the volume and detail of what the platform captures.
 
 | Level | Writes (create/update/delete/patch) | Reads (get/list/watch) | Request body | Response body |
 |-------|-------------------------------------|------------------------|:------------:|:-------------:|
-| 1 | Metadata only; creates also log the request body | Not logged | Creates only | <Icon type="cross" /> |
-| 2 | Metadata only; creates also log the request body | Metadata only | Creates only | <Icon type="cross" /> |
+| 1 | Metadata only, but creates also log the request body | Not logged | Creates only | <Icon type="cross" /> |
+| 2 | Metadata only, but creates also log the request body | Metadata only | Creates only | <Icon type="cross" /> |
 | 3 | Logged with request body | Logged with request body | <Icon type="check" /> | <Icon type="cross" /> |
 | 4 | Logged with request and response | Logged with request and response | <Icon type="check" /> | <Icon type="check" /> |
 

--- a/platform/maintenance/logging/overview.mdx
+++ b/platform/maintenance/logging/overview.mdx
@@ -33,8 +33,8 @@ Four audit levels control the volume and detail of what the platform captures.
 
 | Level | Writes (create/update/delete/patch) | Reads (get/list/watch) | Request body | Response body |
 |-------|-------------------------------------|------------------------|:------------:|:-------------:|
-| 1 | Metadata only | Not logged | <Icon type="cross" /> | <Icon type="cross" /> |
-| 2 | Metadata only | Metadata only | <Icon type="cross" /> | <Icon type="cross" /> |
+| 1 | Metadata only; creates also log the request body | Not logged | Creates only | <Icon type="cross" /> |
+| 2 | Metadata only; creates also log the request body | Metadata only | Creates only | <Icon type="cross" /> |
 | 3 | Logged with request body | Logged with request body | <Icon type="check" /> | <Icon type="cross" /> |
 | 4 | Logged with request and response | Logged with request and response | <Icon type="check" /> | <Icon type="check" /> |
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

The platform audit fix shipped in loft-sh/loft-enterprise#7305 (ENGPLAT-758 / ENGPLAT-18) changed how the platform handles captured request and response payloads: events with payloads that are not plain JSON used to be dropped entirely, and are now stored normalized or kept with an annotation. This PR documents that behavior on the platform audit page.

**Changes**

Two pages changed.

`platform/configure/platform-configs/audit.mdx`:

1. A short note in the "Audit levels" section: captured payloads are normalized before they are stored (plain JSON stays unchanged, compressed or protobuf-encoded payloads are converted to plain JSON), and a size limit applies.

2. A new "Request and response payload storage" section covering:
    - Which policy levels store which payloads: `Request` stores the request payload,
`RequestResponse` also stores the response payload, and what that means for the preconfigured audit
levels 1 to 4.
    - The exceptions: payloads are stored for resource requests only, and long-running requests as
well as creates of sensitive resources stay metadata-only on every level.
    - How payloads are stored: always as JSON (unchanged, decompressed, or converted from the
Kubernetes Protobuf format).
    - The 2 MB per-payload capture limit.
    - The omission annotations (`audit.platform.vcluster.com/request-object-omitted` and
`response-object-omitted`) and their five reason values, as two reference tables.

3. Two unrelated cleanups picked up along the way: the "Audit policy" warning admonition recommending
audit levels over policy, and the "Regional Cluster Endpoints" info admonition about
`disableAgentSyncBack`, are both folded into plain sentences instead of callout boxes. Content is
unchanged, only the presentation.

`platform/maintenance/logging/overview.mdx`:

- Updated the audit-levels summary table to reflect that levels 1 and 2 also log the request body for
creates, matching the detail added to `audit.mdx`.

## Preview Link 
<!-- The preview link or links to the documents-->

https://deploy-preview-2373--vcluster-docs-site.netlify.app/docs/platform/next/configure/platform-configs/audit

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->

Closes ENGPLAT-758
Closes ENGPLAT-18


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
