### PR TITLE
Codeblock colors updated to match vCluster Platform

### DIFF
--- a/src/css/content/code.scss
+++ b/src/css/content/code.scss
@@ -2,6 +2,10 @@
   margin-top: var(--ifm-pre-padding);
 }
 
+[class*="codeBlockTitle"] {
+  color: #eceaea;
+}
+
 .docusaurus-highlight-code-line {
     background-color: rgba(255, 255, 255, 0.08);
     display: block;

--- a/src/prism-theme.js
+++ b/src/prism-theme.js
@@ -1,78 +1,80 @@
 /**
  * vCluster brand-aligned Prism syntax highlighting theme.
  *
- * Background: Black Pearl (#050B24)
- * Plain text: #CDD3DE (cool near-white, easy on the eyes)
+ * Background: #312727 (dark warm brown - from loft-enterprise Figma design tokens)
+ * Plain text: #eceaea (foreground - warm near-white default)
  *
- * Token palette — five deliberate choices:
- *   Sky blue     #48B5FF  strings / inserted diffs (matches vcluster.com highlight.js)
- *   Light orange #FFA366  numbers, booleans, variables (literal values)
- *   White        #FFFFFF  keywords, tags (structural / declarative tokens)
- *   Pale orange  #FFE0CC  YAML keys, bash commands, class names (brand family, readable)
- *   Blaze Orange #FF6600  shebangs, YAML anchors (rare, maximum signal)
- *   Slate       #7B8BB2  comments, punctuation, null (muted / de-emphasized)
+ * Token palette sourced from loft-enterprise terminal Figma design tokens,
+ * mapped by hue to preserve color intent:
+ *   foreground   #eceaea  plain text / default fallback
+ *   brightBlue   #6eb2fe  strings / inserted diffs (sky blue, hue ~212 deg)
+ *   brightYellow #f9905c  numbers, booleans, variables (warm orange, hue ~20 deg)
+ *   brightWhite  #faf8f8  keywords, tags, properties, command names
+ *   white        #b7b5b5  operators (slightly dimmed, low visual noise)
+ *   yellow       #f86f1f  shebangs, YAML anchors (rare, high-signal)
+ *   brightBlack  #6e6a6a  comments, punctuation, null (muted gray)
  *
  * @type {import('prism-react-renderer').PrismTheme}
  */
 const vClusterTheme = {
   plain: {
-    color: "#CDD3DE",
-    backgroundColor: "#050B24",
+    color: "#eceaea",
+    backgroundColor: "#312727",
   },
   styles: [
     // ── De-emphasized structural characters ─────────────────────────────────
     {
       types: ["comment", "prolog", "doctype", "cdata"],
-      style: { color: "#7B8BB2", fontStyle: "italic" },
+      style: { color: "#6e6a6a", fontStyle: "italic" },
     },
     {
       types: ["punctuation"],
-      style: { color: "#7B8BB2" },
+      style: { color: "#6e6a6a" },
     },
     {
       types: ["null", "undefined"],
-      style: { color: "#7B8BB2" },
+      style: { color: "#6e6a6a" },
     },
 
-    // ── Strings and inserted diff lines — soft teal ─────────────────────────
+    // ── Strings and inserted diff lines — sky blue ──────────────────────────
     {
       types: ["string", "char", "inserted", "attr-value"],
-      style: { color: "#48B5FF" },
+      style: { color: "#6eb2fe" },
     },
 
-    // ── Literal values — Soft Orange ────────────────────────────────────────
+    // ── Literal values — warm orange ────────────────────────────────────────
     // numbers, booleans, $VARIABLES, regex patterns
     {
       types: ["number", "boolean", "variable", "regex"],
-      style: { color: "#FFA366" },
+      style: { color: "#f9905c" },
     },
 
-    // ── Structural keywords and tags — warm amber ───────────────────────────
+    // ── Structural keywords and tags ─────────────────────────────────────────
     // bash: if / for / do / fi / while; YAML tags; CSS selectors
     {
       types: ["keyword", "tag", "selector"],
-      style: { color: "#FFFFFF" },
+      style: { color: "#faf8f8" },
     },
 
-    // ── Properties and command names — pale orange ──────────────────────────
+    // ── Properties and command names — bright white ──────────────────────────
     // YAML mapping keys (key + attr-name), object properties, class names,
     // and bash/HCL command/function names all share this shade
     {
       types: ["key", "attr-name", "property", "class-name", "namespace", "function", "builtin"],
-      style: { color: "#FFE0CC" },
+      style: { color: "#faf8f8" },
     },
 
-    // ── Operators — near-plain, low visual noise ────────────────────────────
+    // ── Operators — slightly dimmed, low visual noise ────────────────────────
     {
       types: ["operator"],
-      style: { color: "#CDD3DE" },
+      style: { color: "#b7b5b5" },
     },
 
-    // ── High-signal tokens — Blaze Orange ───────────────────────────────────
+    // ── High-signal tokens — deep orange ────────────────────────────────────
     // shebangs (#!/bin/bash), YAML anchors (&anchor / *alias) — used sparingly
     {
       types: ["important"],
-      style: { color: "#FF6600", fontWeight: "bold" },
+      style: { color: "#f86f1f", fontWeight: "bold" },
     },
     {
       types: ["bold"],
@@ -86,13 +88,13 @@ const vClusterTheme = {
     // ── Diff markers ────────────────────────────────────────────────────────
     {
       types: ["deleted"],
-      style: { color: "#EF4444" },
+      style: { color: "#e47c72" },
     },
 
     // ── URLs ────────────────────────────────────────────────────────────────
     {
       types: ["url"],
-      style: { color: "#FF6600" },
+      style: { color: "#f86f1f" },
     },
   ],
 };


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
The colors of code blocks have been updated to match the vCluster Platform's terminal theme.

Additionally, the optional title of code blocks has been changed to the default fg color.

Before:
<img width="558" height="700" alt="Screenshot 2026-07-13 at 09 58 35" src="https://github.com/user-attachments/assets/f18a8702-52ab-4e7f-99af-228b68006292" />
After:
<img width="599" height="655" alt="Screenshot 2026-07-13 at 09 58 32" src="https://github.com/user-attachments/assets/65f5c432-04ce-4b7d-b238-f55054ab1905" />

Before:
<img width="551" height="577" alt="Screenshot 2026-07-13 at 09 58 14" src="https://github.com/user-attachments/assets/012ef2f3-e56d-4a66-be9d-36cdac929b02" />
After:
<img width="635" height="573" alt="Screenshot 2026-07-13 at 09 58 12" src="https://github.com/user-attachments/assets/7ea16058-4b7a-48e3-ba82-8efdd3ba19eb" />


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

