### PR TITLE
docs(DOC-1618): restore k8s compatibility known issue and add troubleshooting page

### DIFF
--- a/static/api/k8s-compatibility.json
+++ b/static/api/k8s-compatibility.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-28",
+  "lastUpdated": "2026-07-14",
   "kubernetesVersions": [
     "1.36",
     "1.35",
@@ -11,9 +11,18 @@
       "host": "1.36",
       "vcluster": {
         "1.36": "tested",
-        "1.35": "compatible",
-        "1.34": "compatible",
-        "1.33": "compatible"
+        "1.35": {
+          "status": "known-issue",
+          "note": 1
+        },
+        "1.34": {
+          "status": "known-issue",
+          "note": 1
+        },
+        "1.33": {
+          "status": "known-issue",
+          "note": 1
+        }
       }
     },
     {
@@ -21,8 +30,14 @@
       "vcluster": {
         "1.36": "compatible",
         "1.35": "tested",
-        "1.34": "compatible",
-        "1.33": "compatible"
+        "1.34": {
+          "status": "known-issue",
+          "note": 1
+        },
+        "1.33": {
+          "status": "known-issue",
+          "note": 1
+        }
       }
     },
     {
@@ -31,7 +46,10 @@
         "1.36": "compatible",
         "1.35": "compatible",
         "1.34": "tested",
-        "1.33": "compatible"
+        "1.33": {
+          "status": "known-issue",
+          "note": 1
+        }
       }
     },
     {
@@ -42,6 +60,12 @@
         "1.34": "compatible",
         "1.33": "tested"
       }
+    }
+  ],
+  "notes": [
+    {
+      "id": 1,
+      "text": "Pods can get stuck with a `Ready=False` status when the tenant cluster runs an older Kubernetes version than the control plane cluster. This keeps their Deployments and StatefulSets from becoming ready. See [troubleshooting steps and fix status](/docs/vcluster/troubleshoot/pod-stuck-ready-false-version-skew) for details."
     }
   ],
   "statuses": {

--- a/static/api/k8s-compatibility.json
+++ b/static/api/k8s-compatibility.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-07-14",
+  "lastUpdated": "2026-07-15",
   "kubernetesVersions": [
     "1.36",
     "1.35",
@@ -11,14 +11,8 @@
       "host": "1.36",
       "vcluster": {
         "1.36": "tested",
-        "1.35": {
-          "status": "known-issue",
-          "note": 1
-        },
-        "1.34": {
-          "status": "known-issue",
-          "note": 1
-        },
+        "1.35": "compatible",
+        "1.34": "compatible",
         "1.33": {
           "status": "known-issue",
           "note": 1
@@ -30,10 +24,7 @@
       "vcluster": {
         "1.36": "compatible",
         "1.35": "tested",
-        "1.34": {
-          "status": "known-issue",
-          "note": 1
-        },
+        "1.34": "compatible",
         "1.33": {
           "status": "known-issue",
           "note": 1

--- a/static/api/k8s-compatibility.json
+++ b/static/api/k8s-compatibility.json
@@ -56,7 +56,7 @@
   "notes": [
     {
       "id": 1,
-      "text": "Pods can get stuck with a `Ready=False` status when the tenant cluster runs an older Kubernetes version than the control plane cluster. This keeps their Deployments and StatefulSets from becoming ready. See [troubleshooting steps and fix status](/docs/vcluster/troubleshoot/pod-stuck-ready-false-version-skew) for details."
+      "text": "Pods can get stuck with a `Ready=False` status when the tenant cluster runs Kubernetes 1.33 or earlier and the control plane cluster runs Kubernetes 1.34 or later. This keeps their Deployments and StatefulSets from becoming ready. See [troubleshooting steps and fix status](/docs/vcluster/troubleshoot/pod-stuck-ready-false-version-skew) for details."
     }
   ],
   "statuses": {

--- a/vcluster/troubleshoot/pod-stuck-ready-false-version-skew.mdx
+++ b/vcluster/troubleshoot/pod-stuck-ready-false-version-skew.mdx
@@ -1,0 +1,53 @@
+---
+title: Resolve pods stuck at Ready=False with control plane and tenant version skew
+sidebar_label: Pod stuck Ready=False (version skew)
+description: Troubleshoot pods and Deployments stuck at Ready=False when the tenant cluster runs an older Kubernetes version than the control plane cluster.
+keywords: [ready false, qosClass immutable, observedGeneration, version skew, pod sync]
+---
+
+When the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs an older Kubernetes version than the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, synced pods can get stuck reporting `Ready=False` even though the pod itself is running. Deployments and StatefulSets never show as ready, because they wait on that pod condition.
+
+## Symptoms
+
+A pod's containers are all `Running`, but its owning Deployment or StatefulSet never reaches the desired ready count:
+
+```bash title="Pod is Running, but the Deployment is not Ready"
+kubectl get pods
+# NAME                          READY   STATUS    RESTARTS   AGE
+# my-app-7cf4ddcbbf-k5m2n       1/1     Running   0          127m
+
+kubectl get deployments
+# NAME     READY   UP-TO-DATE   AVAILABLE   AGE
+# my-app   0/1     1            0           127m
+```
+
+The <GlossaryTerm term="syncer">syncer</GlossaryTerm> logs a reconcile error for the pod, similar to:
+
+```text title="Syncer log"
+ERROR   controller/controller.go:474    Reconciler error    {"component": "vcluster", "controller": "pod", ..., "error": "sync: patch host object: update object status: Pod \"my-app-7cf4ddcbbf-k5m2n--b21ec34921\" is invalid: status.qosClass: Invalid value: \"BestEffort\": field is immutable"}
+```
+
+Restarting the control plane's <GlossaryTerm term="api-server">API server</GlossaryTerm> pod can temporarily clear some of these errors, but they come back after creating or updating deployments.
+
+## Cause
+
+This is a known issue tracked in [vCluster GitHub Issue #3578](https://github.com/loft-sh/vcluster/issues/3578), with two contributing root causes:
+
+- **QoS class immutability**: the pod syncer copies the tenant pod's QoS class onto the host object before patching. Kubernetes 1.32 and later rejects that patch because `status.qosClass` is immutable once set.
+- **`observedGeneration` mismatch**: starting in Kubernetes 1.34, the host kubelet sets `observedGeneration` on pod status and conditions. A tenant API server on Kubernetes older than 1.34 drops that field on write, since `PodObservedGenerationTracking` is alpha or off by default there. The syncer then sees the object cache and the informer disagree on every reconcile, reads that as a real condition change, and keeps overwriting the tenant's `Ready=True` condition with stale data.
+
+Both root causes only trigger when the tenant runs an older Kubernetes version than the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster. See the [Kubernetes compatibility matrix](/docs/vcluster/manage/upgrade/supported_versions#kubernetes-compatibility-matrix) for the specific control plane and tenant version combinations flagged with this known issue.
+
+## Workaround
+
+There is no reliable workaround available today. Restarting the control plane's API server pod clears the immediate errors, but they recur as soon as new pods sync. The most effective mitigation is to keep the tenant cluster on the same Kubernetes minor version as the control plane cluster until the fix ships.
+
+## Fix status
+
+A fix is in progress in [GitHub Issue #4037](https://github.com/loft-sh/vcluster/pull/4037), which stops the syncer from writing the immutable QoS class to the host and ignores `observedGeneration` when the tenant cluster doesn't persist it.
+
+## Related resources
+
+- [Kubernetes compatibility matrix](/docs/vcluster/manage/upgrade/supported_versions#kubernetes-compatibility-matrix)
+- [vcluster#3578](https://github.com/loft-sh/vcluster/issues/3578)
+- [vcluster#4037](https://github.com/loft-sh/vcluster/pull/4037)

--- a/vcluster/troubleshoot/pod-stuck-ready-false-version-skew.mdx
+++ b/vcluster/troubleshoot/pod-stuck-ready-false-version-skew.mdx
@@ -1,11 +1,11 @@
 ---
 title: Resolve pods stuck at Ready=False with control plane and tenant version skew
 sidebar_label: Pod stuck Ready=False (version skew)
-description: Troubleshoot pods and Deployments stuck at Ready=False when the tenant cluster runs an older Kubernetes version than the control plane cluster.
+description: Troubleshoot pods and Deployments stuck at Ready=False when the tenant cluster runs Kubernetes 1.33 or earlier and the control plane cluster runs 1.34 or later.
 keywords: [ready false, qosClass immutable, observedGeneration, version skew, pod sync]
 ---
 
-When the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs an older Kubernetes version than the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, synced pods can get stuck reporting `Ready=False` even though the pod itself is running. Deployments and StatefulSets never show as ready, because they wait on that pod condition.
+When the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs Kubernetes 1.33 or earlier and the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm> runs Kubernetes 1.34 or later, synced pods can get stuck reporting `Ready=False` even though the pod itself is running. Deployments and StatefulSets never show as ready, because they wait on that pod condition.
 
 ## Symptoms
 
@@ -36,11 +36,11 @@ This is a known issue tracked in [vCluster GitHub Issue #3578](https://github.co
 - **QoS class immutability**: the pod syncer copies the tenant pod's QoS class onto the host object before patching. Kubernetes 1.32 and later rejects that patch because `status.qosClass` is immutable once set.
 - **`observedGeneration` mismatch**: starting in Kubernetes 1.34, the host kubelet sets `observedGeneration` on pod status and conditions. A tenant API server on Kubernetes older than 1.34 drops that field on write, since `PodObservedGenerationTracking` is alpha or off by default there. The syncer then sees the object cache and the informer disagree on every reconcile, reads that as a real condition change, and keeps overwriting the tenant's `Ready=True` condition with stale data.
 
-Both root causes only trigger when the tenant runs an older Kubernetes version than the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster. See the [Kubernetes compatibility matrix](/docs/vcluster/manage/upgrade/supported_versions#kubernetes-compatibility-matrix) for the specific control plane and tenant version combinations flagged with this known issue.
+Both root causes only trigger when the tenant cluster runs Kubernetes 1.33 or earlier and the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster runs Kubernetes 1.34 or later. See the [Kubernetes compatibility matrix](/docs/vcluster/manage/upgrade/supported_versions#kubernetes-compatibility-matrix) for the specific version combinations flagged with this known issue.
 
 ## Workaround
 
-There is no reliable workaround available today. Restarting the control plane's API server pod clears the immediate errors, but they recur as soon as new pods sync. The most effective mitigation is to keep the tenant cluster on the same Kubernetes minor version as the control plane cluster until the fix ships.
+There is no reliable workaround available today. Restarting the control plane's API server pod clears the immediate errors, but they recur as soon as new pods sync. The most effective mitigation is to keep the tenant cluster on Kubernetes 1.34 or later whenever the control plane cluster runs Kubernetes 1.34 or later, until the fix ships.
 
 ## Fix status
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Adds the "Known issues" warning in the Kubernetes compatibility matrix for 1.34+ control plane clusters paired with an older tenant cluster (1.33 or 1.34). The warning now points at the actual bug hitting these version combinations today: pods stuck at `Ready=False` due to a QoS class immutability issue and an `observedGeneration` mismatch (tracked upstream in [vcluster#3578](https://github.com/loft-sh/vcluster/issues/3578), fix in progress in [vcluster#4037](https://github.com/loft-sh/vcluster/pull/4037)).

Also adds a new troubleshooting page documenting the symptoms, root cause, and current workaround/fix status, and points the matrix footnote at it.

## Preview Link 
<!-- The preview link or links to the documents-->
- [Updated compatibility matrix](https://deploy-preview-2388--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/upgrade/supported_versions#kubernetes-compatibility-matrix)
- [New troubleshooting page about the issue](https://deploy-preview-2388--vcluster-docs-site.netlify.app/docs/vcluster/next/troubleshoot/pod-stuck-ready-false-version-skew)

## Internal Reference
Closes DOC-1618

Also tracked in ENGNODE-105.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs