### PR TITLE
docs(DOC-1632): detect new upstream api kinds missing from platform docs generator

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -179,6 +179,27 @@ jobs:
           go mod tidy
           go mod vendor
 
+      # Checks whether the freshly-bumped loft-sh/api vendor tree registered
+      # any Kind that hack/platform/partials/main.go has no
+      # util.GenerateObjectOverview call for — the class of gap DOC-1630
+      # fixed for 8 pre-existing Kinds (see DOC-1632). Non-fatal: a missing
+      # Kind needs a human to write a realistic example object informed by
+      # how it's actually used, the same investigation DOC-1630 required, so
+      # this only surfaces the gap as a warning rather than blocking the
+      # canonical-docs sync PR or attempting to auto-fix it.
+      - name: Check platform resource generator coverage
+        if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
+        continue-on-error: true
+        run: |
+          set +e
+          go run ./hack/platform/check-resource-coverage --json-output coverage-report.json
+          set -e
+          gaps=$(jq -r '.gaps | length' coverage-report.json)
+          if [ "$gaps" -gt 0 ]; then
+            names=$(jq -r '.gaps | join(", ")' coverage-report.json)
+            echo "::warning::check-resource-coverage found $gaps registered API Kind(s) with no generator coverage: $names"
+          fi
+
       # vcluster + vcluster-cli generators consume the released vCluster
       # source tree. Platform generator builds against API types pinned in
       # this repo's go.mod (see bump step above), so no source checkout is

--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -192,11 +192,16 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          go run ./hack/platform/check-resource-coverage --json-output coverage-report.json
+          go run ./hack/platform/check-resource-coverage --json-output "${RUNNER_TEMP}/coverage-report.json"
+          status=$?
           set -e
-          gaps=$(jq -r '.gaps | length' coverage-report.json)
+          if [ ! -f "${RUNNER_TEMP}/coverage-report.json" ]; then
+            echo "::warning::check-resource-coverage exited $status without writing a report (tool may need updating, e.g. after a major API version bump); skipping coverage check"
+            exit 0
+          fi
+          gaps=$(jq -r '.gaps | length' "${RUNNER_TEMP}/coverage-report.json")
           if [ "$gaps" -gt 0 ]; then
-            names=$(jq -r '.gaps | join(", ")' coverage-report.json)
+            names=$(jq -r '.gaps | join(", ")' "${RUNNER_TEMP}/coverage-report.json")
             echo "::warning::check-resource-coverage found $gaps registered API Kind(s) with no generator coverage: $names"
           fi
 

--- a/hack/platform/check-resource-coverage/exclude.txt
+++ b/hack/platform/check-resource-coverage/exclude.txt
@@ -1,0 +1,22 @@
+# Kinds registered in loft-sh/api's management API scheme that have been
+# reviewed and confirmed as internal/action-style endpoints rather than real
+# user-authored resources, so check-resource-coverage does not flag them.
+#
+# Add an entry (one PascalCase Kind name per line) only after confirming it
+# genuinely doesn't warrant a user-facing reference page. Do NOT add a Kind
+# here just to silence a run — leave undecided Kinds off this list so the
+# checker keeps surfacing them for triage. See DOC-1632.
+
+# RBAC self-check endpoints, not resources a user creates.
+SubjectAccessReview
+SelfSubjectAccessReview
+
+# RPC-style action endpoints (verb-shaped names), not persistent resources.
+ConvertVirtualClusterConfig
+RenderVirtualClusterTemplate
+TranslateVClusterResourceName
+RegisterVirtualCluster
+
+# Internal/utility endpoints.
+RedirectToken
+UsageDownload

--- a/hack/platform/check-resource-coverage/main.go
+++ b/hack/platform/check-resource-coverage/main.go
@@ -1,0 +1,149 @@
+// Command check-resource-coverage detects loft-sh/api management API
+// resources that are registered upstream but have no corresponding
+// util.GenerateObjectOverview call in hack/platform/partials/main.go, so a
+// new Kind doesn't silently miss generated reference docs the way the 8
+// types fixed by DOC-1630 did.
+//
+// Ground truth: every `Management<Name>Storage = builders.NewApiResourceWithStorage(`
+// entry in the loft-sh/api management API registration file.
+// Covered set: every `Resource:` field passed to util.GenerateObjectOverview
+// in the platform partials generator.
+// Exclude list: a plain manifest of Kinds reviewed and confirmed as
+// internal/action-style rather than real user-authored resources. Kinds not
+// yet triaged are deliberately left off so this keeps surfacing them.
+//
+// Exit codes: 0 = no new gaps, 1 = gaps found, 2 = error.
+//
+// Usage:
+//
+//	go run ./hack/platform/check-resource-coverage \
+//	  [--register <path>] [--generator <path>] [--exclude <path>] \
+//	  [--json-output <path>]
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	pluralize "github.com/gertd/go-pluralize"
+)
+
+var (
+	registerPattern = regexp.MustCompile(`Management([A-Za-z]+)Storage\s*=\s*builders\.NewApiResourceWithStorage`)
+	// (?m)^\s*Resource: anchors on line start so this doesn't also match
+	// SubResource: fields, which contain "Resource:" as a substring.
+	generatorPattern = regexp.MustCompile(`(?m)^\s*Resource:\s*"([a-z0-9]+)"`)
+	pluralizeClient  = pluralize.NewClient()
+)
+
+// normalize collapses a Kind name (PascalCase, e.g. "MachineConfigTemplate")
+// or a resource path (plural lowercase, e.g. "machineconfigtemplates") down
+// to the same comparable form so both sides of the diff line up regardless
+// of casing or pluralization.
+func normalize(s string) string {
+	return strings.ToLower(pluralizeClient.Singular(s))
+}
+
+type Report struct {
+	RegisteredCount int      `json:"registered_count"`
+	CoveredCount    int      `json:"covered_count"`
+	ExcludedCount   int      `json:"excluded_count"`
+	Gaps            []string `json:"gaps"`
+}
+
+func main() {
+	registerPath := flag.String("register", "vendor/github.com/loft-sh/api/v4/pkg/apis/management/zz_generated.api.register.go", "path to the loft-sh/api management API registration file")
+	generatorPath := flag.String("generator", "hack/platform/partials/main.go", "path to the platform partials generator")
+	excludePath := flag.String("exclude", "hack/platform/check-resource-coverage/exclude.txt", "path to the manifest of Kinds intentionally excluded from generation")
+	jsonOutput := flag.String("json-output", "", "path to write a JSON report")
+	flag.Parse()
+
+	registerData, err := os.ReadFile(*registerPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: reading %s: %v\n", *registerPath, err)
+		os.Exit(2)
+	}
+	registered := map[string]string{} // normalized -> original PascalCase Kind
+	for _, m := range registerPattern.FindAllStringSubmatch(string(registerData), -1) {
+		registered[normalize(m[1])] = m[1]
+	}
+	if len(registered) == 0 {
+		fmt.Fprintf(os.Stderr, "ERROR: found 0 registered resources in %s; regex may be stale\n", *registerPath)
+		os.Exit(2)
+	}
+
+	generatorData, err := os.ReadFile(*generatorPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: reading %s: %v\n", *generatorPath, err)
+		os.Exit(2)
+	}
+	covered := map[string]bool{}
+	for _, m := range generatorPattern.FindAllStringSubmatch(string(generatorData), -1) {
+		covered[normalize(m[1])] = true
+	}
+
+	excluded := map[string]bool{}
+	excludeData, err := os.ReadFile(*excludePath)
+	switch {
+	case err == nil:
+		for _, line := range strings.Split(string(excludeData), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			excluded[normalize(line)] = true
+		}
+	case os.IsNotExist(err):
+		// No exclude list yet; treat as empty rather than erroring.
+	default:
+		fmt.Fprintf(os.Stderr, "ERROR: reading %s: %v\n", *excludePath, err)
+		os.Exit(2)
+	}
+
+	var gaps []string
+	for key, original := range registered {
+		if covered[key] || excluded[key] {
+			continue
+		}
+		gaps = append(gaps, original)
+	}
+	sort.Strings(gaps)
+
+	report := Report{
+		RegisteredCount: len(registered),
+		CoveredCount:    len(covered),
+		ExcludedCount:   len(excluded),
+		Gaps:            gaps,
+	}
+
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: marshaling JSON: %v\n", err)
+		os.Exit(2)
+	}
+
+	if *jsonOutput != "" {
+		if err := os.WriteFile(*jsonOutput, data, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: writing %s: %v\n", *jsonOutput, err)
+			os.Exit(2)
+		}
+		fmt.Printf("Wrote report to %s\n", *jsonOutput)
+	} else {
+		fmt.Println(string(data))
+	}
+
+	fmt.Printf("Registered: %d, Covered: %d, Excluded: %d, Gaps: %d\n", report.RegisteredCount, report.CoveredCount, report.ExcludedCount, len(gaps))
+	if len(gaps) > 0 {
+		fmt.Println("Kinds registered upstream with no generator coverage and no exclude entry:")
+		for _, g := range gaps {
+			fmt.Printf("  - %s\n", g)
+		}
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/hack/platform/check-resource-coverage/main_test.go
+++ b/hack/platform/check-resource-coverage/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestGeneratorPattern(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "matches a Resource field",
+			src:  "\t\tResource:    \"virtualclusterinstances\",\n",
+			want: []string{"virtualclusterinstances"},
+		},
+		{
+			name: "ignores a standalone SubResource field",
+			src:  "\t\tSubResource: \"kubeconfig\",\n",
+			want: nil,
+		},
+		{
+			name: "matches Resource but not the adjacent SubResource field",
+			src:  "\t\tResource:    \"virtualclusterinstances\",\n\t\tSubResource: \"kubeconfig\",\n",
+			want: []string{"virtualclusterinstances"},
+		},
+		{
+			name: "matches multiple Resource fields across separate calls",
+			src:  "\t\tResource: \"spaceinstances\",\n\t)\n\t...\n\t\tResource: \"projects\",\n",
+			want: []string{"spaceinstances", "projects"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := generatorPattern.FindAllStringSubmatch(tt.src, -1)
+			var got []string
+			for _, m := range matches {
+				got = append(got, m[1])
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("generatorPattern matches = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("generatorPattern matches = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Content Description
Adds an ongoing check so the next batch of missing platform resource types (like the 8 fixed in DOC-1630) gets caught automatically instead of piling up silently.

- New tool: `hack/platform/check-resource-coverage` diffs every Kind registered in `loft-sh/api`'s management API scheme (parsed from `vendor/.../zz_generated.api.register.go`) against every `Resource:` field `hack/platform/partials/main.go` actually generates a reference page for. Exit codes 0/1/2 match the existing `hack/annotations` convention.
- New manifest: `hack/platform/check-resource-coverage/exclude.txt`, seeded with the 8 Kinds I could confidently classify as internal/action-style (RBAC self-checks like `SubjectAccessReview`, RPC-style action endpoints like `ConvertVirtualClusterConfig`). Deliberately does **not** include the other ~17 currently-uncovered Kinds (`AgentAuditEvent`, `Announcement`, `NodeType`, `NodeEnvironment`, `ResetAccessKey`, `Task`, etc.) — those haven't been individually vetted the way DOC-1630's 8 were, so the tool will correctly keep flagging them until someone does that triage (tracked separately, not blocking this PR).
- Wired into `handle-source-release.yml`'s `platform-released` path, right after the `loft-sh/api`/`agentapi` vendor bump (the step that makes a new Kind available in the first place). Non-fatal — emits a `::warning::` annotation rather than blocking the canonical-docs sync PR, since actually fixing a gap needs a human to write a realistic example object informed by real usage, the same investigation DOC-1630 required.

**Caught a bug while building it**: my first regex (`Resource:\s*"..."`) also matched `SubResource:` fields (substring match), inflating the covered count. Fixed by anchoring on line start (`(?m)^\s*Resource:`). Also found that my manual DOC-1630 investigation undercounted by 2 — `ResetAccessKey` and `Task` are genuinely registered resources I missed by hand that the tool now catches correctly.

**Verified**: ran locally against current `main` (17 covered, 25 gaps including DOC-1630's 8) and against DOC-1630's branch directly (25 covered, the 8 correctly drop out of the gap list, 17 remain for future triage).

## Preview Link
N/A — this PR only touches `hack/` tooling and CI workflow, no docs content.

## Internal Reference
Closes DOC-1632


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs