### PR TITLE
docs(doc-1635): drop unsupported disruption budget reasons field

### DIFF
--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -43,7 +43,7 @@ privateNodes:
     dynamic:
       - name: my-dynamic-node-pool
         limits:
-          nodes: 3
+          nodes: "3"
 ```
 
 :::info No vCluster restart required
@@ -65,27 +65,37 @@ privateNodes:
   enabled: true
   autoNodes:
     - provider: my-provider
-      properties:
-        # Exact match
-        my-propert: my-value
-
-        # One of
-        my-property/value-1: true
-        my-property/value-2: true
-        my-property/value-3: true
-
-        # Not in
-        my-property/value-1: false
-        my-property/value-2: false
-        my-property/value-3: false
-
-        # Exists
-        my-property: true
-
-        # Not exists
-        my-property: false
       static:
         - name: my-static-pool
+          quantity: 1
+          nodeTypeSelector:
+            # Exact match
+            - property: my-property
+              value: my-value
+
+            # One of
+            - property: my-property
+              operator: In
+              values:
+                - value-1
+                - value-2
+                - value-3
+
+            # Not in
+            - property: my-property
+              operator: NotIn
+              values:
+                - value-1
+                - value-2
+                - value-3
+
+            # Exists
+            - property: my-property
+              operator: Exists
+
+            # Not exists
+            - property: my-property
+              operator: NotExists
 ```
 
 The following operators are available and supported:
@@ -164,8 +174,8 @@ privateNodes:
       dynamic:
         - name: my-dynamic-node-pool
           limits:
-            cpu: 100  # either combined amount of cpus across all nodes in this node pool
-            nodes: 10 # or maximum amount of nodes
+            cpu: "100"  # either combined amount of cpus across all nodes in this node pool
+            nodes: "10" # or maximum amount of nodes
 ```
 
 :::warning Too small limits

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -130,7 +130,7 @@ privateNodes:
 Disruption configures how Karpenter should disrupt nodes and the config corresponds to the [Karpenter disruption config](https://karpenter.sh/docs/concepts/disruption/).
 By default, Karpenter will disrupt nodes if they are empty or underutilized after 30 seconds of inactivity.
 
-You can define more advanced ways of disruptions using schedules or budgets according to the [Karpenter config](https://karpenter.sh/docs/concepts/disruption/#nodepool-disruption-budgets).
+You can define more advanced ways of disruptions using schedules or budgets according to the [Karpenter config](https://karpenter.sh/docs/concepts/disruption/#nodepool-disruption-budgets). Each budget supports the `nodes`, `schedule`, and `duration` fields.
 
 ```yaml title="Example of creating advanced disruption configuration"
 privateNodes:
@@ -144,15 +144,10 @@ privateNodes:
           consolidateAfter: 10s
           budgets:
             - nodes: "20%"
-              reasons:
-                - "Empty"
-                - "Drifted"
             - nodes: "5"
             - nodes: "0"
               schedule: "@daily"
               duration: 10m
-              reasons:
-                - "Underutilized"
 ```
 
 #### Limits

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -64,28 +64,28 @@ Node type selector on a node pool can be used to include or exclude certain node
 privateNodes:
   enabled: true
   autoNodes:
-    provider: my-provider
-    properties:
-      # Exact match
-      my-propert: my-value
+    - provider: my-provider
+      properties:
+        # Exact match
+        my-propert: my-value
 
-      # One of
-      my-property/value-1: true
-      my-property/value-2: true
-      my-property/value-3: true
-      
-      # Not in
-      my-property/value-1: false
-      my-property/value-2: false
-      my-property/value-3: false
+        # One of
+        my-property/value-1: true
+        my-property/value-2: true
+        my-property/value-3: true
 
-      # Exists
-      my-property: true
+        # Not in
+        my-property/value-1: false
+        my-property/value-2: false
+        my-property/value-3: false
 
-      # Not exists
-      my-property: false
-    static:
-      - name: my-static-pool
+        # Exists
+        my-property: true
+
+        # Not exists
+        my-property: false
+      static:
+        - name: my-static-pool
 ```
 
 The following operators are available and supported:
@@ -120,9 +120,9 @@ privateNodes:
   # Private nodes need to be enabled for this feature to work
   enabled: true 
   autoNodes:
-    provider: my-node-provider
-    dynamic:
-      - name: my-dynamic-node-pool
+    - provider: my-node-provider
+      dynamic:
+        - name: my-dynamic-node-pool
 ```
 
 #### Disruption
@@ -136,18 +136,18 @@ You can define more advanced ways of disruptions using schedules or budgets acco
 privateNodes:
   enabled: true
   autoNodes:
-    provider: my-provider
-    dynamic:
-      - name: my-dynamic-node-pool
-        disruption:
-          consolidationPolicy: WhenEmptyOrUnderutilized
-          consolidateAfter: 10s
-          budgets:
-            - nodes: "20%"
-            - nodes: "5"
-            - nodes: "0"
-              schedule: "@daily"
-              duration: 10m
+    - provider: my-provider
+      dynamic:
+        - name: my-dynamic-node-pool
+          disruption:
+            consolidationPolicy: WhenEmptyOrUnderutilized
+            consolidateAfter: 10s
+            budgets:
+              - nodes: "20%"
+              - nodes: "5"
+              - nodes: "0"
+                schedule: "@daily"
+                duration: 10m
 ```
 
 #### Limits
@@ -160,12 +160,12 @@ The number of nodes specified in limits can be modified after the nodes are prov
 privateNodes:
   enabled: true 
   autoNodes:
-    provider: my-provider
-    dynamic:
-      - name: my-dynamic-node-pool
-        limits:
-          cpu: 100  # either combined amount of cpus across all nodes in this node pool
-          nodes: 10 # or maximum amount of nodes
+    - provider: my-provider
+      dynamic:
+        - name: my-dynamic-node-pool
+          limits:
+            cpu: 100  # either combined amount of cpus across all nodes in this node pool
+            nodes: 10 # or maximum amount of nodes
 ```
 
 :::warning Too small limits
@@ -183,10 +183,10 @@ privateNodes:
   # Private nodes need to be enabled for this feature to work
   enabled: true 
   autoNodes:
-    provider: my-provider
-    static:
-      - name: my-static-node-pool
-        quantity: 2
+    - provider: my-provider
+      static:
+        - name: my-static-node-pool
+          quantity: 2
 ```
 
 You can change the quantity of static node pools without restarting vCluster and vCluster will scale these nodes up or down based on the changing quantity.
@@ -199,22 +199,22 @@ You can define taints and node labels for each node pool using the `taints` and 
 privateNodes:
   enabled: true
   autoNodes:
-    provider: my-provider
-    static:
-      - name: my-static-pool
-        quantity: 1
-        nodeLabels:
-          my-label: my-value
-        taints:
-          - key: my-taint
-            effect: NoSchedule
-    dynamic:
-      - name: my-static-pool
-        nodeLabels:
-          my-label: my-value
-        taints:
-          - key: my-taint
-            effect: NoSchedule
+    - provider: my-provider
+      static:
+        - name: my-static-pool
+          quantity: 1
+          nodeLabels:
+            my-label: my-value
+          taints:
+            - key: my-taint
+              effect: NoSchedule
+      dynamic:
+        - name: my-static-pool
+          nodeLabels:
+            my-label: my-value
+          taints:
+            - key: my-taint
+              effect: NoSchedule
 
 ```
 


### PR DESCRIPTION
# Content Description

Align the auto nodes disruption budget example with the shipped vCluster values schema. The page documented a `reasons` field under `privateNodes.autoNodes.dynamic.disruption.budgets` that the schema does not accept, so the example, as written, fails validation.

## Key Changes

- Removed `reasons` from the disruption budget example in `vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx`.
- Added a one-line note that each budget supports the `nodes`, `schedule`, and `duration` fields.

## Evidence

Checked against `loft-sh/vcluster` (main, `76a1613f`):

- The `DynamicNodePoolDisruptionBudget` Go struct (`config/config.go`) exposes only `nodes`, `schedule`, and `duration`.
- The generated `chart/values.schema.json` marks that object `additionalProperties: false`, so a budget carrying `reasons` is rejected at config validation.
- `git log -S Reasons -- config/config.go` is empty: the field has never existed in the vCluster config.
- Upstream (vendored) Karpenter does expose `reasons` on its budget type, which is what the docs example had mirrored.

Verified drift-clean with the DOC-1626 `config-drift` checker (rebuilt from source): auto-nodes findings went from 2 to 0, total unknown findings 25 to 23, with no new findings introduced.

## Backporting

The same example appears in the released versions `0.28`, `0.33`, `0.34`, `0.35`, and `0.36`. Per repo convention, `vcluster_versioned_docs/` is not edited by hand and is backported automatically, so this PR touches only the `next` (top-level `vcluster/`) copy. The backport should carry this fix to those versions.

## Preview Link

- https://deploy-preview-2418--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes

## Internal Reference

Closes DOC-1635

<!-- Do not change the line below -->
@netlify /docs