### PR TITLE
docs(DOC-1630): add 8 missing resource types to platform api docs generator

### DIFF
--- a/hack/platform/partials/main.go
+++ b/hack/platform/partials/main.go
@@ -16,6 +16,7 @@ import (
 	clusterv1 "github.com/loft-sh/agentapi/v4/pkg/apis/loft/cluster/v1"
 	managementv1 "github.com/loft-sh/api/v4/pkg/apis/management/v1"
 	storagev1 "github.com/loft-sh/api/v4/pkg/apis/storage/v1"
+	argoapplicationsv1alpha1 "github.com/loft-sh/external-types/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1129,6 +1130,284 @@ spec:
 			Status: managementv1.NodeProviderStatus{},
 		},
 		Create: true,
+	})
+
+	// MachineConfigTemplate
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "Machine Config Template",
+		Name:        "MachineConfigTemplate",
+		Resource:    "machineconfigtemplates",
+		Description: "MachineConfigTemplate holds a reusable Go template for a cloud-init (user data) or network-data document. A node provider renders the template when it provisions a Machine.",
+		File:        path.Join(util.BaseResourcesPath, "machineconfigtemplate.mdx"),
+		Object: &managementv1.MachineConfigTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MachineConfigTemplate",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ubuntu-cloud-init",
+			},
+			Spec: managementv1.MachineConfigTemplateSpec{
+				MachineConfigTemplateSpec: storagev1.MachineConfigTemplateSpec{
+					DisplayName: "Ubuntu cloud-init",
+					CloudInitTemplate: `#cloud-config
+hostname: {{ .Values.NodeClaim.Name }}
+users:
+  - name: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL`,
+				},
+			},
+		},
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// SSHKey
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "SSH Key",
+		Name:        "SSHKey",
+		Resource:    "sshkeys",
+		Description: "SSHKey holds a public SSH key that can be attached to auto-provisioned or manually joined nodes.",
+		File:        path.Join(util.BaseResourcesPath, "sshkey.mdx"),
+		Object: &managementv1.SSHKey{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "SSHKey",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-ssh-key",
+			},
+			Spec: managementv1.SSHKeySpec{
+				SSHKeySpec: storagev1.SSHKeySpec{
+					DisplayName: "My SSH Key",
+					Description: "Development access key",
+					PublicKey:   "ssh-ed25519 AAAA... user@host",
+				},
+			},
+		},
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// OSImage
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "OS Image",
+		Name:        "OSImage",
+		Resource:    "osimages",
+		Description: "OSImage describes an operating system image available for bare metal provisioning.",
+		File:        path.Join(util.BaseResourcesPath, "osimage.mdx"),
+		Object: &managementv1.OSImage{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "OSImage",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ubuntu-noble",
+			},
+			Spec: managementv1.OSImageSpec{
+				OSImageSpec: storagev1.OSImageSpec{
+					DisplayName: "Ubuntu Noble (24.04 LTS)",
+					Description: "Ubuntu Noble (24.04) server cloud image for bare metal provisioning",
+					Properties: map[string]string{
+						"metal3.vcluster.com/image-url":           "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
+						"metal3.vcluster.com/image-checksum":      "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS",
+						"metal3.vcluster.com/image-checksum-type": "sha256",
+					},
+				},
+			},
+		},
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// NodeProfile
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "Node Profile",
+		Name:        "NodeProfile",
+		Resource:    "nodeprofiles",
+		Description: "NodeProfile holds reusable node runtime configuration (labels, annotations, and taints) that can be referenced by manual joins, auto nodes, and platform NodeClaims.",
+		File:        path.Join(util.BaseResourcesPath, "nodeprofile.mdx"),
+		Object: &managementv1.NodeProfile{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodeProfile",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gpu-training",
+			},
+			Spec: managementv1.NodeProfileSpec{
+				NodeProfileSpec: storagev1.NodeProfileSpec{
+					DisplayName: "GPU Training",
+					Description: "GPU worker defaults for training workloads.",
+					NodeLabels: map[string]string{
+						"workload.vcluster.com/class": "gpu",
+					},
+					NodeAnnotations: map[string]string{
+						"ops.vcluster.com/owner": "ml-platform",
+					},
+					Taints: []corev1.Taint{
+						{
+							Key:    "nvidia.com/gpu",
+							Value:  "true",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// NodeClaim - typically created automatically by auto-nodes rather than
+	// authored by hand, so Create is intentionally omitted; Retrieve/Delete
+	// cover inspecting and deprovisioning a claim.
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "Node Claim",
+		Name:        "NodeClaim",
+		Resource:    "nodeclaims",
+		Description: "NodeClaim tracks a node that the platform has provisioned or is provisioning for a tenant cluster. Auto-nodes creates these automatically; they are not typically authored by hand.",
+		File:        path.Join(util.BaseResourcesPath, "nodeclaim.mdx"),
+		Object: &managementv1.NodeClaim{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodeClaim",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vcluster-62ftb",
+				Namespace: "p-default",
+			},
+			Spec: managementv1.NodeClaimSpec{
+				NodeClaimSpec: storagev1.NodeClaimSpec{
+					ProviderRef: "my-node-provider",
+					VClusterRef: "my-vcluster",
+					DesiredCapacity: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("120m"),
+						corev1.ResourceMemory: resource.MustParse("114Mi"),
+					},
+				},
+			},
+		},
+		Project:  true,
+		Retrieve: true,
+		Delete:   true,
+	})
+
+	// ProjectSecret
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "Project Secret",
+		Name:        "ProjectSecret",
+		Resource:    "projectsecrets",
+		Description: "ProjectSecret is a Kubernetes Secret managed by the platform inside a project, often synced from an external secret store such as HashiCorp Vault.",
+		File:        path.Join(util.BaseResourcesPath, "projectsecret.mdx"),
+		Object: &managementv1.ProjectSecret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ProjectSecret",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: "loft-p-my-project",
+			},
+			Spec: managementv1.ProjectSecretSpec{
+				DisplayName: "My Secret",
+				Data: map[string][]byte{
+					"password": []byte("password"),
+				},
+			},
+		},
+		Project:  true,
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// ArgoCDApplicationTemplate
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "ArgoCD Application Template",
+		Name:        "ArgoCDApplicationTemplate",
+		Resource:    "argocdapplicationtemplates",
+		Description: "ArgoCDApplicationTemplate is a reusable Argo CD ApplicationSpec that can be referenced by name from an ArgoCDApplication to avoid duplicating configuration across tenant clusters.",
+		File:        path.Join(util.BaseResourcesPath, "argocdapplicationtemplate.mdx"),
+		Object: &managementv1.ArgoCDApplicationTemplate{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ArgoCDApplicationTemplate",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "app-template",
+			},
+			Spec: managementv1.ArgoCDApplicationTemplateSpec{
+				ArgoCDApplicationTemplateSpec: storagev1.ArgoCDApplicationTemplateSpec{
+					Template: storagev1.ArgoCDApplicationTemplateDefinition{
+						Spec: argoapplicationsv1alpha1.ApplicationSpec{
+							Source: &argoapplicationsv1alpha1.ApplicationSource{
+								RepoURL:        "https://github.com/acme/app-charts",
+								Path:           "app",
+								TargetRevision: "main",
+							},
+							Project: "default",
+							SyncPolicy: &argoapplicationsv1alpha1.SyncPolicy{
+								Automated: &argoapplicationsv1alpha1.SyncPolicyAutomated{
+									Prune:    true,
+									SelfHeal: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
+	})
+
+	// ArgoCDApplication
+	util.GenerateObjectOverview(&util.ObjectInformation{
+		Title:       "ArgoCD Application",
+		Name:        "ArgoCDApplication",
+		Resource:    "argocdapplications",
+		Description: "ArgoCDApplication declares an Argo CD Application that the platform reconciles and syncs to a connected Argo CD instance.",
+		File:        path.Join(util.BaseResourcesPath, "argocdapplication.mdx"),
+		Object: &managementv1.ArgoCDApplication{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ArgoCDApplication",
+				APIVersion: managementv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-infra",
+				Namespace: "p-my-project",
+			},
+			Spec: managementv1.ArgoCDApplicationSpec{
+				ArgoCDApplicationSpec: storagev1.ArgoCDApplicationSpec{
+					DisplayName: "Shared Infrastructure",
+					Destination: storagev1.ArgoCDDestination{
+						Cluster: &storagev1.ArgoCDDestinationCluster{
+							Name: "loft-cluster",
+						},
+					},
+					TemplateRef: &storagev1.ArgoCDApplicationTemplateRef{
+						Name: "infra-template",
+					},
+				},
+			},
+		},
+		Project:  true,
+		Create:   true,
+		Retrieve: true,
+		Update:   true,
+		Delete:   true,
 	})
 }
 

--- a/platform/api/_partials/resources/argocdapplications/create.mdx
+++ b/platform/api/_partials/resources/argocdapplications/create.mdx
@@ -1,0 +1,74 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new ArgoCDApplication.
+Make sure to set the project in the `metadata.namespace` field you want to create the ArgoCDApplication in. If your project has the id `my-project`, the corresponding namespace would be `loft-p-my-project`.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplication
+metadata:
+  name: shared-infra
+  namespace: p-my-project
+spec:
+  destination:
+    cluster:
+      name: loft-cluster
+  displayName: Shared Infrastructure
+  templateRef:
+    name: infra-template
+status: {}
+
+```
+
+Then create the ArgoCDApplication `shared-infra` in project `my-project` with:
+```bash
+kubectl create -f object.yaml -n loft-p-my-project
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplication
+metadata:
+  name: shared-infra
+  namespace: p-my-project
+spec:
+  destination:
+    cluster:
+      name: loft-cluster
+  displayName: Shared Infrastructure
+  templateRef:
+    name: infra-template
+status: {}
+
+```
+
+Run the following curl command to create a new ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplications/delete.mdx
+++ b/platform/api/_partials/resources/argocdapplications/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete ArgoCDApplications.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+kubectl delete argocdapplications.management.loft.sh shared-infra -n loft-p-my-project
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+# Replace the shared-infra in the url below with the name of the ArgoCDApplication you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications/shared-infra" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplications/reference.mdx
+++ b/platform/api/_partials/resources/argocdapplications/reference.mdx
@@ -1,0 +1,9365 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes an OS image
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `templateRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef}
+
+TemplateRef holds the Argo CD application template reference
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-templateRef-name}
+
+Name holds the name of the blueprint template to reference.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+
+Template is the Argo CD application template definition
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+
+Labels are labels on the object
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+
+Annotations are annotations on the object
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec}
+
+Spec is the spec of the Argo CD application
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `source` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-chart}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ref` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-ref}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `destination` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-server}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `project` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-project}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `automated` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `prune` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-prune}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `selfHeal` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-selfHeal}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowEmpty` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-allowEmpty}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-enabled}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-syncOptions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `retry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-limit}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `backoff` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-duration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `factor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-factor}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `maxDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-maxDuration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `refresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-refresh}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `managedNamespaceMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata-labels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata-annotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `ignoreDifferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-ignoreDifferences}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revisionHistoryLimit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-revisionHistoryLimit}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sourceHydrator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `drySource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hydrateTo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-hydrateTo}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-hydrateTo-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+
+Parameters are values to pass to the template.
+The values should be encoded as YAML string where each parameter is represented as a top-level field key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `destination` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination}
+
+Destination holds the Argo CD target reference
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `virtualCluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination-virtualCluster}
+
+VirtualCluster name. Mutually exclusive with Cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination-virtualCluster-name}
+
+Name of the tenant cluster
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `target` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination-virtualCluster-target}
+
+Target of the tenant cluster
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `cluster` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination-cluster}
+
+Cluster name. Mutually exclusive with VirtualCluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-destination-cluster-name}
+
+Name of the cluster
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+
+Conditions holds several conditions the tenant cluster might be in
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `host` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-host}
+
+Host of the Argo CD server
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `application` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application}
+
+Application holds the status of the Argo CD application
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-group}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kind` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-kind}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-status}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `health` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-health}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-health-status}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-health-message}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `lastTransitionTime` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-health-lastTransitionTime}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-hook}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `requiresPruning` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-requiresPruning}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `syncWave` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-syncWave}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `requiresDeletionConfirmation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resources-requiresDeletionConfirmation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `status` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-status}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `comparedTo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `source` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-chart}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ref` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-ref}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-source-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `destination` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-destination}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-destination-server}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-destination-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-destination-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-sources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `ignoreDifferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-comparedTo-ignoreDifferences}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-revision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revisions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sync-revisions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `health` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-health}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-health-status}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-health-message}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `lastTransitionTime` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-health-lastTransitionTime}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `history` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-history}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-conditions}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `type` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-conditions-type}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `message` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-conditions-message}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `lastTransitionTime` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-conditions-lastTransitionTime}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `reconciledAt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-reconciledAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `operationState` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `operation` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sync` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-revision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `prune` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-prune}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `dryRun` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-dryRun}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncStrategy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncStrategy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `apply` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncStrategy-apply}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `force` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncStrategy-apply-force}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hook` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncStrategy-hook}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `force` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncStrategy-hook-force}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-resources}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `group` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-resources-group}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kind` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-resources-kind}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-resources-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-resources-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `source` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-chart}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ref` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-ref}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-source-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `manifests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-manifests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-syncOptions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-sources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revisions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-revisions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `autoHealAttemptsCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-sync-autoHealAttemptsCount}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `initiatedBy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-initiatedBy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `username` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-initiatedBy-username}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `automated` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-initiatedBy-automated}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-info}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-info-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-info-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `retry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-limit}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `backoff` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-backoff}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-backoff-duration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `factor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-backoff-factor}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `maxDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-backoff-maxDuration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `refresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-operation-retry-refresh}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `phase` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-phase}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-message}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncResult` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `resources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-resources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revision` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-revision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `source` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-chart}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ref` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-ref}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-source-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-sources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revisions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-revisions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `managedNamespaceMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-managedNamespaceMetadata}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-managedNamespaceMetadata-labels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-syncResult-managedNamespaceMetadata-annotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `startedAt` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-startedAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `finishedAt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-finishedAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `retryCount` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-operationState-retryCount}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `observedAt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-observedAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `sourceType` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceType}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `summary` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-summary}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `externalURLs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-summary-externalURLs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-summary-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `resourceHealthSource` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-resourceHealthSource}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `sourceTypes` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceTypes}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `controllerNamespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-controllerNamespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `sourceHydrator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `lastSuccessfulOperation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `drySHA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-drySHA}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hydratedSHA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-hydratedSHA}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sourceHydrator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `drySource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-drySource-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-syncSource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-syncSource-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-syncSource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hydrateTo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-hydrateTo}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-lastSuccessfulOperation-sourceHydrator-hydrateTo-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `currentOperation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `startedAt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-startedAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `finishedAt` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-finishedAt}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `phase` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-phase}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `message` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-message}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `drySHA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-drySHA}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `hydratedSHA` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-hydratedSHA}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sourceHydrator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `drySource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-drySource-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-syncSource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-syncSource-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-syncSource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hydrateTo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-hydrateTo}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-application-sourceHydrator-currentOperation-sourceHydrator-hydrateTo-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>

--- a/platform/api/_partials/resources/argocdapplications/retrieve.mdx
+++ b/platform/api/_partials/resources/argocdapplications/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve ArgoCDApplications.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of ArgoCDApplications
+Run the following command to list all ArgoCDApplications in project `my-project`:
+```bash
+kubectl get argocdapplications.management.loft.sh -n loft-p-my-project -o yaml
+```
+
+### Retrieve a single ArgoCDApplication by name
+Run the following kubectl command to get ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+kubectl get argocdapplications.management.loft.sh shared-infra -n loft-p-my-project -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of ArgoCDApplications
+Run the following curl command to list all ArgoCDApplications in project `my-project`:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single ArgoCDApplication by name
+Run the following curl command to get ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+# Exchange shared-infra in the url below with the name of the ArgoCDApplication
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications/shared-infra" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplications/update.mdx
+++ b/platform/api/_partials/resources/argocdapplications/update.mdx
@@ -1,0 +1,93 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update ArgoCDApplications.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update ArgoCDApplication
+
+Run the following command to update ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+kubectl edit argocdapplications.management.loft.sh shared-infra -n loft-p-my-project
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch ArgoCDApplication
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the ArgoCDApplication `shared-infra` in project `my-project` via a patch:
+```bash
+kubectl patch argocdapplications.management.loft.sh shared-infra -n loft-p-my-project \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update ArgoCDApplication
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplication
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: shared-infra
+  namespace: p-my-project
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  destination:
+    cluster:
+      name: loft-cluster
+  displayName: Shared Infrastructure
+  templateRef:
+    name: infra-template
+status: {}
+
+```
+
+Run the following curl command to update a single ArgoCDApplication `shared-infra` in project `my-project`:
+```bash
+# Replace the shared-infra in the url below with the name of the ArgoCDApplication you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications/shared-infra" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch ArgoCDApplication
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the ArgoCDApplication `shared-infra` in project `my-project` via a patch:
+```bash
+# Replace the shared-infra in the url below with the name of the ArgoCDApplication you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/argocdapplications/shared-infra" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplicationtemplates/create.mdx
+++ b/platform/api/_partials/resources/argocdapplicationtemplates/create.mdx
@@ -1,0 +1,85 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new ArgoCDApplicationTemplate.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplicationTemplate
+metadata:
+  name: app-template
+spec:
+  template:
+    metadata: {}
+    spec:
+      destination: {}
+      project: default
+      source:
+        path: app
+        repoURL: https://github.com/acme/app-charts
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+status: {}
+
+```
+
+Then create the ArgoCDApplicationTemplate `app-template` with:
+```bash
+kubectl create -f object.yaml 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplicationTemplate
+metadata:
+  name: app-template
+spec:
+  template:
+    metadata: {}
+    spec:
+      destination: {}
+      project: default
+      source:
+        path: app
+        repoURL: https://github.com/acme/app-charts
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+status: {}
+
+```
+
+Run the following curl command to create a new ArgoCDApplicationTemplate `app-template`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplicationtemplates/delete.mdx
+++ b/platform/api/_partials/resources/argocdapplicationtemplates/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete ArgoCDApplicationTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete ArgoCDApplicationTemplate `app-template`:
+```bash
+kubectl delete argocdapplicationtemplates.management.loft.sh app-template 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete ArgoCDApplicationTemplate `app-template`:
+```bash
+# Replace the app-template in the url below with the name of the ArgoCDApplicationTemplate you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates/app-template" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplicationtemplates/reference.mdx
+++ b/platform/api/_partials/resources/argocdapplicationtemplates/reference.mdx
@@ -1,0 +1,2900 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes an OS image
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `template` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template}
+
+Template is the blueprint template definition
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `metadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-labels}
+
+Labels are labels on the object
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-metadata-annotations}
+
+Annotations are annotations on the object
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec}
+
+Spec is the spec of the Argo CD application
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `source` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `chart` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-chart}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ref` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-ref}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-source-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `destination` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-server}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-destination-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `project` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-project}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncPolicy` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `automated` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `prune` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-prune}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `selfHeal` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-selfHeal}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `allowEmpty` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-allowEmpty}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-automated-enabled}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncOptions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-syncOptions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `retry` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-limit}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `backoff` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `duration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-duration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `factor` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-factor}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `maxDuration` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-backoff-maxDuration}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `refresh` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-retry-refresh}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `managedNamespaceMetadata` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata-labels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-syncPolicy-managedNamespaceMetadata-annotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `ignoreDifferences` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-ignoreDifferences}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `info` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-info-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `revisionHistoryLimit` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-revisionHistoryLimit}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sources}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `sourceHydrator` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `drySource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repoURL` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-repoURL}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetRevision` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-targetRevision}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `helm` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `valueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-valueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceString` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-parameters-forceString}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `releaseName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-releaseName}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-values}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `fileParameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-fileParameters-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `passCredentials` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-passCredentials}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingValueFiles` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-ignoreMissingValueFiles}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipCrds` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipCrds}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `valuesObject` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-valuesObject}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipTests` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipTests}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipSchemaValidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-helm-skipSchemaValidation}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kustomize` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePrefix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-namePrefix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameSuffix` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-nameSuffix}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `images` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-images}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `version` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-version}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-forceCommonLabels}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `forceCommonAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-forceCommonAnnotations}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespace` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-namespace}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `commonAnnotationsEnvsubst` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-commonAnnotationsEnvsubst}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-replicas}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `patches` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-patches}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `components` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-components}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignoreMissingComponents` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-ignoreMissingComponents}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelWithoutSelector` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-labelWithoutSelector}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kubeVersion` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-kubeVersion}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-apiVersions}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labelIncludeTemplates` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-kustomize-labelIncludeTemplates}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `directory` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `recurse` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-recurse}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `jsonnet` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `extVars` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-extVars-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tlas` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `code` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-tlas-code}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `libs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-jsonnet-libs}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `exclude` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-exclude}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `include` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-directory-include}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `plugin` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-name}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-env}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-drySource-plugin-parameters}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `syncSource` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-syncSource-path}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hydrateTo` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-hydrateTo}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `targetBranch` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-template-spec-sourceHydrator-hydrateTo-targetBranch}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `parameters` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters}
+
+Parameters define additional app parameters that will set helm values
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `variable` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-variable}
+
+Variable is the path of the variable. Can be foo or foo.bar for nested objects.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `label` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-label}
+
+Label is the label to show for this parameter
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-description}
+
+Description is the description to show for this parameter
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `type` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-type}
+
+Type of the parameter. Can be one of:
+string, multiline, boolean, number and password
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `options` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-options}
+
+Options is a slice of strings, where each string represents a mutually exclusive choice.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `min` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-min}
+
+Min is the minimum number if type is number
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `max` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-max}
+
+Max is the maximum number if type is number
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `required` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-required}
+
+Required specifies if this parameter is required
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `defaultValue` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-defaultValue}
+
+DefaultValue is the default value if none is specified
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `placeholder` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-placeholder}
+
+Placeholder shown in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `invalidation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-invalidation}
+
+Invalidation regex that if matched will reject the input
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `validation` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-validation}
+
+Validation regex that if matched will allow the input
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `section` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-parameters-section}
+
+Section where this app should be displayed. Apps with the same section name will be grouped together
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+</details>

--- a/platform/api/_partials/resources/argocdapplicationtemplates/retrieve.mdx
+++ b/platform/api/_partials/resources/argocdapplicationtemplates/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve ArgoCDApplicationTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of ArgoCDApplicationTemplates
+Run the following command to list all ArgoCDApplicationTemplates:
+```bash
+kubectl get argocdapplicationtemplates.management.loft.sh  -o yaml
+```
+
+### Retrieve a single ArgoCDApplicationTemplate by name
+Run the following kubectl command to get ArgoCDApplicationTemplate `app-template`:
+```bash
+kubectl get argocdapplicationtemplates.management.loft.sh app-template  -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of ArgoCDApplicationTemplates
+Run the following curl command to list all ArgoCDApplicationTemplates:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single ArgoCDApplicationTemplate by name
+Run the following curl command to get ArgoCDApplicationTemplate `app-template`:
+```bash
+# Exchange app-template in the url below with the name of the ArgoCDApplicationTemplate
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates/app-template" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/argocdapplicationtemplates/update.mdx
+++ b/platform/api/_partials/resources/argocdapplicationtemplates/update.mdx
@@ -1,0 +1,99 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update ArgoCDApplicationTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update ArgoCDApplicationTemplate
+
+Run the following command to update ArgoCDApplicationTemplate `app-template`:
+```bash
+kubectl edit argocdapplicationtemplates.management.loft.sh app-template 
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch ArgoCDApplicationTemplate
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the ArgoCDApplicationTemplate `app-template` via a patch:
+```bash
+kubectl patch argocdapplicationtemplates.management.loft.sh app-template  \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update ArgoCDApplicationTemplate
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplicationTemplate
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: app-template
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  template:
+    metadata: {}
+    spec:
+      destination: {}
+      project: default
+      source:
+        path: app
+        repoURL: https://github.com/acme/app-charts
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+status: {}
+
+```
+
+Run the following curl command to update a single ArgoCDApplicationTemplate `app-template`:
+```bash
+# Replace the app-template in the url below with the name of the ArgoCDApplicationTemplate you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates/app-template" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch ArgoCDApplicationTemplate
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the ArgoCDApplicationTemplate `app-template` via a patch:
+```bash
+# Replace the app-template in the url below with the name of the ArgoCDApplicationTemplate you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/argocdapplicationtemplates/app-template" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/machineconfigtemplates/create.mdx
+++ b/platform/api/_partials/resources/machineconfigtemplates/create.mdx
@@ -1,0 +1,73 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new MachineConfigTemplate.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: MachineConfigTemplate
+metadata:
+  name: ubuntu-cloud-init
+spec:
+  cloudInitTemplate: |-
+    #cloud-config
+    hostname: {{ .Values.NodeClaim.Name }}
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  displayName: Ubuntu cloud-init
+status: {}
+
+```
+
+Then create the MachineConfigTemplate `ubuntu-cloud-init` with:
+```bash
+kubectl create -f object.yaml 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: MachineConfigTemplate
+metadata:
+  name: ubuntu-cloud-init
+spec:
+  cloudInitTemplate: |-
+    #cloud-config
+    hostname: {{ .Values.NodeClaim.Name }}
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  displayName: Ubuntu cloud-init
+status: {}
+
+```
+
+Run the following curl command to create a new MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/machineconfigtemplates/delete.mdx
+++ b/platform/api/_partials/resources/machineconfigtemplates/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete MachineConfigTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+kubectl delete machineconfigtemplates.management.loft.sh ubuntu-cloud-init 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+# Replace the ubuntu-cloud-init in the url below with the name of the MachineConfigTemplate you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates/ubuntu-cloud-init" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/machineconfigtemplates/reference.mdx
+++ b/platform/api/_partials/resources/machineconfigtemplates/reference.mdx
@@ -1,0 +1,214 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name of the NodeClaim that is displayed in the UI.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `cloudInitTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-cloudInitTemplate}
+
+CloudInitTemplate is the cloud init template to use for the machine config.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `networkDataTemplate` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-networkDataTemplate}
+
+NetworkDataTemplate is the network data template to use for the machine config.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+</details>

--- a/platform/api/_partials/resources/machineconfigtemplates/retrieve.mdx
+++ b/platform/api/_partials/resources/machineconfigtemplates/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve MachineConfigTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of MachineConfigTemplates
+Run the following command to list all MachineConfigTemplates:
+```bash
+kubectl get machineconfigtemplates.management.loft.sh  -o yaml
+```
+
+### Retrieve a single MachineConfigTemplate by name
+Run the following kubectl command to get MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+kubectl get machineconfigtemplates.management.loft.sh ubuntu-cloud-init  -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of MachineConfigTemplates
+Run the following curl command to list all MachineConfigTemplates:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single MachineConfigTemplate by name
+Run the following curl command to get MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+# Exchange ubuntu-cloud-init in the url below with the name of the MachineConfigTemplate
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates/ubuntu-cloud-init" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/machineconfigtemplates/update.mdx
+++ b/platform/api/_partials/resources/machineconfigtemplates/update.mdx
@@ -1,0 +1,93 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update MachineConfigTemplates.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update MachineConfigTemplate
+
+Run the following command to update MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+kubectl edit machineconfigtemplates.management.loft.sh ubuntu-cloud-init 
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch MachineConfigTemplate
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the MachineConfigTemplate `ubuntu-cloud-init` via a patch:
+```bash
+kubectl patch machineconfigtemplates.management.loft.sh ubuntu-cloud-init  \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update MachineConfigTemplate
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: MachineConfigTemplate
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: ubuntu-cloud-init
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  cloudInitTemplate: |-
+    #cloud-config
+    hostname: {{ .Values.NodeClaim.Name }}
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  displayName: Ubuntu cloud-init
+status: {}
+
+```
+
+Run the following curl command to update a single MachineConfigTemplate `ubuntu-cloud-init`:
+```bash
+# Replace the ubuntu-cloud-init in the url below with the name of the MachineConfigTemplate you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates/ubuntu-cloud-init" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch MachineConfigTemplate
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the MachineConfigTemplate `ubuntu-cloud-init` via a patch:
+```bash
+# Replace the ubuntu-cloud-init in the url below with the name of the MachineConfigTemplate you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/machineconfigtemplates/ubuntu-cloud-init" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeclaims/delete.mdx
+++ b/platform/api/_partials/resources/nodeclaims/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete NodeClaims.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete NodeClaim `vcluster-62ftb` in project `my-project`:
+```bash
+kubectl delete nodeclaims.management.loft.sh vcluster-62ftb -n loft-p-my-project
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete NodeClaim `vcluster-62ftb` in project `my-project`:
+```bash
+# Replace the vcluster-62ftb in the url below with the name of the NodeClaim you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/nodeclaims/vcluster-62ftb" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeclaims/reference.mdx
+++ b/platform/api/_partials/resources/nodeclaims/reference.mdx
@@ -1,0 +1,680 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name of the NodeClaim that is displayed in the UI.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `providerRef` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-providerRef}
+
+ProviderRef is the name of the NodeProvider that this NodeClaim is based on.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `typeRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-typeRef}
+
+TypeRef is the full name of the NodeType that this NodeClaim is based on.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `environmentRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-environmentRef}
+
+EnvironmentRef is the name of the NodeEnvironment that this NodeClaim is based on.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
+
+Properties are extra properties for the NodeClaim.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `vClusterRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-vClusterRef}
+
+VClusterRef references source vCluster.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `controlPlane` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-controlPlane}
+
+ControlPlane indicates if the node claim is for a control plane node. This is intentionally not omitempty as
+we want to ensure that the control plane is always set for easier checking in for example terraform templates.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints}
+
+Taints will be applied to the NodeClaim's node.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `key` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `effect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `timeAdded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-timeAdded}
+
+TimeAdded represents the time at which the taint was added.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `startupTaints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints}
+
+StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `key` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `effect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `timeAdded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-timeAdded}
+
+TimeAdded represents the time at which the taint was added.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `kubeletArgs` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-kubeletArgs}
+
+KubeletArgs are additional arguments to pass to the kubelet.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `profileRef` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-profileRef}
+
+ProfileRef is the name of a NodeProfile in the catalog to apply to the
+resulting node. The referenced profile must exist and must be permitted
+by the owning project's allowedNodeProfiles. Optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `desiredCapacity` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-desiredCapacity}
+
+DesiredCapacity specifies the resources requested by the NodeClaim.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `requirements` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirements}
+
+Requirements are the requirements for the NodeClaim.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `key` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirements-key}
+
+The label key that the selector applies to.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `operator` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirements-operator}
+
+Represents a key's relationship to a set of values.
+Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `values` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-requirements-values}
+
+An array of string values. If the operator is In or NotIn,
+the values array must be non-empty. If the operator is Exists or DoesNotExist,
+the values array must be empty. If the operator is Gt or Lt, the values
+array must have a single element, which will be interpreted as an integer.
+This array is replaced during a strategic merge patch.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `power` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-power}
+
+Power describes the desired power state of the machine.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `state` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-power-state}
+
+State is the power state.
+
+In spec, only "On" and "Off" are meaningful; an empty value is treated
+as "On".
+
+In status, "On" and "Off" indicate the observed state is stable.
+Providers may also surface their native intermediate state (e.g.
+"Starting", "Stopping", "Migrating", ...) as a passthrough. An empty
+value means the state could not be determined.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `phase` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-phase}
+
+Phase is the current lifecycle phase of the NodeClaim.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `reason` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-reason}
+
+Reason describes the reason in machine-readable form
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `message` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-message}
+
+Message describes the reason in human-readable form
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+
+Conditions describe the current state of the platform NodeClaim.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `power` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-power}
+
+Power describes the observed power state of the machine.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `state` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-power-state}
+
+State is the power state.
+
+In spec, only "On" and "Off" are meaningful; an empty value is treated
+as "On".
+
+In status, "On" and "Off" indicate the observed state is stable.
+Providers may also surface their native intermediate state (e.g.
+"Starting", "Stopping", "Migrating", ...) as a passthrough. An empty
+value means the state could not be determined.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>

--- a/platform/api/_partials/resources/nodeclaims/retrieve.mdx
+++ b/platform/api/_partials/resources/nodeclaims/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve NodeClaims.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of NodeClaims
+Run the following command to list all NodeClaims in project `my-project`:
+```bash
+kubectl get nodeclaims.management.loft.sh -n loft-p-my-project -o yaml
+```
+
+### Retrieve a single NodeClaim by name
+Run the following kubectl command to get NodeClaim `vcluster-62ftb` in project `my-project`:
+```bash
+kubectl get nodeclaims.management.loft.sh vcluster-62ftb -n loft-p-my-project -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of NodeClaims
+Run the following curl command to list all NodeClaims in project `my-project`:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/nodeclaims" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single NodeClaim by name
+Run the following curl command to get NodeClaim `vcluster-62ftb` in project `my-project`:
+```bash
+# Exchange vcluster-62ftb in the url below with the name of the NodeClaim
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/nodeclaims/vcluster-62ftb" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeprofiles/create.mdx
+++ b/platform/api/_partials/resources/nodeprofiles/create.mdx
@@ -1,0 +1,79 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new NodeProfile.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  name: gpu-training
+spec:
+  description: GPU worker defaults for training workloads.
+  displayName: GPU Training
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+  taints:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    value: "true"
+status: {}
+
+```
+
+Then create the NodeProfile `gpu-training` with:
+```bash
+kubectl create -f object.yaml 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  name: gpu-training
+spec:
+  description: GPU worker defaults for training workloads.
+  displayName: GPU Training
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+  taints:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    value: "true"
+status: {}
+
+```
+
+Run the following curl command to create a new NodeProfile `gpu-training`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeprofiles/delete.mdx
+++ b/platform/api/_partials/resources/nodeprofiles/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete NodeProfiles.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete NodeProfile `gpu-training`:
+```bash
+kubectl delete nodeprofiles.management.loft.sh gpu-training 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete NodeProfile `gpu-training`:
+```bash
+# Replace the gpu-training in the url below with the name of the NodeProfile you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles/gpu-training" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeprofiles/reference.mdx
+++ b/platform/api/_partials/resources/nodeprofiles/reference.mdx
@@ -1,0 +1,248 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes what the profile is intended for.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `taints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints}
+
+Taints are taints that should be applied to the joined node.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `key` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `effect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `timeAdded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-taints-timeAdded}
+
+TimeAdded represents the time at which the taint was added.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `startupTaints` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints}
+
+StartupTaints are temporary taints applied while the node initializes.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `key` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `value` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `effect` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `timeAdded` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-startupTaints-timeAdded}
+
+TimeAdded represents the time at which the taint was added.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `nodeLabels` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-nodeLabels}
+
+NodeLabels are labels that should be applied to the joined node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `nodeAnnotations` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-nodeAnnotations}
+
+NodeAnnotations are annotations that should be applied to the joined node.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+</details>

--- a/platform/api/_partials/resources/nodeprofiles/retrieve.mdx
+++ b/platform/api/_partials/resources/nodeprofiles/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve NodeProfiles.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of NodeProfiles
+Run the following command to list all NodeProfiles:
+```bash
+kubectl get nodeprofiles.management.loft.sh  -o yaml
+```
+
+### Retrieve a single NodeProfile by name
+Run the following kubectl command to get NodeProfile `gpu-training`:
+```bash
+kubectl get nodeprofiles.management.loft.sh gpu-training  -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of NodeProfiles
+Run the following curl command to list all NodeProfiles:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single NodeProfile by name
+Run the following curl command to get NodeProfile `gpu-training`:
+```bash
+# Exchange gpu-training in the url below with the name of the NodeProfile
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles/gpu-training" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/nodeprofiles/update.mdx
+++ b/platform/api/_partials/resources/nodeprofiles/update.mdx
@@ -1,0 +1,96 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update NodeProfiles.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update NodeProfile
+
+Run the following command to update NodeProfile `gpu-training`:
+```bash
+kubectl edit nodeprofiles.management.loft.sh gpu-training 
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch NodeProfile
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the NodeProfile `gpu-training` via a patch:
+```bash
+kubectl patch nodeprofiles.management.loft.sh gpu-training  \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update NodeProfile
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: gpu-training
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  description: GPU worker defaults for training workloads.
+  displayName: GPU Training
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+  taints:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    value: "true"
+status: {}
+
+```
+
+Run the following curl command to update a single NodeProfile `gpu-training`:
+```bash
+# Replace the gpu-training in the url below with the name of the NodeProfile you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles/gpu-training" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch NodeProfile
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the NodeProfile `gpu-training` via a patch:
+```bash
+# Replace the gpu-training in the url below with the name of the NodeProfile you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/nodeprofiles/gpu-training" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/osimages/create.mdx
+++ b/platform/api/_partials/resources/osimages/create.mdx
@@ -1,0 +1,71 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new OSImage.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: OSImage
+metadata:
+  name: ubuntu-noble
+spec:
+  description: Ubuntu Noble (24.04) server cloud image for bare metal provisioning
+  displayName: Ubuntu Noble (24.04 LTS)
+  properties:
+    metal3.vcluster.com/image-checksum: https://cloud-images.ubuntu.com/noble/current/SHA256SUMS
+    metal3.vcluster.com/image-checksum-type: sha256
+    metal3.vcluster.com/image-url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+status: {}
+
+```
+
+Then create the OSImage `ubuntu-noble` with:
+```bash
+kubectl create -f object.yaml 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: OSImage
+metadata:
+  name: ubuntu-noble
+spec:
+  description: Ubuntu Noble (24.04) server cloud image for bare metal provisioning
+  displayName: Ubuntu Noble (24.04 LTS)
+  properties:
+    metal3.vcluster.com/image-checksum: https://cloud-images.ubuntu.com/noble/current/SHA256SUMS
+    metal3.vcluster.com/image-checksum-type: sha256
+    metal3.vcluster.com/image-url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+status: {}
+
+```
+
+Run the following curl command to create a new OSImage `ubuntu-noble`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/osimages/delete.mdx
+++ b/platform/api/_partials/resources/osimages/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete OSImages.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete OSImage `ubuntu-noble`:
+```bash
+kubectl delete osimages.management.loft.sh ubuntu-noble 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete OSImage `ubuntu-noble`:
+```bash
+# Replace the ubuntu-noble in the url below with the name of the OSImage you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages/ubuntu-noble" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/osimages/reference.mdx
+++ b/platform/api/_partials/resources/osimages/reference.mdx
@@ -1,0 +1,214 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes an OS image
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `properties` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-properties}
+
+Properties is the configuration for the OS image
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+</details>

--- a/platform/api/_partials/resources/osimages/retrieve.mdx
+++ b/platform/api/_partials/resources/osimages/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve OSImages.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of OSImages
+Run the following command to list all OSImages:
+```bash
+kubectl get osimages.management.loft.sh  -o yaml
+```
+
+### Retrieve a single OSImage by name
+Run the following kubectl command to get OSImage `ubuntu-noble`:
+```bash
+kubectl get osimages.management.loft.sh ubuntu-noble  -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of OSImages
+Run the following curl command to list all OSImages:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single OSImage by name
+Run the following curl command to get OSImage `ubuntu-noble`:
+```bash
+# Exchange ubuntu-noble in the url below with the name of the OSImage
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages/ubuntu-noble" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/osimages/update.mdx
+++ b/platform/api/_partials/resources/osimages/update.mdx
@@ -1,0 +1,92 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update OSImages.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update OSImage
+
+Run the following command to update OSImage `ubuntu-noble`:
+```bash
+kubectl edit osimages.management.loft.sh ubuntu-noble 
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch OSImage
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the OSImage `ubuntu-noble` via a patch:
+```bash
+kubectl patch osimages.management.loft.sh ubuntu-noble  \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update OSImage
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: OSImage
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: ubuntu-noble
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  description: Ubuntu Noble (24.04) server cloud image for bare metal provisioning
+  displayName: Ubuntu Noble (24.04 LTS)
+  properties:
+    metal3.vcluster.com/image-checksum: https://cloud-images.ubuntu.com/noble/current/SHA256SUMS
+    metal3.vcluster.com/image-checksum-type: sha256
+    metal3.vcluster.com/image-url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+status: {}
+
+```
+
+Run the following curl command to update a single OSImage `ubuntu-noble`:
+```bash
+# Replace the ubuntu-noble in the url below with the name of the OSImage you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages/ubuntu-noble" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch OSImage
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the OSImage `ubuntu-noble` via a patch:
+```bash
+# Replace the ubuntu-noble in the url below with the name of the OSImage you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/osimages/ubuntu-noble" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/projectsecrets/create.mdx
+++ b/platform/api/_partials/resources/projectsecrets/create.mdx
@@ -1,0 +1,68 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new ProjectSecret.
+Make sure to set the project in the `metadata.namespace` field you want to create the ProjectSecret in. If your project has the id `my-project`, the corresponding namespace would be `loft-p-my-project`.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ProjectSecret
+metadata:
+  name: my-secret
+  namespace: loft-p-my-project
+spec:
+  data:
+    password: cGFzc3dvcmQ=
+  displayName: My Secret
+status: {}
+
+```
+
+Then create the ProjectSecret `my-secret` in project `my-project` with:
+```bash
+kubectl create -f object.yaml -n loft-p-my-project
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ProjectSecret
+metadata:
+  name: my-secret
+  namespace: loft-p-my-project
+spec:
+  data:
+    password: cGFzc3dvcmQ=
+  displayName: My Secret
+status: {}
+
+```
+
+Run the following curl command to create a new ProjectSecret `my-secret` in project `my-project`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/projectsecrets/delete.mdx
+++ b/platform/api/_partials/resources/projectsecrets/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete ProjectSecrets.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete ProjectSecret `my-secret` in project `my-project`:
+```bash
+kubectl delete projectsecrets.management.loft.sh my-secret -n loft-p-my-project
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete ProjectSecret `my-secret` in project `my-project`:
+```bash
+# Replace the my-secret in the url below with the name of the ProjectSecret you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets/my-secret" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/projectsecrets/reference.mdx
+++ b/platform/api/_partials/resources/projectsecrets/reference.mdx
@@ -1,0 +1,232 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes a Project secret
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `data` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-data}
+
+Data contains the secret data. Each key must consist of alphanumeric
+characters, '-', '_' or '.'. The serialized form of the secret data is a
+base64 encoded string, representing the arbitrary (possibly non-string)
+data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `conditions` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status-conditions}
+
+Conditions holds several conditions the project might be in
+
+</summary>
+
+
+
+</details>
+
+
+</details>

--- a/platform/api/_partials/resources/projectsecrets/retrieve.mdx
+++ b/platform/api/_partials/resources/projectsecrets/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve ProjectSecrets.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of ProjectSecrets
+Run the following command to list all ProjectSecrets in project `my-project`:
+```bash
+kubectl get projectsecrets.management.loft.sh -n loft-p-my-project -o yaml
+```
+
+### Retrieve a single ProjectSecret by name
+Run the following kubectl command to get ProjectSecret `my-secret` in project `my-project`:
+```bash
+kubectl get projectsecrets.management.loft.sh my-secret -n loft-p-my-project -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of ProjectSecrets
+Run the following curl command to list all ProjectSecrets in project `my-project`:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single ProjectSecret by name
+Run the following curl command to get ProjectSecret `my-secret` in project `my-project`:
+```bash
+# Exchange my-secret in the url below with the name of the ProjectSecret
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets/my-secret" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/projectsecrets/update.mdx
+++ b/platform/api/_partials/resources/projectsecrets/update.mdx
@@ -1,0 +1,90 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update ProjectSecrets.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update ProjectSecret
+
+Run the following command to update ProjectSecret `my-secret` in project `my-project`:
+```bash
+kubectl edit projectsecrets.management.loft.sh my-secret -n loft-p-my-project
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch ProjectSecret
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the ProjectSecret `my-secret` in project `my-project` via a patch:
+```bash
+kubectl patch projectsecrets.management.loft.sh my-secret -n loft-p-my-project \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update ProjectSecret
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ProjectSecret
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: my-secret
+  namespace: loft-p-my-project
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  data:
+    password: cGFzc3dvcmQ=
+  displayName: My Secret
+status: {}
+
+```
+
+Run the following curl command to update a single ProjectSecret `my-secret` in project `my-project`:
+```bash
+# Replace the my-secret in the url below with the name of the ProjectSecret you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets/my-secret" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch ProjectSecret
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the ProjectSecret `my-secret` in project `my-project` via a patch:
+```bash
+# Replace the my-secret in the url below with the name of the ProjectSecret you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/namespaces/loft-p-my-project/projectsecrets/my-secret" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/sshkeys/create.mdx
+++ b/platform/api/_partials/resources/sshkeys/create.mdx
@@ -1,0 +1,65 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to create a new SSHKey.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: SSHKey
+metadata:
+  name: my-ssh-key
+spec:
+  description: Development access key
+  displayName: My SSH Key
+  publicKey: ssh-ed25519 AAAA... user@host
+status: {}
+
+```
+
+Then create the SSHKey `my-ssh-key` with:
+```bash
+kubectl create -f object.yaml 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Create a file `object.yaml` with the following contents:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: SSHKey
+metadata:
+  name: my-ssh-key
+spec:
+  description: Development access key
+  displayName: My SSH Key
+  publicKey: ssh-ed25519 AAAA... user@host
+status: {}
+
+```
+
+Run the following curl command to create a new SSHKey `my-ssh-key`:
+```bash
+curl -s -X POST --insecure \
+     "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys" \
+     --data-binary "$(cat object.yaml)" \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/sshkeys/delete.mdx
+++ b/platform/api/_partials/resources/sshkeys/delete.mdx
@@ -1,0 +1,36 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to delete SSHKeys.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+Run the following command to delete SSHKey `my-ssh-key`:
+```bash
+kubectl delete sshkeys.management.loft.sh my-ssh-key 
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+Run the following curl command to delete SSHKey `my-ssh-key`:
+```bash
+# Replace the my-ssh-key in the url below with the name of the SSHKey you want to delete
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys/my-ssh-key" \
+     -X DELETE --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/sshkeys/reference.mdx
+++ b/platform/api/_partials/resources/sshkeys/reference.mdx
@@ -1,0 +1,214 @@
+
+import Metadata from "../metadata/reference.mdx"
+
+<Metadata />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `spec` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `displayName` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-displayName}
+
+DisplayName is the name that should be displayed in the UI
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `description` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-description}
+
+Description describes an SSH key
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `owner` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner}
+
+Owner holds the owner of this object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `user` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-user}
+
+User specifies a Loft user.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `team` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-owner-team}
+
+Team specifies a Loft team.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `access` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access}
+
+Access holds the access rights for users and teams
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `name` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-name}
+
+Name is an optional name that is used for this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `verbs` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-verbs}
+
+Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule. VerbAll represents all kinds.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `subresources` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-subresources}
+
+Subresources defines the sub resources that are allowed by this access rule
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `users` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-users}
+
+Users specifies which users should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `teams` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-access-teams}
+
+Teams specifies which teams should be able to access this secret with the aforementioned verbs
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `publicKey` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#spec-publicKey}
+
+PublicKey is the public SSH key
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `status` <span className="config-field-required" data-required="false"></span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#status}
+
+
+
+</summary>
+
+
+
+</details>

--- a/platform/api/_partials/resources/sshkeys/retrieve.mdx
+++ b/platform/api/_partials/resources/sshkeys/retrieve.mdx
@@ -1,0 +1,52 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to retrieve SSHKeys.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Retrieve a list of SSHKeys
+Run the following command to list all SSHKeys:
+```bash
+kubectl get sshkeys.management.loft.sh  -o yaml
+```
+
+### Retrieve a single SSHKey by name
+Run the following kubectl command to get SSHKey `my-ssh-key`:
+```bash
+kubectl get sshkeys.management.loft.sh my-ssh-key  -o yaml
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Retrieve a list of SSHKeys
+Run the following curl command to list all SSHKeys:
+```bash
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+### Get a single SSHKey by name
+Run the following curl command to get SSHKey `my-ssh-key`:
+```bash
+# Exchange my-ssh-key in the url below with the name of the SSHKey
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys/my-ssh-key" \
+     -X GET --insecure \
+     -H "Authorization: Bearer $ACCESS_KEY"
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/_partials/resources/sshkeys/update.mdx
+++ b/platform/api/_partials/resources/sshkeys/update.mdx
@@ -1,0 +1,89 @@
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+You can either use curl or kubectl to update SSHKeys.
+
+<Tabs
+    defaultValue="kubectl"
+    values={[
+      {label: 'kubectl', value: 'kubectl'},
+      {label: 'curl', value: 'curl'},
+    ]}>
+  <TabItem value="kubectl">
+
+
+### Update SSHKey
+
+Run the following command to update SSHKey `my-ssh-key`:
+```bash
+kubectl edit sshkeys.management.loft.sh my-ssh-key 
+```
+
+Then edit the object and upon save, kubectl will update the resource.
+
+### Patch SSHKey
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following kubectl command to add a new annotation `my-annotation: my-value` to the SSHKey `my-ssh-key` via a patch:
+```bash
+kubectl patch sshkeys.management.loft.sh my-ssh-key  \
+        --type json \
+        -p '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+  <TabItem value="curl">
+
+
+### Update SSHKey
+
+First retrieve the current object into a file `object.yaml`. This could look like:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: SSHKey
+metadata:
+  creationTimestamp: "2023-04-03T00:00:00Z"
+  generation: 12
+  name: my-ssh-key
+  resourceVersion: "66325905"
+  uid: af5f9f0f-8ab9-4b4b-a595-a95a5921f3c2
+spec:
+  description: Development access key
+  displayName: My SSH Key
+  publicKey: ssh-ed25519 AAAA... user@host
+status: {}
+
+```
+
+Run the following curl command to update a single SSHKey `my-ssh-key`:
+```bash
+# Replace the my-ssh-key in the url below with the name of the SSHKey you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys/my-ssh-key" \
+     -X PUT --insecure \
+     -H "Content-Type: application/yaml" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data-binary "$(cat object.yaml)"
+```
+
+### Patch SSHKey
+
+Patching a resource is useful if you want to generically exchange only a small portion of the object instead of retrieving the whole object first and then modifying it.
+To learn more about patches in Kubernetes, please take a look at the [official docs](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/#use-a-json-merge-patch-to-update-a-deployment).
+
+Run the following curl command to add a new annotation `my-annotation: my-value` to the SSHKey `my-ssh-key` via a patch:
+```bash
+# Replace the my-ssh-key in the url below with the name of the SSHKey you want to update
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/sshkeys/my-ssh-key" \
+     -X PATCH --insecure \
+     -H "Content-Type: application/json-patch+json" \
+     -H "Authorization: Bearer $ACCESS_KEY" \
+     --data '[{"op": "add", "path": "/metadata/annotations/my-annotation", "value": "my-value"}]'
+```
+
+
+  </TabItem>
+</Tabs>

--- a/platform/api/resources/argocdapplication.mdx
+++ b/platform/api/resources/argocdapplication.mdx
@@ -1,0 +1,53 @@
+---
+title: ArgoCD Application
+sidebar_label: ArgoCD Application
+---
+import Reference from "../_partials/resources/argocdapplications/reference.mdx"
+import Retrieve from "../_partials/resources/argocdapplications/retrieve.mdx"
+import Create from "../_partials/resources/argocdapplications/create.mdx"
+import Update from "../_partials/resources/argocdapplications/update.mdx"
+import Delete from "../_partials/resources/argocdapplications/delete.mdx"
+
+ArgoCDApplication declares an Argo CD Application that the platform reconciles and syncs to a connected Argo CD instance.
+
+## ArgoCDApplication example
+
+An example ArgoCDApplication:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplication
+metadata:
+  name: shared-infra
+  namespace: p-my-project
+spec:
+  destination:
+    cluster:
+      name: loft-cluster
+  displayName: Shared Infrastructure
+  templateRef:
+    name: infra-template
+status: {}
+
+```
+
+## ArgoCDApplication reference
+
+<Reference />
+
+## Retrieve: ArgoCDApplications
+
+<Retrieve />
+
+## Create: ArgoCDApplication
+
+<Create />
+
+## Update: ArgoCDApplication
+
+<Update />
+
+## Delete: ArgoCDApplication
+
+<Delete />
+
+

--- a/platform/api/resources/argocdapplicationtemplate.mdx
+++ b/platform/api/resources/argocdapplicationtemplate.mdx
@@ -1,0 +1,59 @@
+---
+title: ArgoCD Application Template
+sidebar_label: ArgoCD Application Template
+---
+import Reference from "../_partials/resources/argocdapplicationtemplates/reference.mdx"
+import Retrieve from "../_partials/resources/argocdapplicationtemplates/retrieve.mdx"
+import Create from "../_partials/resources/argocdapplicationtemplates/create.mdx"
+import Update from "../_partials/resources/argocdapplicationtemplates/update.mdx"
+import Delete from "../_partials/resources/argocdapplicationtemplates/delete.mdx"
+
+ArgoCDApplicationTemplate is a reusable Argo CD ApplicationSpec that can be referenced by name from an ArgoCDApplication to avoid duplicating configuration across tenant clusters.
+
+## ArgoCDApplicationTemplate example
+
+An example ArgoCDApplicationTemplate:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplicationTemplate
+metadata:
+  name: app-template
+spec:
+  template:
+    metadata: {}
+    spec:
+      destination: {}
+      project: default
+      source:
+        path: app
+        repoURL: https://github.com/acme/app-charts
+        targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+status: {}
+
+```
+
+## ArgoCDApplicationTemplate reference
+
+<Reference />
+
+## Retrieve: ArgoCDApplicationTemplates
+
+<Retrieve />
+
+## Create: ArgoCDApplicationTemplate
+
+<Create />
+
+## Update: ArgoCDApplicationTemplate
+
+<Update />
+
+## Delete: ArgoCDApplicationTemplate
+
+<Delete />
+
+

--- a/platform/api/resources/machineconfigtemplate.mdx
+++ b/platform/api/resources/machineconfigtemplate.mdx
@@ -1,0 +1,53 @@
+---
+title: Machine Config Template
+sidebar_label: Machine Config Template
+---
+import Reference from "../_partials/resources/machineconfigtemplates/reference.mdx"
+import Retrieve from "../_partials/resources/machineconfigtemplates/retrieve.mdx"
+import Create from "../_partials/resources/machineconfigtemplates/create.mdx"
+import Update from "../_partials/resources/machineconfigtemplates/update.mdx"
+import Delete from "../_partials/resources/machineconfigtemplates/delete.mdx"
+
+MachineConfigTemplate holds a reusable Go template for a cloud-init (user data) or network-data document. A node provider renders the template when it provisions a Machine.
+
+## MachineConfigTemplate example
+
+An example MachineConfigTemplate:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: MachineConfigTemplate
+metadata:
+  name: ubuntu-cloud-init
+spec:
+  cloudInitTemplate: |-
+    #cloud-config
+    hostname: {{ .Values.NodeClaim.Name }}
+    users:
+      - name: ubuntu
+        sudo: ALL=(ALL) NOPASSWD:ALL
+  displayName: Ubuntu cloud-init
+status: {}
+
+```
+
+## MachineConfigTemplate reference
+
+<Reference />
+
+## Retrieve: MachineConfigTemplates
+
+<Retrieve />
+
+## Create: MachineConfigTemplate
+
+<Create />
+
+## Update: MachineConfigTemplate
+
+<Update />
+
+## Delete: MachineConfigTemplate
+
+<Delete />
+
+

--- a/platform/api/resources/nodeclaim.mdx
+++ b/platform/api/resources/nodeclaim.mdx
@@ -1,0 +1,43 @@
+---
+title: Node Claim
+sidebar_label: Node Claim
+---
+import Reference from "../_partials/resources/nodeclaims/reference.mdx"
+import Retrieve from "../_partials/resources/nodeclaims/retrieve.mdx"
+import Delete from "../_partials/resources/nodeclaims/delete.mdx"
+
+NodeClaim tracks a node that the platform has provisioned or is provisioning for a tenant cluster. Auto-nodes creates these automatically; they are not typically authored by hand.
+
+## NodeClaim example
+
+An example NodeClaim:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeClaim
+metadata:
+  name: vcluster-62ftb
+  namespace: p-default
+spec:
+  controlPlane: false
+  desiredCapacity:
+    cpu: 120m
+    memory: 114Mi
+  providerRef: my-node-provider
+  vClusterRef: my-vcluster
+status: {}
+
+```
+
+## NodeClaim reference
+
+<Reference />
+
+## Retrieve: NodeClaims
+
+<Retrieve />
+
+## Delete: NodeClaim
+
+<Delete />
+
+

--- a/platform/api/resources/nodeprofile.mdx
+++ b/platform/api/resources/nodeprofile.mdx
@@ -1,0 +1,56 @@
+---
+title: Node Profile
+sidebar_label: Node Profile
+---
+import Reference from "../_partials/resources/nodeprofiles/reference.mdx"
+import Retrieve from "../_partials/resources/nodeprofiles/retrieve.mdx"
+import Create from "../_partials/resources/nodeprofiles/create.mdx"
+import Update from "../_partials/resources/nodeprofiles/update.mdx"
+import Delete from "../_partials/resources/nodeprofiles/delete.mdx"
+
+NodeProfile holds reusable node runtime configuration (labels, annotations, and taints) that can be referenced by manual joins, auto nodes, and platform NodeClaims.
+
+## NodeProfile example
+
+An example NodeProfile:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProfile
+metadata:
+  name: gpu-training
+spec:
+  description: GPU worker defaults for training workloads.
+  displayName: GPU Training
+  nodeAnnotations:
+    ops.vcluster.com/owner: ml-platform
+  nodeLabels:
+    workload.vcluster.com/class: gpu
+  taints:
+  - effect: NoSchedule
+    key: nvidia.com/gpu
+    value: "true"
+status: {}
+
+```
+
+## NodeProfile reference
+
+<Reference />
+
+## Retrieve: NodeProfiles
+
+<Retrieve />
+
+## Create: NodeProfile
+
+<Create />
+
+## Update: NodeProfile
+
+<Update />
+
+## Delete: NodeProfile
+
+<Delete />
+
+

--- a/platform/api/resources/osimage.mdx
+++ b/platform/api/resources/osimage.mdx
@@ -1,0 +1,52 @@
+---
+title: OS Image
+sidebar_label: OS Image
+---
+import Reference from "../_partials/resources/osimages/reference.mdx"
+import Retrieve from "../_partials/resources/osimages/retrieve.mdx"
+import Create from "../_partials/resources/osimages/create.mdx"
+import Update from "../_partials/resources/osimages/update.mdx"
+import Delete from "../_partials/resources/osimages/delete.mdx"
+
+OSImage describes an operating system image available for bare metal provisioning.
+
+## OSImage example
+
+An example OSImage:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: OSImage
+metadata:
+  name: ubuntu-noble
+spec:
+  description: Ubuntu Noble (24.04) server cloud image for bare metal provisioning
+  displayName: Ubuntu Noble (24.04 LTS)
+  properties:
+    metal3.vcluster.com/image-checksum: https://cloud-images.ubuntu.com/noble/current/SHA256SUMS
+    metal3.vcluster.com/image-checksum-type: sha256
+    metal3.vcluster.com/image-url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+status: {}
+
+```
+
+## OSImage reference
+
+<Reference />
+
+## Retrieve: OSImages
+
+<Retrieve />
+
+## Create: OSImage
+
+<Create />
+
+## Update: OSImage
+
+<Update />
+
+## Delete: OSImage
+
+<Delete />
+
+

--- a/platform/api/resources/projectsecret.mdx
+++ b/platform/api/resources/projectsecret.mdx
@@ -1,0 +1,50 @@
+---
+title: Project Secret
+sidebar_label: Project Secret
+---
+import Reference from "../_partials/resources/projectsecrets/reference.mdx"
+import Retrieve from "../_partials/resources/projectsecrets/retrieve.mdx"
+import Create from "../_partials/resources/projectsecrets/create.mdx"
+import Update from "../_partials/resources/projectsecrets/update.mdx"
+import Delete from "../_partials/resources/projectsecrets/delete.mdx"
+
+ProjectSecret is a Kubernetes Secret managed by the platform inside a project, often synced from an external secret store such as HashiCorp Vault.
+
+## ProjectSecret example
+
+An example ProjectSecret:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: ProjectSecret
+metadata:
+  name: my-secret
+  namespace: loft-p-my-project
+spec:
+  data:
+    password: cGFzc3dvcmQ=
+  displayName: My Secret
+status: {}
+
+```
+
+## ProjectSecret reference
+
+<Reference />
+
+## Retrieve: ProjectSecrets
+
+<Retrieve />
+
+## Create: ProjectSecret
+
+<Create />
+
+## Update: ProjectSecret
+
+<Update />
+
+## Delete: ProjectSecret
+
+<Delete />
+
+

--- a/platform/api/resources/sshkey.mdx
+++ b/platform/api/resources/sshkey.mdx
@@ -1,0 +1,49 @@
+---
+title: SSH Key
+sidebar_label: SSH Key
+---
+import Reference from "../_partials/resources/sshkeys/reference.mdx"
+import Retrieve from "../_partials/resources/sshkeys/retrieve.mdx"
+import Create from "../_partials/resources/sshkeys/create.mdx"
+import Update from "../_partials/resources/sshkeys/update.mdx"
+import Delete from "../_partials/resources/sshkeys/delete.mdx"
+
+SSHKey holds a public SSH key that can be attached to auto-provisioned or manually joined nodes.
+
+## SSHKey example
+
+An example SSHKey:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: SSHKey
+metadata:
+  name: my-ssh-key
+spec:
+  description: Development access key
+  displayName: My SSH Key
+  publicKey: ssh-ed25519 AAAA... user@host
+status: {}
+
+```
+
+## SSHKey reference
+
+<Reference />
+
+## Retrieve: SSHKeys
+
+<Retrieve />
+
+## Create: SSHKey
+
+<Create />
+
+## Update: SSHKey
+
+<Update />
+
+## Delete: SSHKey
+
+<Delete />
+
+


### PR DESCRIPTION
# Content Description
Adds 8 missing resource types to `hack/platform/partials/main.go` so they get generated API reference pages under `platform/api/resources/`, following the exact pattern already used for the other 17 generated resources.

`ArgoCDApplication`, `ArgoCDApplicationTemplate`, `MachineConfigTemplate`, `NodeClaim`, `NodeProfile`, `OSImage`, `ProjectSecret`, and `SSHKey` all already have embedded YAML examples in hand-written prose docs (found while investigating DOC-1629), but had no generated reference because `main.go` never got a corresponding `util.GenerateObjectOverview` call added — unlike `Runner`, which is explicitly commented out with a note explaining why it's absent, these 8 simply had no entry at all.

All 8 types already exist in the currently-vendored `loft-sh/api` tree (confirmed via `vendor/github.com/loft-sh/api/v4/pkg/apis/management/v1/*_types.go`), so this is purely additive — no `loft-sh/api`/`agentapi` version bump needed.

Example objects are grounded in the existing hand-written prose examples (e.g. `ubuntu-cloud-init` for MachineConfigTemplate, `gpu-training` for NodeProfile, `shared-infra`/`app-template` for the ArgoCD resources) so the new reference pages stay consistent with the guides that already document them.

**One judgment call worth a second look:** `NodeClaim` omits `Create` (only `Retrieve`/`Delete`) since auto-nodes creates these automatically per the existing prose (`vcluster/_fragments/deploy/auto-nodes-scheduling.mdx`) rather than users authoring them by hand. The other 7 get full CRUD matching their sibling resources. Please confirm this matches actual REST support.

**Verified no regressions**: running the generator reproduced byte-identical output for all 17 pre-existing resources — only the 8 new ones are new files.

**Pre-existing, unrelated vale note**: the generator's shared heading template (`## {Name} example`, `## Retrieve: {Plural}`, etc.) already trips `Google.Headings` sentence-case warnings on every generated resource page, including already-merged ones like `virtualclustertemplate.mdx`. The 8 new pages inherit the same pattern for consistency; fixing it would mean changing the shared template and touching all 25 generated pages, which is out of scope here.

## Preview Link
Netlify will post the preview link on this PR.

## Internal Reference
Closes DOC-1630


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs