### PR TITLE
fix(release): skip docs-sync regen for platform lines older than the api pin

### DIFF
--- a/hack/release/classify-version.bats
+++ b/hack/release/classify-version.bats
@@ -49,6 +49,22 @@ EOF
 ]
 EOF
 
+    # go.mod pins the loft-sh/api line the platform generator compiles against.
+    # The fixture's current line is 4.9 (matches highest frozen), so a
+    # platform-released event on an older line (4.5-4.8) must classify as skip
+    # while a 4.9 patch still regenerates. classify-version reads only the
+    # api/v4 pin from this file for the platform stale-line guard.
+    cat >"$FIXTURE/go.mod" <<EOF
+module github.com/loft-sh/vcluster-docs
+
+go 1.26
+
+require (
+	github.com/loft-sh/agentapi/v4 v4.9.0
+	github.com/loft-sh/api/v4 v4.9.0
+)
+EOF
+
     export REPO_ROOT="$FIXTURE"
 }
 
@@ -190,14 +206,36 @@ get() {
     [ "$(get target_folder)" = "vcluster_versioned_docs/version-0.34.0" ]
 }
 
-@test "platform: stable patch on frozen minor → versioned folder" {
-    VERSION=v4.6.5 EVENT_TYPE=platform-released run "$SCRIPT"
+@test "platform: stable patch on the current (generator) minor → versioned folder" {
+    # go.mod pins api to 4.9, so 4.9 is the line the platform generator compiles
+    # against. A patch on it regenerates into its versioned folder.
+    VERSION=v4.9.5 EVENT_TYPE=platform-released run "$SCRIPT"
     [ "$(get skip)" = "false" ]
-    [ "$(get target_folder)" = "platform_versioned_docs/version-4.6.0" ]
+    [ "$(get target_folder)" = "platform_versioned_docs/version-4.9.0" ]
     [ "$(get channel)" = "stable" ]
 }
 
+@test "platform: stable patch on a line older than the generator → skip (stale-line)" {
+    # 4.6 < the go.mod api line (4.9). The platform generator can't compile
+    # against the older api pin (types moved/added at minor boundaries), so the
+    # receiver must skip rather than fail. Folder version-4.6.0 exists, proving
+    # the guard fires before folder-based routing. See DEVOPS-1168.
+    VERSION=v4.6.5 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "stale-line" ]
+}
+
+@test "platform: rc on a line older than the generator → skip (stale-line)" {
+    VERSION=v4.8.0-rc.1 EVENT_TYPE=platform-released run "$SCRIPT"
+    [ "$(get skip)" = "true" ]
+    [ "$(get target_folder)" = "" ]
+    [ "$(get channel)" = "stale-line" ]
+}
+
 @test "platform: release of next minor → current docs folder" {
+    # 4.10 is newer than the highest frozen line (4.9): it routes to the current
+    # docs root and is never subject to the older-line guard.
     VERSION=v4.10.0 EVENT_TYPE=platform-released run "$SCRIPT"
     [ "$(get skip)" = "false" ]
     [ "$(get target_folder)" = "platform" ]

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -145,7 +145,10 @@ fi
 if [[ "$EVENT_TYPE" == "platform-released" ]]; then
     gen_key=-1
     if [[ -f "${REPO_ROOT}/go.mod" ]]; then
-        gen_line=$(sed -n 's#^[[:space:]]*github\.com/loft-sh/api/v[0-9]\+ v\([0-9]\+\.[0-9]\+\)\..*#\1#p' "${REPO_ROOT}/go.mod" | head -n1)
+        # Extended regex (-E) so the quantifiers are portable: BSD sed on
+        # macOS does not accept GNU basic-regex \+, which would silently
+        # extract no pin and leave the guard inert for local contributors.
+        gen_line=$(sed -nE 's#^[[:space:]]*github\.com/loft-sh/api/v[0-9]+ v([0-9]+\.[0-9]+)\..*#\1#p' "${REPO_ROOT}/go.mod" | head -n1)
         if [[ "$gen_line" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
             gen_key=$(( BASH_REMATCH[1] * 100000 + BASH_REMATCH[2] ))
         fi

--- a/hack/release/classify-version.sh
+++ b/hack/release/classify-version.sh
@@ -5,7 +5,7 @@
 # Maps a released VERSION + EVENT_TYPE to a routing decision:
 #   - skip:           true if the version should not produce docs
 #   - target_folder:  path (relative to REPO_ROOT) where generated docs land
-#   - channel:        stable | rc | alpha | beta | next | invalid | unknown-event
+#   - channel:        stable | rc | alpha | beta | next | stale-line | invalid | unknown-event
 #
 # Inputs (env):
 #   VERSION      Released version, e.g. v0.34.5, v0.34.0-rc.3, v4.6.0-alpha.1
@@ -32,6 +32,11 @@
 #     target = versioned folder (e.g. version-0.34.0)
 #   * MAJOR.MINOR ≤ highest frozen, candidate folder absent → skip
 #     (past minor we don't track)
+#   * platform-released only: MAJOR.MINOR older than the loft-sh/api pin in
+#     go.mod → skip (channel=stale-line). The platform partials generator
+#     reflects against main's pinned api Go types and only compiles against
+#     its own line; regenerating an older line is impossible and unnecessary.
+#     See the guard below for the full rationale.
 
 set -eo pipefail
 
@@ -115,6 +120,39 @@ if (( incoming_key > highest_key )); then
         exit 0
     fi
     emit_skip "$channel"
+fi
+
+# ── Platform generator is current-line-only ───────────────────────────────
+# The platform partials generator (hack/platform/partials/main.go) reflects
+# against the loft-sh/api + loft-sh/agentapi Go types pinned in this repo's
+# go.mod, and the receiver bumps that pin to the released version before
+# running it. The generator source tracks the CURRENT api line: types get
+# moved or added as upstream evolves (e.g. Authentication/Connector moved
+# management/v1 → storage/v1 in v4.11.0 per DEVOPS-1081; NodeProfile is v4.11+
+# only). So it only compiles against its own line. Bumping the pin DOWN to an
+# older released line leaves the generator referencing types that line lacks,
+# and the regen fails to compile — blocking every platform docs sync (see the
+# v4.10.6 receiver failure, DEVOPS-1168). Older frozen platform minors are
+# snapshots whose api reference does not change on a patch release, so skip
+# them rather than fail the receiver. (vcluster + vcluster-cli generators
+# compile the source checked out at the released tag, so they carry no such
+# constraint and older lines still regenerate — this guard is platform-only.)
+#
+# The generator line is read from go.mod's api pin, not from highest_key, so
+# the guard stays correct in the window between manually freezing a new docs
+# version and the receiver bumping the pin to that line. If the pin can't be
+# read, gen_key stays -1 and the guard is inert (preserves prior behavior).
+if [[ "$EVENT_TYPE" == "platform-released" ]]; then
+    gen_key=-1
+    if [[ -f "${REPO_ROOT}/go.mod" ]]; then
+        gen_line=$(sed -n 's#^[[:space:]]*github\.com/loft-sh/api/v[0-9]\+ v\([0-9]\+\.[0-9]\+\)\..*#\1#p' "${REPO_ROOT}/go.mod" | head -n1)
+        if [[ "$gen_line" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+            gen_key=$(( BASH_REMATCH[1] * 100000 + BASH_REMATCH[2] ))
+        fi
+    fi
+    if (( gen_key >= 0 && incoming_key < gen_key )); then
+        emit_skip stale-line
+    fi
 fi
 
 candidate="${versioned_root}/version-${major}.${minor}.0"


### PR DESCRIPTION
# Content Description

Fixes the `handle-source-release` receiver, which failed on `platform-released v4.10.6` ([run 30051361563](https://github.com/loft-sh/vcluster-docs/actions/runs/30051361563)) at the "Generate docs" step. This is a CI/release-automation change only; no docs prose is touched.

## Root cause

The platform partials generator (`hack/platform/partials/main.go`) reflects against the `loft-sh/api` Go types pinned in `go.mod`, and the receiver bumps that pin to the released version before running it. The generator source tracks the current api line: `Authentication`/`Connector`/`AuthenticationGithub` moved `management/v1` -> `storage/v1` in v4.11.0 (DEVOPS-1081, #2379) and `NodeProfile` is v4.11+ only (#2411). When an older line is released (`v4.10.6`), the receiver pins the api down to `v4.10.6`, where those types live elsewhere or do not exist, so the generator fails to compile:

```
undefined: storagev1.Authentication
undefined: storagev1.Connector
undefined: storagev1.AuthenticationGithub
undefined: managementv1.NodeProfile
undefined: managementv1.NodeProfileSpec
undefined: storagev1.NodeProfileSpec
```

One generator source cannot compile against both lines, because the types physically moved packages across the minor boundary. Fixing the forward direction (DEVOPS-1081) is what broke the backward one; that is the loop we keep hitting.

## Fix

`classify-version.sh` now treats platform regeneration as current-line-only: for `platform-released`, it skips (channel `stale-line`) when the released MAJOR.MINOR is older than the `loft-sh/api` pin read from `go.mod`. An older frozen platform minor is a snapshot whose api reference does not change on a patch release, so the receiver goes green and opens no PR instead of failing to compile. vcluster and vcluster-cli generators compile the source checked out at the released tag, so they still regenerate older lines and are untouched.

Verified against the real repo `go.mod` (api pinned at `v4.11.0-rc.6`):

| event | before | after |
|-------|--------|-------|
| `platform-released v4.10.6` | compile failure (red) | skip, `stale-line` (green) |
| `platform-released v4.9.3` | compile failure (red) | skip, `stale-line` (green) |
| `platform-released v4.11.0` | generate `version-4.11.0` | generate `version-4.11.0` |
| `platform-released v4.11.0-rc.7` | generate `version-4.11.0` | generate `version-4.11.0` |
| `platform-released v4.12.0` | current docs root | current docs root |

`classify-version.bats` extended with older-line skip and current-line generate coverage (25/25 pass); `shellcheck` clean; `run-generator.bats` unaffected.

## Internal Reference
Closes DEVOPS-1168

<!-- Do not change the line below -->
@netlify /docs
