### PR TITLE
fix(release): resolve platform api pins via direct vcs, not the go proxy

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -121,13 +121,15 @@ jobs:
       # public proxy, hits 404, then tries an unauthenticated `git
       # ls-remote` and fails.
       #
-      # GOPRIVATE is narrowed to the actually-private patterns. A broad
-      # `github.com/loft-sh/*` pattern forces direct VCS for public deps
-      # too — including the indirect github.com/loft-sh/external-types,
-      # whose sparse-then-dense git history reproducibly triggers a
-      # `git fetch --unshallow` race ("shallow file has changed since
-      # we read it") in `go mod tidy` after the platform pin bump.
-      # Mirrors loft-enterprise#6910.
+      # GOPRIVATE stays narrow: only vcluster-pro* is genuinely private, so
+      # only it is forced to direct VCS on every event. It must NOT widen to
+      # `github.com/loft-sh/*`, which would also force direct VCS for the
+      # indirect github.com/loft-sh/external-types, whose sparse-then-dense
+      # git history reproducibly triggers a `git fetch --unshallow` race
+      # ("shallow file has changed since we read it") in `go mod tidy`.
+      # Mirrors loft-enterprise#6910. The platform pin bump needs api +
+      # agentapi resolved directly too, but only on platform-released and
+      # without disturbing GOPRIVATE; the next step scopes that.
       - name: Configure git for private loft-sh modules
         if: steps.classify.outputs.skip != 'true'
         env:
@@ -138,18 +140,52 @@ jobs:
           echo "GOPRIVATE=github.com/loft-sh/vcluster-pro*" >>"$GITHUB_ENV"
           echo "GOPROXY=https://proxy.golang.org,direct" >>"$GITHUB_ENV"
 
+      # The platform pin bump (below) moves api + agentapi to a version
+      # loft-enterprise tagged moments ago. proxy.golang.org and
+      # sum.golang.org cache a version only after fetching it from origin,
+      # and that propagation lags tag creation on independent, unbounded
+      # timelines: it stalled past the 10-minute wait for platform v4.11.0
+      # (agentapi), and before that under DEVOPS-904, DEVOPS-1008 and
+      # DEVOPS-1041, each "wait longer on Google" patch failing again on the
+      # next release. Route just these two modules to direct VCS (git auth
+      # above) so they are consumable the instant their GitHub tag exists,
+      # which the wait step gates on authoritatively. GONOSUMDB also skips
+      # the checksum DB for them, correct because sum.golang.org has not seen
+      # the version either; go still records their content hashes in go.sum
+      # from the direct download.
+      #
+      # Set GONOPROXY/GONOSUMDB explicitly rather than widening GOPRIVATE:
+      # the explicit values replace the GOPRIVATE-derived defaults, so
+      # vcluster-pro* is repeated here or private-module requests would leak
+      # to the public services. external-types is deliberately absent,
+      # keeping it on the proxy and away from the unshallow race. Scoped to
+      # platform-released so unrelated vcluster/cli generator runs keep
+      # verifying api/agentapi through the checksum DB. Prefix patterns match
+      # on path element boundaries, so `.../api` covers api and api/v4
+      # without matching the sibling `.../apiserver`.
+      - name: Route api + agentapi to direct VCS for the platform pin bump
+        if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
+        run: |
+          set -eo pipefail
+          modules="github.com/loft-sh/vcluster-pro*,github.com/loft-sh/api,github.com/loft-sh/agentapi"
+          echo "GONOPROXY=${modules}" >>"$GITHUB_ENV"
+          echo "GONOSUMDB=${modules}" >>"$GITHUB_ENV"
+
       # loft-enterprise's release pipeline cuts its own tag + release first
       # (which triggers our dispatch), then creates matching upstream tags
-      # in loft-sh/{agentapi,api} and lets them propagate to the Go module
-      # proxy. The bump step's `go mod tidy` below resolves both modules
-      # through GOPROXY, so it must not run until the proxy can serve the
-      # released version, not merely until the GitHub tag exists. The wait
-      # checks tag presence first (a clear "upstream never published"
-      # signal) then module-proxy resolution (the propagation race that
-      # broke platform v4.10.1 under DEVOPS-1008, where the tag existed but
-      # `go mod tidy` still reported `unknown revision`). Logic + bats
-      # coverage live in the script. 10s x 60 = 10 min ceiling per check.
-      - name: Wait for agentapi + api to resolve through the module proxy
+      # in loft-sh/{agentapi,api} a short time later. The bump step below
+      # must not run until those tags exist. Because the bump now resolves
+      # api + agentapi via direct VCS (routing step above), the GitHub tag
+      # existing is sufficient for consumability; we no longer wait on the
+      # public proxy or sum.golang.org, whose propagation lag broke this
+      # receiver repeatedly (DEVOPS-904, DEVOPS-1008, DEVOPS-1041, platform
+      # v4.11.0). The script checks tag presence first (a clear "upstream
+      # never published" signal), then confirms each module resolves via a
+      # direct fetch that mirrors the bump and warms the module cache.
+      # Logic + bats coverage live in the script. Each of the four checks
+      # (tag + resolve, per module) polls 10s x 60 = 10 min, so ~40 min
+      # worst case, though a healthy release passes each on the first try.
+      - name: Wait for agentapi + api release tags to be consumable
         if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
@@ -172,19 +208,15 @@ jobs:
       # vendoring". The bumped vendor tree ships in the same docs-sync PR
       # alongside go.mod/go.sum + regenerated partials — they have to ship
       # together to compile on next regen.
+      #
+      # The bump edits go.mod, runs `go mod tidy` + `go mod vendor`, and
+      # asserts MVS actually selected VERSION (not a higher transitive
+      # require). Logic + bats coverage live in the script.
       - name: Bump loft-sh/api + loft-sh/agentapi pins to released platform version
         if: steps.classify.outputs.skip != 'true' && steps.inputs.outputs.event == 'platform-released'
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
-        run: |
-          set -eo pipefail
-          stripped="${VERSION#v}"
-          major="v${stripped%%.*}"
-          echo "Bumping github.com/loft-sh/{api,agentapi}/${major} to ${VERSION}"
-          go mod edit -require "github.com/loft-sh/agentapi/${major}@${VERSION}"
-          go mod edit -require "github.com/loft-sh/api/${major}@${VERSION}"
-          go mod tidy
-          go mod vendor
+        run: bash hack/release/bump-platform-pins.sh
 
       # Checks whether the freshly-bumped loft-sh/api vendor tree registered
       # any Kind that hack/platform/partials/main.go has no

--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -1,0 +1,37 @@
+name: test-release-scripts
+
+# The docs-sync receiver's release logic lives in hack/release/*.sh with
+# bats coverage alongside each script, but nothing ran those suites in CI, so
+# a regression could only be caught by a live release failing. That is how
+# the proxy-propagation breakage recurred across DEVOPS-904, DEVOPS-1008 and
+# DEVOPS-1041. This workflow runs the bats suites and shellcheck on every PR
+# that touches the release scripts, turning the receiver's logic into a
+# reviewable, test-gated unit.
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'hack/release/**'
+      - '.github/workflows/test-release-scripts.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Shellcheck release scripts
+        run: shellcheck hack/release/*.sh
+
+      - name: Run release-script bats suites
+        run: bats hack/release/*.bats

--- a/hack/release/bump-platform-pins.bats
+++ b/hack/release/bump-platform-pins.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+#
+# Tests for bump-platform-pins.sh. `go` is shimmed onto PATH so the bump
+# runs without network, a real module graph, or a vendor tree. The shim
+# logs every `go` invocation to $SHIM_STATE/go.log so tests can assert on
+# the edited module paths, that the version assertion uses -mod=mod, and
+# that vendoring only happens after the assertion passes.
+#
+# Shim behaviour is driven by env vars:
+#   LIST_VERSION  version `go list -m` reports (default: VERSION). Set it to
+#                 something other than VERSION to simulate MVS selecting a
+#                 higher version than the pin.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/bump-platform-pins.sh"
+    BIN="$(mktemp -d)"
+    SHIM_STATE="$(mktemp -d)"
+    export SHIM_STATE
+    export PATH="$BIN:$PATH"
+    _make_go
+}
+
+teardown() {
+    rm -rf "$BIN" "$SHIM_STATE"
+}
+
+_make_go() {
+    cat >"$BIN/go" <<'SH'
+#!/usr/bin/env bash
+echo "GOFLAGS=${GOFLAGS} args=$*" >>"$SHIM_STATE/go.log"
+# `go list -m -f {{.Version}} <mod>` must print a version for the assertion.
+[ "$1" = "list" ] && printf '%s\n' "${LIST_VERSION:-$VERSION}"
+exit 0
+SH
+    chmod +x "$BIN/go"
+}
+
+@test "bumps both pins, tidies, verifies, and vendors" {
+    VERSION=v4.11.0 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"github.com/loft-sh/agentapi/v4 pinned at v4.11.0"* ]]
+    [[ "$output" == *"github.com/loft-sh/api/v4 pinned at v4.11.0"* ]]
+    grep -q "args=mod edit -require github.com/loft-sh/agentapi/v4@v4.11.0" "$SHIM_STATE/go.log"
+    grep -q "args=mod edit -require github.com/loft-sh/api/v4@v4.11.0" "$SHIM_STATE/go.log"
+    grep -q "args=mod tidy" "$SHIM_STATE/go.log"
+    grep -q "args=mod vendor" "$SHIM_STATE/go.log"
+}
+
+@test "version assertion queries with -mod=mod" {
+    VERSION=v4.11.0 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "GOFLAGS=-mod=mod args=list -m -f {{.Version}} github.com/loft-sh/agentapi/v4" "$SHIM_STATE/go.log"
+    grep -q "GOFLAGS=-mod=mod args=list -m -f {{.Version}} github.com/loft-sh/api/v4" "$SHIM_STATE/go.log"
+}
+
+@test "MVS selecting a higher version than the pin → fails before vendoring" {
+    LIST_VERSION=v4.11.1 VERSION=v4.11.0 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"resolved to v4.11.1, not the released v4.11.0"* ]]
+    # tidy ran, but the failed assertion must stop us before re-vendoring.
+    grep -q "args=mod tidy" "$SHIM_STATE/go.log"
+    ! grep -q "args=mod vendor" "$SHIM_STATE/go.log"
+}
+
+@test "major version is derived from VERSION (v5 needs no code change)" {
+    VERSION=v5.2.0 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "args=mod edit -require github.com/loft-sh/agentapi/v5@v5.2.0" "$SHIM_STATE/go.log"
+    grep -q "args=mod edit -require github.com/loft-sh/api/v5@v5.2.0" "$SHIM_STATE/go.log"
+}
+
+@test "pre-release versions are pinned verbatim" {
+    VERSION=v4.11.0-rc.1 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "args=mod edit -require github.com/loft-sh/agentapi/v4@v4.11.0-rc.1" "$SHIM_STATE/go.log"
+}
+
+@test "missing VERSION env var → exits non-zero" {
+    run "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"VERSION env var required"* ]]
+}

--- a/hack/release/bump-platform-pins.sh
+++ b/hack/release/bump-platform-pins.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# bump-platform-pins.sh: pin this repo's loft-sh/api + loft-sh/agentapi
+# module requirements to the just-released platform version, re-tidy and
+# re-vendor, and assert the selected versions are exactly the release.
+#
+# Run by handle-source-release.yml on platform-released events, after
+# wait-for-platform-modules.sh confirms the tags are consumable.
+#
+# Why bump at all: the platform partials generator reflects against the
+# loft-sh/api + loft-sh/agentapi types pinned here. Without moving the pins
+# to the released version, regen sees identical types and emits no diff, so
+# the receiver produces no PR.
+#
+# Why re-vendor: this repo carries a vendor/ tree and `go run` resolves with
+# vendor semantics. Without re-vendoring, vendor/modules.txt still records
+# the previous version while go.mod claims the new one, and the generator
+# fails with "inconsistent vendoring". go.mod/go.sum + the bumped vendor
+# tree + regenerated partials must ship together in the same docs-sync PR.
+#
+# Why assert the selected version: `go mod edit -require` sets a floor, not
+# a ceiling. Minimal version selection still picks a HIGHER version if any
+# transitive requirement exceeds VERSION, which would generate docs against
+# unreleased types. The post-tidy check fails loudly instead.
+#
+# Resolution routing: the workflow's "Route api + agentapi to direct VCS"
+# step exports GONOPROXY/GONOSUMDB so api + agentapi resolve straight from
+# GitHub, bypassing the public proxy + sum.golang.org whose propagation lag
+# repeatedly broke this receiver (DEVOPS-904/1008/1041, platform v4.11.0).
+# A manual run of this script outside the workflow must export the same:
+#   export GONOPROXY=github.com/loft-sh/vcluster-pro*,github.com/loft-sh/api,github.com/loft-sh/agentapi
+#   export GONOSUMDB=github.com/loft-sh/vcluster-pro*,github.com/loft-sh/api,github.com/loft-sh/agentapi
+#
+# `go list -m` runs with -mod=mod because the vendor tree is stale between
+# `go mod tidy` and `go mod vendor`, and vendor mode cannot answer a
+# version query against an inconsistent tree.
+#
+# The major-version segment is derived from VERSION, so a future v5 cutover
+# needs no change here.
+#
+# Inputs (env):
+#   VERSION   Released platform version, vX.Y.Z[-pre] (required).
+
+set -eo pipefail
+
+: "${VERSION:?VERSION env var required}"
+
+stripped="${VERSION#v}"
+major="v${stripped%%.*}"
+
+echo "Bumping github.com/loft-sh/{api,agentapi}/${major} to ${VERSION}"
+go mod edit -require "github.com/loft-sh/agentapi/${major}@${VERSION}"
+go mod edit -require "github.com/loft-sh/api/${major}@${VERSION}"
+go mod tidy
+
+for mod in "github.com/loft-sh/agentapi/${major}" "github.com/loft-sh/api/${major}"; do
+    selected="$(GOFLAGS=-mod=mod go list -m -f '{{.Version}}' "${mod}")"
+    if [ "${selected}" != "${VERSION}" ]; then
+        echo "::error::${mod} resolved to ${selected}, not the released ${VERSION}; a transitive requirement exceeds the release, so docs would reflect unreleased types" >&2
+        exit 1
+    fi
+    echo "::notice::${mod} pinned at ${selected}"
+done
+
+go mod vendor

--- a/hack/release/wait-for-platform-modules.bats
+++ b/hack/release/wait-for-platform-modules.bats
@@ -34,8 +34,9 @@ _make_gh() {
     cat >"$BIN/gh" <<'SH'
 #!/usr/bin/env bash
 case "${GH_MODE:-ok}" in
-  fail) exit 1 ;;
-  *)    exit 0 ;;
+  fail)    echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+  autherr) echo "gh: Bad credentials (HTTP 401)" >&2; exit 1 ;;
+  *)       exit 0 ;;
 esac
 SH
     chmod +x "$BIN/gh"
@@ -64,13 +65,13 @@ SH
     chmod +x "$BIN/go"
 }
 
-@test "both phases pass when tag is present and the module downloads" {
+@test "both phases pass when tag is present and the module resolves" {
     VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"loft-sh/agentapi: tag v4.10.1 present"* ]]
     [[ "$output" == *"loft-sh/api: tag v4.10.1 present"* ]]
-    [[ "$output" == *"github.com/loft-sh/agentapi/v4: v4.10.1 downloads and checksum-verifies"* ]]
-    [[ "$output" == *"github.com/loft-sh/api/v4: v4.10.1 downloads and checksum-verifies"* ]]
+    [[ "$output" == *"github.com/loft-sh/agentapi/v4: v4.10.1 resolves via direct fetch"* ]]
+    [[ "$output" == *"github.com/loft-sh/api/v4: v4.10.1 resolves via direct fetch"* ]]
 }
 
 @test "phase 2 downloads with -mod=mod for both modules" {
@@ -80,7 +81,7 @@ SH
     grep -q "GOFLAGS=-mod=mod args=mod download github.com/loft-sh/api/v4@v4.10.1" "$SHIM_STATE/go.log"
 }
 
-@test "tag never published → fails with upstream-pipeline error, never reaches download check" {
+@test "tag 404s forever → fails with upstream-pipeline error, never reaches fetch check" {
     GH_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"tag v4.10.1 not present after 5 attempts"* ]]
@@ -88,20 +89,28 @@ SH
     [ ! -f "$SHIM_STATE/go.log" ]
 }
 
-@test "download never verifies → fails with propagation error after the tag check passes" {
+@test "non-404 tag error → surfaced as API/auth problem, not a missing release" {
+    GH_MODE=autherr VERSION=v4.10.1 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"non-404 error"* ]]
+    [[ "$output" == *"GitHub API/auth problem"* ]]
+    [[ "$output" != *"upstream pipeline never published it"* ]]
+    [ ! -f "$SHIM_STATE/go.log" ]
+}
+
+@test "module never resolves → fails with direct-fetch error after the tag check passes" {
     GO_MODE=fail VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 1 ]
     [[ "$output" == *"tag v4.10.1 present"* ]]
-    [[ "$output" == *"was not downloadable and checksum-verified after 5 attempts"* ]]
-    [[ "$output" == *"propagation stalled"* ]]
+    [[ "$output" == *"did not resolve via direct fetch after 5 attempts"* ]]
 }
 
-@test "download lags then verifies within the attempt budget → succeeds" {
-    # Each module fails twice then downloads; MAX_ATTEMPTS=5 leaves headroom.
+@test "fetch lags then resolves within the attempt budget → succeeds" {
+    # Each module fails twice then resolves; MAX_ATTEMPTS=5 leaves headroom.
     GO_MODE=flaky:2 VERSION=v4.10.1 run "$SCRIPT"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"waiting for v4.10.1 to download and checksum-verify"* ]]
-    [[ "$output" == *"v4.10.1 downloads and checksum-verifies"* ]]
+    [[ "$output" == *"waiting for v4.10.1 to resolve via direct fetch"* ]]
+    [[ "$output" == *"v4.10.1 resolves via direct fetch"* ]]
 }
 
 @test "major version is derived from VERSION (v5 needs no code change)" {

--- a/hack/release/wait-for-platform-modules.sh
+++ b/hack/release/wait-for-platform-modules.sh
@@ -4,7 +4,7 @@
 # loft-sh/agentapi module versions are actually consumable by the
 # platform-pin bump step, not merely present as GitHub tags.
 #
-# Run by handle-source-release.yml before the bump step, only for
+# Run by handle-source-release.yml before bump-platform-pins.sh, only for
 # platform-released events.
 #
 # Two checks, in order:
@@ -13,33 +13,38 @@
 #      publishes its own release first (which fires the repository_dispatch
 #      that triggers the receiver), THEN creates the matching tags in
 #      loft-sh/{agentapi,api} a short time later. The bump step must not
-#      run before those tags exist. (DEVOPS-904.)
+#      run before those tags exist. (DEVOPS-904.) A clean 404 means the
+#      upstream tag is not there yet; any other gh error (auth, rate limit,
+#      5xx, network) is a different problem and is surfaced as such instead
+#      of being mislabeled "upstream never published".
 #
-#   2. Checksum-verified download (go mod download <module>@<version>).
-#      The bump step runs `go mod tidy`, which both resolves api/agentapi
-#      through GOPROXY (proxy.golang.org) AND verifies each module against
-#      GOSUMDB (sum.golang.org); these modules are NOT in GOPRIVATE, which
-#      is narrowed to vcluster-pro*, so the checksum database is consulted.
-#      Both Google services cache a version only after fetching it from the
-#      origin, and they lag tag creation independently:
-#        - DEVOPS-1008 (platform v4.10.1): the tag check passed but the
-#          proxy had not cached agentapi/v4@v4.10.1, so `go mod tidy` failed
-#          with `unknown revision`. A `go list -m` probe (proxy only) closed
-#          that gap.
-#        - DEVOPS-1041 (platform v4.10.2): the proxy HAD cached the version
-#          (the `go list -m` probe passed) but sum.golang.org had not, so
-#          `go mod tidy` failed verifying the module: 404 from
-#          `sum.golang.org/lookup/...` ("unknown revision v4.10.2"). The
-#          proxy and the checksum DB propagate on separate timelines, so a
-#          proxy-only probe is not sufficient.
-#      `go mod download` exercises BOTH services exactly as the bump step
-#      does, so the wait does not pass until the release is genuinely
-#      consumable. Gating on tag presence first keeps these requests from
-#      racing ahead of the origin tag; the download then verifies and warms
-#      the module cache, so the bump never runs ahead of propagation.
+#   2. Direct-fetch consumability (go mod download <module>@<version>).
+#      The bump step routes api + agentapi through direct VCS via
+#      GONOPROXY/GONOSUMDB (set by the workflow's "Route api + agentapi to
+#      direct VCS" step), so once the GitHub tag exists the module is
+#      immediately fetchable. This probe fetches exactly the way the bump
+#      does: it confirms the tag resolves to a valid Go module (correct
+#      module path/major, readable go.mod, constructible zip), exercises the
+#      git auth, and warms the module cache so the bump does not re-download.
+#
+#      This used to poll the PUBLIC module proxy + sum.golang.org, whose
+#      propagation lags tag creation on independent, unbounded timelines and
+#      repeatedly stalled this receiver: DEVOPS-1008 (proxy had not cached
+#      the version), DEVOPS-1041 (sum.golang.org had not), and platform
+#      v4.11.0 (agentapi never propagated within the 10-minute wait while
+#      api did). Each "wait longer on Google" fix failed again on the next
+#      release. Fetching direct from GitHub removes that dependency: the
+#      authoritative signal is the GitHub tag, which check 1 already gates.
 #
 # `go mod download <module>@<version>` needs -mod=mod: this repo carries a
 # vendor/ tree, so the default -mod=vendor cannot satisfy a version query.
+#
+# Resolution routing: this script relies on GONOPROXY/GONOSUMDB being set
+# for api + agentapi (the workflow does this before invoking the script). A
+# manual run outside the workflow must export the same, or check 2 falls
+# back to the flaky public proxy:
+#   export GONOPROXY=github.com/loft-sh/vcluster-pro*,github.com/loft-sh/api,github.com/loft-sh/agentapi
+#   export GONOSUMDB=github.com/loft-sh/vcluster-pro*,github.com/loft-sh/api,github.com/loft-sh/agentapi
 #
 # Inputs (env):
 #   VERSION        Released platform version, vX.Y.Z[-pre] (required).
@@ -61,14 +66,31 @@ SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
 stripped="${VERSION#v}"
 major="v${stripped%%.*}"
 
-# Phase 1: GitHub tag presence. Surfaces "upstream never published" as a
-# distinct, actionable error instead of a confusing downstream go mod error.
+# Phase 1: GitHub tag presence. A clean 404 keeps polling (tag not created
+# yet); a non-404 error is surfaced immediately so an auth/API problem is
+# not misreported as a missing upstream release.
 for repo in loft-sh/agentapi loft-sh/api; do
     attempt=0
-    until gh api "repos/${repo}/git/refs/tags/${VERSION}" >/dev/null 2>&1; do
+    last_err=""
+    until last_err="$(gh api "repos/${repo}/git/refs/tags/${VERSION}" 2>&1)"; do
+        # Surface a non-404 (auth, rate limit, 5xx, network) as it happens; a
+        # clean 404 just means the tag is not created yet.
+        case "$last_err" in
+            *404*|*"Not Found"*) : ;;
+            *) echo "::warning::${repo}: tag query failed with a non-404 error (attempt ${attempt}); retrying: ${last_err}" >&2 ;;
+        esac
         attempt=$((attempt + 1))
         if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            echo "::error::${repo}: tag ${VERSION} not present after ${MAX_ATTEMPTS} attempts; upstream pipeline never published it" >&2
+            # Classify on the FINAL error, so a transient early non-404 does
+            # not mislabel a run that ends on a clean 404, or vice versa.
+            case "$last_err" in
+                *404*|*"Not Found"*)
+                    echo "::error::${repo}: tag ${VERSION} not present after ${MAX_ATTEMPTS} attempts; upstream pipeline never published it. last error: ${last_err}" >&2
+                    ;;
+                *)
+                    echo "::error::${repo}: tag ${VERSION} could not be queried after ${MAX_ATTEMPTS} attempts; the last error was not a clean 404, so treat this as a GitHub API/auth problem, not a missing release. last error: ${last_err}" >&2
+                    ;;
+            esac
             exit 1
         fi
         echo "${repo}: waiting for tag ${VERSION} (attempt ${attempt}/${MAX_ATTEMPTS})"
@@ -77,21 +99,20 @@ for repo in loft-sh/agentapi loft-sh/api; do
     echo "::notice::${repo}: tag ${VERSION} present (attempt ${attempt})"
 done
 
-# Phase 2: checksum-verified download. `go mod download` resolves through
-# the proxy AND verifies against the checksum database (sum.golang.org) for
-# these public modules, which is exactly what the bump step's `go mod tidy`
-# requires; gating on it here keeps the bump from racing either service's
-# propagation.
+# Phase 2: direct-fetch consumability. Mirrors the bump step's resolution
+# (GONOPROXY/GONOSUMDB route these two modules to direct VCS) and warms the
+# module cache. Succeeds as soon as the tag from phase 1 is fetchable.
 for mod in "github.com/loft-sh/agentapi/${major}" "github.com/loft-sh/api/${major}"; do
     attempt=0
-    until GOFLAGS=-mod=mod go mod download "${mod}@${VERSION}" >/dev/null 2>&1; do
+    last_err=""
+    until last_err="$(GOFLAGS=-mod=mod go mod download "${mod}@${VERSION}" 2>&1)"; do
         attempt=$((attempt + 1))
         if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            echo "::error::${mod}@${VERSION} was not downloadable and checksum-verified after ${MAX_ATTEMPTS} attempts; proxy or checksum database (sum.golang.org) propagation stalled" >&2
+            echo "::error::${mod}@${VERSION} did not resolve via direct fetch after ${MAX_ATTEMPTS} attempts; the tag exists but its commit is not yet fetchable from GitHub, or the module's go.mod at that tag is invalid. last error: ${last_err}" >&2
             exit 1
         fi
-        echo "${mod}: waiting for ${VERSION} to download and checksum-verify (attempt ${attempt}/${MAX_ATTEMPTS})"
+        echo "${mod}: waiting for ${VERSION} to resolve via direct fetch (attempt ${attempt}/${MAX_ATTEMPTS})"
         sleep "$SLEEP_SECONDS"
     done
-    echo "::notice::${mod}: ${VERSION} downloads and checksum-verifies (attempt ${attempt})"
+    echo "::notice::${mod}: ${VERSION} resolves via direct fetch (attempt ${attempt})"
 done


### PR DESCRIPTION
# What this fixes

The docs-sync receiver (`handle-source-release.yml`) failed again on platform v4.11.0: [run 29742979170](https://github.com/loft-sh/vcluster-docs/actions/runs/29742979170). This is the 4th time this class of failure has hit the receiver.

## Root cause

On every platform release the receiver bumps the `loft-sh/api` and `loft-sh/agentapi` pins in `go.mod`, resolving them through `proxy.golang.org` and `sum.golang.org`. loft-enterprise publishes its release and fires the dispatch first, then creates the api/agentapi tags, then Google's proxy and checksum DB have to fetch and cache them from origin. That propagation lags tag creation on independent, unbounded timelines.

For v4.11.0, `api` propagated but `agentapi` did not within the 10-minute wait: the proxy returned `unknown revision v4.11.0` and `sum.golang.org` 404'd. The three prior fixes (DEVOPS-904, DEVOPS-1008, DEVOPS-1041) each only waited longer on the same public infra, so the failure kept recurring.

## The fix

Stop depending on the public proxy for these two modules. Route only `api` and `agentapi` to direct VCS via `GONOPROXY`/`GONOSUMDB`, scoped to `platform-released`. Git auth is already configured in the workflow, so once the GitHub tag exists (which the wait step gates on authoritatively) the module is consumable immediately.

- `GOPRIVATE` stays narrow at `vcluster-pro*`. Widening it to `loft-sh/*` was rejected before because it forces direct VCS on the indirect `external-types`, whose git history triggers a `git fetch --unshallow` race (loft-enterprise#6910). `external-types` deliberately stays on the proxy.
- The explicit `GONOPROXY`/`GONOSUMDB` values keep `vcluster-pro*` so private-module requests never leak to the public services.
- Scoped to `platform-released` so unrelated vcluster/cli generator runs keep verifying api/agentapi through the checksum DB.

## Hardening included

- Extracted the pin bump into `hack/release/bump-platform-pins.sh` (with bats). It now asserts minimal version selection picked exactly the released version, not a higher transitive require, before vendoring.
- `wait-for-platform-modules.sh` phase 2 now confirms a direct fetch instead of proxy/sumdb propagation, and phase 1 distinguishes a clean 404 (upstream never published) from auth/API errors instead of mislabeling them.
- New `test-release-scripts.yml` runs the `hack/release` bats suites and shellcheck on PRs touching those scripts. These suites never ran in CI before, which is how the proxy regressions kept shipping.

## Validation

- 59 bats tests pass across 5 suites; shellcheck, actionlint, and zizmor all clean.
- Reproduced locally: the public proxy returns `unknown revision v4.11.0` while a direct fetch resolves and caches immediately.
- Design and implementation were reviewed adversarially before submission; findings were folded in.

## Internal reference

Recurrence of DEVOPS-904 / DEVOPS-1008 / DEVOPS-1041. Failing run: https://github.com/loft-sh/vcluster-docs/actions/runs/29742979170

@netlify /docs

https://claude.ai/code/session_011X7gGW9wWWJw1C5kq9aN2U
