### PR TITLE
docs: expose vCluster 0.36 and Platform 4.11 in version dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,20 +262,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "0.35.0",
+        lastVersion: "0.36.0",
         onlyIncludeVersions: ["current", "0.36.0", "0.35.0", "0.34.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "0.36.0": {
-            label: "v0.36",
-            banner: "unreleased",
+            label: "v0.36 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "0.35.0": {
-            label: "v0.35 Stable",
+            label: "v0.35",
             banner: "none",
             badge: true,
           },
@@ -300,20 +299,19 @@ const config = {
         beforeDefaultRemarkPlugins: [
           [remarkVersionTokens, { siteDir: __dirname }],
         ],
-        lastVersion: "4.10.0",
+        lastVersion: "4.11.0",
         onlyIncludeVersions: ["current", "4.11.0", "4.10.0", "4.9.0", "4.8.0"],
         versions: {
           current: {
             label: "main 🚧",
           },
           "4.11.0": {
-            label: "v4.11",
-            banner: "unreleased",
+            label: "v4.11 Stable",
+            banner: "none",
             badge: true,
-            noIndex: true,
           },
           "4.10.0": {
-            label: "v4.10 Stable",
+            label: "v4.10",
             banner: "none",
             badge: true,
           },
@@ -475,9 +473,9 @@ const config = {
         additionalLanguages: ["bash", "hcl"],
       },
       announcementBar: {
-        id: "vcluster-0-35-platform-4-10-release",
+        id: "vcluster-0-36-platform-4-11-release",
         content:
-          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.10 and vCluster 0.35</a></strong>',
+          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.11 and vCluster 0.36</a></strong>',
         backgroundColor: "#050b24",
         textColor: "#ffffff",
         isCloseable: true,

--- a/hack/test-vcluster-0.36.hurl
+++ b/hack/test-vcluster-0.36.hurl
@@ -1,0 +1,416 @@
+# vCluster 0.36 / Platform 4.11 Comprehensive Redirect Tests
+# Generated from netlify.toml redirects
+# Usage: hurl --test --variable BASE_URL=https://deploy-preview-XXXX--vcluster-docs-site.netlify.app hack/test-vcluster-0.36.hurl
+
+# =====================================================
+# Legacy paths redirects
+# =====================================================
+
+# Test 1: Legacy architecture paths
+GET {{BASE_URL}}/docs/architecture/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/architecture/"
+
+# Test 2: CLI paths redirect to vcluster.com
+GET {{BASE_URL}}/docs/cli/vcluster_create
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/cli/vcluster_create"
+
+# Test 3: Deploying vclusters legacy
+GET {{BASE_URL}}/docs/deploying-vclusters/basics
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/deploy/control-plane/kubernetes-pod/basics/basics"
+
+# Test 4: Get started redirect
+GET {{BASE_URL}}/docs/get-started
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 5: Getting started wildcard
+GET {{BASE_URL}}/docs/getting-started/setup
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/"
+
+# Test 6: Networking redirect
+GET {{BASE_URL}}/docs/networking/ingress
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/networking/ingress"
+
+# Test 7: Security redirect
+GET {{BASE_URL}}/docs/security/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/security/"
+
+# Test 8: Syncer redirect
+GET {{BASE_URL}}/docs/syncer/overview
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/architecture#syncer"
+
+# Test 9: Using vclusters redirect
+GET {{BASE_URL}}/docs/using-vclusters/kube-context
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#common-use-cases"
+
+# Test 10: Config reference redirect
+GET {{BASE_URL}}/docs/config-reference/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
+
+# Test 11: Storage redirect
+GET {{BASE_URL}}/docs/storage/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/category/storage"
+
+# Test 12: What are virtual clusters redirect
+GET {{BASE_URL}}/docs/what-are-virtual-clusters/
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# Test 13: Help & tutorials redirect
+GET {{BASE_URL}}/docs/help&tutorials/faq
+HTTP 301
+[Asserts]
+header "Location" contains "https://www.vcluster.com/docs/vcluster/"
+
+# =====================================================
+# Platform UI links for vCluster
+# =====================================================
+
+# Test 14: Backup restore migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backup-restore-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+
+# Test 15: Supported migration options
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/supported-migration-options
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup#supported-migration-options"
+
+# Test 16: Control plane
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/"
+
+# Test 17: Backing store
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/backing-store
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/"
+
+# Test 18: Control plane distro
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/control-plane-distro
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/control-plane/components/distro/"
+
+# Test 19: Resource quota
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/resource-quota
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/policies/resource-quota"
+
+# Test 20: 0.20 migration
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/0-20-migration
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/reference/migrations/0-20-migration"
+
+# Test 21: Sync from host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-from-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/"
+
+# Test 22: Nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/from-host/nodes"
+
+# Test 23: Sync to host
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/sync-to-host
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/"
+
+# Test 24: Hybrid scheduling
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/hybrid-scheduling
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling"
+
+# Test 25: Private nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes"
+
+# Test 26: Private nodes node requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-node-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/worker-nodes/private-nodes/node-requirements"
+
+# Test 27: Private nodes auto nodes
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes"
+
+# Test 28: Private nodes auto nodes requirements
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/private-nodes-auto-nodes-requirements
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes/#requirements"
+
+# Test 29: vcluster.yaml
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/vcluster-yaml
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/configure/vcluster-yaml/"
+
+# Test 29b: Volume snapshots (DOC-1403: removed in 0.36.0, redirects to backup docs)
+GET {{BASE_URL}}/docs/platform-ui-link/vcluster/volume-snapshots
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/manage/backup-restore/backup"
+
+# =====================================================
+# Deploy redirects
+# =====================================================
+
+# Test 30: Deploy control-plane wildcard
+GET {{BASE_URL}}/docs/deploy/control-plane/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/basics"
+
+# Test 31: Deploy wildcard
+GET {{BASE_URL}}/docs/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/basics"
+
+# =====================================================
+# vCluster 0.36.0 redirect (new lastVersion)
+# =====================================================
+
+# Test 32: vCluster 0.36.0 wildcard redirect
+GET {{BASE_URL}}/docs/vcluster/0.36.0/introduction/what-are-virtual-clusters
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/introduction/what-are-virtual-clusters"
+
+# =====================================================
+# vCluster v0.27 restructure redirects
+# =====================================================
+
+# Test 33: Enable debug logging (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 34: Enable debug logging (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/enable-debug-logging
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/control-plane/container/enable-debug-logging"
+
+# Test 35: Configure kai scheduler (next with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 36: Configure kai scheduler (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 37: Configure kai scheduler (current with trailing slash)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler/
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler/"
+
+# Test 38: Configure kai scheduler (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/configure-kai-scheduler
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/scheduler/kai-scheduler"
+
+# Test 39: Control node IP visibility (next)
+GET {{BASE_URL}}/docs/vcluster/next/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 40: Control node IP visibility (current)
+GET {{BASE_URL}}/docs/vcluster/learn-how-to/control-node-ip-visibility
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/learn-how-to/worker-nodes/host-nodes/control-node-ip-visibility"
+
+# Test 41: Integrations wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/integrations/metrics/prometheus
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/third-party-integrations/metrics/prometheus"
+
+# Test 42: Integrations wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/integrations/pod-identity/eks-pod-identity
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/third-party-integrations/pod-identity/eks-pod-identity"
+
+# Test 43: Deploy environment wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/environment/eks
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks"
+
+# Test 44: Deploy environment wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/environment/gke
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/gke"
+
+# Test 45: Deploy topologies wildcard (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/topologies/multi-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/multi-namespace-mode"
+
+# Test 46: Deploy topologies wildcard (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/topologies/single-namespace-mode
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/single-namespace-mode"
+
+# Test 47: Deploy basics (next)
+GET {{BASE_URL}}/docs/vcluster/next/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics"
+
+# Test 48: Deploy basics (current)
+GET {{BASE_URL}}/docs/vcluster/deploy/basics
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/vcluster/deploy/control-plane/kubernetes-pod/basics"
+
+# =====================================================
+# Verification tests - pages that should load
+# =====================================================
+
+# Test 49: vCluster main page should load (serves 0.36.0 as lastVersion)
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 50: vCluster 0.34.0 should still be accessible as versioned doc
+GET {{BASE_URL}}/docs/vcluster/0.34.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 51: vCluster 0.35.0 should now be accessible as versioned doc
+GET {{BASE_URL}}/docs/vcluster/0.35.0/
+HTTP 200
+[Asserts]
+body contains "vCluster"
+
+# Test 52: vCluster CLI pages should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_create/
+HTTP 200
+[Asserts]
+body contains "vcluster create"
+
+# Test 53: vCluster CLI certs page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_certs/
+HTTP 200
+[Asserts]
+body contains "vcluster certs"
+
+# Test 54: vCluster CLI node page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_node/
+HTTP 200
+[Asserts]
+body contains "vcluster node"
+
+# Test 55: vCluster CLI registry page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_registry/
+HTTP 200
+[Asserts]
+body contains "vcluster registry"
+
+# Test 56: vCluster CLI token page should load
+GET {{BASE_URL}}/docs/vcluster/cli/vcluster_token/
+HTTP 200
+[Asserts]
+body contains "vcluster token"
+
+# Test 57: Documentation home page should load
+GET {{BASE_URL}}/docs/
+HTTP 200
+[Asserts]
+body contains "vCluster 0.36"
+body contains "Platform 4.11"
+
+# Test 58: vCluster main page should show v0.36 as stable
+GET {{BASE_URL}}/docs/vcluster/
+HTTP 200
+[Asserts]
+body contains "v0.36 Stable"
+
+# =====================================================
+# Platform 4.11 verification tests
+# =====================================================
+
+# Test 59: Platform main page should load (serves 4.11.0 as lastVersion)
+GET {{BASE_URL}}/docs/platform/
+HTTP 200
+[Asserts]
+body contains "vCluster Platform"
+
+# Test 60: Platform main page should show v4.11 as stable
+GET {{BASE_URL}}/docs/platform/
+HTTP 200
+[Asserts]
+body contains "v4.11 Stable"
+
+# Test 61: Platform 4.10.0 should now be accessible as versioned doc
+GET {{BASE_URL}}/docs/platform/4.10.0/
+HTTP 200
+[Asserts]
+body contains "vCluster Platform"
+
+# Test 62: Platform 4.9.0 should still be accessible as versioned doc
+GET {{BASE_URL}}/docs/platform/4.9.0/
+HTTP 200
+[Asserts]
+body contains "vCluster Platform"
+
+# Test 63: Platform 4.11.0 wildcard redirects to unversioned path
+GET {{BASE_URL}}/docs/platform/4.11.0
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/platform/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -846,13 +846,13 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 
 
 [[redirects]]
-  from = "/docs/vcluster/0.35.0/*"
+  from = "/docs/vcluster/0.36.0/*"
   to = "/docs/vcluster/:splat"
   status = 301
   force = true
 
 [[redirects]]
-  from = "/docs/platform/4.10.0/*"
+  from = "/docs/platform/4.11.0/*"
   to = "/docs/platform/:splat"
   status = 301
   force = true

--- a/platform/_fragments/cli-steps/connect-platform.mdx
+++ b/platform/_fragments/cli-steps/connect-platform.mdx
@@ -1,4 +1,4 @@
-**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/next/administer/authentication/access-keys) for more details.
+**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](../../administer/authentication/access-keys.mdx) for more details.
 
 When you started the platform, you would have automatically connected to the platform when you ran `vcluster platform start`.
 

--- a/platform/administer/clusters/advanced/cluster-upgrades.mdx
+++ b/platform/administer/clusters/advanced/cluster-upgrades.mdx
@@ -33,7 +33,7 @@ As the name suggests, this proxy-only agent solely aims to proxy the communicati
 
 The platform deploys the proxy-only agent by creating a deployment in the connected cluster's agent's namespace. It additionally reuses the agent's service account and associated RBAC permissions.
 Once the proxy-only agent is healthy, the platform upgrades the agent deployment.
-In case of a failure during the upgrade, the platform can still connect via the proxy-only agent and perform a rollback to a previous agent version.
+In case of a failure during the upgrade, the platform can still connect using the proxy-only agent and perform a rollback to a previous agent version.
 
 <DuringSvg1 width="100%" />
 
@@ -68,7 +68,7 @@ If the platform does not manage your agents, you can still manually upgrade them
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../../authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform/administer/clusters/advanced/multi-region/deploy.mdx
@@ -133,7 +133,7 @@ eksctl create addon --name aws-ebs-csi-driver \\
 />
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ## Step 2 - Install AWS load balancer controller
 

--- a/platform/administer/clusters/connect-cluster.mdx
+++ b/platform/administer/clusters/connect-cluster.mdx
@@ -58,7 +58,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform/administer/node-profiles/overview.mdx
+++ b/platform/administer/node-profiles/overview.mdx
@@ -12,7 +12,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="node-profiles" />
 
 
-A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
+A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
 
 The platform doesn't just apply it once. It keeps every node that references the profile in sync as the definition changes, converging edits onto already-joined nodes without re-provisioning them.
 

--- a/platform/administer/node-providers/bcm.mdx
+++ b/platform/administer/node-providers/bcm.mdx
@@ -14,7 +14,7 @@ In order for this provider to work you need the following prerequisites:
 * vCluster Platform needs to be able to reach BCM control server
 * `admin.key` and `admin.pem` (or similar certificates with access) which can be found at `~/.cm/admin.key` and `~/.cm/admin.pem` on the BCM head node
 
-If the above prerequisites are fulfilled, vCluster platform will be able to schedule nodes you specify within the provider as worker nodes for vCluster. BCM nodes can be either referenced directly via their hostname or via a node group.
+If the above prerequisites are fulfilled, vCluster platform will be able to schedule nodes you specify within the provider as worker nodes for vCluster. BCM nodes can be either referenced directly using their hostname or using a node group.
 vCluster platform will restart (and wipe their contents) as soon as the node is deprovisioned to allow safe reuse of nodes between vCluster.
 
 <br />
@@ -133,7 +133,7 @@ This property may be omitted when the `netris.vcluster.com/server-cluster` is se
 **Type:** `string`
 **Required with:** `bcm.vcluster.com/network-name` or `netris.vcluster.com/server-cluster`
 
-The name of the node's boot network interface, e.g. `eth0`, `bond0`.
+The name of the node's boot network interface, for example `eth0`, `bond0`.
 
 ### `bcm.vcluster.com/network-ip-range`
 
@@ -145,8 +145,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/vcluster/next/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
+The BCM node provider can use the [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/configure/vcluster-yaml/integrations/netris).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -201,4 +201,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -649,7 +649,7 @@ The interface injection itself is a generic mechanism. Netris is one way to driv
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
+- [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
 - vCluster Platform license must include the Netris feature.
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the control plane cluster nodes.
 
@@ -743,4 +743,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform/administer/node-providers/terraform.mdx
+++ b/platform/administer/node-providers/terraform.mdx
@@ -11,7 +11,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 The terraform provider allows you to use Terraform scripts to automatically create [nodes](./overview.mdx) and [node environments](./overview.mdx). 
 When a vCluster requests a new node, the platform will execute the specified Terraform script to create and join a node automatically into the vCluster. 
-If the node or vCluster is later deleted, the platform will destroy the node via Terraform.
+If the node or vCluster is later deleted, the platform will destroy the node using Terraform.
 
 <br />
 ```mermaid
@@ -133,7 +133,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/vcluster/next/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 
@@ -197,7 +197,7 @@ The node type field `maxCapacity` allows you to specify an upper limit of how ma
 
 ## Node environment template
 
-[Node environments](./overview.mdx) can be configured similar to node templates either inline or via git. Each node environment will be created once per vCluster before the first node claim is provisioned. Only if a vCluster is using a node the provider a new node environment is provisioned.
+[Node environments](./overview.mdx) can be configured similar to node templates either inline or using git. Each node environment will be created once per vCluster before the first node claim is provisioned. Only if a vCluster is using a node the provider a new node environment is provisioned.
 
 The following example specifies a very simple inline template to create an AWS VPC instance for a vCluster:
 ```yaml
@@ -240,7 +240,7 @@ spec:
         ...
 ```
 
-The defined output `vpc_id` within the node environment can be accessed in the node template via `var.vcluster.nodeEnvironment.outputs["vpc_id"]`.
+The defined output `vpc_id` within the node environment can be accessed in the node template using `var.vcluster.nodeEnvironment.outputs["vpc_id"]`.
 
 ### Available terraform vCluster variables
 
@@ -253,12 +253,12 @@ Besides the user-defined credentials specified below, the platform passes a `var
 
 ## Credentials
 
-Credentials to the Terraform scripts can be defined via Kubernetes secrets. The key and values of these secrets can then be passed as either environment variables or regular variables to the Terraform commands.
+Credentials to the Terraform scripts can be defined using Kubernetes secrets. The key and values of these secrets can then be passed as either environment variables or regular variables to the Terraform commands.
 
-Within the vCluster you can select the credentials to use via the `terraform.vcluster.com/credentials` property. This allows you to specify different credentials for different teams or users and select the dynmically.
+Within the vCluster you can select the credentials using the `terraform.vcluster.com/credentials` property. This allows you to specify different credentials for different teams or users and select the dynmically.
 
 :::tip Dynamic Credentials
-If possible we recommend to use [dynamic credentials](https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials) for providers instead of long-living hardcoded credentials via Kubernetes secrets. Almost all Terraform providers support this and marks the additional configuration via Kubernetes secrets obsolete.
+If possible we recommend to use [dynamic credentials](https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials) for providers instead of long-living hardcoded credentials using Kubernetes secrets. Almost all Terraform providers support this and marks the additional configuration using Kubernetes secrets obsolete.
 :::
 
 ### Environment variables secret
@@ -301,7 +301,7 @@ data:
   aws_secret_access_key: ...
 ```
 
-This will lead to the platform passing the Terraform variables `aws_access_key_id` and `aws_secret_access_key` to the `tofu init` and `tofu apply` commands via `-var aws_access_key_id=VALUE`.
+This will lead to the platform passing the Terraform variables `aws_access_key_id` and `aws_secret_access_key` to the `tofu init` and `tofu apply` commands using `-var aws_access_key_id=VALUE`.
 
 ## Terraform backend
 By default, the platform will use the [Kubernetes backend](https://developer.hashicorp.com/terraform/language/backend/kubernetes) to store the state of the nodes and node environments in Kubernetes secrets in the `vcluster-platform` namespace. 

--- a/platform/administer/templates/overview.mdx
+++ b/platform/administer/templates/overview.mdx
@@ -39,20 +39,20 @@ vCluster Platform includes templates for tenant clusters, applications, and name
 
 <br />
 
-You can [create templates](/docs/platform/next/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
+You can [create templates](./create-templates.mdx) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
 
 
 ## Apply parameters and versioning
 
 Templates support optional parameterization and versioning. Optionally, you can apply:
 
-- [Parameters](/docs/platform/next/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
+- [Parameters](./parameters.mdx) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
 
-- [Versioning](/docs/platform/next/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
+- [Versioning](./versioning.mdx) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
 
 
 ## Next steps
 
-- [Create a template](/docs/platform/next/administer/templates/create-templates) to define a reusable configuration.
-- Optionally, [configure template parameters](/docs/platform/next/administer/templates/parameters) to allow user customization.
-- Optionally, [set up template versioning](/docs/platform/next/administer/templates/versioning) to manage template updates.
+- [Create a template](./create-templates.mdx) to define a reusable configuration.
+- Optionally, [configure template parameters](./parameters.mdx) to allow user customization.
+- Optionally, [set up template versioning](./versioning.mdx) to manage template updates.

--- a/platform/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform/administer/users-permissions/managing-users/impersonate.mdx
@@ -188,5 +188,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for tenant clusters](/docs/vcluster/next/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for tenant clusters](/docs/vcluster/configure/vcluster-yaml/sleep)**
 :::

--- a/platform/configure/agent-settings/overview.mdx
+++ b/platform/configure/agent-settings/overview.mdx
@@ -67,7 +67,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../../administer/authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform/configure/installation-options/domain.mdx
+++ b/platform/configure/installation-options/domain.mdx
@@ -29,7 +29,7 @@ Setting up the platform for access through a routable IP or domain name, and sec
 
 ## External access
 
-The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/next/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/next/manage/ingress-nginx-to-gateway-api).
+The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/manage/ingress-nginx-to-gateway-api).
 
 <details>
   <summary>

--- a/platform/integrations/argocd/deploy-applications.mdx
+++ b/platform/integrations/argocd/deploy-applications.mdx
@@ -101,7 +101,7 @@ Argo CD requires application names to be unique across all projects. Platform sa
 Applications deployed to a tenant cluster are declared in the cluster's `vcluster.yaml` under `deploy.argoCD.applications`. Each entry can target:
 
 - **`vcluster`** (default): the tenant cluster itself
-- **`host`**: the control plane cluster the tenant cluster runs on (see [Deploying to the control plane cluster](#deploying-to-the-control-plane-cluster))
+- **`host`**: the control plane cluster the tenant cluster runs on (see [Deploy to the control plane cluster](#deploy-to-the-control-plane-cluster))
 
 <Tabs
   defaultValue="ui"

--- a/platform/introduction/platform_intro.mdx
+++ b/platform/introduction/platform_intro.mdx
@@ -115,7 +115,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
   <figcaption>Sleeping tenant clusters remain visible in Platform and can be woken when users need them again.</figcaption>
 </figure>
 
-[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform/understand/control-plane-outages.mdx
+++ b/platform/understand/control-plane-outages.mdx
@@ -35,7 +35,7 @@ A connected control plane cluster is a Kubernetes cluster where Platform can dep
 | Tenant cluster reconciliation | Unavailable | Platform-managed reconciliation pauses or fails for tenant clusters on the unavailable cluster. |
 | Tenant workloads | Limited | Availability depends on whether their control planes and worker nodes are still running and reachable. |
 
-If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/next/understand/control-plane-outages).
+If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/understand/control-plane-outages).
 
 ## Tenant cluster control plane outage
 

--- a/platform/understand/externally-vs-platform-deployed.mdx
+++ b/platform/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Tenant cluster custom links
-For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -118,7 +118,7 @@ Organizations often have existing deployment pipelines using tools like Helm, Ar
 
 After deploying your vCluster using your existing tools, add it to <GlossaryTerm term="platform">the Platform</GlossaryTerm> and enable full management.
 
-First, login with the platform [access key](/docs/platform/next/administer/authentication/access-keys):
+First, login with the platform [access key](../../administer/authentication/access-keys.mdx):
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
@@ -143,7 +143,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/next/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -285,8 +285,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -322,6 +322,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/next/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 

--- a/platform_versioned_docs/version-4.11.0/_fragments/cli-steps/connect-platform.mdx
+++ b/platform_versioned_docs/version-4.11.0/_fragments/cli-steps/connect-platform.mdx
@@ -1,4 +1,4 @@
-**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/next/administer/authentication/access-keys) for more details.
+**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](../../administer/authentication/access-keys.mdx) for more details.
 
 When you started the platform, you would have automatically connected to the platform when you ran `vcluster platform start`.
 

--- a/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/cluster-upgrades.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/cluster-upgrades.mdx
@@ -33,7 +33,7 @@ As the name suggests, this proxy-only agent solely aims to proxy the communicati
 
 The platform deploys the proxy-only agent by creating a deployment in the connected cluster's agent's namespace. It additionally reuses the agent's service account and associated RBAC permissions.
 Once the proxy-only agent is healthy, the platform upgrades the agent deployment.
-In case of a failure during the upgrade, the platform can still connect via the proxy-only agent and perform a rollback to a previous agent version.
+In case of a failure during the upgrade, the platform can still connect using the proxy-only agent and perform a rollback to a previous agent version.
 
 <DuringSvg1 width="100%" />
 
@@ -68,7 +68,7 @@ If the platform does not manage your agents, you can still manually upgrade them
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../../authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/multi-region/deploy.mdx
@@ -133,7 +133,7 @@ eksctl create addon --name aws-ebs-csi-driver \\
 />
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/0.36.0/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ## Step 2 - Install AWS load balancer controller
 

--- a/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/clusters/advanced/multi-region/deploy.mdx
@@ -133,7 +133,7 @@ eksctl create addon --name aws-ebs-csi-driver \\
 />
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/0.36.0/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ## Step 2 - Install AWS load balancer controller
 

--- a/platform_versioned_docs/version-4.11.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/clusters/connect-cluster.mdx
@@ -58,7 +58,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.11.0/administer/node-profiles/overview.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-profiles/overview.mdx
@@ -12,7 +12,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="node-profiles" />
 
 
-A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/0.36.0/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
+A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
 
 The platform doesn't just apply it once. It keeps every node that references the profile in sync as the definition changes, converging edits onto already-joined nodes without re-provisioning them.
 

--- a/platform_versioned_docs/version-4.11.0/administer/node-profiles/overview.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-profiles/overview.mdx
@@ -12,7 +12,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="node-profiles" />
 
 
-A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/next/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/next/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
+A NodeProfile is a named, reusable configuration for a class of nodes, for example every GPU training node. Reference the same profile from a [manual join](/docs/vcluster/0.36.0/deploy/worker-nodes/private-nodes/join) or a static or dynamic [auto-node pool](/docs/vcluster/0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes), and every node gets that configuration, regardless of how it joined.
 
 The platform doesn't just apply it once. It keeps every node that references the profile in sync as the definition changes, converging edits onto already-joined nodes without re-provisioning them.
 

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/bcm.mdx
@@ -145,8 +145,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).
+The BCM node provider can use the [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/configure/vcluster-yaml/integrations/netris).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -201,4 +201,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/bcm.mdx
@@ -14,7 +14,7 @@ In order for this provider to work you need the following prerequisites:
 * vCluster Platform needs to be able to reach BCM control server
 * `admin.key` and `admin.pem` (or similar certificates with access) which can be found at `~/.cm/admin.key` and `~/.cm/admin.pem` on the BCM head node
 
-If the above prerequisites are fulfilled, vCluster platform will be able to schedule nodes you specify within the provider as worker nodes for vCluster. BCM nodes can be either referenced directly via their hostname or via a node group.
+If the above prerequisites are fulfilled, vCluster platform will be able to schedule nodes you specify within the provider as worker nodes for vCluster. BCM nodes can be either referenced directly using their hostname or using a node group.
 vCluster platform will restart (and wipe their contents) as soon as the node is deprovisioned to allow safe reuse of nodes between vCluster.
 
 <br />
@@ -133,7 +133,7 @@ This property may be omitted when the `netris.vcluster.com/server-cluster` is se
 **Type:** `string`
 **Required with:** `bcm.vcluster.com/network-name` or `netris.vcluster.com/server-cluster`
 
-The name of the node's boot network interface, e.g. `eth0`, `bond0`.
+The name of the node's boot network interface, for example `eth0`, `bond0`.
 
 ### `bcm.vcluster.com/network-ip-range`
 
@@ -145,8 +145,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/vcluster/next/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
+The BCM node provider can use the [Netris integration](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -201,4 +201,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/kubevirt.mdx
@@ -649,7 +649,7 @@ The interface injection itself is a generic mechanism. Netris is one way to driv
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
+- [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
 - vCluster Platform license must include the Netris feature.
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the control plane cluster nodes.
 
@@ -743,4 +743,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/kubevirt.mdx
@@ -649,7 +649,7 @@ The interface injection itself is a generic mechanism. Netris is one way to driv
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
+- [Netris integration](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
 - vCluster Platform license must include the Netris feature.
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the control plane cluster nodes.
 
@@ -743,4 +743,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/0.36.0/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/terraform.mdx
@@ -11,7 +11,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 The terraform provider allows you to use Terraform scripts to automatically create [nodes](./overview.mdx) and [node environments](./overview.mdx). 
 When a vCluster requests a new node, the platform will execute the specified Terraform script to create and join a node automatically into the vCluster. 
-If the node or vCluster is later deleted, the platform will destroy the node via Terraform.
+If the node or vCluster is later deleted, the platform will destroy the node using Terraform.
 
 <br />
 ```mermaid
@@ -133,7 +133,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/vcluster/next/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/0.36.0/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 
@@ -197,7 +197,7 @@ The node type field `maxCapacity` allows you to specify an upper limit of how ma
 
 ## Node environment template
 
-[Node environments](./overview.mdx) can be configured similar to node templates either inline or via git. Each node environment will be created once per vCluster before the first node claim is provisioned. Only if a vCluster is using a node the provider a new node environment is provisioned.
+[Node environments](./overview.mdx) can be configured similar to node templates either inline or using git. Each node environment will be created once per vCluster before the first node claim is provisioned. Only if a vCluster is using a node the provider a new node environment is provisioned.
 
 The following example specifies a very simple inline template to create an AWS VPC instance for a vCluster:
 ```yaml
@@ -240,7 +240,7 @@ spec:
         ...
 ```
 
-The defined output `vpc_id` within the node environment can be accessed in the node template via `var.vcluster.nodeEnvironment.outputs["vpc_id"]`.
+The defined output `vpc_id` within the node environment can be accessed in the node template using `var.vcluster.nodeEnvironment.outputs["vpc_id"]`.
 
 ### Available terraform vCluster variables
 
@@ -253,12 +253,12 @@ Besides the user-defined credentials specified below, the platform passes a `var
 
 ## Credentials
 
-Credentials to the Terraform scripts can be defined via Kubernetes secrets. The key and values of these secrets can then be passed as either environment variables or regular variables to the Terraform commands.
+Credentials to the Terraform scripts can be defined using Kubernetes secrets. The key and values of these secrets can then be passed as either environment variables or regular variables to the Terraform commands.
 
-Within the vCluster you can select the credentials to use via the `terraform.vcluster.com/credentials` property. This allows you to specify different credentials for different teams or users and select the dynmically.
+Within the vCluster you can select the credentials using the `terraform.vcluster.com/credentials` property. This allows you to specify different credentials for different teams or users and select the dynmically.
 
 :::tip Dynamic Credentials
-If possible we recommend to use [dynamic credentials](https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials) for providers instead of long-living hardcoded credentials via Kubernetes secrets. Almost all Terraform providers support this and marks the additional configuration via Kubernetes secrets obsolete.
+If possible we recommend to use [dynamic credentials](https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials) for providers instead of long-living hardcoded credentials using Kubernetes secrets. Almost all Terraform providers support this and marks the additional configuration using Kubernetes secrets obsolete.
 :::
 
 ### Environment variables secret
@@ -301,7 +301,7 @@ data:
   aws_secret_access_key: ...
 ```
 
-This will lead to the platform passing the Terraform variables `aws_access_key_id` and `aws_secret_access_key` to the `tofu init` and `tofu apply` commands via `-var aws_access_key_id=VALUE`.
+This will lead to the platform passing the Terraform variables `aws_access_key_id` and `aws_secret_access_key` to the `tofu init` and `tofu apply` commands using `-var aws_access_key_id=VALUE`.
 
 ## Terraform backend
 By default, the platform will use the [Kubernetes backend](https://developer.hashicorp.com/terraform/language/backend/kubernetes) to store the state of the nodes and node environments in Kubernetes secrets in the `vcluster-platform` namespace. 

--- a/platform_versioned_docs/version-4.11.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/node-providers/terraform.mdx
@@ -133,7 +133,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/docs/vcluster/0.36.0/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 

--- a/platform_versioned_docs/version-4.11.0/administer/templates/overview.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/templates/overview.mdx
@@ -39,20 +39,20 @@ vCluster Platform includes templates for tenant clusters, applications, and name
 
 <br />
 
-You can [create templates](/docs/platform/next/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
+You can [create templates](./create-templates.mdx) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
 
 
 ## Apply parameters and versioning
 
 Templates support optional parameterization and versioning. Optionally, you can apply:
 
-- [Parameters](/docs/platform/next/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
+- [Parameters](./parameters.mdx) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
 
-- [Versioning](/docs/platform/next/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
+- [Versioning](./versioning.mdx) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
 
 
 ## Next steps
 
-- [Create a template](/docs/platform/next/administer/templates/create-templates) to define a reusable configuration.
-- Optionally, [configure template parameters](/docs/platform/next/administer/templates/parameters) to allow user customization.
-- Optionally, [set up template versioning](/docs/platform/next/administer/templates/versioning) to manage template updates.
+- [Create a template](./create-templates.mdx) to define a reusable configuration.
+- Optionally, [configure template parameters](./parameters.mdx) to allow user customization.
+- Optionally, [set up template versioning](./versioning.mdx) to manage template updates.

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -29,7 +29,7 @@ admins and users that have the management role `Impersonator` assigned, can impe
     In the user row you want to impersonate, select <Label>Impersonate</Label>
   </Step>
   <Step>
-    To stop impersonation, either press <Label>Logout</Label> or click on the{" "}
+    To stop impersonation, either press <Label>Logout</Label> or click the{" "}
     <Label>Stop Impersonation</Label> button at the top.
   </Step>
 </Flow>
@@ -43,7 +43,7 @@ sure you are taking advantage of Projects when considering your RBAC strategy.
 ### 1. Create test user
 
 vCluster Platform lets you connect a variety of SSO providers for authentication but for the sake of
-simplicity, let's just manually create a user to learn more about vCluster Platform's cluster access features:
+simplicity, this guide manually creates a user to explore vCluster Platform's cluster access features:
 
 <Flow id="create-user">
   <Step>
@@ -59,7 +59,7 @@ simplicity, let's just manually create a user to learn more about vCluster Platf
     'metadata. name' field.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button> button.
+    Click the <Button>Save Changes</Button> button.
   </Step>
   <Step image="">
     Close the popup using the button <Button>Copy & Close</Button>
@@ -69,13 +69,13 @@ simplicity, let's just manually create a user to learn more about vCluster Platf
 :::tip 100% Kubernetes Native
 Remember: Everything you do in vCluster Platform UI, including creating a user, is effectively a kubectl
 command under the hood. So, everything you do in this guide creates or changes objects in your
-cluster and you could also manage these actions via kubectl or any kind of GitOps tool.
+cluster and you could also manage these actions using kubectl or any kind of GitOps tool.
 :::
 
 ### 2. Impersonate user
 
-vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. Let's try this to see
-how vCluster Platform UI would look like for our newly created user:
+vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. Try this to see
+how vCluster Platform UI would look like for the newly created user:
 
 <Flow id="impersonate-user">
   <Step>
@@ -83,7 +83,7 @@ how vCluster Platform UI would look like for our newly created user:
   </Step>
   <Step>
     Find the user `Anna` in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click on the{" "}
+    arrow in the Display Name column and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"
@@ -103,7 +103,7 @@ how vCluster Platform UI would look like for our newly created user:
     button to <Label>Impersonate</Label> the user.
   </Step>
   <Step>
-    In the popup, click on the <Button>Impersonate</Button> button to confirm
+    In the popup, click the <Button>Impersonate</Button> button to confirm
     that you want to start impersonation.
   </Step>
   <Step>
@@ -123,7 +123,7 @@ command while the impersonation is active.
 vcluster platform login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
 ```
 
-You can verify the login and print your user information via:
+You can verify the login and print your user information using:
 
 ```bash
 vcluster platform login
@@ -131,21 +131,21 @@ vcluster platform login
 
 ### 3. Configure cluster access
 
-Let's give our test user Anna access to one of the clusters connected to this vCluster Platform instance:
+Give the test user Anna access to one of the clusters connected to this vCluster Platform instance:
 
 <PartialClusterAccessCreateUI />
 
 :::note Single Sign-On + Cluster Access
 You can connect a variety of SSO providers to vCluster Platform. To automatically give users access to
 clusters based on their SSO user groups, you can switch to the <Label>Team Members</Label> tab
-to grant cluster access for each member of a team (e.g. for each member of a group in Active
-Directory, Okta, SAML, etc.), check out the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
+to grant cluster access for each member of a team (for example, for each member of a group in Active
+Directory, Okta, or SAML), check out the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
 more details.
 :::
 
 ### 4. Verify cluster access
 
-After configuring the cluster access for test user Anna, let's verify that she can access the
+After configuring the cluster access for test user Anna, verify that she can access the
 cluster:
 
 <Flow id="impersonate-user-with-cluster-access">
@@ -174,7 +174,7 @@ cluster:
     button to <Label>Impersonate</Label> the user.
   </Step>
   <Step>
-    In the popup, click on the <Button>Impersonate</Button> button to confirm
+    In the popup, click the <Button>Impersonate</Button> button to confirm
     that you want to start impersonation.
   </Step>
   <Step>
@@ -194,5 +194,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for tenant clusters](/docs/vcluster/next/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for tenant clusters](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)**
 :::

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -194,5 +194,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for tenant clusters](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for tenant clusters](/docs/vcluster/configure/vcluster-yaml/sleep)**
 :::

--- a/platform_versioned_docs/version-4.11.0/configure/agent-settings/overview.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/agent-settings/overview.mdx
@@ -67,7 +67,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](../../administer/authentication/access-keys.mdx#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.11.0/configure/installation-options/domain.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/installation-options/domain.mdx
@@ -29,7 +29,7 @@ Setting up the platform for access through a routable IP or domain name, and sec
 
 ## External access
 
-The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/0.36.0/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/0.36.0/manage/ingress-nginx-to-gateway-api).
+The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/manage/ingress-nginx-to-gateway-api).
 
 <details>
   <summary>

--- a/platform_versioned_docs/version-4.11.0/configure/installation-options/domain.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/installation-options/domain.mdx
@@ -29,7 +29,7 @@ Setting up the platform for access through a routable IP or domain name, and sec
 
 ## External access
 
-The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/next/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/next/manage/ingress-nginx-to-gateway-api).
+The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/0.36.0/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/0.36.0/manage/ingress-nginx-to-gateway-api).
 
 <details>
   <summary>

--- a/platform_versioned_docs/version-4.11.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.11.0/introduction/platform_intro.mdx
@@ -115,7 +115,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
   <figcaption>Sleeping tenant clusters remain visible in Platform and can be woken when users need them again.</figcaption>
 </figure>
 
-[Configure sleep mode →](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform_versioned_docs/version-4.11.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.11.0/introduction/platform_intro.mdx
@@ -115,7 +115,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
   <figcaption>Sleeping tenant clusters remain visible in Platform and can be woken when users need them again.</figcaption>
 </figure>
 
-[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform_versioned_docs/version-4.11.0/understand/control-plane-outages.mdx
+++ b/platform_versioned_docs/version-4.11.0/understand/control-plane-outages.mdx
@@ -35,7 +35,7 @@ A connected control plane cluster is a Kubernetes cluster where Platform can dep
 | Tenant cluster reconciliation | Unavailable | Platform-managed reconciliation pauses or fails for tenant clusters on the unavailable cluster. |
 | Tenant workloads | Limited | Availability depends on whether their control planes and worker nodes are still running and reachable. |
 
-If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/0.36.0/understand/control-plane-outages).
+If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/understand/control-plane-outages).
 
 ## Tenant cluster control plane outage
 

--- a/platform_versioned_docs/version-4.11.0/understand/control-plane-outages.mdx
+++ b/platform_versioned_docs/version-4.11.0/understand/control-plane-outages.mdx
@@ -35,7 +35,7 @@ A connected control plane cluster is a Kubernetes cluster where Platform can dep
 | Tenant cluster reconciliation | Unavailable | Platform-managed reconciliation pauses or fails for tenant clusters on the unavailable cluster. |
 | Tenant workloads | Limited | Availability depends on whether their control planes and worker nodes are still running and reachable. |
 
-If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/next/understand/control-plane-outages).
+If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/0.36.0/understand/control-plane-outages).
 
 ## Tenant cluster control plane outage
 

--- a/platform_versioned_docs/version-4.11.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.11.0/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/0.36.0/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform_versioned_docs/version-4.11.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.11.0/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/0.36.0/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Tenant cluster custom links
-For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/0.36.0/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Tenant cluster custom links
-For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/0.36.0/key-features/custom-links) documentation.
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -118,7 +118,7 @@ Organizations often have existing deployment pipelines using tools like Helm, Ar
 
 After deploying your vCluster using your existing tools, add it to <GlossaryTerm term="platform">the Platform</GlossaryTerm> and enable full management.
 
-First, login with the platform [access key](/docs/platform/next/administer/authentication/access-keys):
+First, login with the platform [access key](../../administer/authentication/access-keys.mdx):
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
@@ -143,7 +143,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/next/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/0.36.0/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -285,8 +285,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -322,6 +322,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -143,7 +143,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/0.36.0/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -285,8 +285,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -322,6 +322,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/0.36.0/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/0.36.0/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/next/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/0.36.0/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 

--- a/src/components/InterpolatedCodeBlock/index.js
+++ b/src/components/InterpolatedCodeBlock/index.js
@@ -6,8 +6,8 @@ import { usePageVariables } from '../PageVariables/PageVariablesContext';
 
 // Latest versions - fallback if not in versioned docs context
 const LATEST_VERSIONS = {
-  platform: '4.10.5',
-  vcluster: '0.35.2',
+  platform: '4.11.0',
+  vcluster: '0.36.0',
 };
 
 /**

--- a/src/config/docsearch.js
+++ b/src/config/docsearch.js
@@ -5,14 +5,14 @@ export const DOCSEARCH_PRODUCTS = {
   vcluster: {
     pluginId: "vcluster",
     displayName: "vCluster",
-    stableVersion: "0.35.0",
-    stableLabel: "v0.35 Stable",
+    stableVersion: "0.36.0",
+    stableLabel: "v0.36 Stable",
   },
   platform: {
     pluginId: "platform",
     displayName: "Platform",
-    stableVersion: "4.10.0",
-    stableLabel: "v4.10 Stable",
+    stableVersion: "4.11.0",
+    stableLabel: "v4.11 Stable",
   },
   vnode: {
     pluginId: "vnode",

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -8,8 +8,8 @@
  * `versions` and `onlyIncludeVersions` config.
  */
 
-export const vclusterHiddenVersions = ["0.36.0"];
-export const platformHiddenVersions = ["4.11.0"];
+export const vclusterHiddenVersions = [];
+export const platformHiddenVersions = [];
 
 export const vclusterEOLVersions = [
   { to: "https://vcluster.com/docs/v0.33", label: "v0.33 (EOS)" },

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -12,8 +12,8 @@ import BackingStore from '../../../../../_partials/config/controlPlane/backingSt
 
 Each tenant cluster requires a backing store and vCluster provides two different types of backing store options:
 
-* [etcd](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd)
-* [database](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database)
+* [etcd](./etcd/README.mdx)
+* [database](./database/README.mdx)
 
 There are different ways to deploy the type of backing store.
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
@@ -20,7 +20,7 @@ For step-by-step instructions on deploying <GlossaryTerm term="vcluster">vCluste
 
 ## Default node profile
 
-Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/next/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
+Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
 
 ```yaml title="Set a default node profile"
 privateNodes:
@@ -28,7 +28,7 @@ privateNodes:
   defaultProfile: general-compute
 ```
 
-This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
+This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -231,7 +231,7 @@ privateNodes:
 
 ### Node profiles
 
-Each static or dynamic node pool can reference a [node profile](/docs/platform/next/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
+Each static or dynamic node pool can reference a [node profile](/docs/platform/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
 
 ```yaml title="Example of a node pool referencing a node profile"
 privateNodes:

--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -88,13 +88,13 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
 
 1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
 2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 
-The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
+The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
 
 ## Available flags to use in the script to join nodes
 

--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -76,7 +76,7 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/next/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
+A node that joined with a [node profile](/docs/platform/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
 
 Convergence is prompt rather than tied to a polling interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/snapshots.mdx
@@ -36,7 +36,7 @@ For on-demand snapshot creation and restore operations, see the [vCluster Snapsh
 This allows administrators to capture and store the vCluster state in scheduled intervals to help protect
 against infrastructure failures, data corruption, and configuration errors. By maintaining consistent
 recovery points, administrators can quickly restore the vCluster to a known good state without relying on manual backup processes.
-For more details on how snapshots work, refer to the [Snapshot and Restore](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
+For more details on how snapshots work, refer to the [Snapshot and Restore](../../manage/backup-restore/volume-snapshots/setup.mdx) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
 
 In the `vcluster.yaml`, it is configured under `snapshots`. Using the UI, you
 can configure the management of snapshots in the config options of a tenant cluster under **Snapshots**. Though
@@ -87,7 +87,7 @@ snapshots:
 
 :::warning
 In order to create volume snapshots, several installation and configuration steps have to be done in your control plane cluster or tenant cluster.
-Check the [Volume Snapshot](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation page to learn more about getting your cluster ready for snapshotting volumes
+Check the [Volume Snapshot](../../manage/backup-restore/volume-snapshots/setup.mdx) documentation page to learn more about getting your cluster ready for snapshotting volumes
 :::
 
 ### AWS S3 bucket example

--- a/vcluster_versioned_docs/version-0.34.0/key-features/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/key-features/snapshots.mdx
@@ -44,4 +44,4 @@ When volume snapshotting is enabled, there will be transitions between various v
 | `Completed` | Volume snapshot was successfully taken |
 | `Failed` | Volume snapshot failed to be taken |
 
-These phases are displayed in the platform UI on the Snapshot View page and help to identify the current status of each volume snapshot. You can also refer to the [Troubleshoot Issues](/vcluster/manage/backup-restore/volume-snapshots/setup#troubleshoot-issues) section of the vCluster Volume Snapshot documentation to help identify and resolve potential issues.
+These phases are displayed in the platform UI on the Snapshot View page and help to identify the current status of each volume snapshot. You can also refer to the [Troubleshoot Issues](../manage/backup-restore/volume-snapshots/setup.mdx#troubleshoot-issues) section of the vCluster Volume Snapshot documentation to help identify and resolve potential issues.

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/snapshots.mdx
@@ -36,7 +36,7 @@ For on-demand snapshot creation and restore operations, see the [vCluster Snapsh
 This allows administrators to capture and store the vCluster state in scheduled intervals to help protect
 against infrastructure failures, data corruption, and configuration errors. By maintaining consistent
 recovery points, administrators can quickly restore the vCluster to a known good state without relying on manual backup processes.
-For more details on how snapshots work, refer to the [Snapshot and Restore](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
+For more details on how snapshots work, refer to the [Snapshot and Restore](../../manage/backup-restore/volume-snapshots/setup.mdx) documentation. If you use private nodes, see [Use snapshots with private nodes](../../manage/backup-restore/restore.mdx#use-snapshots-with-private-nodes) for additional restore steps.
 
 In the `vcluster.yaml`, it is configured under `snapshots`. Using the UI, you
 can configure the management of snapshots in the config options of a tenant cluster under **Snapshots**. Though
@@ -87,7 +87,7 @@ snapshots:
 
 :::warning
 In order to create volume snapshots, several installation and configuration steps have to be done in your control plane cluster or tenant cluster.
-Check the [Volume Snapshot](/vcluster/manage/backup-restore/volume-snapshots/setup) documentation page to learn more about getting your cluster ready for snapshotting volumes
+Check the [Volume Snapshot](../../manage/backup-restore/volume-snapshots/setup.mdx) documentation page to learn more about getting your cluster ready for snapshotting volumes
 :::
 
 ### AWS S3 bucket example

--- a/vcluster_versioned_docs/version-0.35.0/key-features/snapshots.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/key-features/snapshots.mdx
@@ -44,4 +44,4 @@ When volume snapshotting is enabled, there will be transitions between various v
 | `Completed` | Volume snapshot was successfully taken |
 | `Failed` | Volume snapshot failed to be taken |
 
-These phases are displayed in the platform UI on the Snapshot View page and help to identify the current status of each volume snapshot. You can also refer to the [Troubleshoot Issues](/vcluster/manage/backup-restore/volume-snapshots/setup#troubleshoot-issues) section of the vCluster Volume Snapshot documentation to help identify and resolve potential issues.
+These phases are displayed in the platform UI on the Snapshot View page and help to identify the current status of each volume snapshot. You can also refer to the [Troubleshoot Issues](../manage/backup-restore/volume-snapshots/setup.mdx#troubleshoot-issues) section of the vCluster Volume Snapshot documentation to help identify and resolve potential issues.

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -12,8 +12,8 @@ import BackingStore from '../../../../../_partials/config/controlPlane/backingSt
 
 Each tenant cluster requires a backing store and vCluster provides two different types of backing store options:
 
-* [etcd](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd)
-* [database](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database)
+* [etcd](./etcd/README.mdx)
+* [database](./database/README.mdx)
 
 There are different ways to deploy the type of backing store.
 

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/README.mdx
@@ -20,7 +20,7 @@ For step-by-step instructions on deploying <GlossaryTerm term="vcluster">vCluste
 
 ## Default node profile
 
-Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/next/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
+Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
 
 ```yaml title="Set a default node profile"
 privateNodes:
@@ -28,7 +28,7 @@ privateNodes:
   defaultProfile: general-compute
 ```
 
-This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
+This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/4.11.0/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/README.mdx
@@ -20,7 +20,7 @@ For step-by-step instructions on deploying <GlossaryTerm term="vcluster">vCluste
 
 ## Default node profile
 
-Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
+Set `privateNodes.defaultProfile` to a [node profile](/docs/platform/administer/node-profiles/overview) name to apply it to any node that joins the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> without an explicit profile:
 
 ```yaml title="Set a default node profile"
 privateNodes:
@@ -28,7 +28,7 @@ privateNodes:
   defaultProfile: general-compute
 ```
 
-This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/4.11.0/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
+This takes precedence over the project's default node profile, if the project also has one configured. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for the full resolution order.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -231,7 +231,7 @@ privateNodes:
 
 ### Node profiles
 
-Each static or dynamic node pool can reference a [node profile](/docs/platform/next/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
+Each static or dynamic node pool can reference a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
 
 ```yaml title="Example of a node pool referencing a node profile"
 privateNodes:

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -231,7 +231,7 @@ privateNodes:
 
 ### Node profiles
 
-Each static or dynamic node pool can reference a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
+Each static or dynamic node pool can reference a [node profile](/docs/platform/administer/node-profiles/overview) using the `profile` field. The platform continuously reconciles the profile's labels, annotations, and taints onto every node the pool provisions, so editing the profile updates those nodes without a rollout.
 
 ```yaml title="Example of a node pool referencing a node profile"
 privateNodes:

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
@@ -88,13 +88,13 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
 
 1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
 2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 
-The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/4.11.0/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
+The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
 
 ## Available flags to use in the script to join nodes
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
@@ -88,13 +88,13 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/next/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
 
 1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
 2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 
-The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/next/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
+The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/4.11.0/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.
 
 ## Available flags to use in the script to join nodes
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/manage.mdx
@@ -76,7 +76,7 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/next/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/next/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
+A node that joined with a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/4.11.0/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
 
 Convergence is prompt rather than tied to a polling interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/manage.mdx
@@ -76,7 +76,7 @@ Alternatively, you can manually upgrade by following the [official Kubeadm Kuber
 
 ## Node profiles
 
-A node that joined with a [node profile](/docs/platform/4.11.0/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/4.11.0/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
+A node that joined with a [node profile](/docs/platform/administer/node-profiles/overview) stays in sync with that profile for as long as it's part of the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Edits to the profile converge onto every node referencing it, and removed keys are pruned, except `startupTaints`, which apply only at join. See [Continuous reconciliation](/docs/platform/administer/node-profiles/overview#continuous-reconciliation) for the full behavior.
 
 Convergence is prompt rather than tied to a polling interval, so edits are typically reflected within moments in `kubectl get node <node-name> -o yaml`.
 


### PR DESCRIPTION
# Content Description
Release-day config flip to make the pre-deployed v0.36 (vCluster) and v4.11 (Platform) docs visible in the version dropdown. All content and API partials were deployed hidden at rc-1; this PR only flips visibility, promotes the new versions to stable, demotes the previous stable versions, updates search/announcement config, and swaps the netlify redirect for the new `lastVersion` on each plugin.

## Preview Link
Netlify deploy preview link will be posted by the Netlify bot on this PR.

## Internal Reference
Closes DOC-1582
Closes DOC-1583

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs