### PR TITLE
fix(observability): correct aggregating metrics dashboard defects

### DIFF
--- a/platform/maintenance/monitoring/aggregating-metrics.mdx
+++ b/platform/maintenance/monitoring/aggregating-metrics.mdx
@@ -183,7 +183,7 @@ dashboards:
   default:
     vcluster-platform-metrics:
       json: |
-        {"title":"CPU and Memory usage by Project, Space, Virtual Cluster","panels":[{"gridPos":{"h":8,"w":12,"x":0,"y":0},"id":3,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by(loft_virtualcluster_name) (k8s_pod_cpu_time_seconds_total{loft_virtualcluster_name=~\".+\"})","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Virtual Cluster","type":"timeseries"},{"gridPos":{"h":8,"w":12,"x":12,"y":0},"id":4,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_virtualcluster_name) (k8s_pod_memory_usage_bytes{loft_virtualcluster_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Virtual Cluster","type":"timeseries"},{"gridPos":{"h":8,"w":12,"x":0,"y":8},"id":2,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"builder","expr":"sum by(loft_project_name) (k8s_pod_cpu_time_seconds_total{loft_project_name=~\".+\"})","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"interval":"","legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Project","type":"timeseries"},{"gridPos":{"h":8,"w":12,"x":12,"y":8},"id":1,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_project_name) (k8s_pod_memory_usage_bytes{loft_project_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Project","type":"timeseries"},{"gridPos":{"h":8,"w":12,"x":0,"y":16},"id":6,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by(loft_space_name) (k8s_pod_cpu_time_seconds_total{loft_space_name=~\".+\"})","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Space","type":"timeseries"},{"gridPos":{"h":8,"w":12,"x":12,"y":16},"id":5,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_space_name) (k8s_pod_memory_usage_bytes{loft_space_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Space","type":"timeseries"}],"schemaVersion":38}
+        {"title":"CPU and Memory usage by Project, Space, Virtual Cluster","panels":[{"gridPos":{"h":8,"w":12,"x":0,"y":0},"id":3,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by(loft_virtualcluster_name) (rate(k8s_pod_cpu_time_seconds_total{loft_virtualcluster_name=~\".+\"}[5m]))","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Virtual Cluster","type":"timeseries","fieldConfig":{"defaults":{"unit":"short"},"overrides":[]}},{"gridPos":{"h":8,"w":12,"x":12,"y":0},"id":4,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_virtualcluster_name) (k8s_pod_memory_usage_bytes{loft_virtualcluster_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Virtual Cluster","type":"timeseries","fieldConfig":{"defaults":{"unit":"decmbytes"},"overrides":[]}},{"gridPos":{"h":8,"w":12,"x":0,"y":8},"id":2,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"builder","expr":"sum by(loft_project_name) (rate(k8s_pod_cpu_time_seconds_total{loft_project_name=~\".+\"}[5m]))","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"interval":"","legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Project","type":"timeseries","fieldConfig":{"defaults":{"unit":"short"},"overrides":[]}},{"gridPos":{"h":8,"w":12,"x":12,"y":8},"id":1,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_project_name) (k8s_pod_memory_usage_bytes{loft_project_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Project","type":"timeseries","fieldConfig":{"defaults":{"unit":"decmbytes"},"overrides":[]}},{"gridPos":{"h":8,"w":12,"x":0,"y":16},"id":6,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by(loft_space_name) (rate(k8s_pod_cpu_time_seconds_total{loft_space_name=~\".+\"}[5m]))","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"CPU Usage by Space","type":"timeseries","fieldConfig":{"defaults":{"unit":"short"},"overrides":[]}},{"gridPos":{"h":8,"w":12,"x":12,"y":16},"id":5,"options":{"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":true}},"targets":[{"disableTextWrap":false,"editorMode":"code","expr":"sum by (loft_space_name) (k8s_pod_memory_usage_bytes{loft_space_name=~\".+\"})\n/1024/1024","fullMetaSearch":false,"includeNullMetadata":true,"instant":false,"legendFormat":"__auto","range":true,"refId":"A","useBackend":false}],"title":"Memory Usage (MiB) by Space","type":"timeseries","fieldConfig":{"defaults":{"unit":"decmbytes"},"overrides":[]}}],"schemaVersion":38}
 ```
 
 Click <Button>Install</Button> to deploy Grafana.
@@ -264,10 +264,10 @@ Navigate to your configured hostname and log in with the admin credentials.
 
 After collecting data with OpenTelemetry, you can aggregate the metrics using the associated labels like the vCluster name.
 
-Here's an example Prometheus query showing the CPU usage aggregated by the vCluster name:
+`k8s_pod_cpu_time_seconds_total` is a cumulative counter, so wrap it in `rate()` to get CPU cores used rather than an ever-increasing total. Here's an example Prometheus query showing the CPU usage aggregated by the vCluster name:
 
 ```promql
-sum by(loft_virtualcluster_name) (k8s_pod_cpu_time_seconds_total{loft_virtualcluster_name=~".+"})
+sum by(loft_virtualcluster_name) (rate(k8s_pod_cpu_time_seconds_total{loft_virtualcluster_name=~".+"}[5m]))
 ```
 
 ### Available labels
@@ -279,7 +279,11 @@ The OpenTelemetry Collector adds the following vCluster Platform labels to metri
 | `loft_project_name` | The vCluster Platform project name |
 | `loft_virtualcluster_name` | The tenant cluster name |
 | `loft_space_name` | The space name |
-| `loft_cluster_name` | The connected cluster name |
+| `cluster` | The connected cluster name |
+
+:::info Space label only applies to Space-type tenants
+`loft_space_name` is only populated for namespaces backing a Space-type tenant. Environments with only vCluster-type tenants won't have any series for this label, so queries and dashboard panels aggregated `by(loft_space_name)` show no data.
+:::
 
 ### Example queries
 
@@ -290,7 +294,7 @@ sum by (loft_project_name) (k8s_pod_memory_usage_bytes{loft_project_name=~".+"})
 
 **CPU usage by space:**
 ```promql
-sum by(loft_space_name) (k8s_pod_cpu_time_seconds_total{loft_space_name=~".+"})
+sum by(loft_space_name) (rate(k8s_pod_cpu_time_seconds_total{loft_space_name=~".+"}[5m]))
 ```
 
 ## Example dashboard
@@ -298,5 +302,7 @@ sum by(loft_space_name) (k8s_pod_cpu_time_seconds_total{loft_space_name=~".+"})
 The Grafana deployment includes a pre-built dashboard that visualizes CPU and Memory usage aggregated by vCluster, Project, and Space.
 
 <img src={GrafanaExample} width="100%" alt="Grafana dashboard showing CPU and Memory usage by Project, Space, and Tenant Cluster"/>
+
+The **by Space** panels only show data if your environment has Space-type tenants. In a vCluster-only environment, they stay empty.
 
 You can also [import](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/) additional dashboards or create custom visualizations using the available labels.


### PR DESCRIPTION
# Content Description
Fixes three defects in the pre-built Grafana dashboard on the Aggregating Metrics page: CPU panels graphed a raw cumulative counter instead of a rate, no panel had units, and the "by Space" panels are always empty for vCluster-only environments with no caveat. Also corrects a mislabeled `loft_cluster_name` entry in the labels table to the actual `cluster` label.

## Preview Link
https://deploy-preview-2477--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/monitoring/aggregating-metrics

## Internal Reference
Closes DOC-1620

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs