### PR TITLE
docs(doc-1634): fix invalid imagePullSecrets example on coredns page

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -67,8 +67,6 @@ The configuration you choose depends on your deployment model. The following exa
 <Tabs>
 <TabItem value="separate" label="Separate (Default)" default>
 
-Based on the config reference you provided, here are the correct configurations:
-
 ### Basic CoreDNS configuration
 
 ```yaml title="Basic CoreDNS configuration"
@@ -88,17 +86,29 @@ controlPlane:
 
 ### Private registry CoreDNS configuration
 
+CoreDNS runs as a synced workload on the control plane cluster, so its image is
+pulled using the vCluster workload service account. To pull the CoreDNS image
+from a private registry, set the pull secret on
+`controlPlane.advanced.workloadServiceAccount.imagePullSecrets`. The CoreDNS
+deployment has no pull-secret field of its own.
+
 ```yaml title="Private registry CoreDNS configuration"
 controlPlane:
   coredns:
     deployment:
       image: "registry.company.com/coredns"
-
-# imagePullSecrets must be configured at the root level
-# since it's not available in the coreDNS configuration
-imagePullSecrets:
-  - name: company-registry-credentials
+  advanced:
+    workloadServiceAccount:
+      imagePullSecrets:
+        - name: company-registry-credentials
 ```
+
+:::note
+`controlPlane.advanced.serviceAccount.imagePullSecrets` also reaches the
+CoreDNS image pull, because vCluster merges both service accounts' pull secrets
+onto the workload service account. Use `workloadServiceAccount` for pull secrets
+that apply to synced workloads.
+:::
 
 ### Custom CoreDNS configuration
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -107,7 +107,7 @@ controlPlane:
 `controlPlane.advanced.serviceAccount.imagePullSecrets` also reaches the
 CoreDNS image pull, because vCluster merges both service accounts' pull secrets
 onto the workload service account. Use `workloadServiceAccount` for pull secrets
-that apply to synced workloads.
+that apply to synced workloads. If `sync.toHost.serviceAccounts.enabled` is `true`, CoreDNS uses its own synced service account instead, and the pull secret belongs there.
 :::
 
 ### Custom CoreDNS configuration


### PR DESCRIPTION
# Content Description
Fixes the private-registry example on the CoreDNS page, which taught a root-level `imagePullSecrets` key that the vCluster schema does not define. The corrected example sets the pull secret on `controlPlane.advanced.workloadServiceAccount.imagePullSecrets`, the service account CoreDNS actually pulls its image under.

## Summary
The CoreDNS page's "Private registry" example placed `imagePullSecrets` at the root of `vcluster.yaml`. The schema has no such top-level key, so the config is rejected and readers had no working way to pull the CoreDNS image from a private registry.

Source evidence (loft-sh/vcluster):
- The CoreDNS deployment is rendered from `pkg/coredns/template.go`; its pod spec uses `serviceAccountName: coredns` and templates no `imagePullSecrets` field of its own.
- `chart/templates/workload-serviceaccount.yaml` merges `controlPlane.advanced.serviceAccount.imagePullSecrets` and `controlPlane.advanced.workloadServiceAccount.imagePullSecrets` onto the workload service account, which runs synced workloads (CoreDNS included).

## Key Changes
- Replace the invalid root-level `imagePullSecrets` block with `controlPlane.advanced.workloadServiceAccount.imagePullSecrets`, validated against the schema (`valid: true`).
- Add a short explanation of why the pull secret lives on the workload service account, plus a note that `serviceAccount.imagePullSecrets` also applies.
- Remove the leftover "Based on the config reference you provided" authoring artifact above the examples.

## Dependencies
None.

## TODO
- [x] Backporting: the same invalid example exists in `vcluster_versioned_docs/version-{0.28.0,0.33.0,0.34.0,0.35.0,0.36.0}`. Per repo convention these are backported automatically via CI; flagging for reviewer awareness since this is a factual correction that applies to released versions.

## Preview Link
https://deploy-preview-2420--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/coredns

## Internal Reference
Closes DOC-1634

<!-- Do not change the line below -->
@netlify /docs