### PR TITLE
docs(DOC-1588): fix stale flags and undocumented exportKubeConfig fields

### DIFF
--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -147,9 +147,7 @@ kubectl port-forward my-vcluster-0 -n test 8443
 ```
 
 :::tip
-You can specify a different namespace where the kubeconfig secret gets created with the `exportKubeConfig.secret.namespace` field in `vcluster.yaml`. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace.
-
-`exportKubeConfig.secret` is deprecated in favor of `exportKubeConfig.additionalSecrets`, which lets you emit multiple kubeconfig secrets, each with its own namespace. See [Access vCluster externally](#access-vcluster-externally) below.
+You can specify a different namespace where the kubeconfig secret gets created with the `exportKubeConfig.additionalSecrets` field in `vcluster.yaml`. This lets you emit multiple kubeconfig secrets, each with its own namespace. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace. See [Access vCluster externally](#access-vcluster-externally) below.
 :::
 
 ### Access vCluster externally

--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -34,7 +34,7 @@ vcluster connect my-vcluster --print
 vcluster disconnect
 
 # Create a separate kube config to use instead of changing the current context
-vcluster connect my-vcluster --update-current=false
+vcluster connect my-vcluster --print > kubeconfig.yaml
 
 # Execute a command directly with vCluster context without changing the current context
 vcluster connect my-vcluster -- kubectl get namespaces
@@ -113,7 +113,7 @@ There might be cases where connecting to a vCluster with the CLI is not feasible
 The secret is prefixed with `vc-` and ends with the vCluster name, so a vCluster called `my-vcluster` in namespace `test` would create a secret called `vc-my-vcluster` in the namespace `test`. You can retrieve the kubeconfig after the vCluster has started with:
 
 ```
-kubectl get secret vc-my-vcluster -n test --template={{.data.config}} | base64 -D
+kubectl get secret vc-my-vcluster -n test --template={{.data.config}} | base64 --decode
 ```
 
 The secret holds a kubeconfig in this format:
@@ -147,12 +147,14 @@ kubectl port-forward my-vcluster-0 -n test 8443
 ```
 
 :::tip
-With the syncer flag `--out-kube-config-secret-namespace` you can specify a different namespace where the kubeconfig secret should be created in. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace.
+You can specify a different namespace where the kubeconfig secret gets created with the `exportKubeConfig.secret.namespace` field in `vcluster.yaml`. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace.
+
+`exportKubeConfig.secret` is deprecated in favor of `exportKubeConfig.additionalSecrets`, which lets you emit multiple kubeconfig secrets, each with its own namespace. See [Access vCluster externally](#access-vcluster-externally) below.
 :::
 
 ### Access vCluster externally
 
-If you have [exposed the vCluster](#expose-vcluster), you can also tell the vCluster to create the kubeconfig secret with another server endpoint through the `exportKubeConfig` flag.
+If you have [exposed the vCluster](#expose-vcluster), you can also tell the vCluster to create the kubeconfig secret with another server endpoint through the `exportKubeConfig` field.
 
 For example, if you want to expose a vCluster at `https://my-domain.org`, you can create a `vcluster.yaml` like this:
 ```yaml
@@ -169,6 +171,37 @@ exportKubeConfig:
   server: https://my-domain.org:443
 ```
 
+`exportKubeConfig` also supports these fields.
+
+- `context` sets the context name and `current-context` in the generated kubeconfig.
+- `insecure` sets `insecure-skip-tls-verify: true` and removes the CA data from the generated kubeconfig.
+- `serviceAccount.name`, `serviceAccount.namespace` (defaults to `kube-system`), and `serviceAccount.clusterRole` generate a service account token instead of the default admin client certificate. vCluster creates the service account and a cluster role binding to the given `clusterRole` inside the tenant cluster.
+- `additionalSecrets` emits multiple kubeconfig secrets, each with its own `name`, `namespace`, `server`, `context`, `insecure`, and `serviceAccount`.
+
+:::info
+`exportKubeConfig.secret` is deprecated in favor of `additionalSecrets`.
+:::
+
+For example, to export three kubeconfig secrets with different access levels:
+```yaml
+exportKubeConfig:
+  additionalSecrets:
+  - name: kubeconfig-admin
+    namespace: my-vcluster
+    server: https://my-domain.org:443
+  - name: kubeconfig-viewer
+    namespace: my-vcluster
+    server: https://my-domain.org:443
+    serviceAccount:
+      name: my-viewer
+      namespace: kube-system
+      clusterRole: view
+  - name: kubeconfig-insecure
+    namespace: my-vcluster
+    server: https://my-domain.org:443
+    insecure: true
+```
+
 Then you can create or upgrade the vCluster with:
 
 ```
@@ -178,7 +211,7 @@ vcluster create my-vcluster -n my-vcluster --upgrade --connect=false -f values.y
 Wait until the vCluster has started and you can retrieve the kubeconfig with:
 
 ```
-kubectl get secret vc-my-vcluster -n my-vcluster --template={{.data.config}} | base64 -D
+kubectl get secret vc-my-vcluster -n my-vcluster --template={{.data.config}} | base64 --decode
 ```
 
 <div class="videoWrapper">
@@ -215,7 +248,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
         { label: 'Ingress without SSL (Deprecated)', value: 'ingress-wo-ssl', },
         { label: 'Load Balancer Service', value: 'load-balancer-service', },
         { label: 'NodePort Service', value: 'node-port-service', },
-        { label: 'From Host Cluster', value: 'from-host-cluster', },
+        { label: 'From Control Plane Cluster', value: 'from-host-cluster', },
     ]}>
 <TabItem value="tlsroute">
 
@@ -467,8 +500,10 @@ The annotations in the example below are specific to ingress-nginx, which is dep
 
   Update the current kube config via:
   ```
-  # Update the current kube config (or use --update-current=false to create a separate one)
   vcluster connect my-vcluster -n my-vcluster --server=https://x.x.x.x
+
+  # OR: create a separate kube config file instead of updating the current context
+  vcluster connect my-vcluster -n my-vcluster --server=https://x.x.x.x --print > kubeconfig.yaml
   ```
 
   Access the vCluster:
@@ -535,7 +570,7 @@ The annotations in the example below are specific to ingress-nginx, which is dep
 
   Retrieve the kube config via:
   ```
-  vcluster connect my-vcluster -n my-vcluster --update-current=false --server=https://x.x.x.x
+  vcluster connect my-vcluster -n my-vcluster --server=https://x.x.x.x --print > kubeconfig.yaml
   ```
 
   Access the vCluster:
@@ -550,7 +585,7 @@ The annotations in the example below are specific to ingress-nginx, which is dep
 
   To access the tenant cluster from within the control plane cluster, you can directly connect to the vCluster service. Make sure you can access that service and then create a kube config in the following form:
   ```
-  vcluster connect my-vcluster -n my-vcluster --server=my-vcluster.my-vcluster --insecure --update-current=false
+  vcluster connect my-vcluster -n my-vcluster --server=my-vcluster.my-vcluster --insecure --print > kubeconfig.yaml
   ```
 
   Now access the tenant cluster with:


### PR DESCRIPTION
# Content Description
Fixes drift in `accessing-vcluster.mdx` flagged in DOC-1588: a stale removed syncer flag, a deprecated CLI flag used in four examples, under-documented `exportKubeConfig` fields, a stale tab label, and a macOS-only command.

- Replace the removed `--out-kube-config-secret-namespace` syncer flag with `exportKubeConfig.secret.namespace`, and note `secret` is deprecated in favor of `additionalSecrets`.
- Sweep all four uses of the deprecated `--update-current` connect flag, replacing with `--print > kubeconfig.yaml` (verified against vcluster 0.35.1 CLI deprecation warning and source).
- Document `exportKubeConfig.context`, `.insecure`, `.serviceAccount`, and `.additionalSecrets`, with a worked multi-secret example.
- Relabel the "From Host Cluster" tab to "From Control Plane Cluster" (tab `value` unchanged).
- Fix `base64 -D` (macOS-only) to the portable `base64 --decode` (both occurrences).

## Preview Link 
[Accessing and Exposing vCluster](https://deploy-preview-2408--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/accessing-vcluster)

## Internal Reference
Closes DOC-1588


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs