### PR TITLE
docs(doc-1626): teach current virtual scheduler config path in prose

### DIFF
--- a/vcluster/_fragments/private-nodes-limitations.mdx
+++ b/vcluster/_fragments/private-nodes-limitations.mdx
@@ -15,24 +15,20 @@ The following features are not available:
 ```yaml title="Unsupported vcluster.yaml options with private nodes"
 # These configurations are NOT supported with private nodes
 
-# Resource syncing between virtual and host clusters is disabled
+# Resource syncing between tenant and control plane clusters is disabled
 sync:
-  services:
-    enabled: false  # Services cannot be synced to host cluster
-  secrets:
-    enabled: false  # Secrets cannot be synced to host cluster
-                    # All other sync options (pods, configmaps, etc.) are also disabled
+  toHost:
+    services:
+      enabled: false  # Services cannot be synced to the control plane cluster
+    secrets:
+      enabled: false  # Secrets cannot be synced to the control plane cluster
+                      # All other sync options (pods, configmaps, etc.) are also disabled
 
 # Platform integrations require syncing functionality
 integrations:
   metricsServer:
     enabled: false  # Metrics server integration not supported
                     # All other integrations are disabled due to sync dependency
-
-# Service replication to host cluster is not available
-networking:
-  replicateServices:
-    enabled: false  # Services run entirely within virtual cluster
 
 controlPlane:
   # DNS configuration limitations
@@ -47,6 +43,5 @@ controlPlane:
   hostPathMapper:
     enabled: false
 
-# Sleep mode is not available
-sleep:
-  enabled: false
+# Service replication (networking.replicateServices) and sleep mode
+# (sleep.*) are also unavailable; see the list above.

--- a/vcluster/_fragments/private-nodes-limitations.mdx
+++ b/vcluster/_fragments/private-nodes-limitations.mdx
@@ -8,7 +8,7 @@ The following features are not available:
 - `integrations.*` - Integrations depend on syncing functionality
 - `networking.replicateServices` - Services are not replicated to host
 - `controlPlane.coredns.embedded: true` - Embedded CoreDNS conflicts with custom CNI
-- `controlPlane.advanced.virtualScheduler.enabled: false` - Virtual scheduler cannot be disabled
+- `controlPlane.distro.k8s.scheduler.enabled: false` - Virtual scheduler cannot be disabled
 - `sleep.*` - No ability to use auto sleep for workloads or control plane
 
 
@@ -38,10 +38,11 @@ controlPlane:
   # DNS configuration limitations
   coredns:
     embedded: false   # Embedded CoreDNS conflicts with custom CNI options
-  advanced:
-    # Virtual scheduler is required for workload placement
-    virtualScheduler:
-      enabled: true   # Always enabled (cannot be disabled)
+  distro:
+    k8s:
+      # Virtual scheduler is required for workload placement
+      scheduler:
+        enabled: true   # Always enabled (cannot be disabled)
   # Host Path Mapper is not supported
   hostPathMapper:
     enabled: false

--- a/vcluster/_fragments/private-nodes.mdx
+++ b/vcluster/_fragments/private-nodes.mdx
@@ -70,9 +70,10 @@ When private nodes are enabled, scheduling is handled by the tenant cluster and 
 # Enabling private nodes enables the virtual scheduler
 # Disabling the virtual scheduler is not possible
 controlPlane:
-  advanced:
-    virtualScheduler:
-      enabled: true
+  distro:
+    k8s:
+      scheduler:
+        enabled: true
 ```
 
 <PrivateNodeLimitations />

--- a/vcluster/_partials/deploy/fips-config.mdx
+++ b/vcluster/_partials/deploy/fips-config.mdx
@@ -2,8 +2,6 @@
 controlPlane:
   advanced:
     defaultImageRegistry: ghcr.io
-    virtualScheduler:
-      enabled: true
   backingStore:
     etcd:
       embedded:
@@ -16,6 +14,8 @@ controlPlane:
       image:
         repository: loft-sh/kubernetes-fips
         tag: v1.28.14
+      scheduler:
+        enabled: true
   hostPathMapper:
     enabled: true
   statefulSet:

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx
@@ -15,6 +15,10 @@ import TenancySupport from '../../../../../_fragments/tenancy-support.mdx';
 
 # Virtual scheduler
 
+:::warning virtualScheduler is deprecated
+The `controlPlane.advanced.virtualScheduler` field is deprecated since vCluster 0.26. Use `controlPlane.distro.k8s.scheduler.enabled` instead. The deprecated field still works, but new configurations should use the current path.
+:::
+
 By default, vCluster reuses the control plane cluster scheduler to schedule workloads. This conserves compute resources.
 
 If you also [sync PersistentVolumeClaim resources](../../../sync/to-host/storage/persistent-volume-claims.mdx), vCluster mirrors the related `CSIDriver`, `CSINode`, and `CSIStorageCapacity` objects into the tenant cluster. This allows the virtual scheduler to make storage-aware scheduling decisions.
@@ -28,7 +32,7 @@ To support these use cases, vCluster allows you to run a scheduler inside the te
 To use the virtual scheduler, you must enable the following:
 
 - Syncing nodes from the control plane cluster (`sync.fromHost.nodes.enabled`)
-- The virtual scheduler (`controlPlane.advanced.virtualScheduler.enabled`)
+- The virtual scheduler (`controlPlane.distro.k8s.scheduler.enabled`)
 
 When the virtual scheduler is enabled:
 
@@ -44,9 +48,10 @@ sync:
       enabled: true
 
 controlPlane:
-  advanced:
-    virtualScheduler:
-      enabled: true
+  distro:
+    k8s:
+      scheduler:
+        enabled: true
 
 ```
 
@@ -75,11 +80,12 @@ Manually disabling these features might result in incorrect pod scheduling behav
 
 If your `vcluster.yaml` is configured as:
 
-```bash 
+```yaml
 controlPlane:
-  advanced:
-    virtualScheduler:
-      enabled: true
+  distro:
+    k8s:
+      scheduler:
+        enabled: true
 
 sync:
   toHost:
@@ -98,11 +104,12 @@ sync:
 
 Then, vCluster automatically updates the config to:
 
-```bash
+```yaml
 controlPlane:
-  advanced:
-    virtualScheduler:
-      enabled: true
+  distro:
+    k8s:
+      scheduler:
+        enabled: true
 
 sync:
   toHost:

--- a/vcluster/configure/vcluster-yaml/rbac.mdx
+++ b/vcluster/configure/vcluster-yaml/rbac.mdx
@@ -17,7 +17,7 @@ vCluster automatically generates the RBAC roles and bindings it needs based on t
 :::note
 Some configuration options modify or add to the default RBAC rules. If you're using any of the following, vCluster includes the necessary permissions. When enabled, the following configuration fields modify the default behavior:
 
-- [`controlPlane.advanced.virtualScheduler`](../vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx): Adds required read permissions for the virtual scheduler.
+- [`controlPlane.distro.k8s.scheduler`](../vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx): Adds required read permissions for the virtual scheduler.
 - [`networking.replicateServices.fromHost`](../vcluster-yaml/networking/replicate-services.mdx): Adds required permissions to manage endpoints and services.
 - [`integrations.metrics.proxy.nodes`](../../integrations/metrics-server.mdx): Adds required read permissions for node resources.
 - [`plugins`](../vcluster-yaml/plugins.mdx): Adds `roles` and `clusterRoles` defined by each plugin.

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/1-control-plane-components.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/1-control-plane-components.mdx
@@ -1863,11 +1863,9 @@ controlPlane:
     k8s:
       enabled: true
       scheduler:
+        enabled: true
         extraArgs:
         - --profiling=false
-  advanced:
-    virtualScheduler:
-      enabled: true
 sync:
   fromHost:
     nodes:
@@ -1921,9 +1919,8 @@ controlPlane:
   distro:
     k8s:
       enabled: true
-  advanced:
-    virtualScheduler:
-      enabled: true
+      scheduler:
+        enabled: true
 sync:
   fromHost:
     nodes:

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx
@@ -290,11 +290,9 @@ Since the worker nodes of a vCluster can be either shared nodes from the Control
             - --terminated-pod-gc-threshold=12500
             - --profiling=false
           scheduler:
+            enabled: true
             extraArgs:
             - --profiling=false
-      advanced:
-        virtualScheduler:
-          enabled: true
       backingStore:
         etcd:
           embedded:

--- a/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/1-control-plane-components.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/1-control-plane-components.mdx
@@ -1916,11 +1916,9 @@ controlPlane:
     k8s:
       enabled: true
       scheduler:
+        enabled: true
         extraArgs:
         - --profiling=false
-  advanced:
-    virtualScheduler:
-      enabled: true
 sync:
   fromHost:
     nodes:
@@ -1974,9 +1972,8 @@ controlPlane:
   distro:
     k8s:
       enabled: true
-  advanced:
-    virtualScheduler:
-      enabled: true
+      scheduler:
+        enabled: true
 sync:
   fromHost:
     nodes:


### PR DESCRIPTION
# Content Description

A drift audit for DOC-1626 found prose still teaching `controlPlane.advanced.virtualScheduler.enabled`, deprecated since vCluster 0.26 in favor of `controlPlane.distro.k8s.scheduler.enabled`. This PR updates every example and inline reference to the current path and adds a deprecation admonition on the virtual scheduler page. The page still documents the deprecated field, since that page describes the field itself.

Files changed:

- `virtual-scheduler.mdx`: deprecation admonition, examples moved to the current path, two `bash` fences containing YAML relabeled `yaml`
- `rbac.mdx`: RBAC note references the current path
- `private-nodes.mdx` and `private-nodes-limitations.mdx` fragments: examples and the limitations bullet use the current path
- `private-nodes-limitations.mdx`: the unsupported-options example also had invalid YAML shapes; `services` and `secrets` are now nested under `sync.toHost`, and invented `networking.replicateServices.enabled` and `sleep.enabled` stanzas were replaced with a comment pointing at the list above
- `fips-config.mdx` partial: scheduler enabled under `distro.k8s` instead of `advanced.virtualScheduler`
- Hardening guide (overview, host nodes, private nodes): `scheduler.enabled: true` merged into the existing `distro.k8s.scheduler` blocks

Versioned docs are untouched. The same drift exists in 0.33 through 0.35.

## Preview Link

- [virtual-scheduler](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler)
- [rbac](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/rbac)
- [hardening-guide overview](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/security/hardening-guide/overview)
- [hardening-guide host nodes control plane components](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/security/hardening-guide/host-nodes/control-plane-components)
- [hardening-guide private nodes control plane components](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/security/hardening-guide/private-nodes/control-plane-components)
- [private nodes (configure), renders private-nodes fragment](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/private-nodes)
- [private nodes (deploy), renders private-nodes fragment](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes)
- [standalone troubleshooting, renders limitations fragment](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/binary/troubleshooting)
- [air-gapped, renders fips-config partial](https://deploy-preview-2415--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/security/air-gapped)

## Dependencies

Part of the DOC-1626 audit. The drift detection tooling PR #2416 carries the `Closes`; #2417 (prose drift fixes) is the other sibling.

## Internal Reference

References DOC-1626

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs

