### PR TITLE
fix(ci): skip docs-sync prs for -next prereleases

### DIFF
--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -132,6 +132,41 @@ get() {
     [ "$(get channel)" = "beta" ]
 }
 
+@test "vcluster: -next prerelease on a frozen minor is always skipped" {
+    # -next.internal.* tags are cut from feature branches (DEVOPS-1092).
+    # 0.34.0 is frozen with a folder, so without the -next guard this would
+    # classify skip=false and open a docs-sync PR. The guard must win.
+    VERSION=v0.34.0-next.internal.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "next" ]
+}
+
+@test "vcluster: -next prerelease of the next minor is always skipped" {
+    # 0.35 is max-frozen+1, which would otherwise route to the current docs
+    # folder. The -next guard fires before either routing branch.
+    VERSION=v0.35.0-next.internal.0 EVENT_TYPE=vcluster-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "next" ]
+}
+
+@test "vcluster-cli: -next prerelease is always skipped" {
+    VERSION=v0.34.0-next.internal.0 EVENT_TYPE=vcluster-cli-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "next" ]
+}
+
+@test "platform: -next prerelease is always skipped" {
+    # Real-world shape from DEVOPS-1092: v4.11.0-next.internal.5.
+    VERSION=v4.9.0-next.internal.5 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ "$(get skip)" = "true" ]
+    [ "$(get channel)" = "next" ]
+}
+
 @test "vcluster: frozen-but-pruned minor (in versions.json, no folder) → skip" {
     # 0.26.0 is in versions.json but no folder exists for it.
     VERSION=v0.26.5 EVENT_TYPE=vcluster-released run "$SCRIPT"

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -5,7 +5,7 @@
 # Maps a released VERSION + EVENT_TYPE to a routing decision:
 #   - skip:           true if the version should not produce docs
 #   - target_folder:  path (relative to REPO_ROOT) where generated docs land
-#   - channel:        stable | rc | alpha | beta | invalid | unknown-event
+#   - channel:        stable | rc | alpha | beta | next | invalid | unknown-event
 #
 # Inputs (env):
 #   VERSION      Released version, e.g. v0.34.5, v0.34.0-rc.3, v4.6.0-alpha.1
@@ -22,7 +22,9 @@
 #
 # Routing rules (matches A4 design appendix B):
 #
-#   * alpha / beta  → always skip
+#   * alpha / beta / next → always skip (next = -next.internal.* prereleases
+#     cut from feature branches; these must never open a docs-sync PR, per
+#     DEVOPS-1092)
 #   * MAJOR.MINOR strictly newer than the highest frozen MAJOR.MINOR in the
 #     event's versions.json → target = current docs root (the unreleased
 #     "next" docs folder)
@@ -74,6 +76,7 @@ channel=stable
 case "$stripped" in
     *-alpha*) emit_skip alpha ;;
     *-beta*)  emit_skip beta  ;;
+    *-next*)  emit_skip next  ;;
     *-rc.*|*-rc[0-9]*) channel=rc ;;
 esac
 


### PR DESCRIPTION
# Content Description
The release-dispatch classifier (`hack/release/classify-version.sh`, used by `handle-source-release.yml`) skipped `-alpha` and `-beta` prereleases but let `-next.internal.*` tags fall through as `channel=stable`, so each one opened a docs-sync PR. Those tags are cut from feature branches and must never be merged. This adds a `*-next*` skip rule alongside alpha/beta, plus bats coverage. `rc.*` behavior is unchanged: RCs are real release candidates and still open a PR.

## Preview Link
N/A — CI/scripts only, no docs content changed.

## Internal Reference
Closes DEVOPS-1092

Reported in Slack: a release lead-up produced `sync ... v0.36.0-next.internal.0`, `v4.11.0-next.internal.5`, `v4.11.0-next.internal.6` docs-sync PRs. Denise confirmed none of the `-next` PRs should be merged and asked to stop the actions creating them.

### Verification
`bats hack/release/classify-version.bats` — 23/23 pass (4 new). `shellcheck` clean. rc paths still route (tests 6/7).

<!-- Do not change the line below -->
@netlify /docs