### PR TITLE
docs(doc-1626): fix cli and vcluster.yaml drift found by one-time audit

### DIFF
--- a/vcluster/_fragments/snapshots-oci.mdx
+++ b/vcluster/_fragments/snapshots-oci.mdx
@@ -78,7 +78,6 @@ snapshots:
         # Location of OCI registry
         # Must be prefixed with `oci://`
         repository: oci://my-registry/snapshots
-        credential:
-          username: "my-username"
-          password: "my-pasword"
+        username: "my-username"
+        password: "my-password"
 ```

--- a/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -21,7 +21,7 @@ This feature enables adding custom DNS rules to the tenant cluster to allow comm
 Enable embedded CoreDNS to ensure DNS resolution works inside the vCluster. Without this setting, DNS queries inside the vCluster, such as resolving services or external domains, fail. Ensure the following is added to `vcluster.yaml` or Helm values file:
 
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true
@@ -33,7 +33,7 @@ controlplane:
 This is a URL-based mapping of one tenant cluster hostname to another hostname. A `wikipedia.com` DNS lookup would return a DNS response with answer as `en.wikipedia.org`.
 
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true 
@@ -49,7 +49,7 @@ networking:
 This is a URL-based mapping of one tenant cluster hostname to another hostname. A `test.svc.kubernetes` DNS lookup would return a DNS response with answer as `test.svc.cluster.local`.
 
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true 
@@ -65,7 +65,7 @@ networking:
 This example maps the tenant cluster's `my-namespace/my-svc` resource to the control plane cluster's `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
 
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true 
@@ -82,7 +82,7 @@ This example maps a tenant cluster Service to another Service in a separate tena
 `my-ns-in-vcluster/my-svc-vcluster` maps to  `dns-test-in-vcluster-ns/test-in-vcluster-service` in a vCluster instance named `test-cluster` deployed in the host namespace `test-vcluster-ns`.
 
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true 
@@ -97,7 +97,7 @@ networking:
 
 Map all services under a tenant cluster namespace to a host namespace. This host namespace could also contain another vCluster instance, thereby mapping all vCluster services to another vCluster instance.
 ```yaml
-controlplane:
+controlPlane:
   coredns:
     enabled: true
     embedded: true 

--- a/vcluster/configure/vcluster-yaml/policies/limit-range.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/limit-range.mdx
@@ -41,11 +41,11 @@ policies:
   limitRange:
     enabled: true
     default:
-    memory: 512Mi
-    cpu: "1"
-  defaultRequest:
-    memory: 128Mi
-    cpu: 100m
+      memory: 512Mi
+      cpu: "1"
+    defaultRequest:
+      memory: 128Mi
+      cpu: 100m
 
 ```
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -50,9 +50,10 @@ sync:
   fromHost:
     nodes:
       enabled: true
-      labels:
-        environment: production
-        team: backend
+      selector:
+        labels:
+          environment: production
+          team: backend
 ```
 
 :::tip Example

--- a/vcluster/configure/what-is-vcluster-yaml.mdx
+++ b/vcluster/configure/what-is-vcluster-yaml.mdx
@@ -108,8 +108,8 @@ sync:
 exportKubeConfig:
   context: my-vcluster-context  # Name in the kubeconfig file
   server: https://vcluster-k8s-api.example.com  # API server URL
-  secret:
-    name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
+  additionalSecrets:
+  - name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
 ```
 
 
@@ -139,8 +139,8 @@ privateNodes:
 exportKubeConfig:
   context: my-vcluster-context  # Name in the kubeconfig file
   server: https://vcluster-k8s-api.example.com  # API server URL
-  secret:
-    name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
+  additionalSecrets:
+  - name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
 ```
 
 ### Control plane as a binary and private nodes
@@ -170,8 +170,8 @@ privateNodes:
 exportKubeConfig:
   context: my-vcluster-context  # Name in the kubeconfig file
   server: https://vcluster-k8s-api.example.com  # API server URL
-  secret:
-    name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
+  additionalSecrets:
+  - name: my-vcluster-kubeconfig  # Secret name for storing kubeconfig
 ```
 
 ## Deploy a tenant cluster 

--- a/vcluster/deploy/control-plane/kubernetes-pod/environment/netris.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/environment/netris.mdx
@@ -246,8 +246,9 @@ The following steps can be repeated for additional vCluster deployments.
           ipRange: "192.168.67.253-192.168.67.253" # fixed ip for this guide
 
     controlPlane:
-      highAvailability:
-        replicas: 3
+      statefulSet:
+        highAvailability:
+          replicas: 3
       backingStore:
         etcd:
           embedded:

--- a/vcluster/learn-how-to/control-plane/container/override-alpine-sidecar.mdx
+++ b/vcluster/learn-how-to/control-plane/container/override-alpine-sidecar.mdx
@@ -321,7 +321,7 @@ After updating your `vcluster.yaml` file, apply the configuration:
   </TabItem>
   <TabItem value="existing" label="Existing vCluster">
     ```bash
-    vcluster upgrade my-vcluster --values vcluster.yaml
+    vcluster create my-vcluster --upgrade --values vcluster.yaml
     ```
     
     This applies your new Alpine image configuration to an existing vCluster. New pods use the custom image immediately, while existing pods use it when they restart.

--- a/vcluster/production-guide/cicd-platform.mdx
+++ b/vcluster/production-guide/cicd-platform.mdx
@@ -17,7 +17,7 @@ If you are building an internal platform that includes both long-running team cl
 
 | Decision | Read next | Outcome |
 | --- | --- | --- |
-| Define cluster TTL and cleanup policy | [Sleep mode](../configure/vcluster-yaml/sleep.mdx), [auto-delete](../configure/vcluster-yaml/sleep.mdx#configure-auto-delete) | Set a default TTL for CI clusters. Decide between auto-delete after inactivity, after a fixed duration, or on pipeline completion via CLI. |
+| Define cluster TTL and cleanup policy | [Sleep mode](../configure/vcluster-yaml/sleep.mdx), [auto-delete](../configure/vcluster-yaml/sleep.mdx#configure-auto-delete) | Set a default TTL for CI clusters. Decide between auto-delete after inactivity, after a fixed duration, or on pipeline completion using the CLI. |
 | Choose pipeline integration method | [vCluster CLI](../cli/vcluster_create.md), [Terraform](/platform/administer/node-providers/terraform), [Argo CD](/platform/integrations/argocd) | Determine how pipelines provision and teardown clusters: CLI commands in workflow steps, Terraform in GitOps, or Platform API. |
 | Define resource quotas | [Quotas](/platform/administer/projects/quotas), [resource quota](../configure/vcluster-yaml/policies/resource-quota.mdx) | Cap how many concurrent CI clusters a project can run to prevent node saturation during peak pipeline load. |
 | Plan image caching | [Pull-through registry](../configure/vcluster-yaml/control-plane/components/coredns.mdx) | Decide whether CI clusters pull images directly from registries or use a cache. Warm cache significantly reduces job time. |
@@ -28,10 +28,9 @@ Follow the [Internal Kubernetes Platform](./internal-k8s-platform.mdx) Day 1 ste
 
 6. Create a CI-specific [template](/platform/administer/templates/overview) with auto-delete enabled after your target TTL:
    ```yaml
-   external:
-     platform:
-       autoDelete:
-         afterInactivity: 3600
+   deletion:
+     auto:
+       afterInactivity: 1h
    ```
 7. Set [project quotas](/platform/administer/projects/quotas) on maximum concurrent CI clusters per team or pipeline.
 8. Configure your CI system to create clusters using the CLI or Terraform:

--- a/vcluster/production-guide/cicd-platform.mdx
+++ b/vcluster/production-guide/cicd-platform.mdx
@@ -28,9 +28,10 @@ Follow the [Internal Kubernetes Platform](./internal-k8s-platform.mdx) Day 1 ste
 
 6. Create a CI-specific [template](/platform/administer/templates/overview) with auto-delete enabled after your target TTL:
    ```yaml
-   sleep:
-     autoDelete:
-       afterInactivity: 3600
+   external:
+     platform:
+       autoDelete:
+         afterInactivity: 3600
    ```
 7. Set [project quotas](/platform/administer/projects/quotas) on maximum concurrent CI clusters per team or pipeline.
 8. Configure your CI system to create clusters using the CLI or Terraform:

--- a/vcluster/third-party-integrations/git-operations/flux.mdx
+++ b/vcluster/third-party-integrations/git-operations/flux.mdx
@@ -120,9 +120,12 @@ exportKubeConfig:
   server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
   # Skip TLS verification when Flux connects to the vCluster
   insecure: true
-  # Specify the secret where the kubeconfig is stored
-  secret:
-    name: vcluster-flux-kubeconfig
+  # Export an additional kubeconfig secret for Flux to consume
+  additionalSecrets:
+  - name: vcluster-flux-kubeconfig
+    context: default
+    server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
+    insecure: true
 controlPlane:
   proxy:
     extraSANs:
@@ -555,8 +558,10 @@ controlPlane:
 exportKubeConfig:
   server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
   insecure: true
-  secret:
-    name: vcluster-flux-kubeconfig
+  additionalSecrets:
+  - name: vcluster-flux-kubeconfig
+    server: https://vcluster-name.vcluster-namespace.svc.cluster.local:443
+    insecure: true
 ```
 
 This ensures the certificate includes the correct SAN for the service DNS name.


### PR DESCRIPTION
# Content Description
Fixes vcluster.yaml and CLI drift in prose docs found by the DOC-1626 audit: deprecated or removed fields replaced with their current schema paths, plus one incorrect CLI command.

## Key Changes

- `what-is-vcluster-yaml.mdx`: `exportKubeConfig.secret` replaced with `exportKubeConfig.additionalSecrets` (list form, deprecated since 0.24)
- `flux.mdx`: same replacement; each entry now carries its own `context`, `server`, and `insecure`
- `override-alpine-sidecar.mdx`: `vcluster upgrade --values` replaced with `vcluster create --upgrade --values` (`vcluster upgrade` only upgrades the CLI binary)
- `hybrid-scheduling.mdx`: `sync.fromHost.nodes.labels` replaced with `sync.fromHost.nodes.selector.labels`
- `cicd-platform.mdx`: invalid `sleep.autoDelete` replaced with `external.platform.autoDelete.afterInactivity`
- `netris.mdx` (bare-metal page): `controlPlane.highAvailability` replaced with `controlPlane.statefulSet.highAvailability`
- `snapshots-oci.mdx`: `oci.credential.username/password` replaced with `oci.username/password`; fixed a password placeholder typo
- `resolve-dns.mdx`: `controlplane` key casing corrected to `controlPlane`
- `limit-range.mdx`: `defaultRequest` indentation corrected

## Preview Link

- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/what-is-vcluster-yaml
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/networking/resolve-dns
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/policies/limit-range
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/snapshots
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/learn-how-to/control-plane/container/override-alpine-sidecar
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/production-guide/cicd-platform
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/bare-metal
- https://deploy-preview-2417--vcluster-docs-site.netlify.app/docs/vcluster/next/third-party-integrations/git-operations/flux

## Dependencies

Part of the DOC-1626 audit. The drift detection tooling PR #2416 carries the `Closes`; #2415 (virtualScheduler sweep) is the other sibling.

The same drift exists in versioned docs 0.33 to 0.35; those folders are updated by the CI backport process, not in this PR.

## Internal Reference
References DOC-1626


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
