### PR TITLE
fix(platform-generator): reference storage/v1 auth types for api v4.11.0

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -880,11 +880,15 @@ spec:
 			},
 			ObjectMeta: metav1.ObjectMeta{},
 			Status: managementv1.ConfigStatus{
-				Authentication: managementv1.Authentication{
+				// Authentication + its Connector/AuthenticationGithub types moved from
+				// management/v1 to storage/v1 in loft-sh/api v4.11.0 (storage/v1 owns the
+				// canonical definition so the storage/v1.Tenant CRD can reference it without
+				// an import cycle). ConfigStatus.Authentication is now storagev1.Authentication.
+				Authentication: storagev1.Authentication{
 					AccessKeyMaxTTLSeconds:   10 * 60 * 60,
 					LoginAccessKeyTTLSeconds: &sixty,
-					Connector: managementv1.Connector{
-						Github: &managementv1.AuthenticationGithub{
+					Connector: storagev1.Connector{
+						Github: &storagev1.AuthenticationGithub{
 							ClientID:     "my-client-id",
 							ClientSecret: "my-client-secret",
 							RedirectURI:  "https://my-redirect-uri",


### PR DESCRIPTION
## What

The `handle-source-release` docs-sync receiver failed on `platform-released` `v4.11.0-next.internal.4` ([run #146](https://github.com/loft-sh/vcluster-docs/actions/runs/29265877512)) at the **Generate docs** step:

```
hack/platform/partials/main.go:883: undefined: managementv1.Authentication
hack/platform/partials/main.go:886: undefined: managementv1.Connector
hack/platform/partials/main.go:887: undefined: managementv1.AuthenticationGithub
```

loft-sh/api v4.11.0 moved `Authentication`, `Connector`, and `AuthenticationGithub` from `management/v1` to `storage/v1` (storage/v1 owns the canonical definition so `storage/v1.Tenant` can reference it without an import cycle). The generator built the `Config` example against the old `management/v1` location, so it failed to compile once the receiver bumped the api pin to the released version. The receiver never reached the PR step, so every platform docs sync was blocked.

## Fix

Point the three references at `storagev1`, which is already imported. The moved types keep identical fields, so the rendered `Config` example (github auth block) is byte-identical.

## Verification

Reproduced the receiver's api-pin bump locally against `v4.11.0-next.internal.4`:

- `go build ./hack/platform/partials/` compiles (was the failing step).
- Generator runs end-to-end, producing the expected reference-doc diffs; the auth example is unchanged.
- `classify-version` + `run-generator` bats suites pass (29/29).
- go.mod/go.sum/vendor left at baseline; the receiver bumps them at release time and commits them in its auto-PR (existing design, confirmed by prior DEVOPS-888 work).

## Not in scope (flagged for follow-up)

The classifier treats `v4.11.0-next.internal.4` as `stable` because it only special-cases `-alpha`/`-beta`/`-rc`. Internal `-next.internal.N` builds therefore trigger docs generation as if they were stable releases. Whether to skip those is a separate policy decision; happy to open a follow-up if we want to suppress internal-build events.

Closes DEVOPS-1081