### PR TITLE
docs(doc-1636): fix migration docs for removed vcluster convert command

### DIFF
--- a/docs/_partials/0-20.migration.mdx
+++ b/docs/_partials/0-20.migration.mdx
@@ -49,11 +49,22 @@ Replace:
 
 
 
-A new command has been added to support converting from the old `values.yaml` format to the new `vcluster.yaml`.
+The `convert config` command converts the old `values.yaml` format to the new `vcluster.yaml`.
+
+:::warning `convert config` was removed in v0.32.0
+The `convert config` command was removed from the vCluster CLI in v0.32.0. Run this one-time conversion with a vCluster CLI release earlier than v0.32.0 (v0.31.3 is the last release that ships the command), then upgrade your instance with your current CLI.
+
+Download a pre-v0.32.0 CLI for your platform and invoke it as `./vcluster` for the conversion steps below. Adjust the OS and architecture in the URL if needed:
+
+```bash
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/download/v0.31.3/vcluster-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
+chmod +x vcluster
+```
+:::
 
 ```BASH
 Usage:
-  vcluster convert config [flags]
+  ./vcluster convert config [flags]
 Flags:
       --distro string   Kubernetes distro used
   -f, --file string     Path to the input file
@@ -97,10 +108,10 @@ Replace:
 
 ## Convert your `values.yaml` to `vcluster.yaml`
 
-Convert your `values.yaml` to the new `vcluster.yaml` configuration file format by running:
+Convert your `values.yaml` to the new `vcluster.yaml` configuration file format by running the pre-v0.32.0 CLI you downloaded above:
 
 ```BASH
-vcluster convert config --distro <KUBERNETES_DISTRO> -f <VALUES_FILE> > vcluster.yaml
+./vcluster convert config --distro <KUBERNETES_DISTRO> -f <VALUES_FILE> > vcluster.yaml
 ```
 
 Replace:
@@ -112,7 +123,7 @@ Replace:
 For example:
 
 ```BASH
-vcluster convert config --distro k8s -f /my/k8s/values.yaml > vcluster.yaml
+./vcluster convert config --distro k8s -f /my/k8s/values.yaml > vcluster.yaml
 ```
 
 ### Notes about Changes for your `vcluster.yaml`
@@ -149,7 +160,7 @@ The Kubernetes distribution of the virtual cluster doesn't need to match the dis
 In order to continue using your virtual clusters that have EKS as the distribution, you can convert to using the k8s distribution and replace the images with the EKS images. While this was tested when v0.20.0 was released, it is not continuously tested. It's recommended spinning up new virtual clusters with the k8s distribution and migrate your workloads to them.
 
 ```bash
-vcluster convert config --distro k8s -f /my/k8s/values.yaml > vcluster.yaml
+./vcluster convert config --distro k8s -f /my/k8s/values.yaml > vcluster.yaml
 ```
 
 After the conversion, you need to update the `vcluster.yaml` and change the images to be used. Refer to the EKS registries for [kube-apiserver](https://gallery.ecr.aws/eks-distro/kubernetes/kube-apiserver), [controller-manager](https://gallery.ecr.aws/eks-distro/kubernetes/kube-controller-manager) and [kube-scheduler](https://gallery.ecr.aws/eks-distro/kubernetes/kube-scheduler) for the specific tags you might want to use.

--- a/vcluster/reference/migrations/0-20-cli-changes.mdx
+++ b/vcluster/reference/migrations/0-20-cli-changes.mdx
@@ -15,8 +15,7 @@ With these two significant changes, there were duplicate features from the older
 
 ## New commands in v0.20.0
 
-* `vcluster convert` : Convert tenant cluster config values - This command is used to convert pre-v0.20 values.yaml files to the new vcluster.yaml
-  format. More details on how to convert your pre v0.20 `values.yaml` can be found in the [dedicated migration guide](0-20-migration.mdx).
+* `convert` : Converted a pre-v0.20 `values.yaml` to the new `vcluster.yaml` format. This command was removed from the vCluster CLI in v0.32.0. See the [dedicated migration guide](0-20-migration.mdx) for how to convert legacy values files with an older CLI release.
 
 * `vcluster set` : Set configuration
 

--- a/vcluster/reference/migrations/0-20-cli-changes.mdx
+++ b/vcluster/reference/migrations/0-20-cli-changes.mdx
@@ -15,7 +15,7 @@ With these two significant changes, there were duplicate features from the older
 
 ## New commands in v0.20.0
 
-* `convert` : Converted a pre-v0.20 `values.yaml` to the new `vcluster.yaml` format. This command was removed from the vCluster CLI in v0.32.0. See the [dedicated migration guide](0-20-migration.mdx) for how to convert legacy values files with an older CLI release.
+* `vcluster convert` : Converted a pre-v0.20 `values.yaml` to the new `vcluster.yaml` format. This command was removed from the vCluster CLI in v0.32.0. See the [dedicated migration guide](0-20-migration.mdx) for how to convert legacy values files with an older CLI release.
 
 * `vcluster set` : Set configuration
 
@@ -68,7 +68,7 @@ This is a list of commands that were formerly in the `loft` CLI and now renamed 
 
 * `vcluster platform sleep` : Put a tenant cluster/namespace to sleep
 
-* `vcluster platform start` : Start a vCluster Platform instance and connect via port-forwarding
+* `vcluster platform start` : Start a vCluster Platform instance and connect using port-forwarding
 
 * `vcluster platform wakeup` : Wake up a tenant cluster/namespace
 


### PR DESCRIPTION
# Content Description
The pre-v0.20 migration docs still taught `vcluster convert config` to translate legacy `values.yaml` files, but that command was removed from the vCluster CLI in v0.32.0, so readers on a current CLI followed steps that no longer run. The guide now states the removal, names the release, and gives a working path.

## Summary
Both the migration how-to and the v0.20 CLI-changes reference presented the `convert config` command as the way to convert legacy `values.yaml` files. The command was removed in v0.32.0. This PR states the removal and points to a working alternative: run the one-time conversion with a vCluster CLI release earlier than v0.32.0 (v0.31.3 is the last that ships the command), then upgrade with the current CLI.

## Key Changes
- `docs/_partials/0-20.migration.mdx`: added a removal admonition and switched the conversion steps to a downloaded pre-v0.32.0 CLI invoked as `./vcluster`. This is a shared partial imported by every versioned migration page, so the fix reaches all versions at once.
- `vcluster/reference/migrations/0-20-cli-changes.mdx`: the `convert` bullet now notes the command was removed in v0.32.0 and links to the migration guide.
- Verified against the DOC-1626 cli-drift checker (PR #2416): both pages report zero findings, under both a recent old-ref and a deep pre-0.32 old-ref.

## Preview Link
- Migration guide: https://deploy-preview-2419--vcluster-docs-site.netlify.app/docs/vcluster/next/reference/migrations/0-20-migration
- v0.20 CLI changes: https://deploy-preview-2419--vcluster-docs-site.netlify.app/docs/vcluster/next/reference/migrations/0-20-cli-changes

## Dependencies
Soft dependency on DOC-1626 (PR #2416), which adds the cli-drift checker referenced by the acceptance criteria. No file overlap, so no merge conflict is expected.

## Backporting
The migration how-to fix lives in a shared partial imported by all versioned migration pages, so it applies to every version automatically. The `0-20-cli-changes.mdx` reference is per-version: this PR fixes `current` (next), and the same removal note applies to the 0.33/0.34/0.35/0.36 versioned copies (all post-0.32), handled by the repo backport process.

## TODO
- [ ] tech-writer review

## Internal Reference
Closes DOC-1636


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs