### PR TITLE
docs: add platform create cli command to deploy basics page

### DIFF
--- a/platform/_partials/vcluster/create-cli.mdx
+++ b/platform/_partials/vcluster/create-cli.mdx
@@ -1,16 +1,18 @@
-When creating a virtual cluster from the vCluster CLI, you will need to provide the name of the
-project in which to deploy the virtual cluster, and the name of template to use:
+When creating a tenant cluster from the vCluster CLI, provide the project name to deploy into and the template name to use:
 
 ```bash
 vcluster create [vcluster-name] --project [project-name] --template [template-name] --driver platform
 ```
 
-:::info Template
-If you omit specifying a template, vCluster Platform will automatically select one for you (if there is a
-default template in the project specified) or prompt you to select a template.
-:::
+If you omit `--template`, vCluster Platform resolves one automatically.
+
+- Uses the project's default template if one is set.
+- Auto-selects the template if the project only allows one.
+- Prompts you to choose if the project allows multiple templates without defining a default.
+- Fails with an error if no templates are allowed in the project.
 
 :::info Kube-Context
-Running `vcluster create` will automatically add a kube-context to your kube-config file,
-so you can immediately run `kubectl` commands right after creating a virtual cluster.
+Running `vcluster create` adds a kube-context to your kube-config file and switches your active context to it. This allows you to immediately run `kubectl` commands for the new cluster right after creating it.
+
+Disable the automatic context switch by adding `--connect=false` to the `create` command.
 :::

--- a/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
@@ -11,6 +11,7 @@ import ControlPlaneOptions from '../../../_fragments/deploy/control-plane.mdx'
 import PreRequisites from '../../../_partials/quick-start-guide/pre-requisites.mdx'
 import Deploy from '../../../_partials/deploy/deploy.mdx'
 import DefaultK8sVersion from '../../../_fragments/default-k8s-version.mdx'
+import PlatformCreateCLI from '@site/platform/_partials/vcluster/create-cli.mdx'
 
 There are multiple ways to deploy and manage your vCluster. Review the different choices and choose the one that suits your needs.
 
@@ -46,4 +47,8 @@ Tenant clusters can be deployed directly as described above, or managed centrall
 
 There are many [features](/platform/) included as part of vCluster Platform beyond central management.
 
-If you already have vCluster Platform, [learn how to deploy tenant clusters in the platform](/platform/use-platform/virtual-clusters/create/create-no-template).
+If you already have vCluster Platform, you can create a tenant cluster directly from the CLI.
+
+<PlatformCreateCLI />
+
+For the full workflow, including the platform UI steps, see [deploy tenant clusters in the platform](/platform/use-platform/virtual-clusters/create/create-no-template).

--- a/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
+++ b/vcluster/deploy/control-plane/kubernetes-pod/basics.mdx
@@ -49,6 +49,8 @@ There are many [features](/platform/) included as part of vCluster Platform beyo
 
 If you already have vCluster Platform, you can create a tenant cluster directly from the CLI.
 
+Don't have Platform yet? Run `vcluster platform start` against your control plane cluster. See the [Platform install guide](/docs/platform/install/quick-start-guide) for the full process.
+
 <PlatformCreateCLI />
 
 For the full workflow, including the platform UI steps, see [deploy tenant clusters in the platform](/platform/use-platform/virtual-clusters/create/create-no-template).


### PR DESCRIPTION
# Content Description
Adds the vCluster Platform CLI create command to the "Deploy with vCluster Platform" section on the deploy basics page, reusing the existing `platform/_partials/vcluster/create-cli.mdx` partial instead of duplicating the command. Also fixes stale "virtual cluster" wording in that partial to "tenant cluster" and tightens its prose.

## Preview Link 
https://deploy-preview-2479--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/kubernetes-pod/basics#deploy-with-vcluster-platform

## Internal Reference
Closes DOC-1644


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs