### PR TITLE
docs: fill storage, security, and GPU scheduling gaps in GPU production paths

### DIFF
--- a/vcluster/production-guide/ai-cloud.mdx
+++ b/vcluster/production-guide/ai-cloud.mdx
@@ -7,7 +7,7 @@ description: Build a managed Kubernetes service on GPU infrastructure. Day 0, Da
 
 Run a managed Kubernetes service on your GPU infrastructure. Each customer gets an isolated tenant cluster with dedicated GPU nodes. Your product is what customers interact with. Platform is the operations layer your team runs behind it.
 
-**Typical stack:** Standalone (HA) as the Control Plane Cluster. Private nodes per customer cluster. vMetal for bare metal GPU lifecycle. vNode for workload runtime isolation.
+**Typical stack:** Standalone (HA) as the control plane cluster. Private nodes per customer cluster. vMetal for bare metal GPU lifecycle. vNode for workload runtime isolation.
 
 <figure>
   <img
@@ -18,20 +18,24 @@ Run a managed Kubernetes service on your GPU infrastructure. Each customer gets 
   <figcaption>Central control plane managing tenant clusters for customers</figcaption>
 </figure>
 
-**What makes this path different:** Customers never touch Platform. They interact with your product. Platform RBAC locks direct access to your platform engineering team. This architecture also maps to the cluster-level isolation criteria that AI cloud buyers evaluate in frameworks like [ClusterMAX](https://www.vcluster.com/clustermax).
+**What makes this path different:** Customers never access Platform directly. They interact with your product. Platform RBAC locks direct access to your platform engineering team. This architecture also maps to the cluster-level isolation criteria that AI cloud buyers evaluate in frameworks like [ClusterMAX](https://www.vcluster.com/clustermax).
 
 ## Day 0: Design decisions
 
 | Decision | Read next | Outcome |
 | --- | --- | --- |
 | Choose the control plane deployment model | [Standalone deployment](../deploy/control-plane/binary/basics.mdx), [Architecture](../introduction/architecture.mdx) | Control planes as pods on an existing Kubernetes cluster, or Standalone on dedicated CPU nodes. Standalone is the common choice when no prior Kubernetes substrate exists. |
-| Plan bare metal GPU provisioning | [vMetal docs](https://www.vmetal.ai/docs/), [Metal3 node provider](/platform/administer/node-providers/metal3), [bare metal overview](/platform/administer/bare-metal/overview) | Decide whether vMetal manages the full machine lifecycle (PXE, OS imaging, BMC, reclaim) or nodes are joined manually or via another provisioner. |
+| Plan bare metal GPU provisioning | [vMetal docs](https://www.vmetal.ai/docs/), [Metal3 node provider](/platform/administer/node-providers/metal3), [bare metal overview](/platform/administer/bare-metal/overview) | Decide whether vMetal manages the full machine lifecycle (PXE, OS imaging, BMC, reclaim) or nodes are joined manually or using another provisioner. |
 | Define per-customer node isolation | [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx), [node requirements](../deploy/worker-nodes/private-nodes/node-requirements.mdx) | Each customer's tenant cluster gets its own dedicated GPU node pool with a separate CNI/CSI, eliminating interference between customers. |
 | Plan network isolation | [VPN](../deploy/worker-nodes/private-nodes/vpn.mdx), [Netris integration](../deploy/control-plane/kubernetes-pod/environment/netris.mdx) | Tenant clusters connect to their private nodes over an encrypted VPN tunnel. Netris integration adds switch-level VLAN/VXLAN isolation per tenant. |
+| Define the default network policy posture | [Network policy](../configure/vcluster-yaml/policies/network-policy.mdx) | Set a default-deny east-west posture per tenant template and confirm the control plane cluster's CNI enforces it. Some CNIs accept NetworkPolicy objects without enforcing them. |
 | Choose runtime isolation model | [vNode docs](https://www.vnode.com/docs/), [Virtual Nodes](../introduction/architecture.mdx#virtual-nodes) | vNode provides kernel-level container isolation without VM overhead. Recommended when customers run privileged workloads, dynamic code execution, or need GPU access via CDI. |
+| Choose the GPU scheduling model | [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx), [DRA ResourceClaims](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) | Device-plugin-style `DeviceClass` sync covers simple, whole-GPU allocation. DRA `ResourceClaim` sync (Pro) supports fine-grained and shared GPU allocation. |
+| Plan tenant storage | [Storage classes from host](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx), [CSI storage capacities](../configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx) | Decide which storage classes each tenant tier can request (etcd/control-plane storage vs. model weights and checkpoints), and whether to sync host `CSIStorageCapacity` for scheduler-aware placement. |
 | Define cluster templates and AI stacks | [Templates](/platform/administer/templates/overview), [Certified Stacks](/platform/integrations/certified-stacks) | Each customer cluster template includes GPU Operator, a scheduler (Run.ai, Kueue, Volcano), and optionally a developer environment. Certified Stacks provide pre-validated configurations. |
 | Plan the customer-facing provisioning API | [Projects](/platform/administer/projects/create), [Quotas](/platform/administer/projects/quotas), Platform API | Your product API calls Platform to provision tenant clusters. Define the project structure, quota model, and automation hooks that back your customer-facing workflows. |
 | Plan durability | [Backing store](../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx), [container control plane HA](../deploy/control-plane/kubernetes-pod/high-availability.mdx), [Standalone HA](../deploy/control-plane/binary/high-availability.mdx), [Platform HA](/platform/maintenance/reliability-scaling/high-availability) | Choose the data store and replica model for Platform and per-customer control planes. |
+| Plan security hardening and audit logging | [Security baseline](../security/README.mdx), [CIS hardening guide](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx), [Platform audit logging](/platform/configure/platform-configs/audit) | Apply a CIS benchmark baseline to the control plane cluster and decide audit log retention and SIEM integration before onboarding tenants. |
 
 ## Day 1: Stand up the first production customer cluster
 
@@ -44,11 +48,14 @@ Steps 3 and 4 configure Platform for your platform engineering team, not for you
 3. Configure [SSO](/platform/configure/platform-configs/single-sign-on) and [permissions](/platform/administer/users-permissions/overview) for your platform engineering team.
 4. Create [projects](/platform/administer/projects/create), [templates](/platform/administer/templates/overview), [quotas](/platform/administer/projects/quotas), and [Auto Nodes](/platform/administer/node-providers/overview) to back your customer provisioning workflows.
 5. Set up [vMetal](https://www.vmetal.ai/docs/) and the [Metal3 node provider](/platform/administer/node-providers/metal3): register BMC credentials, configure PXE networking, define OS images, and verify bare metal hosts reach `available`.
-6. Configure per-customer network isolation with [VPN](../deploy/worker-nodes/private-nodes/vpn.mdx) and, if using Netris, the [Netris integration](../deploy/control-plane/kubernetes-pod/environment/netris.mdx).
-7. Install [vNode](https://www.vnode.com/docs/) on eligible GPU nodes. Configure `sync.toHost.pods.runtimeClassName: vnode` in the cluster template.
-8. Deploy the first customer template using [Certified Stacks](/platform/integrations/certified-stacks) as the starting point for GPU Operator, scheduler, and AI tooling.
-9. Validate tenant isolation from inside the tenant cluster: confirm the customer cannot see the Control Plane Cluster, other tenants, or platform internals.
-10. Wire your product API to Platform's provisioning endpoints and test the end-to-end customer onboarding flow.
+6. Configure per-customer network isolation with [VPN](../deploy/worker-nodes/private-nodes/vpn.mdx) and, if using Netris, the [Netris integration](../deploy/control-plane/kubernetes-pod/environment/netris.mdx). Apply a default-deny [network policy](../configure/vcluster-yaml/policies/network-policy.mdx) per customer template and confirm the control plane cluster's CNI enforces it.
+7. Configure per-tier [storage classes](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx) and, if the scheduler needs capacity-aware placement, sync [CSI storage capacities](../configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx).
+8. Configure GPU scheduling: sync [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx) for device-plugin allocation, or enable [DRA ResourceClaim sync](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) for fine-grained allocation.
+9. Apply the [CIS hardening baseline](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx) to the control plane cluster and enable [Platform audit logging](/platform/configure/platform-configs/audit).
+10. Install [vNode](https://www.vnode.com/docs/) on eligible GPU nodes. Configure `sync.toHost.pods.runtimeClassName: vnode` in the cluster template.
+11. Deploy the first customer template using [Certified Stacks](/platform/integrations/certified-stacks) as the starting point for GPU Operator, scheduler, and AI tooling.
+12. Validate tenant isolation from inside the tenant cluster: confirm the customer cannot see the control plane cluster, other tenants, or platform internals.
+13. Wire your product API to Platform's provisioning endpoints and test the end-to-end customer onboarding flow.
 
 ## Day 2: Operate
 
@@ -59,4 +66,6 @@ Steps 3 and 4 configure Platform for your platform engineering team, not for you
 | Upgrade Platform and tenant clusters | [Upgrade vCluster](../manage/upgrade/upgrade-version.mdx), [upgrade Platform](/platform/maintenance/upgrade-migrate/upgrade) |
 | Back up and restore tenant clusters and Platform | [Snapshots](../manage/backup-restore/backup.mdx), [restore](../manage/backup-restore/restore.mdx), [Platform backup](/platform/maintenance/backup-restore/backup-restore-platform) |
 | Manage vNode compatibility during upgrades | [vNode limitations](https://www.vnode.com/docs/limitations/), [vNode configuration](https://www.vnode.com/docs/configuration/) |
-| Scale the Control Plane Cluster | [Platform HA](/platform/maintenance/reliability-scaling/high-availability), [multi-region Platform](/platform/administer/clusters/advanced/multi-region/overview) |
+| Scale the control plane cluster | [Platform HA](/platform/maintenance/reliability-scaling/high-availability), [multi-region Platform](/platform/administer/clusters/advanced/multi-region/overview) |
+| Track GPU utilization and faults for metering and troubleshooting | [GPU observability templates](/platform/maintenance/observability/gpu-observability-templates), [NVSentinel GPU observability](/platform/maintenance/observability/nvsentinel-gpu-observability) |
+| Review audit logs and security posture | [Platform audit logging](/platform/configure/platform-configs/audit), [security baseline](../security/README.mdx) |

--- a/vcluster/production-guide/distributed-compute.mdx
+++ b/vcluster/production-guide/distributed-compute.mdx
@@ -5,9 +5,9 @@ sidebar_position: 4
 description: Unify GPU compute from multiple sources under one management plane. Day 0, Day 1, and Day 2 path for compute aggregators.
 ---
 
-One management plane for GPU compute from every source you own or contract. Whether that is a cloud region, a co-located data center, or a compute supplier, each site runs a Standalone Control Plane Cluster. Your central Platform instance sees the full fleet.
+One management plane for GPU compute from every source you own or contract. Whether that is a cloud region, a co-located data center, or a compute supplier, each site runs a Standalone control plane cluster. Your central Platform instance sees the full fleet.
 
-**Typical stack:** Central Platform (global). Per-DC Standalone Control Plane Cluster. Private GPU nodes co-located with each Standalone instance. vMetal for owned bare metal sites.
+**Typical stack:** Central Platform (global). Per-DC Standalone control plane cluster. Private GPU nodes co-located with each Standalone instance. vMetal for owned bare metal sites.
 
 <figure>
   <img
@@ -27,17 +27,25 @@ One management plane for GPU compute from every source you own or contract. Whet
 | Design the central-regional topology | [Multi-region Platform](/platform/administer/clusters/advanced/multi-region/overview), [Standalone deployment](../deploy/control-plane/binary/basics.mdx) | Central Platform registers each DC's Standalone instance as a connected cluster. Tenant control planes run co-located with their GPU nodes at each site. |
 | Define the supplier onboarding playbook | [Standalone HA](../deploy/control-plane/binary/high-availability.mdx), [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx), [Auto Nodes](/platform/administer/node-providers/overview) | Standardize the steps to register a new compute source: install Standalone, connect to central Platform, join GPU inventory, validate. |
 | Plan networking between sites | [VPN](../deploy/worker-nodes/private-nodes/vpn.mdx) | Each site's tenant clusters connect to their private nodes over VPN. Define whether tenants can span sites or are bound to a single DC. |
+| Define the default network policy posture | [Network policy](../configure/vcluster-yaml/policies/network-policy.mdx) | Set a default-deny east-west posture per tenant template at every site and confirm each site's CNI enforces it. Some CNIs accept NetworkPolicy objects without enforcing them. |
 | Define tenant isolation at each site | [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx), [vNode docs](https://www.vnode.com/docs/) | Each tenant cluster at a site gets its own dedicated GPU nodes. vNode adds runtime isolation for untrusted workloads. |
+| Choose the GPU scheduling model | [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx), [DRA ResourceClaims](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) | Device-plugin-style `DeviceClass` sync covers simple, whole-GPU allocation. DRA `ResourceClaim` sync (Pro) supports fine-grained and shared GPU allocation, consistently across every compute source. |
+| Plan tenant storage per site | [Storage classes from host](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx), [CSI storage capacities](../configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx) | Decide which storage classes are available at each site, since local NVMe or shared storage availability can differ by compute source, and whether to sync host `CSIStorageCapacity` for scheduler-aware placement. |
+| Plan security hardening and audit logging | [Security baseline](../security/README.mdx), [CIS hardening guide](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx), [Platform audit logging](/platform/configure/platform-configs/audit) | Apply a consistent CIS benchmark baseline across every site's control plane cluster and decide audit log retention and SIEM integration before onboarding tenants. |
 
 ## Day 1: Stand up the first compute source
 
 1. Deploy [vCluster Platform](/platform/install/quick-start-guide) in the central region. Configure [Platform HA](/platform/maintenance/reliability-scaling/high-availability) and [backup](/platform/maintenance/backup-restore/backup-restore-platform).
 2. At the first compute site, install [vCluster Standalone](../deploy/control-plane/binary/basics.mdx) and move to [HA](../deploy/control-plane/binary/high-availability.mdx).
-3. Register the site's Standalone Control Plane Cluster with central Platform.
+3. Register the site's Standalone control plane cluster with central Platform.
 4. Join the site's GPU inventory as private nodes. Configure [Auto Nodes](/platform/administer/node-providers/overview) or [vMetal](https://www.vmetal.ai/docs/) for automated provisioning and reclaim.
 5. Configure [templates](/platform/administer/templates/overview) and [quotas](/platform/administer/projects/quotas) in central Platform for this compute source.
-6. Provision a test tenant cluster at the site. Validate that it appears in central Platform and that workloads land on the correct GPU nodes.
-7. Document the supplier onboarding playbook. Repeat steps 2-6 for each additional compute source.
+6. Apply a default-deny [network policy](../configure/vcluster-yaml/policies/network-policy.mdx) in the site's template and confirm the site's CNI enforces it.
+7. Configure per-site [storage classes](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx) for the template.
+8. Configure GPU scheduling: sync [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx) for device-plugin allocation, or enable [DRA ResourceClaim sync](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) for fine-grained allocation.
+9. Apply the [CIS hardening baseline](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx) to the site's control plane cluster and enable [Platform audit logging](/platform/configure/platform-configs/audit).
+10. Provision a test tenant cluster at the site. Validate that it appears in central Platform and that workloads land on the correct GPU nodes.
+11. Document the supplier onboarding playbook. Repeat steps 2-10 for each additional compute source.
 
 ## Day 2: Operate
 
@@ -47,3 +55,5 @@ One management plane for GPU compute from every source you own or contract. Whet
 | Onboard a new compute source | Supplier onboarding playbook (internal), [Standalone deployment](../deploy/control-plane/binary/basics.mdx) |
 | Upgrade across sites | [Upgrade vCluster](../manage/upgrade/upgrade-version.mdx), [upgrade Platform](/platform/maintenance/upgrade-migrate/upgrade) |
 | Handle site failures | [Platform HA](/platform/maintenance/reliability-scaling/high-availability), [multi-region Platform](/platform/administer/clusters/advanced/multi-region/overview) |
+| Track GPU utilization and faults across sites | [GPU observability templates](/platform/maintenance/observability/gpu-observability-templates), [NVSentinel GPU observability](/platform/maintenance/observability/nvsentinel-gpu-observability) |
+| Review audit logs and security posture across the fleet | [Platform audit logging](/platform/configure/platform-configs/audit), [security baseline](../security/README.mdx) |

--- a/vcluster/production-guide/single-tenant.mdx
+++ b/vcluster/production-guide/single-tenant.mdx
@@ -16,16 +16,24 @@ Give each enterprise customer their own complete cluster stack. Dedicated nodes,
 | Decision | Read next | Outcome |
 | --- | --- | --- |
 | Define per-customer node allocation | [Private Nodes](../deploy/worker-nodes/private-nodes/overview.mdx), [Auto Nodes](/platform/administer/node-providers/overview) | Each customer cluster maps to a dedicated node pool. Auto Nodes provisions and reclaims nodes as customers are added or removed. |
+| Define the default network policy posture | [Network policy](../configure/vcluster-yaml/policies/network-policy.mdx) | Set a default-deny east-west posture per customer template and confirm the control plane cluster's CNI enforces it. Some CNIs accept NetworkPolicy objects without enforcing them. |
+| Choose the GPU scheduling model | [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx), [DRA ResourceClaims](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) | Device-plugin-style `DeviceClass` sync covers simple, whole-GPU allocation. DRA `ResourceClaim` sync (Pro) supports fine-grained and shared GPU allocation, relevant if customers get cluster-admin access to schedule their own workloads. |
+| Plan tenant storage | [Storage classes from host](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx), [CSI storage capacities](../configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx) | Decide which storage classes each customer can request, and whether to sync host `CSIStorageCapacity` for scheduler-aware placement. |
 | Plan provisioning automation | [Templates](/platform/administer/templates/overview), [Terraform](/platform/administer/node-providers/terraform) | Customer cluster creation is triggered by your CRM or provisioning system, not by manual Platform operations. |
 | Define offboarding and node reclaim | [Manage private nodes](../deploy/worker-nodes/private-nodes/manage.mdx), [vMetal docs](https://www.vmetal.ai/docs/) | Document how nodes are reclaimed and reimaged when a customer offboards. |
+| Plan security hardening and audit logging | [Security baseline](../security/README.mdx), [CIS hardening guide](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx), [Platform audit logging](/platform/configure/platform-configs/audit) | Apply a CIS benchmark baseline to the control plane cluster and decide audit log retention and SIEM integration, especially where customers hold cluster-admin access to their own cluster. |
 
 ## Day 1: Stand up the first customer cluster
 
 1. Install [vCluster Platform](/platform/install/quick-start-guide).
 2. Configure [Auto Nodes](/platform/administer/node-providers/overview) or [vMetal](https://www.vmetal.ai/docs/) for automated node provisioning and reclaim.
 3. Create a per-customer cluster template with [private nodes](../deploy/worker-nodes/private-nodes/overview.mdx), [backing store](../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx), and [HA](../deploy/control-plane/kubernetes-pod/high-availability.mdx).
-4. Wire provisioning automation to Platform via Terraform, CLI, or API.
-5. Validate the full customer lifecycle: provision, validate isolation, access as cluster-admin, offboard, and verify node reclaim.
+4. Apply a default-deny [network policy](../configure/vcluster-yaml/policies/network-policy.mdx) in the template and confirm the control plane cluster's CNI enforces it.
+5. Configure per-customer [storage classes](../configure/vcluster-yaml/sync/from-host/storage-classes.mdx) in the template.
+6. Configure GPU scheduling: sync [DeviceClasses](../configure/vcluster-yaml/sync/from-host/device-classes.mdx) for device-plugin allocation, or enable [DRA ResourceClaim sync](../configure/vcluster-yaml/sync/to-host/DRA/resourceclaims.mdx) for fine-grained allocation.
+7. Apply the [CIS hardening baseline](../deploy/control-plane/kubernetes-pod/security/hardening-guide/overview.mdx) to the control plane cluster and enable [Platform audit logging](/platform/configure/platform-configs/audit).
+8. Wire provisioning automation to Platform using Terraform, CLI, or API.
+9. Validate the full customer lifecycle: provision, validate isolation, access as cluster-admin, offboard, and verify node reclaim.
 
 ## Day 2: Operate
 
@@ -34,3 +42,5 @@ Give each enterprise customer their own complete cluster stack. Dedicated nodes,
 | Add and remove customers | [Auto Nodes](/platform/administer/node-providers/overview), provisioning automation |
 | Back up and restore per-customer | [Snapshots](../manage/backup-restore/backup.mdx), [restore](../manage/backup-restore/restore.mdx) |
 | Upgrade customer clusters | [Upgrade vCluster](../manage/upgrade/upgrade-version.mdx) |
+| Track GPU utilization and faults for metering and troubleshooting | [GPU observability templates](/platform/maintenance/observability/gpu-observability-templates), [NVSentinel GPU observability](/platform/maintenance/observability/nvsentinel-gpu-observability) |
+| Review audit logs and security posture | [Platform audit logging](/platform/configure/platform-configs/audit), [security baseline](../security/README.mdx) |


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds storage strategy, GPU scheduling model (DRA vs. device-plugin), default network policy posture, and security hardening/audit logging as explicit Day 0/1/2 items across the AI Cloud, Distributed Compute, and Single-Tenant production guides, based on gaps surfaced by CSE's AI Cloud implementation plan.

## Preview Link 
<!-- The preview link or links to the documents-->
Netlify will post the deploy preview link on this PR once CI runs.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
No linked Linear issue.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs