### PR TITLE
docs: (DOC-1655) add CoreDNS scaling guidance for large node counts

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -125,3 +125,12 @@ BasedOnStyles =
 [CONTRIBUTING.md]
 Google.Headings = NO
 Loft.imperative-headings = NO
+
+# "etcd storage class" and "API server concurrency" are correct sentence case
+# (etcd is always lowercase per its own branding; API is a correctly-cased
+# acronym), but Google.Headings still flags both. Inline vale toggles around
+# these headings don't suppress the rule, so scope it off for the whole page
+# instead, matching the precedent in deploy-with-argocd.mdx.
+[**/deploy/control-plane/sizing-and-performance.mdx]
+BasedOnStyles = Loft, Google, Vale
+Google.Headings = NO

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -59,6 +59,9 @@ The embedded CoreDNS feature allows you to run CoreDNS as part of the syncer, wh
 
 The embedded approach requires consideration of operational trade-offs. Troubleshooting becomes more complex since DNS and sync functions share the same container and process space. Updates and restarts affect both DNS and sync capabilities simultaneously, though all CoreDNS features remain supported.
 
+## Scale for large node counts
+
+By default, CoreDNS runs a single replica. This is sufficient for most tenant clusters, but large node counts, particularly AI and ML workloads with many pods per node, can exceed what one replica handles. For guidance on when to scale and how, see [Scale CoreDNS for large node counts](../../../../deploy/control-plane/sizing-and-performance.mdx#scale-coredns-for-large-node-counts) in the control plane sizing and performance guide.
 
 ## Example
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -65,9 +65,12 @@ This applies to the separate deployment type (the default) only. With
 `controlPlane.coredns.embedded: true`, there's no `coredns` Deployment in
 `kube-system`: vCluster removes it entirely, so
 `controlPlane.coredns.deployment.replicas` and Deployment-level scaling don't
-apply. Embedded mode can't add independent CoreDNS replicas, but it can
-receive more capacity by raising `controlPlane.statefulSet.resources`, which
-resizes the whole control-plane pod rather than CoreDNS specifically.
+apply. Embedded mode can't add independent CoreDNS Deployment replicas, but
+two options still add DNS capacity. Raising `controlPlane.statefulSet.resources`
+resizes the whole control-plane pod rather than CoreDNS specifically, and
+raising `controlPlane.statefulSet.highAvailability.replicas` adds more active
+CoreDNS instances, since the `vc-kube-dns` Service points at the syncer pods
+when embedded is on.
 
 By default, CoreDNS runs a single replica. This is sufficient for most tenant
 clusters, but high query volume, particularly from AI and ML workloads with

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -61,7 +61,20 @@ The embedded approach requires consideration of operational trade-offs. Troubles
 
 ## Scale for large node counts
 
-By default, CoreDNS runs a single replica. This is sufficient for most tenant clusters, but large node counts, particularly AI and ML workloads with many pods per node, can exceed what one replica handles. For guidance on when to scale and how, see [Scale CoreDNS for large node counts](../../../../deploy/control-plane/sizing-and-performance.mdx#scale-coredns-for-large-node-counts) in the control plane sizing and performance guide.
+This applies to the separate deployment type (the default) only. With
+`controlPlane.coredns.embedded: true`, there's no `coredns` Deployment in
+`kube-system`: vCluster removes it entirely, so
+`controlPlane.coredns.deployment.replicas` and Deployment-level scaling don't
+apply. There's currently no supported way to add DNS capacity in embedded
+mode.
+
+By default, CoreDNS runs a single replica. This is sufficient for most tenant
+clusters, but high query volume, particularly from AI and ML workloads with
+bursty pod scheduling, can exceed what one replica handles. For why that
+happens, see
+[Why does CoreDNS become a DNS bottleneck?](../../../../understand/coredns-bottlenecks.mdx).
+For how to scale it, see
+[Scale CoreDNS for large node counts](../../../../deploy/control-plane/coredns-scaling.mdx).
 
 ## Example
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -69,7 +69,7 @@ apply. Embedded mode can't add independent CoreDNS Deployment replicas, but
 two options still add DNS capacity. Raising `controlPlane.statefulSet.resources`
 resizes the whole control-plane pod rather than CoreDNS specifically, and
 raising `controlPlane.statefulSet.highAvailability.replicas` adds more active
-CoreDNS instances, since the `vc-kube-dns` Service points at the syncer pods
+CoreDNS instances, since the `kube-dns` Service points at the syncer pods
 when embedded is on.
 
 By default, CoreDNS runs a single replica. This is sufficient for most tenant

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -65,8 +65,9 @@ This applies to the separate deployment type (the default) only. With
 `controlPlane.coredns.embedded: true`, there's no `coredns` Deployment in
 `kube-system`: vCluster removes it entirely, so
 `controlPlane.coredns.deployment.replicas` and Deployment-level scaling don't
-apply. There's currently no supported way to add DNS capacity in embedded
-mode.
+apply. Embedded mode can't add independent CoreDNS replicas, but it can
+receive more capacity by raising `controlPlane.statefulSet.resources`, which
+resizes the whole control-plane pod rather than CoreDNS specifically.
 
 By default, CoreDNS runs a single replica. This is sufficient for most tenant
 clusters, but high query volume, particularly from AI and ML workloads with

--- a/vcluster/deploy/control-plane/benchmark-methodology.mdx
+++ b/vcluster/deploy/control-plane/benchmark-methodology.mdx
@@ -1,7 +1,7 @@
 ---
 title: Control plane benchmark methodology
 sidebar_label: Benchmark methodology
-sidebar_position: 1
+sidebar_position: 2
 description: Test setup, service level indicators, and analysis for vCluster control plane scalability benchmarks.
 ---
 

--- a/vcluster/deploy/control-plane/binary/_category_.json
+++ b/vcluster/deploy/control-plane/binary/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "As a binary",
-  "position": "3",
+  "position": "6",
   "className": "standalone private-nodes"
 }

--- a/vcluster/deploy/control-plane/coredns-scaling.mdx
+++ b/vcluster/deploy/control-plane/coredns-scaling.mdx
@@ -49,13 +49,13 @@ controlPlane:
       replicas: 3
 ```
 
-vCluster re-applies the CoreDNS Deployment, including `spec.replicas`, every
-time the control plane pod starts, using a client-side apply that overwrites
-the live object. A restart, upgrade, or leader change resets `replicas` back
-to whatever `vcluster.yaml` specifies. Set `replicas` in `vcluster.yaml` to the
-floor you want rather than scaling the Deployment directly. The same
-overwrite-on-restart behavior applies to any other CoreDNS setting changed
-out-of-band. See [Configuration Persistence](../../configure/vcluster-yaml/control-plane/components/coredns.mdx#deploy-separate-coredns) for details.
+vCluster re-applies the CoreDNS Deployment every time the control plane pod
+starts, reconciling it against `vcluster.yaml` the same way `kubectl apply`
+reconciles a manifest against a live object. `replicas`, and any other
+CoreDNS setting, converges to whatever `vcluster.yaml` specifies rather than
+to a value set by a direct edit. Set `replicas` in `vcluster.yaml` to the
+floor you want instead of scaling the Deployment directly. See
+[Configuration Persistence](../../configure/vcluster-yaml/control-plane/components/coredns.mdx#deploy-separate-coredns) for details.
 
 ### Run a node-proportional autoscaler
 
@@ -187,15 +187,21 @@ query volume tells you a node needs more headroom than that.
 
 ### Settings to avoid
 
-Upstream offers a `coresPerReplica` companion ratio (256 cores per replica). Avoid it unless
+Upstream offers a `coresPerReplica` companion ratio (256 cores per replica).
+On shared nodes, avoid it unless
 [`sync.fromHost.nodes.enabled`](../../configure/vcluster-yaml/sync/from-host/nodes.mdx)
 is `true`. With the default `sync.fromHost.nodes.enabled: false`, the tenant
-cluster's API server only has Node objects for nodes actually running tenant
-pods. Those synthesized nodes report a fixed 16 CPU allocatable regardless of
-the real node's CPU count, which breaks core-based scaling. That same default
-also means the autoscaler's node count lags real fleet size. A node the
-physical cluster just added doesn't show up in the tenant cluster until a
-tenant pod actually lands on it.
+cluster's API server only synthesizes Node objects for nodes actually running
+tenant pods. Those synthesized nodes report a fixed 16 CPU allocatable
+regardless of the real node's CPU count, which breaks core-based scaling.
+That same default also means the autoscaler's node count lags real fleet
+size. A node the physical cluster just added doesn't show up in the tenant
+cluster until a tenant pod actually lands on it.
+
+On [private nodes](../worker-nodes/private-nodes/join.mdx), this caveat
+doesn't apply. Private-node kubelets register real Node objects directly,
+with real CPU capacity, so `coresPerReplica` can be an appropriate ratio and
+node discovery doesn't lag pod placement.
 
 `preventSinglePointFailure: true` doesn't override `min`. It raises the
 node-derived replica count to 2 once the tenant cluster has more than one

--- a/vcluster/deploy/control-plane/coredns-scaling.mdx
+++ b/vcluster/deploy/control-plane/coredns-scaling.mdx
@@ -24,7 +24,7 @@ works with `controlPlane.coredns.embedded: true`: there's no `coredns`
 Deployment to scale, and `controlPlane.coredns.deployment.replicas` is
 silently ignored. See
 [Why embedded CoreDNS can't scale the same way](../../understand/coredns-bottlenecks.mdx#why-embedded-coredns-cant-scale-the-same-way)
-for why, and for the one workaround available.
+for why, and for the options available instead.
 :::
 
 ## Scale CoreDNS

--- a/vcluster/deploy/control-plane/coredns-scaling.mdx
+++ b/vcluster/deploy/control-plane/coredns-scaling.mdx
@@ -1,0 +1,275 @@
+---
+title: Scale CoreDNS for large node counts
+sidebar_label: CoreDNS scaling
+sidebar_position: 3
+description: How to scale CoreDNS in a tenant cluster when a single replica can't keep up with DNS query volume.
+---
+
+CoreDNS handles DNS resolution for every pod in the tenant cluster. By default,
+it runs a single replica (`controlPlane.coredns.deployment.replicas: 1`) as a
+separate Deployment, sized for small and medium tenant clusters. High DNS
+query volume, most often from AI and ML workloads with bursty pod scheduling,
+can push demand past what one replica handles. For why that happens, see
+[Why does CoreDNS become a DNS bottleneck?](../../understand/coredns-bottlenecks.mdx).
+See [CoreDNS configuration](../../configure/vcluster-yaml/control-plane/components/coredns.mdx)
+for the full deployment and configuration reference. Already seeing DNS
+timeouts or `SERVFAIL` errors right now? See
+[Resolve CoreDNS DNS timeouts and SERVFAIL errors](../../troubleshoot/coredns-dns-timeouts.mdx)
+instead.
+
+:::warning Doesn't apply to embedded CoreDNS
+This page covers the separate CoreDNS deployment type
+(`controlPlane.coredns.embedded: false`, the default). Neither approach below
+works with `controlPlane.coredns.embedded: true`: there's no `coredns`
+Deployment to scale, and `controlPlane.coredns.deployment.replicas` is
+silently ignored. See
+[Why embedded CoreDNS can't scale the same way](../../understand/coredns-bottlenecks.mdx#why-embedded-coredns-cant-scale-the-same-way)
+for why, and for the one workaround available.
+:::
+
+## Scale CoreDNS
+
+Scale CoreDNS by either increasing the replica count or by running an
+autoscaler. Which one to reach for depends on how stable your node count is:
+
+- **Fixed or slow-changing node count** — increase the replica count directly.
+  It's simpler to reason about and doesn't add an extra component to operate.
+- **Node count that changes over time**, such as autoscaling GPU node pools —
+  run a node-proportional autoscaler so replica count tracks it automatically.
+
+### Increase the replica count
+
+For a fixed increase that doesn't need to track node count, raise `replicas`
+directly:
+
+```yaml title="vcluster.yaml — CoreDNS replica count"
+controlPlane:
+  coredns:
+    deployment:
+      replicas: 3
+```
+
+vCluster re-applies the CoreDNS Deployment, including `spec.replicas`, every
+time the control plane pod starts, using a client-side apply that overwrites
+the live object. A restart, upgrade, or leader change resets `replicas` back
+to whatever `vcluster.yaml` specifies. Set `replicas` in `vcluster.yaml` to the
+floor you want rather than scaling the Deployment directly. The same
+overwrite-on-restart behavior applies to any other CoreDNS setting changed
+out-of-band. See [Configuration Persistence](../../configure/vcluster-yaml/control-plane/components/coredns.mdx#deploy-separate-coredns) for details.
+
+The default CoreDNS Deployment also sets a topology spread constraint
+(`maxSkew: 1` over `kubernetes.io/hostname`, `whenUnsatisfiable: DoNotSchedule`),
+which allows only one CoreDNS pod per node. Raising `replicas` above the
+tenant cluster's schedulable node count leaves the extra pods `Pending`
+instead of running, so check node count before raising `replicas` past it.
+
+### Run a node-proportional autoscaler
+
+For tenant clusters where node count changes over time, such as
+autoscaling GPU node pools, keep the CoreDNS replica count proportional to
+node count. Don't rely on a fixed value. Start from upstream CoreDNS's own
+[cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler)
+convention of one replica per 16 nodes, then tighten it against your own
+measured query volume. One deployment on a small number of very large
+bare-metal GPU nodes tightened its ratio to 1:8. Its per-node core count was
+high enough that core-based scaling alone under-provisioned.
+
+The `coredns` Deployment in `kube-system` is a native object
+inside the tenant cluster, not a synced mirror of something on the control
+plane cluster. Run the autoscaler directly against the tenant cluster's own
+API server. It watches the tenant cluster's node count and scales `coredns`
+directly. The tenant cluster's own controller manager reconciles the change,
+and the resulting pods sync to the control plane cluster automatically.
+
+Apply the following to the tenant cluster, not the control plane cluster:
+
+```yaml title="coredns-autoscaler.yaml — apply inside the tenant cluster"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coredns-autoscaler-nodes
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coredns-autoscaler-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns-autoscaler-nodes
+subjects:
+  - kind: ServiceAccount
+    name: coredns-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    resourceNames: ["coredns"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coredns-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: coredns-autoscaler
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+data:
+  linear: |-
+    {"nodesPerReplica": 16, "min": 1, "preventSinglePointFailure": true}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: coredns-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-autoscaler
+    spec:
+      serviceAccountName: coredns-autoscaler
+      containers:
+        - name: autoscaler
+          # check the project's releases page for the current tag
+          image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.10.3
+          command:
+            - /cluster-proportional-autoscaler
+            - --namespace=kube-system
+            - --configmap=coredns-autoscaler
+            - --target=deployment/coredns
+            - --logtostderr=true
+            - --v=2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+```
+
+The `linear` mode config's `nodesPerReplica: 16` reproduces upstream's
+node-based convention. Tighten it, for example to 8, once your own measured
+query volume tells you a node needs more headroom than that.
+
+### Settings to avoid
+
+Upstream offers a `coresPerReplica` companion ratio (256 cores per replica). Avoid it unless
+[`sync.fromHost.nodes.enabled`](../../configure/vcluster-yaml/sync/from-host/nodes.mdx)
+is `true`. With the default `sync.fromHost.nodes.enabled: false`, the tenant
+cluster's API server only has Node objects for nodes actually running tenant
+pods. Those synthesized nodes report a fixed 16 CPU allocatable regardless of
+the real node's CPU count, which breaks core-based scaling. That same default
+also means the autoscaler's node count lags real fleet size. A node the
+physical cluster just added doesn't show up in the tenant cluster until a
+tenant pod actually lands on it.
+
+`preventSinglePointFailure: true` doesn't override `min`. It raises the
+node-derived replica count to 2 once the tenant cluster has more than one
+schedulable Ready node. It can also override `max` if `max` is set below 2.
+Below that threshold, or with a single schedulable node, `min` still governs.
+
+## What to watch
+
+Monitor CoreDNS alongside the [control-plane conditions](./sizing-and-performance.mdx#operational-guidance),
+using CoreDNS's own Prometheus metrics
+([CoreDNS metrics reference](https://coredns.io/plugins/metrics/)). vCluster's
+control-plane load-testing framework doesn't model DNS load today. Its
+existing KWOK and kube-burner workloads don't generate DNS traffic, so there's
+no vCluster-published SLO threshold for these signals yet. Establish your own
+baseline against your fleet's real query volume and pod density instead of
+borrowing a threshold from a workload that isn't yours.
+
+### Request latency (p99)
+
+```promql
+histogram_quantile(0.99,
+  sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) by (le)
+)
+```
+
+**Why:** Tail DNS resolution latency over a 5-minute rate window. Validating a
+real boundary needs a sustained query rate matching your target pod density
+and churn.
+
+### Error rate
+
+```promql
+sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))
+```
+
+**Why:** `SERVFAIL` over a 5-minute window is the reliable overload signal,
+unlike `NXDOMAIN`. See
+[What an overloaded CoreDNS looks like](../../understand/coredns-bottlenecks.mdx#what-an-overloaded-coredns-looks-like)
+for why `NXDOMAIN` alone isn't reliable. Validating a real boundary needs
+induced upstream or API server latency to trigger genuine failures, not just
+query volume.
+
+### Request throughput
+
+```promql
+sum(rate(coredns_dns_requests_total[5m]))
+```
+
+**Why:** Total query rate over a 5-minute window. This is informational for
+capacity planning, not an alerting signal on its own.
+
+### Replica CPU saturation
+
+**Why:** CoreDNS container CPU usage against the default 1 CPU limit signals
+when a replica is approaching the ceiling described in
+[Why does CoreDNS become a DNS bottleneck?](../../understand/coredns-bottlenecks.mdx).
+The Control Plane team's existing container CPU dashboards should already
+have a query for this; validating a real boundary needs the same dedicated
+DNS workload as the other signals above.
+
+### Replica memory saturation
+
+**Why:** CoreDNS's default memory limit is 170Mi per replica, independent of
+the CPU limit and independent of replica count. An OOMKilled CoreDNS pod
+produces the same symptoms as a CPU-saturated one, DNS timeouts and
+`SERVFAIL`. Adding replicas doesn't help. Each new replica gets the same
+170Mi ceiling, not a larger share of memory. Check container restart reason
+before attributing a DNS incident to query volume.
+
+For control-plane sizing and alert thresholds unrelated to DNS, see
+[Sizing and performance](./sizing-and-performance.mdx).

--- a/vcluster/deploy/control-plane/coredns-scaling.mdx
+++ b/vcluster/deploy/control-plane/coredns-scaling.mdx
@@ -57,12 +57,6 @@ floor you want rather than scaling the Deployment directly. The same
 overwrite-on-restart behavior applies to any other CoreDNS setting changed
 out-of-band. See [Configuration Persistence](../../configure/vcluster-yaml/control-plane/components/coredns.mdx#deploy-separate-coredns) for details.
 
-The default CoreDNS Deployment also sets a topology spread constraint
-(`maxSkew: 1` over `kubernetes.io/hostname`, `whenUnsatisfiable: DoNotSchedule`),
-which allows only one CoreDNS pod per node. Raising `replicas` above the
-tenant cluster's schedulable node count leaves the extra pods `Pending`
-instead of running, so check node count before raising `replicas` past it.
-
 ### Run a node-proportional autoscaler
 
 For tenant clusters where node count changes over time, such as

--- a/vcluster/deploy/control-plane/docker-container/_category_.json
+++ b/vcluster/deploy/control-plane/docker-container/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "As a Docker container",
-    "position": "2",
+    "position": "5",
     "collapsible": true,
     "collapsed": true
 }

--- a/vcluster/deploy/control-plane/kubernetes-pod/_category_.json
+++ b/vcluster/deploy/control-plane/kubernetes-pod/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "As a Kubernetes pod",
-    "position": "1",
+    "position": "4",
     "collapsible": true,
     "collapsed": true
 }

--- a/vcluster/deploy/control-plane/sizing-and-performance.mdx
+++ b/vcluster/deploy/control-plane/sizing-and-performance.mdx
@@ -20,6 +20,10 @@ load. They don't describe data-plane capacity, networking throughput, storage
 backend behavior, or the runtime cost of your actual workloads.
 :::
 
+:::note CoreDNS is covered here too
+CoreDNS is a control-plane-managed component, but its default replica count directly affects data-plane DNS resolution for tenant workloads. This page covers CoreDNS scaling alongside the control-plane sizing guidance above.
+:::
+
 **The load is simulated, not real.** Tests use [KWOK](https://kwok.sigs.k8s.io/)
 fake nodes with no real container runtime or kubelet.
 [kube-burner](https://kube-burner.github.io/kube-burner/) drives object
@@ -109,7 +113,7 @@ Tenant Cluster.
 | Small team | P2 | 2 | 4 GiB | Up to a few hundred long-running services |
 | Standard production | P3 | 4 | 8 GiB | Most production tenants — recommended starting point |
 | Large production | P4 | 8 | 16 GiB | Heavy churn or dense deployments |
-| Enterprise / AI Cloud | P5 | 16 | 32 GiB | High-density GPU clusters; operator-rich workloads (cert-manager, external-secrets, GPU Operator, Argo, KServe, etc.) |
+| Enterprise / AI Cloud | P5 | 16 | 32 GiB | High-density GPU clusters; operator-rich workloads such as cert-manager, external-secrets, GPU Operator, Argo, and KServe |
 | Hyperscale | P6 | 32 | 64 GiB | Latency headroom above P5; same node ceiling, marginal API p99 improvement |
 
 **Key principles:**
@@ -171,9 +175,7 @@ under sustained churn. Set `GOMEMLIMIT` to about 75% of your profile's memory
 limit. For example, use `12000MiB` for a P4 16 GiB pod, or `6000MiB` for a
 P3 8 GiB pod.
 
-<!-- vale Google.Headings off -->
 ### etcd storage class
-<!-- vale Google.Headings on -->
 
 Embedded etcd is sensitive to WAL fsync latency. Use a high-IOPS
 StorageClass for the etcd PersistentVolume:
@@ -197,9 +199,7 @@ above the 25 ms warn threshold. For example, AWS `gp3` defaults to 3K IOPS
 and 125 MB/s. A high-IOPS class keeps WAL fsync p99 well within the warn
 threshold even under sustained load.
 
-<!-- vale Google.Headings off -->
 ### API server concurrency
-<!-- vale Google.Headings on -->
 
 The Kubernetes defaults (400 / 200) are sufficient for most workloads. For
 operator-rich Tenant Clusters with many persistent controllers, double them to
@@ -260,7 +260,7 @@ Lifting one without the others shifts the bottleneck rather than removing it:
 | --- | --- | --- |
 | Tenant controller manager / scheduler → tenant API server | 200 | 400 |
 | Syncer → Control Plane Cluster API server | 400 | 800 |
-| Client (kubectl, CI pipelines, etc.) | 100 | 200 |
+| Client (kubectl, CI pipelines, and so on) | 100 | 200 |
 
 ### Bootstrap replica order
 
@@ -269,6 +269,176 @@ When provisioning a new HA Tenant Cluster with embedded etcd, bring up replica
 condition where all three replicas try to become the etcd cluster founder
 simultaneously. The vCluster CLI handles this automatically. In self-managed
 Helm pipelines, handle it explicitly.
+
+## Scale CoreDNS for large node counts
+
+CoreDNS handles DNS resolution for every pod in the tenant cluster. By default,
+it runs a single replica (`controlPlane.coredns.deployment.replicas: 1`), sized
+for small and medium tenant clusters. Large node counts, especially AI Cloud
+and ML workloads with high pod density per node, can push DNS query volume
+past what one replica handles. See
+[CoreDNS configuration](../../configure/vcluster-yaml/control-plane/components/coredns.mdx)
+for the full deployment and configuration reference.
+
+### When it becomes a bottleneck
+
+:::caution Needs confirmation from the Control Plane team
+The numbers below are estimates derived from CoreDNS's default resource limits
+and general Kubernetes DNS-scaling conventions, not from vCluster's own
+benchmark methodology. Confirm before publishing.
+:::
+
+A single CoreDNS replica is CPU-bound at vCluster's default 1 CPU limit.
+Cache-miss queries on the `kubernetes` and `forward` plugin path typically cap
+out around 2,000-3,000 queries per second per core.
+
+The node count where this becomes a bottleneck depends on pod density and
+churn. It's roughly 16-30 nodes for general-purpose Tenant Clusters, tightening
+to 8-16 nodes for AI and ML fleets with dense GPU node pools. `ndots:5`
+search-domain expansion multiplies query volume per lookup, compounding the
+effect.
+
+Tenant workloads see this as DNS resolution timeouts, intermittent `SERVFAIL`
+or `NXDOMAIN` responses, and slower pod startup when init containers or
+sidecars wait on DNS lookups.
+
+### Scale CoreDNS today
+
+Scale CoreDNS with one of these approaches.
+
+#### Increase the replica count
+
+For a fixed increase that doesn't need to track node count, raise `replicas`
+directly:
+
+```yaml title="vcluster.yaml — CoreDNS replica count"
+controlPlane:
+  coredns:
+    deployment:
+      replicas: 3
+```
+
+#### Run a node-proportional autoscaler
+
+For tenant clusters where node count changes over time, such as
+autoscaling GPU node pools, keep the CoreDNS replica count proportional to
+node count instead of using a fixed value. AI Cloud accounts running large
+GPU fleets have used a 1:8 CoreDNS-to-node ratio as a starting point.
+
+You can use [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler)
+to do this. The `coredns` Deployment in `kube-system` is a native object
+inside the tenant cluster, not a synced mirror of something on the control
+plane cluster, so run the autoscaler directly against the tenant cluster's own
+API server. It watches the tenant cluster's node count and scales `coredns`
+directly. The tenant cluster's own controller manager reconciles the change,
+and the resulting pods sync to the control plane cluster automatically.
+
+Apply the following to the tenant cluster, not the control plane cluster:
+
+```yaml title="coredns-autoscaler.yaml — apply inside the tenant cluster"
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coredns-autoscaler-nodes
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coredns-autoscaler-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coredns-autoscaler-nodes
+subjects:
+  - kind: ServiceAccount
+    name: coredns-autoscaler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    resourceNames: ["coredns"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: coredns-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: coredns-autoscaler
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+data:
+  linear: |-
+    {"nodesPerReplica": 8, "min": 1, "preventSinglePointFailure": true}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-autoscaler
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: coredns-autoscaler
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns-autoscaler
+    spec:
+      serviceAccountName: coredns-autoscaler
+      containers:
+        - name: autoscaler
+          # check the project's releases page for the current tag
+          image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.14
+          command:
+            - /cluster-proportional-autoscaler
+            - --namespace=kube-system
+            - --configmap=coredns-autoscaler
+            - --target=deployment/coredns
+            - --logtostderr=true
+            - --v=2
+```
+
+The `linear` mode config's `nodesPerReplica: 8` reproduces the 1:8 ratio
+directly. Adjust it to match your own DNS query volume per node.
+
+### What to watch
+
+Monitor CoreDNS query latency and error rate alongside the control-plane
+conditions above. See the alert thresholds table in
+[Operational guidance](#operational-guidance) for the specific metrics and
+thresholds once confirmed.
 
 ## Operational guidance
 
@@ -285,6 +455,11 @@ Karpenter with `consolidationPolicy: WhenEmpty` and a 5-minute
 | etcd DB size | > 4 GB (warn) / 12 GB (fail) |
 | Dropped watches per second | > 0 sustained |
 | Node convergence ratio | < 98% |
+| DNS query p99 latency | Needs confirmation |
+| DNS error rate (`SERVFAIL` / `NXDOMAIN`) | Needs confirmation |
+
+DNS thresholds are pending confirmation from the Control Plane team. See
+[Scale CoreDNS for large node counts](#scale-coredns-for-large-node-counts).
 
 **Tenant Isolation is per-Tenant-Cluster.** Each Tenant Cluster is fully
 isolated. Control-plane sizing is per-tenant, not aggregate. A single Control

--- a/vcluster/deploy/control-plane/sizing-and-performance.mdx
+++ b/vcluster/deploy/control-plane/sizing-and-performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Control plane sizing and performance
 sidebar_label: Sizing and performance
-sidebar_position: 0
+sidebar_position: 1
 description: How to evaluate, size, and tune a Tenant Cluster's Virtual Control Plane for your environment.
 ---
 
@@ -9,7 +9,9 @@ This page explains how to evaluate and tune a Tenant Cluster's Virtual Control
 Plane for your environment. It covers the evaluation framework, monitoring
 thresholds, resource profile starting points, and validated tuning settings.
 For the test methodology and analysis behind the profiles, see
-[Benchmark methodology](./benchmark-methodology.mdx).
+[Benchmark methodology](./benchmark-methodology.mdx). For CoreDNS, a
+control-plane-managed component with its own scaling path, see
+[Scale CoreDNS for large node counts](./coredns-scaling.mdx).
 
 ## Scope and caveats
 
@@ -18,10 +20,6 @@ The numbers on this page describe the capacity of the Virtual Control Plane
 (API server, controller manager, scheduler, and embedded etcd) under simulated
 load. They don't describe data-plane capacity, networking throughput, storage
 backend behavior, or the runtime cost of your actual workloads.
-:::
-
-:::note CoreDNS is covered here too
-CoreDNS is a control-plane-managed component, but its default replica count directly affects data-plane DNS resolution for tenant workloads. This page covers CoreDNS scaling alongside the control-plane sizing guidance above.
 :::
 
 **The load is simulated, not real.** Tests use [KWOK](https://kwok.sigs.k8s.io/)
@@ -41,8 +39,8 @@ that matters.
 ## How to evaluate your environment
 
 The recommended approach is to run the benchmark framework against a
-representative subset of your real configuration: your operators, your CRDs,
-your object density. Measure the control-plane response as it runs. The same
+representative subset of your real configuration. Match your own operators,
+CRDs, and object density. Measure the control-plane response as it runs. The same
 SLI checks the framework uses internally make a portable monitoring template
 you can apply to any Tenant Cluster.
 
@@ -55,9 +53,9 @@ configurations, the 13-SLI evaluation checks, and the doubling-ladder and
 binary-search scripts. See [Benchmark methodology](./benchmark-methodology.mdx)
 for test setup details.
 
-Customize the workload (`kube-burner/configs/`) to match your tenant — your
-CRD mix, your operator density, your churn pattern — then run the ladder
-against your candidate profile.
+Customize the workload (`kube-burner/configs/`) to match your tenant. Adjust
+CRD mix, operator density, and churn pattern to your own workload, then run
+the ladder against your candidate profile.
 
 ### What to monitor
 
@@ -90,13 +88,13 @@ Synthetic testing covers the control-plane portion of sizing. Real validation
 is needed for:
 
 - **Pod startup latency SLOs** — image pulls, scheduling under contention, and
-  kubelet binding latency are not modeled by KWOK.
+  kubelet binding latency aren't modeled by KWOK.
 - **Network programming p99** — Service, EndpointSlice, kube-proxy, and CNI
-  interactions are not modeled.
+  interactions aren't modeled.
 - **CRD-heavy operator workloads** — each CRD adds a separate watch cache and
   informer that KWOK doesn't exercise.
 - **Real container runtime behavior** — image pulls, probes, and evictions
-  create event storms that synthetic load cannot reproduce.
+  create event storms that synthetic load can't reproduce.
 
 If your customer-visible claim is a node count or pod count, validate it on
 real nodes at the scale that matters.
@@ -270,231 +268,6 @@ condition where all three replicas try to become the etcd cluster founder
 simultaneously. The vCluster CLI handles this automatically. In self-managed
 Helm pipelines, handle it explicitly.
 
-## Scale CoreDNS for large node counts
-
-CoreDNS handles DNS resolution for every pod in the tenant cluster. By default,
-it runs a single replica (`controlPlane.coredns.deployment.replicas: 1`), sized
-for small and medium tenant clusters. Large node counts, especially AI Cloud
-and ML workloads with high pod density per node, can push DNS query volume
-past what one replica handles. See
-[CoreDNS configuration](../../configure/vcluster-yaml/control-plane/components/coredns.mdx)
-for the full deployment and configuration reference.
-
-### When it becomes a bottleneck
-
-:::caution Needs confirmation from the Control Plane team
-The numbers below are estimates derived from CoreDNS's default resource limits
-and general Kubernetes DNS-scaling conventions, not from vCluster's own
-benchmark methodology. The control-plane load-testing framework doesn't model
-DNS load today, so confirming these numbers needs a new DNS-focused workload
-or real deployment telemetry, not a re-read of existing benchmark runs.
-:::
-
-A single CoreDNS replica is CPU-bound at vCluster's default 1 CPU limit.
-Cache-miss queries on the `kubernetes` and `forward` plugin path typically cap
-out around 2,000-3,000 queries per second per core.
-
-The node count where this becomes a bottleneck depends on pod density and
-churn. It's roughly 16-30 nodes for general-purpose Tenant Clusters, tightening
-to 8-16 nodes for AI and ML fleets with dense GPU node pools. `ndots:5`
-search-domain expansion multiplies query volume per lookup, compounding the
-effect.
-
-Tenant workloads see this as DNS resolution timeouts, intermittent `SERVFAIL`
-responses, and slower pod startup when init containers or sidecars wait on DNS
-lookups. `NXDOMAIN` responses aren't a reliable signal on their own, since
-`ndots:5` search-path expansion produces them as a normal byproduct of
-everyday lookups.
-
-### Scale CoreDNS today
-
-Scale CoreDNS with one of these approaches.
-
-#### Increase the replica count
-
-For a fixed increase that doesn't need to track node count, raise `replicas`
-directly:
-
-```yaml title="vcluster.yaml — CoreDNS replica count"
-controlPlane:
-  coredns:
-    deployment:
-      replicas: 3
-```
-
-#### Run a node-proportional autoscaler
-
-For tenant clusters where node count changes over time, such as
-autoscaling GPU node pools, keep the CoreDNS replica count proportional to
-node count instead of using a fixed value. AI Cloud accounts running large
-GPU fleets have used a 1:8 CoreDNS-to-node ratio as a starting point.
-
-You can use [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler)
-to do this. The `coredns` Deployment in `kube-system` is a native object
-inside the tenant cluster, not a synced mirror of something on the control
-plane cluster, so run the autoscaler directly against the tenant cluster's own
-API server. It watches the tenant cluster's node count and scales `coredns`
-directly. The tenant cluster's own controller manager reconciles the change,
-and the resulting pods sync to the control plane cluster automatically.
-
-Apply the following to the tenant cluster, not the control plane cluster:
-
-```yaml title="coredns-autoscaler.yaml — apply inside the tenant cluster"
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: coredns-autoscaler
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: coredns-autoscaler-nodes
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: coredns-autoscaler-nodes
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: coredns-autoscaler-nodes
-subjects:
-  - kind: ServiceAccount
-    name: coredns-autoscaler
-    namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: coredns-autoscaler
-  namespace: kube-system
-rules:
-  - apiGroups: ["apps"]
-    resources: ["deployments/scale"]
-    resourceNames: ["coredns"]
-    verbs: ["get", "update"]
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: coredns-autoscaler
-  namespace: kube-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: coredns-autoscaler
-subjects:
-  - kind: ServiceAccount
-    name: coredns-autoscaler
-    namespace: kube-system
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns-autoscaler
-  namespace: kube-system
-data:
-  linear: |-
-    {"nodesPerReplica": 8, "min": 1, "preventSinglePointFailure": true}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: coredns-autoscaler
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      k8s-app: coredns-autoscaler
-  template:
-    metadata:
-      labels:
-        k8s-app: coredns-autoscaler
-    spec:
-      serviceAccountName: coredns-autoscaler
-      containers:
-        - name: autoscaler
-          # check the project's releases page for the current tag
-          image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.10.3
-          command:
-            - /cluster-proportional-autoscaler
-            - --namespace=kube-system
-            - --configmap=coredns-autoscaler
-            - --target=deployment/coredns
-            - --logtostderr=true
-            - --v=2
-```
-
-The `linear` mode config's `nodesPerReplica: 8` reproduces the 1:8 ratio
-directly. Adjust it to match your own DNS query volume per node.
-`preventSinglePointFailure: true` overrides `min` once the tenant cluster has
-more than one node: the autoscaler then enforces a floor of 2 replicas
-regardless of the ratio, so CoreDNS is never a single point of failure on a
-multi-node tenant cluster.
-
-### What to watch
-
-Monitor CoreDNS alongside the control-plane conditions above, using CoreDNS's
-own Prometheus metrics
-([CoreDNS metrics reference](https://coredns.io/plugins/metrics/)). Getting
-real SLO boundaries for the signals below needs a dedicated DNS workload in
-the control-plane load-testing framework, or telemetry from a real production
-deployment. The framework's existing KWOK and kube-burner workloads don't
-generate DNS traffic today, so treat every boundary here as `Needs
-confirmation` until then. See the summary rows in
-[Operational guidance](#operational-guidance) for the production alert-list
-view of the same signals.
-
-#### Request latency (P99)
-
-```promql
-histogram_quantile(0.99,
-  sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) by (le)
-)
-```
-
-**Why:** Tail DNS resolution latency over a 5-minute rate window. Validating a
-real boundary needs a sustained query rate matching your target pod density
-and churn.
-
-#### Error rate
-
-```promql
-sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))
-```
-
-**Why:** `SERVFAIL` over a 5-minute window is the reliable overload signal,
-unlike `NXDOMAIN` (see above). Validating a real boundary needs induced
-upstream or API server latency to trigger genuine failures, not just query
-volume.
-
-#### Request throughput
-
-```promql
-sum(rate(coredns_dns_requests_total[5m]))
-```
-
-**Why:** Total query rate over a 5-minute window. This is informational for
-capacity planning, not an alerting signal on its own.
-
-#### Replica CPU saturation
-
-**Why:** CoreDNS container CPU usage against the default 1 CPU limit signals
-when a replica is approaching the ceiling described in
-[When it becomes a bottleneck](#when-it-becomes-a-bottleneck). The Control
-Plane team's existing container CPU dashboards should already have a query for
-this; validating a real boundary needs the same dedicated DNS workload as the
-other signals above.
-
 ## Operational guidance
 
 **Plan Control Plane Cluster node capacity.** A P5 Virtual Control Plane runs
@@ -510,12 +283,13 @@ Karpenter with `consolidationPolicy: WhenEmpty` and a 5-minute
 | etcd DB size | > 4 GB (warn) / 12 GB (fail) |
 | Dropped watches per second | > 0 sustained |
 | Node convergence ratio | < 98% |
-| DNS query p99 latency | Needs confirmation |
-| DNS error rate (`SERVFAIL`) | Needs confirmation |
 
-DNS thresholds are pending confirmation from the Control Plane team. See
-[Scale CoreDNS for large node counts](#scale-coredns-for-large-node-counts)
-for the underlying metric expressions.
+There's no vCluster-published alert threshold for DNS query latency or error
+rate. Both depend on your own query volume and pod density, not a fixed
+number this table can give you. See
+[What to watch](./coredns-scaling.mdx#what-to-watch) in
+[Scale CoreDNS for large node counts](./coredns-scaling.mdx) for the metric
+expressions and how to build your own baseline.
 
 **Tenant Isolation is per-Tenant-Cluster.** Each Tenant Cluster is fully
 isolated. Control-plane sizing is per-tenant, not aggregate. A single Control

--- a/vcluster/deploy/control-plane/sizing-and-performance.mdx
+++ b/vcluster/deploy/control-plane/sizing-and-performance.mdx
@@ -285,7 +285,9 @@ for the full deployment and configuration reference.
 :::caution Needs confirmation from the Control Plane team
 The numbers below are estimates derived from CoreDNS's default resource limits
 and general Kubernetes DNS-scaling conventions, not from vCluster's own
-benchmark methodology. Confirm before publishing.
+benchmark methodology. The control-plane load-testing framework doesn't model
+DNS load today, so confirming these numbers needs a new DNS-focused workload
+or real deployment telemetry, not a re-read of existing benchmark runs.
 :::
 
 A single CoreDNS replica is CPU-bound at vCluster's default 1 CPU limit.
@@ -299,8 +301,10 @@ search-domain expansion multiplies query volume per lookup, compounding the
 effect.
 
 Tenant workloads see this as DNS resolution timeouts, intermittent `SERVFAIL`
-or `NXDOMAIN` responses, and slower pod startup when init containers or
-sidecars wait on DNS lookups.
+responses, and slower pod startup when init containers or sidecars wait on DNS
+lookups. `NXDOMAIN` responses aren't a reliable signal on their own, since
+`ndots:5` search-path expansion produces them as a normal byproduct of
+everyday lookups.
 
 ### Scale CoreDNS today
 
@@ -420,7 +424,7 @@ spec:
       containers:
         - name: autoscaler
           # check the project's releases page for the current tag
-          image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.8.14
+          image: registry.k8s.io/cpa/cluster-proportional-autoscaler:v1.10.3
           command:
             - /cluster-proportional-autoscaler
             - --namespace=kube-system
@@ -432,13 +436,30 @@ spec:
 
 The `linear` mode config's `nodesPerReplica: 8` reproduces the 1:8 ratio
 directly. Adjust it to match your own DNS query volume per node.
+`preventSinglePointFailure: true` overrides `min` once the tenant cluster has
+more than one node: the autoscaler then enforces a floor of 2 replicas
+regardless of the ratio, so CoreDNS is never a single point of failure on a
+multi-node tenant cluster.
 
 ### What to watch
 
-Monitor CoreDNS query latency and error rate alongside the control-plane
-conditions above. See the alert thresholds table in
-[Operational guidance](#operational-guidance) for the specific metrics and
-thresholds once confirmed.
+Monitor CoreDNS alongside the control-plane conditions above, using CoreDNS's
+own Prometheus metrics
+([CoreDNS metrics reference](https://coredns.io/plugins/metrics/)):
+
+| Signal | Metric expression | Window | Workload input needed | SLO boundary |
+| --- | --- | --- | --- | --- |
+| Request latency (P99) | `histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) by (le))` | 5m | Sustained query rate matching target pod density and churn | Needs confirmation |
+| Error rate | `sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))` | 5m | Same, plus induced upstream or API server latency to trigger genuine failures | Needs confirmation |
+| Request throughput | `sum(rate(coredns_dns_requests_total[5m]))` | 5m | Same | Informational, for capacity planning |
+| Replica CPU saturation | CoreDNS container CPU usage against the 1 CPU limit | 5m average | Same | Needs confirmation |
+
+Getting real SLO boundaries for this table needs a dedicated DNS workload in
+the control-plane load-testing framework, or telemetry from a real production
+deployment. The framework's existing KWOK and kube-burner workloads don't
+generate DNS traffic today. See the summary rows in
+[Operational guidance](#operational-guidance) for the production alert-list
+view of the same signals.
 
 ## Operational guidance
 
@@ -456,10 +477,11 @@ Karpenter with `consolidationPolicy: WhenEmpty` and a 5-minute
 | Dropped watches per second | > 0 sustained |
 | Node convergence ratio | < 98% |
 | DNS query p99 latency | Needs confirmation |
-| DNS error rate (`SERVFAIL` / `NXDOMAIN`) | Needs confirmation |
+| DNS error rate (`SERVFAIL`) | Needs confirmation |
 
 DNS thresholds are pending confirmation from the Control Plane team. See
-[Scale CoreDNS for large node counts](#scale-coredns-for-large-node-counts).
+[Scale CoreDNS for large node counts](#scale-coredns-for-large-node-counts)
+for the underlying metric expressions.
 
 **Tenant Isolation is per-Tenant-Cluster.** Each Tenant Cluster is fully
 isolated. Control-plane sizing is per-tenant, not aggregate. A single Control

--- a/vcluster/deploy/control-plane/sizing-and-performance.mdx
+++ b/vcluster/deploy/control-plane/sizing-and-performance.mdx
@@ -445,21 +445,55 @@ multi-node tenant cluster.
 
 Monitor CoreDNS alongside the control-plane conditions above, using CoreDNS's
 own Prometheus metrics
-([CoreDNS metrics reference](https://coredns.io/plugins/metrics/)):
-
-| Signal | Metric expression | Window | Workload input needed | SLO boundary |
-| --- | --- | --- | --- | --- |
-| Request latency (P99) | `histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) by (le))` | 5m | Sustained query rate matching target pod density and churn | Needs confirmation |
-| Error rate | `sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))` | 5m | Same, plus induced upstream or API server latency to trigger genuine failures | Needs confirmation |
-| Request throughput | `sum(rate(coredns_dns_requests_total[5m]))` | 5m | Same | Informational, for capacity planning |
-| Replica CPU saturation | CoreDNS container CPU usage against the 1 CPU limit | 5m average | Same | Needs confirmation |
-
-Getting real SLO boundaries for this table needs a dedicated DNS workload in
+([CoreDNS metrics reference](https://coredns.io/plugins/metrics/)). Getting
+real SLO boundaries for the signals below needs a dedicated DNS workload in
 the control-plane load-testing framework, or telemetry from a real production
 deployment. The framework's existing KWOK and kube-burner workloads don't
-generate DNS traffic today. See the summary rows in
+generate DNS traffic today, so treat every boundary here as `Needs
+confirmation` until then. See the summary rows in
 [Operational guidance](#operational-guidance) for the production alert-list
 view of the same signals.
+
+#### Request latency (P99)
+
+```promql
+histogram_quantile(0.99,
+  sum(rate(coredns_dns_request_duration_seconds_bucket[5m])) by (le)
+)
+```
+
+**Why:** Tail DNS resolution latency over a 5-minute rate window. Validating a
+real boundary needs a sustained query rate matching your target pod density
+and churn.
+
+#### Error rate
+
+```promql
+sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m]))
+```
+
+**Why:** `SERVFAIL` over a 5-minute window is the reliable overload signal,
+unlike `NXDOMAIN` (see above). Validating a real boundary needs induced
+upstream or API server latency to trigger genuine failures, not just query
+volume.
+
+#### Request throughput
+
+```promql
+sum(rate(coredns_dns_requests_total[5m]))
+```
+
+**Why:** Total query rate over a 5-minute window. This is informational for
+capacity planning, not an alerting signal on its own.
+
+#### Replica CPU saturation
+
+**Why:** CoreDNS container CPU usage against the default 1 CPU limit signals
+when a replica is approaching the ceiling described in
+[When it becomes a bottleneck](#when-it-becomes-a-bottleneck). The Control
+Plane team's existing container CPU dashboards should already have a query for
+this; validating a real boundary needs the same dedicated DNS workload as the
+other signals above.
 
 ## Operational guidance
 

--- a/vcluster/troubleshoot/coredns-dns-timeouts.mdx
+++ b/vcluster/troubleshoot/coredns-dns-timeouts.mdx
@@ -93,7 +93,7 @@ through a normal upgrade on your live tenant cluster, no redeploy needed:
 - Raise `controlPlane.statefulSet.resources`. It resizes the whole
   control-plane pod rather than CoreDNS specifically.
 - Raise `controlPlane.statefulSet.highAvailability.replicas`. More syncer
-  replicas means more active CoreDNS instances, since the `vc-kube-dns`
+  replicas means more active CoreDNS instances, since the `kube-dns`
   Service points at the syncer pods (`TCP`/`UDP` 1053) when embedded is on.
 
 Switching CoreDNS from embedded to a separate Deployment can be done on a

--- a/vcluster/troubleshoot/coredns-dns-timeouts.mdx
+++ b/vcluster/troubleshoot/coredns-dns-timeouts.mdx
@@ -87,14 +87,18 @@ See
 [Why embedded CoreDNS can't scale the same way](../understand/coredns-bottlenecks.mdx#why-embedded-coredns-cant-scale-the-same-way)
 for why.
 
-The workaround is to raise `controlPlane.statefulSet.resources` on your live
-tenant cluster, an ordinary `vcluster.yaml` change applied through a normal
-upgrade, no redeploy needed. It resizes the whole control-plane pod rather
-than CoreDNS specifically.
+Two options add capacity instead, both ordinary `vcluster.yaml` changes applied
+through a normal upgrade on your live tenant cluster, no redeploy needed:
 
-Switching CoreDNS from embedded to a separate Deployment is a different matter.
-That choice is fixed at deploy time. You can't flip it on a live tenant cluster
-without redeploying it.
+- Raise `controlPlane.statefulSet.resources`. It resizes the whole
+  control-plane pod rather than CoreDNS specifically.
+- Raise `controlPlane.statefulSet.highAvailability.replicas`. More syncer
+  replicas means more active CoreDNS instances, since the `vc-kube-dns`
+  Service points at the syncer pods (`TCP`/`UDP` 1053) when embedded is on.
+
+Switching CoreDNS from embedded to a separate Deployment can be done on a
+live tenant cluster without redeploying it. You may see a brief DNS gap
+during the switch.
 
 ## Related resources
 

--- a/vcluster/troubleshoot/coredns-dns-timeouts.mdx
+++ b/vcluster/troubleshoot/coredns-dns-timeouts.mdx
@@ -69,17 +69,6 @@ for the full explanation.
 [Scale CoreDNS for large node counts](../deploy/control-plane/coredns-scaling.mdx)
 for raising the replica count or running an autoscaler.
 
-Before raising `replicas`, check your tenant cluster's schedulable node
-count. The default topology spread constraint allows only one CoreDNS pod
-per node, so replicas above that count stay `Pending` instead of fixing
-anything:
-
-```bash title="Check for CoreDNS pods stuck Pending"
-kubectl get pods -n kube-system | grep ^coredns
-kubectl describe pod -n kube-system <pending-coredns-pod>
-# look for a FailedScheduling event mentioning the topology spread constraint
-```
-
 ### Check a node-proportional autoscaler
 
 **If you already run a node-proportional autoscaler**, confirm it's actually
@@ -103,7 +92,7 @@ tenant cluster, an ordinary `vcluster.yaml` change applied through a normal
 upgrade, no redeploy needed. It resizes the whole control-plane pod rather
 than CoreDNS specifically.
 
-Switching CoreDNS from embedded to a separate Deployment is a different matter. 
+Switching CoreDNS from embedded to a separate Deployment is a different matter.
 That choice is fixed at deploy time. You can't flip it on a live tenant cluster
 without redeploying it.
 

--- a/vcluster/troubleshoot/coredns-dns-timeouts.mdx
+++ b/vcluster/troubleshoot/coredns-dns-timeouts.mdx
@@ -1,0 +1,114 @@
+---
+title: Resolve CoreDNS DNS timeouts and SERVFAIL errors
+sidebar_label: CoreDNS DNS timeouts
+description: Diagnose and resolve DNS resolution timeouts and SERVFAIL errors caused by CoreDNS running out of capacity in a tenant cluster.
+---
+
+## Symptoms
+
+Tenant workloads see one or more of:
+
+- DNS resolution timeouts, or slower pod startup when init containers or
+  sidecars wait on DNS lookups.
+- Intermittent `SERVFAIL` responses from CoreDNS.
+- Sustained `NXDOMAIN` for a Service the tenant API server can still resolve.
+  Occasional `NXDOMAIN` alone isn't this: `ndots:5` search-path expansion
+  produces it as a normal byproduct of everyday lookups. It's only a signal
+  when it's sustained for a name that actually exists.
+
+## Confirm it's CoreDNS, not something else
+
+Test DNS resolution directly from a pod in the tenant cluster:
+
+```bash title="Test DNS resolution from inside the tenant cluster"
+kubectl run dns-test --rm -it --restart=Never --image=busybox:1.36 -- nslookup kubernetes.default.svc.cluster.local
+```
+
+Repeat it a few times in quick succession. Intermittent failures or slow
+responses point at CoreDNS capacity. Consistent, immediate failures point
+somewhere else, a NetworkPolicy blocking egress to CoreDNS, a misconfigured
+Corefile, or the CoreDNS Service having no endpoints.
+
+Check CoreDNS's own resource usage:
+
+```bash title="Check CoreDNS pod resource usage"
+kubectl top pod -n kube-system | grep ^coredns
+```
+
+If `kubectl top` isn't available (no metrics-server), or you already have
+Prometheus scraping CoreDNS's `:9153` metrics endpoint, use the [PromQL
+queries](../deploy/control-plane/coredns-scaling.mdx#what-to-watch)
+instead. They're more reliable for catching CPU or memory saturation than a
+point-in-time snapshot.
+
+Also check for restarts, which can mean CoreDNS is being OOMKilled rather
+than CPU-saturated. Both produce the same symptoms, but adding replicas only
+helps with the CPU case:
+
+```bash title="Check for OOMKilled restarts"
+kubectl get pods -n kube-system | grep ^coredns
+kubectl describe pod -n kube-system <coredns-pod-name> | grep -A3 "Last State"
+```
+
+## Cause
+
+A single CoreDNS replica is CPU-bound at vCluster's default 1 CPU limit, and
+has a 170Mi memory limit regardless of replica count. High DNS query volume,
+most often from AI and ML workloads with bursty pod scheduling, or from
+search-domain expansion (`ndots:5`) multiplying the number of queries per
+lookup, can exceed either ceiling. See
+[Why does CoreDNS become a DNS bottleneck?](../understand/coredns-bottlenecks.mdx)
+for the full explanation.
+
+## Fix
+
+### Separate CoreDNS deployment
+
+**If you're running the default separate CoreDNS deployment**
+(`controlPlane.coredns.embedded: false`), scale it. See
+[Scale CoreDNS for large node counts](../deploy/control-plane/coredns-scaling.mdx)
+for raising the replica count or running an autoscaler.
+
+Before raising `replicas`, check your tenant cluster's schedulable node
+count. The default topology spread constraint allows only one CoreDNS pod
+per node, so replicas above that count stay `Pending` instead of fixing
+anything:
+
+```bash title="Check for CoreDNS pods stuck Pending"
+kubectl get pods -n kube-system | grep ^coredns
+kubectl describe pod -n kube-system <pending-coredns-pod>
+# look for a FailedScheduling event mentioning the topology spread constraint
+```
+
+### Check a node-proportional autoscaler
+
+**If you already run a node-proportional autoscaler**, confirm it's actually
+acting instead of assuming it is:
+
+```bash title="Watch the autoscaler adjust replica count"
+kubectl -n kube-system get deployment coredns -w
+kubectl -n kube-system logs deployment/coredns-autoscaler
+```
+
+### CoreDNS embedded
+
+**If you're running embedded CoreDNS** (`controlPlane.coredns.embedded: true`),
+neither of those options applies. There's no `coredns` Deployment to scale.
+See
+[Why embedded CoreDNS can't scale the same way](../understand/coredns-bottlenecks.mdx#why-embedded-coredns-cant-scale-the-same-way)
+for why.
+
+The workaround is to raise `controlPlane.statefulSet.resources` on your live
+tenant cluster, an ordinary `vcluster.yaml` change applied through a normal
+upgrade, no redeploy needed. It resizes the whole control-plane pod rather
+than CoreDNS specifically.
+
+Switching CoreDNS from embedded to a separate Deployment is a different matter. 
+That choice is fixed at deploy time. You can't flip it on a live tenant cluster
+without redeploying it.
+
+## Related resources
+
+- [Why does CoreDNS become a DNS bottleneck?](../understand/coredns-bottlenecks.mdx)
+- [Scale CoreDNS for large node counts](../deploy/control-plane/coredns-scaling.mdx)
+- [CoreDNS configuration](../configure/vcluster-yaml/control-plane/components/coredns.mdx)

--- a/vcluster/understand/coredns-bottlenecks.mdx
+++ b/vcluster/understand/coredns-bottlenecks.mdx
@@ -54,20 +54,28 @@ to diagnose and fix an active incident.
 
 ## Why embedded CoreDNS can't scale the same way
 
-With `controlPlane.coredns.embedded: true` (a Pro feature), CoreDNS runs
-inside the syncer container instead of as its own Deployment. There's no
-`coredns` Deployment in `kube-system` for `controlPlane.coredns.deployment.replicas`
-or a Deployment-scaling autoscaler to act on, so both are silently ignored
-rather than rejected with an error.
+With `controlPlane.coredns.embedded: true` (a Pro feature), CoreDNS
+components run as child processes of the syncer, in the same pod, instead of
+as their own Deployment. There's no `coredns` Deployment in `kube-system` for
+`controlPlane.coredns.deployment.replicas` or a Deployment-scaling autoscaler
+to act on, so both are silently ignored rather than rejected with an error.
 
-CoreDNS deployment type is a predeployment decision. You can't
-switch a live tenant cluster between embedded and separate CoreDNS without
-redeploying it. If you're already running embedded CoreDNS and hitting a DNS
-capacity wall, raising `controlPlane.statefulSet.resources` is the only lever
-available, covered in
+<!-- vale Vale.Terms = NO -->
+
+If you're running embedded CoreDNS and hitting a DNS capacity wall, two
+options add capacity instead of a replica count. Raising
+`controlPlane.statefulSet.resources` resizes the whole control-plane pod, not
+CoreDNS specifically, covered in
 [Choose a resource profile](../deploy/control-plane/sizing-and-performance.mdx#choose-a-resource-profile).
-It's a blunt instrument. That setting sizes the whole control-plane pod, not
-CoreDNS specifically.
+Raising `controlPlane.statefulSet.highAvailability.replicas` also adds DNS
+capacity. More syncer replicas means more active CoreDNS instances, since the
+`vc-kube-dns` Service points at the syncer pods (`TCP`/`UDP` 1053) rather than
+at CoreDNS Deployment pods when embedded is on.
+
+You can switch a live tenant cluster between embedded and separate CoreDNS
+without redeploying it. You may see a brief DNS gap during the switch.
+
+<!-- vale Vale.Terms = YES -->
 
 ## Related
 

--- a/vcluster/understand/coredns-bottlenecks.mdx
+++ b/vcluster/understand/coredns-bottlenecks.mdx
@@ -1,0 +1,79 @@
+---
+title: Why does CoreDNS become a DNS bottleneck?
+sidebar_label: CoreDNS bottlenecks
+sidebar_position: 3
+description: Why a single CoreDNS replica runs out of headroom in a tenant cluster, and why embedded CoreDNS can't scale the same way.
+---
+
+CoreDNS handles DNS resolution for every pod in the tenant cluster. By
+default, it runs a single replica (`controlPlane.coredns.deployment.replicas: 1`)
+as a separate Deployment, sized for small and medium tenant clusters. See
+[CoreDNS configuration](../configure/vcluster-yaml/control-plane/components/coredns.mdx)
+for the full deployment and configuration reference, and
+[Scale CoreDNS for large node counts](../deploy/control-plane/coredns-scaling.mdx)
+for how to raise the ceiling described below.
+
+## Why total query volume matters more than node count
+
+A single CoreDNS replica is CPU-bound at vCluster's default 1 CPU limit. What
+matters is total query volume, not node count on its own. Pod count, lookups
+per pod, and search-domain expansion all factor in. `ndots:5` search-domain
+expansion means a single unqualified lookup can generate several sequential
+queries before it resolves, so it's a significant multiplier on the raw
+pod-and-lookup count.
+
+Measure your own fleet's query rate rather than reasoning from node count
+alone. See
+[What to watch](../deploy/control-plane/coredns-scaling.mdx#what-to-watch)
+for the exact queries.
+
+## Why GPU node pools are a common trigger, but not for the obvious reason
+
+GPU node pools are a common trigger for this, but not for the reason pod
+density suggests. GPU nodes typically run fewer pods per node than
+general-purpose nodes, so steady-state DNS load per node is often light. The
+pressure point is the job-launch burst. A batch job scheduling hundreds of
+pods at once produces a synchronized spike in DNS lookups. Every pod resolves
+the same handful of names within seconds of each other, so query rate spikes
+around scheduling events, not just steady-state averages.
+
+## What an overloaded CoreDNS looks like
+
+Tenant workloads see an overloaded CoreDNS as DNS resolution timeouts,
+intermittent `SERVFAIL` responses, and slower pod startup when init containers
+or sidecars wait on DNS lookups. Sustained `NXDOMAIN` for a Service the tenant
+API server can still resolve is a real signal. Ordinary `ndots:5` expansion
+doesn't explain a resolution failure for a name that exists. Treat it
+alongside `SERVFAIL` and latency rather than as a standalone capacity trigger,
+since `ndots:5` search-path expansion also produces `NXDOMAIN` as a normal
+byproduct of everyday lookups, whether or not CoreDNS is under load.
+
+Already seeing these symptoms right now? See
+[Resolve CoreDNS DNS timeouts and SERVFAIL errors](../troubleshoot/coredns-dns-timeouts.mdx)
+to diagnose and fix an active incident.
+
+## Why embedded CoreDNS can't scale the same way
+
+With `controlPlane.coredns.embedded: true` (a Pro feature), CoreDNS runs
+inside the syncer container instead of as its own Deployment. There's no
+`coredns` Deployment in `kube-system` for `controlPlane.coredns.deployment.replicas`
+or a Deployment-scaling autoscaler to act on, so both are silently ignored
+rather than rejected with an error.
+
+CoreDNS deployment type is a predeployment decision. You can't
+switch a live tenant cluster between embedded and separate CoreDNS without
+redeploying it. If you're already running embedded CoreDNS and hitting a DNS
+capacity wall, raising `controlPlane.statefulSet.resources` is the only lever
+available, covered in
+[Choose a resource profile](../deploy/control-plane/sizing-and-performance.mdx#choose-a-resource-profile).
+It's a blunt instrument. That setting sizes the whole control-plane pod, not
+CoreDNS specifically.
+
+## Related
+
+- [Scale CoreDNS for large node counts](../deploy/control-plane/coredns-scaling.mdx) —
+  how to raise the replica count or run an autoscaler.
+- [Resolve CoreDNS DNS timeouts and SERVFAIL errors](../troubleshoot/coredns-dns-timeouts.mdx) —
+  diagnose and fix an active incident.
+- [CoreDNS configuration](../configure/vcluster-yaml/control-plane/components/coredns.mdx) —
+  full deployment and configuration reference.

--- a/vcluster/understand/coredns-bottlenecks.mdx
+++ b/vcluster/understand/coredns-bottlenecks.mdx
@@ -69,7 +69,7 @@ CoreDNS specifically, covered in
 [Choose a resource profile](../deploy/control-plane/sizing-and-performance.mdx#choose-a-resource-profile).
 Raising `controlPlane.statefulSet.highAvailability.replicas` also adds DNS
 capacity. More syncer replicas means more active CoreDNS instances, since the
-`vc-kube-dns` Service points at the syncer pods (`TCP`/`UDP` 1053) rather than
+`kube-dns` Service points at the syncer pods (`TCP`/`UDP` 1053) rather than
 at CoreDNS Deployment pods when embedded is on.
 
 You can switch a live tenant cluster between embedded and separate CoreDNS


### PR DESCRIPTION
# Content Description
Documents CoreDNS's default single-replica setup, when it becomes a bottleneck at large node counts (especially AI/ML fleets), and how to scale it today via a fixed replica bump or a node-proportional autoscaler (cluster-proportional-autoscaler), plus what to monitor. Cross-linked from the CoreDNS config page.

## Preview Link
- [CoreDNS scaling - the decision and how to](https://deploy-preview-2502--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/control-plane/coredns-scaling)
- [CoreDNS bottlenecks - the explanation page](https://deploy-preview-2502--vcluster-docs-site.netlify.app/docs/vcluster/next/understand/coredns-bottlenecks)
- [CoreDNS timeouts - the incident response troubleshooting page](https://deploy-preview-2502--vcluster-docs-site.netlify.app/docs/vcluster/next/troubleshoot/coredns-dns-timeouts)

## Internal Reference
Closes DOC-1655


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs