### PR TITLE
fix(release): stop docs-sync PRs from carrying file-mode-only diffs

### DIFF
--- a/.github/workflows/handle-source-release.yml
+++ b/.github/workflows/handle-source-release.yml
@@ -139,6 +139,13 @@ jobs:
           git config --global url."https://${GH_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
           echo "GOPRIVATE=github.com/loft-sh/vcluster-pro*" >>"$GITHUB_ENV"
           echo "GOPROXY=https://proxy.golang.org,direct" >>"$GITHUB_ENV"
+          # The versioned docs trees were seeded from copies that carried an
+          # executable bit, so many committed partials are 100755 while the
+          # generators write them at 100644. Without this, every sync PR
+          # carries hundreds of spurious 100755->100644 mode-only diffs that
+          # bury the real content changes. .mdx/.md/.json docs are never
+          # executed, so ignore the executable bit repo-wide for the sync.
+          git config core.fileMode false
 
       # The platform pin bump (below) moves api + agentapi to a version
       # loft-enterprise tagged moments ago. proxy.golang.org and


### PR DESCRIPTION
# What this fixes

Successful docs-sync PRs carry hundreds of spurious file-mode-only diffs that bury the real content. Example: #2468 (v4.11.0 sync) had 116 changed files, but only 4 were real (the go.mod/go.sum/vendor pin bump). The other 112 were `100755 -> 100644` mode flips on unchanged `.mdx` partials.

# Root cause

The versioned docs trees (`platform_versioned_docs/version-*`, etc.) were seeded from copies that carried an executable bit, so many committed partials are `100755`. The doc generators write their output at `100644`. The first successful sync into such a tree therefore flips the mode on every unchanged file. This is independent of the module-resolution fix in #2465; it surfaced now only because #2465 let the v4.11.0 sync reach the generate + commit steps for the first time.

# The fix

Set `git config core.fileMode false` in the receiver before it generates and opens the PR. Docs files (`.mdx`, `.md`, `.json`) are never executed, so the executable bit is meaningless. With it ignored, sync PRs contain only real content changes. Applies to all sync event types (platform, vcluster, cli).

# Notes

- One line in `handle-source-release.yml`; actionlint clean.
- After this merges, re-running the receiver for v4.11.0 will refresh #2468 down to just the pin-bump content.

@netlify /docs

https://claude.ai/code/session_011X7gGW9wWWJw1C5kq9aN2U
