### PR TITLE
docs: fix incorrect config path for control plane kubernetes upgrade

### DIFF
--- a/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/manage.mdx
@@ -17,7 +17,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 Do not upgrade multiple minor versions at the same time for the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> as outlined in the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). Instead always upgrade a single minor version, wait until the cluster becomes healthy and then upgrade to the next minor version. For example: `v1.26` -> `v1.27` -> `v1.28`.
 :::
 
-To upgrade the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane, update the Kubernetes `init` container version in your `vcluster.yaml` file.
+To upgrade the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane, update the Kubernetes distro image tag in your `vcluster.yaml` file.
 After the change, vCluster upgrades the control plane automatically. If automatic worker node upgrades are configured, those nodes are also upgraded.
 
 To change the Kubernetes version, add the following to your `vcluster.yaml`:
@@ -25,9 +25,10 @@ To change the Kubernetes version, add the following to your `vcluster.yaml`:
 ```yaml title="Upgrade control plane Kubernetes version"
 ...
 controlPlane:
-  statefulSet:
-    image:
-      tag: v1.31.1 # Or any other Kubernetes version
+  distro:
+    k8s:
+      image:
+        tag: v1.35.6 # Or any other Kubernetes version
 ...
 ```
 


### PR DESCRIPTION
# Content Description
Fixes the private nodes "Manage" page, which told users to set `controlPlane.statefulSet.image.tag` to upgrade the tenant cluster's Kubernetes version. That field sets the vCluster syncer image tag, not the Kubernetes distro version, so following the doc as written would silently not upgrade Kubernetes. Corrected to `controlPlane.distro.k8s.image.tag`, matching every other page in the docs that documents this setting.

## Preview Link 
https://deploy-preview-2478--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes/manage#upgrade-vcluster-control-plane

## Internal Reference
Closes DOC-1638


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs