### PR TITLE
docs: correct CR vs CRD conflation across platform and vcluster docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,31 @@ Reuse `@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx` rather
 than rewriting the caveat. See the "Tenancy Model Positioning" section of
 `.claude/skills/vcluster-docs-writer/SKILL.md` for the full rule.
 
+## CR vs CRD terminology (DOC-1656)
+
+"Custom Resource Definition (CRD)" and "custom resource (CR)" are not
+interchangeable. A CRD is the installed API definition (the schema); a CR is
+an instance created from that definition.
+
+**Use CRD only for:** installing, discovering, versioning, or deleting the
+API definition itself (`apiextensions.k8s.io` objects).
+
+**Use custom resource, resource, object, manifest, or the specific kind name**
+(`VirtualClusterInstance`, `Cluster`, `VirtualClusterTemplate`, `Project`,
+`Team`, and so on) for an instance created from that definition — this
+includes backup contents, GitOps manifests, tab labels for resource YAML, and
+diagram labels that represent stored instances or API traffic rather than the
+definition.
+
+**Common failure pattern:** "Helm/Argo CD/Flux deploys the CRD" almost always
+means it applies a manifest for a specific kind (for example, a
+`VirtualClusterInstance`) — the CRD for that kind is installed once, by the
+platform, not by every GitOps sync.
+
+Before writing "CRD" in prose, check whether the sentence is about the
+definition (schema/install/discovery/deletion) or an instance (create/apply/
+edit/back up/sync/proxy). If it's an instance, don't say CRD.
+
 ## SVG diagrams
 
 SVGs must be imported as React components, not using `require().default`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,18 +250,23 @@ than rewriting the caveat. See the "Tenancy Model Positioning" section of
 ## CR vs CRD terminology (DOC-1656)
 
 "Custom Resource Definition (CRD)" and "custom resource (CR)" are not
-interchangeable. A CRD is the installed API definition (the schema); a CR is
-an instance created from that definition.
+interchangeable. A CRD is the API definition itself — an object with
+`kind: CustomResourceDefinition` (`apiextensions.k8s.io`). A CR is an
+instance of a kind that a CRD defines (`kind: VirtualClusterInstance`,
+`kind: Cluster`, and so on).
 
-**Use CRD only for:** installing, discovering, versioning, or deleting the
-API definition itself (`apiextensions.k8s.io` objects).
+**The deciding factor is the manifest's `kind`, not the verb.** CRDs can be
+legitimately created, applied, updated, or deployed by Helm or GitOps just
+like any other object — that doesn't make them CRs. Use CRD when the
+sentence is about the `CustomResourceDefinition` object itself (however it
+gets installed, discovered, versioned, or deleted).
 
 **Use custom resource, resource, object, manifest, or the specific kind name**
 (`VirtualClusterInstance`, `Cluster`, `VirtualClusterTemplate`, `Project`,
-`Team`, and so on) for an instance created from that definition — this
-includes backup contents, GitOps manifests, tab labels for resource YAML, and
-diagram labels that represent stored instances or API traffic rather than the
-definition.
+`Team`, and so on) when the sentence is about an instance of a defined
+kind — this includes backup contents, GitOps manifests, tab labels for
+resource YAML, and diagram labels that represent stored instances or API
+traffic rather than the definition.
 
 **Common failure pattern:** "Helm/Argo CD/Flux deploys the CRD" almost always
 means it applies a manifest for a specific kind (for example, a
@@ -269,8 +274,9 @@ means it applies a manifest for a specific kind (for example, a
 platform, not by every GitOps sync.
 
 Before writing "CRD" in prose, check whether the sentence is about the
-definition (schema/install/discovery/deletion) or an instance (create/apply/
-edit/back up/sync/proxy). If it's an instance, don't say CRD.
+`CustomResourceDefinition` object itself or about an instance of a kind it
+defines. If it's an instance, don't say CRD — regardless of whether the verb
+is create, apply, deploy, back up, sync, or proxy.
 
 ## SVG diagrams
 

--- a/platform/administer/clusters/advanced/agent-config.mdx
+++ b/platform/administer/clusters/advanced/agent-config.mdx
@@ -55,7 +55,7 @@ The vCluster Platform Agent is installed on the connected cluster as a Helm Rele
 
 ### Set agent values using the CLI
 
-Export the current Cluster resource (this is a platform CRD, not vcluster.yaml):
+Export the current Cluster resource (this is a platform custom resource, not vcluster.yaml):
 
 <InterpolatedCodeBlock
   code={`export CLUSTER_NAME=[[VAR:CLUSTER_NAME:my-cluster]]
@@ -84,7 +84,7 @@ spec:
 ```
 
 :::info
-The Cluster resource is a Custom Resource Definition (CRD) managed by <GlossaryTerm term="platform">the platform</GlossaryTerm>. It represents a connected cluster and stores configuration like agent values.
+The Cluster resource is a custom resource managed by <GlossaryTerm term="platform">the platform</GlossaryTerm>. It represents a connected cluster and stores configuration like agent values.
 :::
 
 Apply the updated configuration:

--- a/platform/administer/templates/create-templates.mdx
+++ b/platform/administer/templates/create-templates.mdx
@@ -253,7 +253,7 @@ This does not affect any tenant clusters or resources that were already created 
 :::warning Delete a template
 
 If you delete a template, any tenant cluster, app, or namespace that references it can no longer be edited or upgraded through the Platform UI’s form-based editor.
-To make changes, you must manually update the corresponding custom resource, by making direct edits to the relevant CustomResourceDefinition (CRD).
+To make changes, you must manually update the corresponding custom resource by editing its manifest directly.
 
 :::
 

--- a/platform/administer/users-permissions/overview.mdx
+++ b/platform/administer/users-permissions/overview.mdx
@@ -7,7 +7,7 @@ description: Learn about RBAC.
 
 # Overview
 
-The platform uses [Kubernetes role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to manage access for platform resources and objects, including platform Custom Resource Definitions (CRDs) and tenant clusters.
+The platform uses [Kubernetes role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to manage access for platform resources and objects, including platform custom resources and tenant clusters.
 
 RBAC manages user and team permissions by assigning them roles that specify what actions they can perform. These permissions are applied using *ClusterRoleBindings*, which connect a specific role to a user or team, which defines their access across platform resources and tenant clusters.
 

--- a/platform/administer/users-permissions/permissions/project.mdx
+++ b/platform/administer/users-permissions/permissions/project.mdx
@@ -37,7 +37,7 @@ Global admins can change these existing roles as well as add new project roles i
   <Step>
     Fill the display name of the role and other information if necessary.
 :::warning
-The created role will be a global role by default. To create the role as a project role, add the `loft.sh/project-role: 'true'` in the labels of the role CRD configuration on the right side of the page.
+The created role will be a global role by default. To create the role as a project role, add the `loft.sh/project-role: 'true'` in the labels of the role resource configuration on the right side of the page.
 ```yaml title="Add the project role configuration"
 apiVersion: management.loft.sh/v1
 kind: ClusterRoleTemplate

--- a/platform/how-to/gitops-end-to-end.mdx
+++ b/platform/how-to/gitops-end-to-end.mdx
@@ -274,7 +274,7 @@ spec:
 The namespace follows the pattern `p-<project-name>`. The platform uses this convention to associate tenant clusters with projects.
 :::
 
-When the `VirtualClusterInstance` reconciles, Platform registers the tenant cluster with Argo CD using the connector credentials. You can then declare Argo CD Applications in the tenant cluster configuration. See [Deploy applications](../integrations/argocd/deploy-applications.mdx).
+When the VirtualClusterInstance reconciles, Platform registers the tenant cluster with Argo CD using the connector credentials. You can then declare Argo CD Applications in the tenant cluster configuration. See [Deploy applications](../integrations/argocd/deploy-applications.mdx).
 
 ### Option B: Deploy with Helm chart directly
 
@@ -312,7 +312,7 @@ Platform controllers may modify certain fields on resources after creation, caus
 ```yaml
 spec:
   ignoreDifferences:
-    # Ignore status for all Platform CRDs
+    # Ignore status for all Platform custom resources
     - group: management.loft.sh
       kind: "*"
       jsonPointers:

--- a/platform/how-to/use-go-template.mdx
+++ b/platform/how-to/use-go-template.mdx
@@ -15,7 +15,7 @@ You can create templates through the vCluster Platform UI or by applying manifes
 The platform provides the VirtualClusterTemplate custom resource for defining templates.
 For more information, see [Creating Templates](../administer/templates/create-templates).
 
-When defining a VirtualClusterTemplate resource, use Go template functions to enable conditional logic and dynamic configuration within your template values and customize 
+When defining a VirtualClusterTemplate resource, use Go template functions to enable conditional logic and dynamic configuration within your template values and customize
 deployments based on context or user input.
 
 <!-- vale off -->

--- a/platform/how-to/use-go-template.mdx
+++ b/platform/how-to/use-go-template.mdx
@@ -12,10 +12,10 @@ chart (which uses Go templates), functions such as `default`, `upper`, and `quot
 
 Templates in vCluster Platform standardize configurations for tenant clusters, namespaces, and applications.
 You can create templates through the vCluster Platform UI or by applying manifests directly to your cluster using vCluster CLI or Helm charts.
-The platform provides the VirtualClusterTemplate CRD for defining templates.
+The platform provides the VirtualClusterTemplate custom resource for defining templates.
 For more information, see [Creating Templates](../administer/templates/create-templates).
 
-When defining a VirtualClusterTemplate CRD, use Go template functions to enable conditional logic and dynamic configuration within your template values and customize 
+When defining a VirtualClusterTemplate resource, use Go template functions to enable conditional logic and dynamic configuration within your template values and customize 
 deployments based on context or user input.
 
 <!-- vale off -->

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -161,9 +161,9 @@ Here is an example of creating a `Team`, and a `Project` that the `Team` is a me
 The following manifests could be added into a custom Helm chart, or used as manifests in a repo connected to ArgoCD. This is a contrived example, of course, but the main point here is that all platform resources are just "normal" Kubernetes (custom) resources that can be managed with your GitOps tooling, or any other Kubernetes-centric tooling.
 
 :::info management.loft.sh vs storage.loft.sh
-When working with Platform CRDs in GitOps workflows, you'll encounter two API groups:
+When working with Platform custom resources in GitOps workflows, you'll encounter two API groups:
 
-- **management.loft.sh**: Use this to define the desired state of resources. All resources you create (Teams, Projects, etc.) should use this API group.
+- **management.loft.sh**: Use this to define the desired state of resources. All resources you create (Teams, Projects, and so on) should use this API group.
 - **storage.loft.sh**: Used internally by Platform controllers to store actual state. This is auto-generated and should not be manually created.
 
 For GitOps, always define resources using `management.loft.sh`. You'll see `storage.loft.sh` referenced in some spec fields (like project members) - this is correct as it references existing storage-backed resources.
@@ -241,10 +241,10 @@ One of the benefits of the platform is that you can easily manage resources loca
 
 When you add a "connected" cluster to the platform, a `Cluster` resource is created and a platform Agent is installed in the cluster to handle local reconciliation tasks.
 
-If you are managing the platform via GitOps, you may also wish to manage these connected clusters in a similar fashion, rather than letting the platform install and manage the Agent.
+If you are managing the platform using GitOps, you may also wish to manage these connected clusters in a similar fashion, rather than letting the platform install and manage the Agent.
 
 :::tip
-Managing connected clusters via GitOps offers several advantages:
+Managing connected clusters using GitOps offers several advantages:
 
 - Consistency: Ensures all clusters are configured identically.
 - Version Control: Keeps track of changes to cluster configurations over time.
@@ -254,7 +254,7 @@ Managing connected clusters via GitOps offers several advantages:
 
 ### Cluster resources
 
-  If you would like to manage the platform _and_ its agents via your GitOps tooling, you likely also want to manage the connected cluster configurations that live inside the platform. For information about networking requirements, see [Networking](/docs/platform/administer/clusters/advanced/networking).
+  If you would like to manage the platform _and_ its agents using your GitOps tooling, you likely also want to manage the connected cluster configurations that live inside the platform. For information about networking requirements, see [Networking](/docs/platform/administer/clusters/advanced/networking).
 
   These configuration elements inform the platform of:
 
@@ -295,11 +295,11 @@ Managing connected clusters via GitOps offers several advantages:
   ```
 
   :::info Who is managing the agent?
-  Remember, if you want to manage the platform agent via your GitOps workflow,
+  Remember, if you want to manage the platform agent using your GitOps workflow,
   make sure you set the `export DISABLE_AGENT=true` environment variable to `true` for your platform installation.
   :::
 
-  The "parent" Helm chart can now include any additional resources that you may want to install with your platform instance. In this case, the chart should include both the Cluster and Secret resources for any connected clusters. You can accomplish this by having a basic template that iterates over an array of clusters that users can provide via values, something like the following:
+  The "parent" Helm chart can now include any additional resources that you may want to install with your platform instance. In this case, the chart should include both the Cluster and Secret resources for any connected clusters. You can accomplish this by having a basic template that iterates over an array of clusters that users can provide using values, something like the following:
 
   ```yaml title="Template for Cluster and Secret resources"
 {{ range .Values.clusters }}
@@ -428,7 +428,7 @@ spec:
 
 <!-- vale on -->
 
-Once again, note that when managing the agent installations via ArgoCD or your GitOps tooling of choice, ensure that the `DISABLE_AGENT` environment variable is set to `true` for your platform deployment.
+Once again, note that when managing the agent installations using ArgoCD or your GitOps tooling of choice, ensure that the `DISABLE_AGENT` environment variable is set to `true` for your platform deployment.
 
 
 ## Manage GitOps drift
@@ -447,7 +447,7 @@ The Platform controllers may add or modify fields on your resources for several 
 
 ### Drift-causing fields by resource type
 
-The following table summarizes fields that commonly cause drift for each Platform CRD:
+The following table summarizes fields that commonly cause drift for each Platform resource type:
 
 | Resource type | Common drift fields | Description |
 |---------------|---------------------|-------------|
@@ -485,7 +485,7 @@ metadata:
 spec:
   # ... other config ...
   ignoreDifferences:
-    # Ignore status for all Platform CRDs
+    # Ignore status for all Platform custom resources
     - group: management.loft.sh
       kind: "*"
       jsonPointers:
@@ -550,7 +550,7 @@ metadata:
   name: argocd-cm
   namespace: argocd
 data:
-  # Ignore status field for all Platform CRDs
+  # Ignore status field for all Platform custom resources
   resource.customizations.ignoreDifferences.management.loft.sh_Project: |
     jsonPointers:
       - /status

--- a/platform/introduction/platform_intro.mdx
+++ b/platform/introduction/platform_intro.mdx
@@ -143,7 +143,7 @@ Node providers integrate with cloud APIs (AWS, GCP, Azure, and others) to provis
 This is the operational foundation for AI cloud providers. Tenant clusters with GPU nodes scale up when a customer submits a job and scale down when it finishes, without manual intervention.
 
 <figure className="platform-screenshot">
-  <img src={NodeProviderConfiguration} alt="Node provider configuration screen showing KubeVirt provider settings, node types, and the generated NodeProvider CRD" />
+  <img src={NodeProviderConfiguration} alt="Node provider configuration screen showing KubeVirt provider settings, node types, and the generated NodeProvider resource" />
   <figcaption>Node providers define the infrastructure and node types Platform can use when tenant clusters need private nodes.</figcaption>
 </figure>
 

--- a/platform/maintenance/backup-restore/backup-restore-platform.mdx
+++ b/platform/maintenance/backup-restore/backup-restore-platform.mdx
@@ -12,7 +12,7 @@ When performing disaster recovery or cluster migrations, ensure you preserve you
 
 See the [Platform CLI hub](../../reference/platform-cli.mdx) for UI-to-CLI equivalents across common Platform tasks, including backup and destroy commands.
 
-The vCluster Platform saves its state as Kubernetes Custom Resource Definition (CRD) objects. You can back up this state using [Velero](https://velero.io) or the vCluster CLI command we created for convenience. This command saves all relevant Kubernetes resources to a single file.
+The vCluster Platform saves its state as Kubernetes custom resource (CR) objects. You can back up this state using [Velero](https://velero.io) or the vCluster CLI command we created for convenience. This command saves all relevant Kubernetes resources to a single file.
 
 You can run the vCluster CLI to back up these components at any time. The backup includes the following resources:
 
@@ -34,10 +34,10 @@ You can run the vCluster CLI to back up these components at any time. The backup
 - `ProjectSecrets`
 <!-- vale on -->
 
-The platform backup includes only Custom Resource Definitions (CRDs). It does not include other resources used by the platform deployment or connected clusters, such as persistent volumes that store cost data. Use a Kubernetes backup solution such as [Velero](https://velero.io) to back up these resources separately.
+The platform backup includes only custom resources. It does not include other resources used by the platform deployment or connected clusters, such as persistent volumes that store cost data. Use a Kubernetes backup solution such as [Velero](https://velero.io) to back up these resources separately.
 
 :::warning Back up persistent volumes separately
-The `vcluster platform backup` command backs up CRDs only. You must separately back up the following PersistentVolumeClaims (PVCs):
+The `vcluster platform backup` command backs up CRs only. You must separately back up the following PersistentVolumeClaims (PVCs):
 
 - `platform-db` - stores platform state and configuration
 - `storage-volume-global-prometheus-server-0` - stores cost metrics data
@@ -76,7 +76,7 @@ The backup file contains the resource manifests for the vCluster Platform manage
 To restore, apply the backup to your cluster using the following command:
 
 :::note
-The backup contains vCluster Platform Custom Resource Definitions (CRDs), which must be installed in the cluster for the restore to succeed.
+The backup contains vCluster Platform custom resources. The corresponding Custom Resource Definitions (CRDs) must already be installed in the cluster for the restore to succeed.
 :::
 
 ```bash

--- a/platform/maintenance/backup-restore/backup-restore-platform.mdx
+++ b/platform/maintenance/backup-restore/backup-restore-platform.mdx
@@ -76,7 +76,7 @@ The backup file contains the resource manifests for the vCluster Platform manage
 To restore, apply the backup to your cluster using the following command:
 
 :::note
-The backup contains vCluster Platform custom resources. The corresponding Custom Resource Definitions (CRDs) must already be installed in the cluster for the restore to succeed.
+The backup contains vCluster Platform custom resources, not the Custom Resource Definitions (CRDs) that define them. Install vCluster Platform on the target cluster before restoring — its Helm chart installs the required CRDs automatically. Restoring onto a cluster without vCluster Platform already installed fails, because the CRDs for those resources don't exist yet.
 :::
 
 ```bash

--- a/platform/maintenance/backup-restore/backup-restore-platform.mdx
+++ b/platform/maintenance/backup-restore/backup-restore-platform.mdx
@@ -34,10 +34,10 @@ You can run the vCluster CLI to back up these components at any time. The backup
 - `ProjectSecrets`
 <!-- vale on -->
 
-The platform backup includes only custom resources. It does not include other resources used by the platform deployment or connected clusters, such as persistent volumes that store cost data. Use a Kubernetes backup solution such as [Velero](https://velero.io) to back up these resources separately.
+The platform backup includes the custom resources listed previously and their associated Kubernetes Secret objects. It does not include other resources used by the platform deployment or connected clusters, such as persistent volumes that store cost data. Use a Kubernetes backup solution such as [Velero](https://velero.io) to back up these resources separately.
 
 :::warning Back up persistent volumes separately
-The `vcluster platform backup` command backs up CRs only. You must separately back up the following PersistentVolumeClaims (PVCs):
+The `vcluster platform backup` command backs up the custom resources and associated Secrets listed previously. You must separately back up the following PersistentVolumeClaims (PVCs):
 
 - `platform-db` - stores platform state and configuration
 - `storage-volume-global-prometheus-server-0` - stores cost metrics data
@@ -76,7 +76,7 @@ The backup file contains the resource manifests for the vCluster Platform manage
 To restore, apply the backup to your cluster using the following command:
 
 :::note
-The backup contains vCluster Platform custom resources, not the Custom Resource Definitions (CRDs) that define them. Install vCluster Platform on the target cluster before restoring — its Helm chart installs the required CRDs automatically. Restoring onto a cluster without vCluster Platform already installed fails, because the CRDs for those resources don't exist yet.
+The backup contains vCluster Platform custom resources and associated Secrets, not the Custom Resource Definitions (CRDs) that define them. Install vCluster Platform on the target cluster before restoring. Its Helm chart installs the required CRDs automatically. Restoring onto a cluster without vCluster Platform already installed fails, because the CRDs for those resources don't exist yet.
 :::
 
 ```bash

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -147,7 +147,7 @@ The platform access key can only be provided as a Kubernetes Secret. You can fin
 
 ### Helm wrapper for VirtualClusterInstance
 
-Create a Helm chart that deploys the VirtualClusterInstance directly, allowing the Platform to manage the vCluster from creation. This approach is ideal when you want Helm to deploy the CRD but let the Platform handle the actual vCluster.
+Create a Helm chart that deploys the VirtualClusterInstance directly, allowing the Platform to manage the vCluster from creation. This approach is ideal when you want Helm to deploy the custom resource but let the Platform handle the actual vCluster.
 
 ```yaml title="templates/virtualclusterinstance.yaml"
 apiVersion: management.loft.sh/v1
@@ -175,7 +175,7 @@ The Platform must create and manage the namespace when `external: false`. Pre-ex
 
 ### GitOps with VirtualClusterInstance
 
-For [GitOps deployments](/docs/platform/install/gitops), create the [VirtualClusterInstance](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx) directly in your Git repository. Tools like [Argo CD](/docs/platform/integrations/argocd) or Flux will apply the CRD, and the Platform will manage the tenant cluster:
+For [GitOps deployments](/docs/platform/install/gitops), create the [VirtualClusterInstance](../../api/resources/virtualclusterinstance/virtualclusterinstance.mdx) directly in your Git repository. Tools like [Argo CD](/docs/platform/integrations/argocd) or Flux apply the manifest, and the Platform manages the tenant cluster:
 
 ```yaml title="gitops/vcluster-instance.yaml"
 apiVersion: management.loft.sh/v1
@@ -204,7 +204,7 @@ spec:
 :::tip GitOps best practices
 - Store VirtualClusterInstance manifests in your Git repository
 - Use Kustomize or Helm for environment-specific configurations
-- Let Argo CD or Flux handle the CRD lifecycle while Platform manages the vCluster
+- Let Argo CD or Flux handle the VirtualClusterInstance lifecycle while Platform manages the vCluster
 - See [Platform GitOps installation guide](/docs/platform/install/gitops) for complete setup
 :::
 
@@ -315,7 +315,7 @@ For specific scenarios where full Platform management isn't suitable:
 
 1. **Hybrid management**: Keep `external: true` to maintain external lifecycle management while still gaining Platform features like SSO and monitoring
 
-2. **GitOps compatibility**: Use VirtualClusterInstance CRDs in your GitOps repository, letting Argo CD deploy them while Platform manages the resulting tenant clusters
+2. **GitOps compatibility**: Use VirtualClusterInstance manifests in your GitOps repository, letting Argo CD deploy them while Platform manages the resulting tenant clusters
 
 3. **Gradual migration**: Start with external management, evaluate Platform features, then transition to full management when ready
 

--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -9,7 +9,7 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 
 :::warning External secrets version
 By default, vCluster uses the same CRD version as the External Secrets Operator installed on your control plane cluster.
-The `version` field allows you to explicitly set which CRD version to use (e.g., `v1beta1` or `v1`).
+The `version` field allows you to explicitly set which CRD version to use (for example, `v1beta1` or `v1`).
 Ensure your chosen version is supported by the External Secrets Operator on your control plane cluster.
 :::
 
@@ -31,7 +31,7 @@ integrations:
           enabled: true
 ```
 
-This enables the integration and the sync for all CRDs:
+This enables the integration and the sync for all custom resources:
 - `ExternalSecret`: namespaced, synced from tenant cluster into control plane cluster and then bi-directionally
 - `SecretStore`: namespaced, synced from tenant cluster into control plane cluster
 - `ClusterSecretStore`: cluster scoped, synced from control plane cluster into tenant cluster

--- a/vcluster/_fragments/multi-namespace-mode-explanation.mdx
+++ b/vcluster/_fragments/multi-namespace-mode-explanation.mdx
@@ -2,13 +2,13 @@ By default, all namespaced resources that need to be synced to the control plane
 
 For example, a pod within the vCluster called `test` in namespace `my-namespace` is rewritten for the control plane cluster to `test-x-my-namespace-x-my-vcluster` to avoid conflicts with other pods that would be named `test` in another namespace within the vCluster.
 
-Because vCluster rewrites the resource name, all references from other objects to that resource will need to get rewritten as well. vCluster does this already for all core resources, e.g. mounting a secret in a pod within the vCluster is automatically rewritten to the correct secret name on the control plane cluster (without seeing that inside the vCluster).
+Because vCluster rewrites the resource name, all references from other objects to that resource will need to get rewritten as well. vCluster does this already for all core resources. For example, mounting a secret in a pod within the vCluster is automatically rewritten to the correct secret name on the control plane cluster (without seeing that inside the vCluster).
 
 However, when using features such as [syncing custom resources](../configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx), it can be tedious to add all used references, or it can become very difficult or even impossible to rewrite certain references.
 
 Hence, vCluster offers a second mode of operation, **Multi-Namespace-Mode** which is more tailored towards syncing custom resources. In multi-namespace mode, vCluster will create a namespace in the control plane cluster for each namespace in the tenant cluster. The namespace name is modified to avoid conflicts between multiple vCluster instances in the same control plane cluster, but the synced namespaced resources are created with the same name as in the tenant cluster.
 
-This is useful to easier sync custom CRDs since you don't need to rewrite most references as if you use a single namespace as sync target.
+This makes it easier to sync custom resources since you don't need to rewrite most references as if you use a single namespace as sync target.
 
 :::warning
 Do not switch the vCluster mode in an already running vCluster. This causes data loss.

--- a/vcluster/_fragments/single-namespace-vs-multi-namespace.mdx
+++ b/vcluster/_fragments/single-namespace-vs-multi-namespace.mdx
@@ -1,31 +1,31 @@
 
-### Single-Namespace Mode (default)
+### Single-namespace mode (default)
 
 #### Choose this if you:
 
-* Not want to sync any CRDs or just CRDs with only a few references to other resources (e.g. Cert Manager or External Secrets)
+* Not want to sync any custom resources, or only custom resources with a few references to other resources (for example, Cert Manager or External Secrets)
 * Not have any global cluster permissions
 
 #### Advantages:
 * No cluster-level permissions required
 * Single namespace per vCluster
-* Easier isolation (single resource quota, limit range etc. per vCluster)
+* Easier isolation (single resource quota, limit range, and so on per vCluster)
 
 #### Disadvantages:
 * Resource names on the control plane cluster are called differently than in the vCluster
-* More complex to sync complex CRDs because of rewritten names (need to configure references on CRDs)
+* More complex to sync complex custom resources because of rewritten names (need to configure references on custom resources)
 
-### Multi-Namespace Mode
+### Multi-namespace mode
 
 #### Choose this if you:
-* Want to sync more complex CRDs (e.g. Knative, Zalando Postgresql or Tekton)
+* Want to sync more complex custom resources (for example, Knative, Zalando Postgresql or Tekton)
 * Are fine with vCluster creating new namespaces on its own
 
 #### Advantages:
 * Resource names on the control plane cluster are called the same than in the vCluster
-* Easier to sync CRDs (no need to configure references)
+* Easier to sync custom resources (no need to configure references)
 * Easier migration of resources into the vCluster
 
 #### Disadvantages:
 * Requires global cluster permissions
-* More effort to isolate multiple namespaces via quotas & policies
+* More effort to isolate multiple namespaces using quotas & policies

--- a/vcluster/_fragments/sync-from-host-resources.mdx
+++ b/vcluster/_fragments/sync-from-host-resources.mdx
@@ -5,7 +5,7 @@ resources are shared across the control plane cluster.
 A good example would be nodes, which are nice to view inside the tenant cluster and can be also used to enabled certain features such as [scheduling inside the vCluster](/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx),
 but you wouldn't want your tenant cluster to change the node itself. Another benefit of only syncing from the control plane cluster is that vCluster itself only requires read-only RBAC permissions.
 
-vCluster also lets you sync custom resources with the [custom resource definitions syncer](../configure/vcluster-yaml/sync/from-host/custom-resources.mdx)
+vCluster also lets you sync custom resources with the [custom resource syncer](../configure/vcluster-yaml/sync/from-host/custom-resources.mdx)
 
 There are a couple of labels that are created on the control plane cluster by vCluster that never get synced to the tenant cluster resource. These labels are:
 

--- a/vcluster/configure/vcluster-yaml/deletion.mdx
+++ b/vcluster/configure/vcluster-yaml/deletion.mdx
@@ -39,7 +39,7 @@ In order for auto deletion to work it requires an agent to be installed on the c
   values={[
     { label: "vcluster.yaml", value: "yaml" },
     { label: "Platform UI", value: "ui" },
-    { label: "Platform CRDs", value: "crds" },
+    { label: "Custom Resource", value: "crds" },
   ]}
 >
 <TabItem value="yaml">

--- a/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/proxy.mdx
@@ -23,7 +23,7 @@ import ProxyWildcardConfig from '!!raw-loader!@site/vcluster/configure/vcluster-
 This feature requires [vCluster Platform][vcluster-platform]. Both the client and target tenant clusters must be managed as [VirtualClusterInstance][virtualclusterinstance-api] within the platform.
 :::
 
-The Resource Proxy feature enables vCluster to proxy custom resource (CRD) requests to other tenant clusters. When enabled, the client tenant cluster transparently stores resources in and delegates management to a target tenant cluster. This enables cross-cluster communication patterns, centralized resource management, and multi-tenant architectures.
+The Resource Proxy feature enables vCluster to proxy custom resource requests to other tenant clusters. When enabled, the client tenant cluster transparently stores resources in and delegates management to a target tenant cluster. This enables cross-cluster communication patterns, centralized resource management, and multi-tenant architectures.
 
 ## How it works {#how-it-works}
 
@@ -50,7 +50,7 @@ flowchart LR
     subgraph target["target vCluster"]
       direction LR
       tapi((API))
-      crd([example.com/v1<br/>MyResource CRD])
+      crd([example.com/v1<br/>MyResource resources])
       ctrl([myresource-controller])
 
       tapi --> crd
@@ -95,7 +95,7 @@ flowchart LR
 
   subgraph target_vc["target vCluster"]
     direction LR
-    t_api((API)) --> t_crd([MyResource CRD])
+    t_api((API)) --> t_crd([MyResource resources])
     t_crd --> wf_a["team-a-resource<br/>(owner: team-a)"]
     t_crd --> wf_b["team-b-resource<br/>(owner: team-b)"]
 
@@ -369,8 +369,8 @@ flowchart LR
   subgraph target_b["target-b vCluster"]
     direction LR
     tb_api((API))
-    tb_exec([OtherResource CRD])
-    tb_task([AdditionalResource CRD])
+    tb_exec([OtherResource resources])
+    tb_task([AdditionalResource resources])
     tb_api --> tb_exec
     tb_api --> tb_task
   end
@@ -378,8 +378,8 @@ flowchart LR
   subgraph target_a["target-a vCluster"]
     direction LR
     ta_api((API))
-    ta_wf([MyResource CRD])
-    ta_pipe([SecondaryResource CRD])
+    ta_wf([MyResource resources])
+    ta_pipe([SecondaryResource resources])
     ta_api --> ta_wf
     ta_api --> ta_pipe
   end
@@ -431,7 +431,7 @@ flowchart TB
 
     subgraph other_project["other-project"]
       direction TB
-      target(["target vCluster<br />(MyResource CRD)"])
+      target(["target vCluster<br />(MyResource resources)"])
     end
   end
 
@@ -452,7 +452,7 @@ flowchart TB
 This is useful for scenarios where:
 - A shared resource storage cluster exists in a centralized project
 - Teams in different projects need to access common resources
-- Tenant clusters across different control plane clusters need to share CRDs
+- Tenant clusters across different control plane clusters need to share custom resources
 - CI/CD environments need access to centralized resource management
 
 ## Access modes {#access-modes}

--- a/vcluster/configure/vcluster-yaml/sleep.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep.mdx
@@ -43,7 +43,7 @@ Auto sleep is intended for pre-production use cases only, and has limitations wh
     { label: "vcluster.yaml", value: "yaml" },
     { label: "vCluster CLI", value: "cli" },
     { label: "Platform UI", value: "ui" },
-    { label: "Platform CRDs", value: "crds" },
+    { label: "Custom Resource", value: "crds" },
   ]}
 >
 <TabItem value="yaml">

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -42,7 +42,7 @@ Cluster-scoped custom resources exist at the cluster level and are not tied to a
 
 To sync cluster-scoped custom resources from the control plane cluster, configure the resource in your `vcluster.yaml` file:
 
-```yaml title="configure cluster-scoped CRD sync from host"
+```yaml title="configure cluster-scoped custom resource sync from host"
 sync:
   fromHost:
     customResources:
@@ -57,13 +57,13 @@ If you want to sync a specific version of a CRD that is not the storage version,
 
 <VersionedCrdSyncing yamlTitle="Configure cluster-scoped CR sync from host" scopeName="Cluster"/>
 
-## Namespace-scoped custom resource definitions
+## Namespace-scoped custom resources
 
 By default, namespace-scoped custom resource syncing is disabled.
 
 Enabling this feature allows you to sync namespaced custom resources from specific namespaces in the control plane cluster to corresponding namespaces in the tenant cluster.
 
-```yaml title="Configure namespace-scoped CRD sync from host"
+```yaml title="Configure namespace-scoped custom resource sync from host"
 sync:
   fromHost:
     customResources:

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -36,7 +36,7 @@ If you want to sync many custom resources, consider using [namespace syncing](..
 
 ## Enable custom resource syncing {#enable-custom-resource-syncing}
 
-To enable custom resource syncing from the tenant cluster to the control plane cluster, first identify which CustomResourceDefinitions (CRDs) you want to sync by running `kubectl get crds`. Then, add the name of each CRD to the `customResources` section under `sync` in your `vcluster.yaml` configuration file.
+To enable custom resource syncing from the tenant cluster to the control plane cluster, first find the CustomResourceDefinition (CRD) name for the resource type you want to sync by running `kubectl get crds`. Then, add that name to the `customResources` section under `sync` in your `vcluster.yaml` configuration file.
 
 Although the custom resources themselves are synced from the tenant cluster to the control plane cluster, vCluster also copies the corresponding CRDs from the control plane cluster into the tenant cluster. This ensures the tenant cluster can understand and manage those custom resources correctly.
 
@@ -85,7 +85,7 @@ sync:
           reverseExpression: "value.startsWith('prod-') ? value.slice(5) : value"
 ```
 
-## Configure Istio waypoint Gateway via custom resources
+## Configure Istio waypoint Gateway using custom resources
 
 :::tip Use native Gateway API sync for core Gateway API resources
 For syncing core Kubernetes Gateway API resources (`Gateway`, `HTTPRoute`, `TLSRoute`, `ReferenceGrant`, `BackendTLSPolicy`), use [native Gateway API sync](../networking/gateway-api.mdx) instead of custom-resource syncing. The example below covers Istio waypoint Gateways using the `HBONE` listener, which is outside the standard Gateway API channel and still requires the custom-resource path.

--- a/vcluster/learn-how-to/airgapped-vcluster-deployment.mdx
+++ b/vcluster/learn-how-to/airgapped-vcluster-deployment.mdx
@@ -93,7 +93,7 @@ You can specify the private repository in your vCluster configuration:
           version: 0.23.0
   ```
 
-##### Use directly in the VirtualClusterInstance CRD
+##### Use directly in the VirtualClusterInstance resource
 
   ```yaml
   kind: VirtualClusterInstance

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -54,7 +54,7 @@ The `NOSPACE` alarm occurs due to two common conditions:
 
 - **Excessive etcd data growth:** A large number of objects—such as Deployments, ConfigMaps, and Secrets—can fill etcd’s storage if regular <GlossaryTerm term="compaction">compaction</GlossaryTerm> is not performed.
 
-- **Synchronization conflicts:** Conflicting objects between the vCluster and <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm> can trigger continuous sync loops. For example, a Custom Resource Definition (CRD) modified by the Control Plane Cluster might sync back to the vCluster repeatedly. This behavior quickly fills etcd’s backend storage.
+- **Synchronization conflicts:** Conflicting objects between the vCluster and <GlossaryTerm term="host-cluster">Control Plane Cluster</GlossaryTerm> can trigger continuous sync loops. For example, a custom resource modified by the Control Plane Cluster might sync back to the vCluster repeatedly. This behavior quickly fills etcd’s backend storage.
 
 ## Solution
 
@@ -326,4 +326,4 @@ To ensure optimal etcd performance in vCluster:
 | Client key | `/run/config/pki/etcd-peer.key` | `/data/pki/etcd/tls.key` |
 | Client certificate | `/run/config/pki/etcd-peer.crt` | `/data/pki/etcd/tls.crt` |
 | Data directory | Separate PVC | `/data` in vCluster PVC |
-| Access method | Via etcd pod | Via vCluster pod |
+| Access method | Using etcd pod | Using vCluster pod |


### PR DESCRIPTION
# Content Description
Audits and corrects places where the docs used "CRD" (Custom Resource Definition) and "custom resource (CR)" interchangeably. CRDs are the installed API definition; CRs are instances created from that definition. Fixes conflations across backup/restore, GitOps, Platform operations, vCluster sync docs, and the Resource Proxy feature, while preserving legitimate CRD install/discovery/version/delete references. Adds a terminology rule to CLAUDE.md to prevent recurrence.

## Preview Link
Numerous pages were updated. For review, the diff should be easy enough without navigating to each page. But if you want to see it in preview, here's one from Platform and one from vCluster to get into the right docs:

- [Platform Add virtual clusters page](https://deploy-preview-2501--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/virtual-clusters/add-virtual-clusters)
- [vCluster vcluste.yaml deletion](https://deploy-preview-2501--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/deletion)

## Internal Reference
Closes DOC-1656

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs