### PR TITLE
docs(argocd): add missing sync permission to argocd rbac policy

### DIFF
--- a/platform/integrations/argocd/connect-argocd.mdx
+++ b/platform/integrations/argocd/connect-argocd.mdx
@@ -34,12 +34,13 @@ policy.csv: |
   p, role:vcluster-platform, applications, create, */*, allow
   p, role:vcluster-platform, applications, update, */*, allow
   p, role:vcluster-platform, applications, delete, */*, allow
+  p, role:vcluster-platform, applications, sync, */*, allow
 ```
 
 | Resource | Actions | Why |
 |----------|---------|-----|
 | `clusters` | `get`, `create`, `update`, `delete` | Register and deregister tenant clusters and control plane clusters |
-| `applications` | `get`, `create`, `update`, `delete` | Create and sync Argo CD Applications across all projects (`*/*`) |
+| `applications` | `get`, `create`, `update`, `delete`, `sync` | Create and sync Argo CD Applications across all projects (`*/*`). `sync` is required to stop in-progress sync operations when deleting a tenant cluster with installed apps |
 
 ## Step 1: Create a connector
 


### PR DESCRIPTION
# Content Description
Adds the missing `applications, sync` Casbin permission to the Argo CD RBAC policy example. Verified against upstream Argo CD source: `sync` is a distinct RBAC action (separate from `update`), and vCluster Platform's cascade-delete flow for tenant clusters calls `TerminateOperation` to stop in-progress syncs before deleting an app, which Argo CD gates on the `sync` action. Without this permission, deleting a tenant cluster with an installed, mid-sync app can fail or stall.

## Preview Link
https://deploy-preview-2480--vcluster-docs-site.netlify.app/docs/platform/next/integrations/argocd/connect-argocd#argo-cd-api-token-permissions

## Internal Reference
Closes DOC-1646

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs