### PR TITLE
docs(restore): correct external database backup and restore limitations

### DIFF
--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -14,10 +14,6 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
 
-:::warning
-External databases such as MySQL or PostgreSQL running outside the vCluster namespace require a separate restore procedure. Refer to the relevant database documentation.
-:::
-
 A vCluster snapshot includes:
 
 - Backing store data (for example, etcd or SQLite)
@@ -253,7 +249,7 @@ When taking snapshots and restoring tenant clusters, there are limitations:
 
 **Tenant clusters using an external database**
 
-- Tenant clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
+- Restoring onto an external database deletes the existing data before replaying the snapshot, and vCluster does not back up or roll back the external database. Before running `vcluster restore`, the database owner or administrator must take a native database backup so that a native external database restore can be triggered if the restore fails.
 
 **vcluster.yaml configuration**
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Snapshot restore now works for tenant clusters backed by an external database (per loft-sh/vcluster#4097), so this removes the stale statements saying external databases need a separate, out-of-band restore procedure and adds a limitation clarifying that vCluster does not back up or roll back the external database, making a native pre-restore backup the owner's/admin's responsibility.

## Preview Link 
<!-- The preview link or links to the documents-->
Netlify deploy preview will be added automatically once the build finishes.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGCP-557


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
