### PR TITLE
fix(generator): automatical add deprecation notice for types

### DIFF
--- a/hack/platform/util/deprecation.go
+++ b/hack/platform/util/deprecation.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+// TypeDeprecationNotice returns the "Deprecated: ..." notice carried by obj's
+// Go type doc comment, or "" if the type isn't deprecated. It re-parses the
+// vendor tree rather than reusing the generator's CommentMap, which collapses
+// type comments to a one-sentence synopsis and would drop the notice.
+func TypeDeprecationNotice(obj interface{}) string {
+	t := reflect.TypeOf(obj)
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t == nil || t.PkgPath() == "" {
+		return ""
+	}
+	return deprecationNotice(typeDoc(filepath.Join("vendor", t.PkgPath()), t.Name()))
+}
+
+// typeDoc returns the full doc comment of typeName in the Go package at dir.
+func typeDoc(dir, typeName string) string {
+	fset := token.NewFileSet()
+	astPkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	return docFromPackages(astPkgs, dir, typeName)
+}
+
+// docFromPackages returns the full doc comment of typeName among astPkgs,
+// which go/doc treats as importable at dir.
+func docFromPackages(astPkgs map[string]*ast.Package, dir, typeName string) string {
+	for _, astPkg := range astPkgs {
+		for _, t := range doc.New(astPkg, dir, doc.AllDecls).Types {
+			if t.Name == typeName {
+				return t.Doc
+			}
+		}
+	}
+	return ""
+}
+
+// deprecationNotice returns the "Deprecated: ..." paragraph of a Go doc
+// comment (per https://go.dev/wiki/Deprecated), or "" if there is none.
+func deprecationNotice(docText string) string {
+	for para := range strings.SplitSeq(docText, "\n\n") {
+		para = strings.TrimSpace(para)
+		if !strings.HasPrefix(para, "Deprecated:") {
+			continue
+		}
+		para, _, _ = strings.Cut(para, "\n+") // drop trailing kubebuilder/genclient "+tag" lines
+		return strings.Join(strings.Fields(para), " ")
+	}
+	return ""
+}

--- a/hack/platform/util/deprecation.go
+++ b/hack/platform/util/deprecation.go
@@ -11,9 +11,7 @@ import (
 )
 
 // TypeDeprecationNotice returns the "Deprecated: ..." notice carried by obj's
-// Go type doc comment, or "" if the type isn't deprecated. It re-parses the
-// vendor tree rather than reusing the generator's CommentMap, which collapses
-// type comments to a one-sentence synopsis and would drop the notice.
+// Go type doc comment, or "" if the type isn't deprecated.
 func TypeDeprecationNotice(obj interface{}) string {
 	t := reflect.TypeOf(obj)
 	for t != nil && t.Kind() == reflect.Ptr {

--- a/hack/platform/util/deprecation.go
+++ b/hack/platform/util/deprecation.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"go/ast"
 	"go/doc"
 	"go/parser"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"unicode"
 )
 
 // TypeDeprecationNotice returns the "Deprecated: ..." notice carried by obj's
@@ -23,27 +25,45 @@ func TypeDeprecationNotice(obj interface{}) string {
 	return deprecationNotice(typeDoc(filepath.Join("vendor", t.PkgPath()), t.Name()))
 }
 
+// typeDocCache holds, per package dir, every type's doc comment already
+// extracted by packageTypeDocs, so sibling types sharing a vendor package
+// don't each re-parse it from disk. It caches the extracted strings rather
+// than the parsed packages because go/doc.New mutates the AST as it consumes
+// doc comments, so running it a second time over an already-processed
+// package silently returns empty docs.
+var typeDocCache = map[string]map[string]string{}
+
 // typeDoc returns the full doc comment of typeName in the Go package at dir.
 func typeDoc(dir, typeName string) string {
+	docs, ok := typeDocCache[dir]
+	if !ok {
+		docs = packageTypeDocs(dir)
+		typeDocCache[dir] = docs
+	}
+	return docs[typeName]
+}
+
+// packageTypeDocs parses the Go package at dir and returns every type's full
+// doc comment, keyed by type name.
+func packageTypeDocs(dir string) map[string]string {
 	fset := token.NewFileSet()
 	astPkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
 	if err != nil {
 		panic(err)
 	}
-	return docFromPackages(astPkgs, dir, typeName)
+	return docsFromPackages(astPkgs, dir)
 }
 
-// docFromPackages returns the full doc comment of typeName among astPkgs,
-// which go/doc treats as importable at dir.
-func docFromPackages(astPkgs map[string]*ast.Package, dir, typeName string) string {
+// docsFromPackages returns every type's full doc comment among astPkgs,
+// which go/doc treats as importable at dir, keyed by type name.
+func docsFromPackages(astPkgs map[string]*ast.Package, dir string) map[string]string {
+	docs := map[string]string{}
 	for _, astPkg := range astPkgs {
 		for _, t := range doc.New(astPkg, dir, doc.AllDecls).Types {
-			if t.Name == typeName {
-				return t.Doc
-			}
+			docs[t.Name] = t.Doc
 		}
 	}
-	return ""
+	return docs
 }
 
 // deprecationNotice returns the "Deprecated: ..." paragraph of a Go doc
@@ -58,4 +78,18 @@ func deprecationNotice(docText string) string {
 		return strings.Join(strings.Fields(para), " ")
 	}
 	return ""
+}
+
+// DeprecationAdmonition renders notice (as returned by TypeDeprecationNotice)
+// as a Docusaurus admonition, dropping the leading "Deprecated:" so it isn't
+// repeated right after the admonition's own "Deprecated" title, and
+// capitalizing the sentence that remains.
+func DeprecationAdmonition(notice string) string {
+	body := strings.TrimSpace(strings.TrimPrefix(notice, "Deprecated:"))
+	if body != "" {
+		r := []rune(body)
+		r[0] = unicode.ToUpper(r[0])
+		body = string(r)
+	}
+	return fmt.Sprintf(":::warning Deprecated\n%s\n:::", body)
 }

--- a/hack/platform/util/deprecation_test.go
+++ b/hack/platform/util/deprecation_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestDeprecationNotice(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{
+			name: "no deprecation",
+			doc:  "Foo holds the foo information",
+			want: "",
+		},
+		{
+			name: "deprecation paragraph after summary",
+			doc: "Foo holds the foo information\n\n" +
+				"Deprecated: use Bar instead.\n+subresource-request",
+			want: "Deprecated: use Bar instead.",
+		},
+		{
+			name: "deprecation is the summary itself",
+			doc:  "Deprecated: Foo is no longer supported.",
+			want: "Deprecated: Foo is no longer supported.",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := deprecationNotice(test.doc); got != test.want {
+				t.Fatalf("deprecationNotice() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDocFromPackages(t *testing.T) {
+	src := `package example
+
+// Foo does something.
+//
+// Deprecated: use Bar instead.
+// +subresource-request
+type Foo struct{}
+
+// Bar does something else.
+type Bar struct{}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "example.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	astPkgs := map[string]*ast.Package{
+		f.Name.Name: {Name: f.Name.Name, Files: map[string]*ast.File{"example.go": f}},
+	}
+
+	if got, want := deprecationNotice(docFromPackages(astPkgs, "example", "Foo")), "Deprecated: use Bar instead."; got != want {
+		t.Fatalf("deprecationNotice(docFromPackages(..., %q)) = %q, want %q", "Foo", got, want)
+	}
+	if got := deprecationNotice(docFromPackages(astPkgs, "example", "Bar")); got != "" {
+		t.Fatalf("deprecationNotice(docFromPackages(..., %q)) = %q, want \"\"", "Bar", got)
+	}
+}

--- a/hack/platform/util/deprecation_test.go
+++ b/hack/platform/util/deprecation_test.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -38,7 +40,45 @@ func TestDeprecationNotice(t *testing.T) {
 	}
 }
 
-func TestDocFromPackages(t *testing.T) {
+func TestDeprecationAdmonition(t *testing.T) {
+	got := DeprecationAdmonition("Deprecated: migrating virtual cluster instances between projects is deprecated and will be removed in a future release.")
+	want := ":::warning Deprecated\n" +
+		"Migrating virtual cluster instances between projects is deprecated and will be removed in a future release.\n" +
+		":::"
+	if got != want {
+		t.Fatalf("DeprecationAdmonition() = %q, want %q", got, want)
+	}
+}
+
+func TestTypeDocCachePreservesSiblingTypes(t *testing.T) {
+	dir := t.TempDir()
+	src := `package example
+
+// Foo does something.
+//
+// Deprecated: use Bar instead.
+type Foo struct{}
+
+// Bar does something else.
+type Bar struct{}
+`
+	if err := os.WriteFile(filepath.Join(dir, "example.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Regression test: typeDoc caches per dir, so Bar is looked up against an
+	// already-cached parse triggered by the earlier Foo lookup. If the cache
+	// stored a *parsed package* instead of pre-extracted doc text, this second
+	// call would silently return "" (see docsFromPackages).
+	if got, want := typeDoc(dir, "Foo"), "Foo does something.\n\nDeprecated: use Bar instead.\n"; got != want {
+		t.Fatalf("typeDoc(dir, %q) = %q, want %q", "Foo", got, want)
+	}
+	if got, want := typeDoc(dir, "Bar"), "Bar does something else.\n"; got != want {
+		t.Fatalf("typeDoc(dir, %q) = %q, want %q", "Bar", got, want)
+	}
+}
+
+func TestDocsFromPackages(t *testing.T) {
 	src := `package example
 
 // Foo does something.
@@ -59,10 +99,14 @@ type Bar struct{}
 		f.Name.Name: {Name: f.Name.Name, Files: map[string]*ast.File{"example.go": f}},
 	}
 
-	if got, want := deprecationNotice(docFromPackages(astPkgs, "example", "Foo")), "Deprecated: use Bar instead."; got != want {
-		t.Fatalf("deprecationNotice(docFromPackages(..., %q)) = %q, want %q", "Foo", got, want)
+	// Both lookups read from the same extracted map, mirroring typeDoc's
+	// cache: a single doc.New pass must capture every type's doc up front,
+	// since running doc.New again over the same ast.Package returns empty docs.
+	docs := docsFromPackages(astPkgs, "example")
+	if got, want := deprecationNotice(docs["Foo"]), "Deprecated: use Bar instead."; got != want {
+		t.Fatalf("deprecationNotice(docs[%q]) = %q, want %q", "Foo", got, want)
 	}
-	if got := deprecationNotice(docFromPackages(astPkgs, "example", "Bar")); got != "" {
-		t.Fatalf("deprecationNotice(docFromPackages(..., %q)) = %q, want \"\"", "Bar", got)
+	if got := deprecationNotice(docs["Bar"]); got != "" {
+		t.Fatalf("deprecationNotice(docs[%q]) = %q, want \"\"", "Bar", got)
 	}
 }

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -312,6 +312,16 @@ func GenerateObjectOverview(information *ObjectInformation) {
 	}
 	relPath = strings.TrimSuffix(relPath, "/")
 
+	extraContentBeforeDescription := information.ExtraContentBeforeDescription
+	if notice := TypeDeprecationNotice(information.Object); notice != "" {
+		admonition := fmt.Sprintf(":::warning Deprecated\n%s\n:::", notice)
+		if extraContentBeforeDescription != "" {
+			extraContentBeforeDescription = admonition + "\n\n" + extraContentBeforeDescription
+		} else {
+			extraContentBeforeDescription = admonition
+		}
+	}
+
 	// write overview
 	writeTemplate(TemplateObjectOverview, information.File, ObjectOverviewValues{
 		Title:        information.Title,
@@ -323,7 +333,7 @@ func GenerateObjectOverview(information *ObjectInformation) {
 		YAMLObject:   string(out),
 
 		ExtraImports:                  information.ExtraImports,
-		ExtraContentBeforeDescription: information.ExtraContentBeforeDescription,
+		ExtraContentBeforeDescription: extraContentBeforeDescription,
 		ExtraContentBeforeExample:     information.ExtraContentBeforeExample,
 		ExtraContentAfterExample:      information.ExtraContentAfterExample,
 

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -314,7 +314,7 @@ func GenerateObjectOverview(information *ObjectInformation) {
 
 	extraContentBeforeDescription := information.ExtraContentBeforeDescription
 	if notice := TypeDeprecationNotice(information.Object); notice != "" {
-		admonition := fmt.Sprintf(":::warning Deprecated\n%s\n:::", notice)
+		admonition := DeprecationAdmonition(notice)
 		if extraContentBeforeDescription != "" {
 			extraContentBeforeDescription = admonition + "\n\n" + extraContentBeforeDescription
 		} else {

--- a/platform/api/resources/project/migratevirtualclusterinstance.mdx
+++ b/platform/api/resources/project/migratevirtualclusterinstance.mdx
@@ -6,7 +6,7 @@ import Reference from "../../_partials/resources/projects/migratevirtualclusteri
 import SubResourceCreate from "../../_partials/resources/projects/migratevirtualclusterinstance/subresourcecreate.mdx"
 
 :::warning Deprecated
-Deprecated: migrating virtual cluster instances between projects is deprecated and will be removed in a future release.
+Migrating virtual cluster instances between projects is deprecated and will be removed in a future release.
 :::
 
 This API can be used to move a virtual cluster from one project to another.

--- a/platform/api/resources/project/migratevirtualclusterinstance.mdx
+++ b/platform/api/resources/project/migratevirtualclusterinstance.mdx
@@ -5,6 +5,10 @@ sidebar_label: Move vCluster To Other Project
 import Reference from "../../_partials/resources/projects/migratevirtualclusterinstance/reference.mdx"
 import SubResourceCreate from "../../_partials/resources/projects/migratevirtualclusterinstance/subresourcecreate.mdx"
 
+:::warning Deprecated
+Deprecated: migrating virtual cluster instances between projects is deprecated and will be removed in a future release.
+:::
+
 This API can be used to move a virtual cluster from one project to another.
 
 ## Move Virtual Cluster To Other Project example


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Types annotated with a "Deprecated: ..." comment (rather than a per-field comment) previously had no way to surface that on the generated overview page, since the generator only ever reads field-level doc comments.
Now there is a well visible deprecation notice added automatically.

https://github.com/loft-sh/vcluster-docs/blob/87b66ab0e542d6842d5a159c349471ef71483a4b/vendor/github.com/loft-sh/api/v4/pkg/apis/management/v1/project_migratevirtualclusterinstance_types.go#L11

https://github.com/loft-sh/vcluster-docs/blob/3c011d922e0c466685bfdd3458ed41417f6287e5/platform/api/resources/project/migratevirtualclusterinstance.mdx?plain=1#L8-L10

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2484--vcluster-docs-site.netlify.app/docs/platform/next/api/resources/project/migratevirtualclusterinstance

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGPLAT-882


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

