### PR TITLE
docs: add default version columns to support tables

### DIFF
--- a/.claude/skills/platform-docs-releaser/SKILL.md
+++ b/.claude/skills/platform-docs-releaser/SKILL.md
@@ -204,12 +204,13 @@ AI performs:
 3. ✅ Verify API partials generated: `ls platform/api/_partials/resources/`
 4. ✅ All config changes applied
 5. ✅ Version is hidden from dropdown (in `platformHiddenVersions` array in `versionConfig.js`)
+6. ✅ Default vCluster Version column verified in `docs/_partials/platform_supported_versions.mdx` (added in [DOC-1658](https://linear.app/loft/issue/DOC-1658)): if the new release's row already exists, confirm the value matches `DefaultVClusterVersion` in `pkg/constants/constants.go` of the `loft-enterprise` repo at this tag; if the row doesn't exist yet, flag it for the User step below
 
 User performs:
 
 1. Build check: `npm run build` (per CLAUDE.md, AI never runs build — user only)
 2. Review enterprise/pro tags (manual)
-3. Update support dates in platform-specific supported versions file
+3. Update support dates AND the Default vCluster Version column in platform-specific supported versions file (`docs/_partials/platform_supported_versions.mdx`)
 4. Update compatibility matrix
 5. Run hurl tests after PR deployed
 
@@ -301,7 +302,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | `src/config/versionConfig.js` | Remove version from `platformHiddenVersions` | Release day |
 | `netlify.toml` | Add redirect for new lastVersion; remove redirect for previous lastVersion | Release day |
 | `hack/test-platform-X.Y.hurl` | New test file | Release day |
-| Platform support dates file | Release/EOL dates | User |
+| Platform support dates file (`docs/_partials/platform_supported_versions.mdx`) | Release/EOL dates + Default vCluster Version column | User adds, AI verifies |
 
 ## Division of Responsibilities
 
@@ -311,6 +312,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 - ✅ **Update docusaurus config** - lastVersion, versions, SEO, banner
 - ✅ **Update netlify redirect** - `netlify.toml`
 - ✅ **Create hurl test** - Including cross-version tests
+- ✅ **Verify Default vCluster Version column** - Check the new row in `platform_supported_versions.mdx` matches `DefaultVClusterVersion` in `loft-enterprise` ([DOC-1658](https://linear.app/loft/issue/DOC-1658))
 
 ### User Handles (Items 2, 6-8):
 - **Create versioned docs** - `npm run docusaurus docs:version:platform X.Y.Z`

--- a/.claude/skills/vcluster-docs-releaser/SKILL.md
+++ b/.claude/skills/vcluster-docs-releaser/SKILL.md
@@ -154,11 +154,12 @@ AI performs:
 4. ✅ Default k8s version fragment updated if version changed (`vcluster/_fragments/default-k8s-version.mdx`)
 5. ✅ All config changes applied
 6. ✅ Version is hidden from dropdown (in `vclusterHiddenVersions` array in `versionConfig.js`)
+7. ✅ Default Kubernetes Version column verified in `docs/_partials/vcluster_supported_versions.mdx` (added in [DOC-1658](https://linear.app/loft/issue/DOC-1658)): if the new release's row already exists, confirm the value matches the distro/version pinned in `chart/values.yaml` of the vcluster OSS repo at this tag (same source of truth as item 4); if the row doesn't exist yet, flag it for the User step below
 
 User performs:
 1. Build check: `npm run build` (not AI's responsibility)
 2. Review enterprise/pro tags (manual)
-3. Update support dates in `vcluster/manage/upgrade/supported_versions.mdx`
+3. Update support dates AND the Default Kubernetes Version column in `vcluster/manage/upgrade/supported_versions.mdx` (`docs/_partials/vcluster_supported_versions.mdx`)
 4. Update compatibility matrix in same file
 5. Verify partials PR merged (automated PR)
 6. Run hurl tests after PR deployed
@@ -262,6 +263,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | `src/config/docsearch.js` | Update `stableVersion` to new stable version string | Release day |
 | `netlify.toml` | Add redirect for new lastVersion; remove redirect for previous lastVersion | Release day |
 | `hack/test-vcluster-0.XX.hurl` | New file | Release day |
+| `docs/_partials/vcluster_supported_versions.mdx` | Add new release row incl. Default Kubernetes Version column | rc-1 (User adds, AI verifies) |
 
 ## Division of Responsibilities
 
@@ -271,12 +273,13 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 - ✅ **Verify CLI commands** - Check files exist
 - ✅ **Create hurl test** - Create new test file
 - ✅ **Update search stable version** - `src/config/docsearch.js` `stableVersion` field (release day only)
+- ✅ **Verify Default Kubernetes Version column** - Check the new row in `vcluster_supported_versions.mdx` matches `default-k8s-version.mdx` / `chart/values.yaml` ([DOC-1658](https://linear.app/loft/issue/DOC-1658))
 
 ### User Handles (Items 1, 6-9):
 - **Create versioned docs** - `npm run docusaurus docs:version:vcluster X.Y.Z`
 - **Review enterprise/pro tags** - Manual review of `<ProAdmonition>` tags
 - **Partials PR** - Verify automation ran
-- **Update support dates** - Edit `vcluster/manage/upgrade/supported_versions.mdx`
+- **Update support dates** - Edit `vcluster/manage/upgrade/supported_versions.mdx` (dates + Default Kubernetes Version column)
 - **Update compatibility matrix** - Edit same file
 - **Run build** - `npm run build`
 - **Run hurl tests** - After PR deployed

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -8,10 +8,11 @@ Any previous versions which are not on the following list, are no longer in any 
 
 <table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
   <colgroup>
-    <col style={{width: '15%'}} />
-    <col style={{width: '28%'}} />
-    <col style={{width: '28%'}} />
-    <col style={{width: '29%'}} />
+    <col style={{width: '13%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '36%'}} />
   </colgroup>
   <thead>
     <tr>
@@ -19,6 +20,7 @@ Any previous versions which are not on the following list, are no longer in any 
       <th>Released</th>
       <th>End of Support (EOS) End Date</th>
       <th>End of Life (EOL) End Date</th>
+      <th>Default vCluster Version</th>
     </tr>
   </thead>
   <tbody>
@@ -27,45 +29,52 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>2026 Jul 22</td>
       <td>2027 Jan 22</td>
       <td>2027 Apr 22</td>
+      <td>v0.36.0</td>
     </tr>
     <tr>
       <td>v4.10</td>
       <td>2026 Jun 15</td>
       <td>2026 Dec 15</td>
       <td>2027 Mar 15</td>
+      <td>v0.35.0</td>
     </tr>
     <tr>
       <td>v4.9</td>
       <td>2026 Apr 29</td>
       <td>2026 Oct 29</td>
       <td>2027 Jan 29</td>
+      <td>v0.34.0</td>
     </tr>
     <tr>
       <td>v4.8</td>
       <td>2026 Mar 16</td>
       <td>2026 Sep 16</td>
       <td>2026 Dec 16</td>
+      <td>v0.33.0</td>
     </tr>
     <tr>
       <td>v4.7</td>
       <td>2026 Feb 18</td>
       <td>2026 Aug 18</td>
       <td>2026 Nov 18</td>
+      <td>v0.32.0</td>
     </tr>
     <tr>
       <td>v4.6</td>
       <td>2026 Jan 29</td>
       <td>2026 Jul 29</td>
       <td>2026 Oct 29</td>
+      <td>v0.31.0-rc.12<sup>&dagger;</sup></td>
     </tr>
     <tr>
       <td>v4.5</td>
       <td>2025 Oct 29</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
+      <td>v0.30.0</td>
     </tr>
     <tr>
-      <td colspan="4" align="center">
+      <td colspan="5" align="center">
         <i>Versions below are no longer supported</i>
       </td>
     </tr>
@@ -74,40 +83,50 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>2025 Sep 09</td>
       <td>2026 Mar 09</td>
       <td>2026 Jun 09</td>
+      <td>v0.28.0</td>
     </tr>
     <tr>
       <td>v4.3</td>
       <td>2025 Jun 03</td>
       <td>2025 Dec 03</td>
       <td>2026 Mar 06</td>
+      <td>v0.25.0</td>
     </tr>
     <tr>
       <td>v4.2</td>
       <td>2024 Dec 17</td>
       <td>2025 Sep 17</td>
       <td>2025 Dec 17</td>
+      <td>v0.21.2</td>
     </tr>
     <tr>
       <td>v4.1</td>
       <td>2024 Nov 12</td>
       <td>2025 Feb 12</td>
       <td>2025 May 12</td>
+      <td>v0.21.0</td>
     </tr>
     <tr>
       <td>v4.0</td>
       <td>2024 Oct 15</td>
       <td>2025 Jan 15</td>
       <td>2025 Apr 15</td>
+      <td>v0.20.1</td>
     </tr>
     <tr>
       <td>v3.4</td>
       <td>2024 Feb 29</td>
       <td>2025 Apr 01<sup>*</sup></td>
       <td>2025 Jul 01</td>
+      <td>v0.19.3</td>
     </tr>
   </tbody>
 </table>
 
 \* Due to the number of breaking changes from vCluster v0.19 to v0.20 and vCluster Platform v3.4 to v4.0, v3.4 has an extended EOS end date. Review the [migration guide](https://platform-v4-5--vcluster-docs-site.netlify.app/docs/platform/reference/migrations/4-0-migration) to upgrade your platform from v3.4 to v4.0.
+
+&dagger; v4.6.0 shipped defaulting to vCluster v0.31.0-rc.12, a pre-release build. This was corrected to v0.31.0 in the v4.6.1 patch release.
+
+The default vCluster version reflects the version pinned at the initial vX.Y.0 release of each Platform version, and does not account for changes made in later patch releases.
 
 <SupportTerminology />

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -67,16 +67,16 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>v0.31</td>
     </tr>
     <tr>
+      <td colspan="5" align="center">
+        <i>Versions below are no longer supported</i>
+      </td>
+    </tr>
+    <tr>
       <td>v4.5</td>
       <td>2025 Oct 29</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
       <td>v0.30</td>
-    </tr>
-    <tr>
-      <td colspan="5" align="center">
-        <i>Versions below are no longer supported</i>
-      </td>
     </tr>
     <tr>
       <td>v4.4</td>

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -6,18 +6,18 @@ Any previous versions which are not on the following list, are no longer in any 
 
 ## Platform supported versions
 
-<table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
+<table style={{tableLayout: 'fixed', width: '80%', textAlign: 'center'}}>
   <colgroup>
-    <col style={{width: '13%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '36%'}} />
+    <col style={{width: '16%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
   </colgroup>
   <thead>
     <tr>
       <th>Release</th>
-      <th>Released</th>
+      <th>Release Date</th>
       <th>End of Support (EOS) End Date</th>
       <th>End of Life (EOL) End Date</th>
       <th>Default vCluster Version</th>

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -29,49 +29,49 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>2026 Jul 22</td>
       <td>2027 Jan 22</td>
       <td>2027 Apr 22</td>
-      <td>v0.36.0</td>
+      <td>v0.36</td>
     </tr>
     <tr>
       <td>v4.10</td>
       <td>2026 Jun 15</td>
       <td>2026 Dec 15</td>
       <td>2027 Mar 15</td>
-      <td>v0.35.0</td>
+      <td>v0.35</td>
     </tr>
     <tr>
       <td>v4.9</td>
       <td>2026 Apr 29</td>
       <td>2026 Oct 29</td>
       <td>2027 Jan 29</td>
-      <td>v0.34.0</td>
+      <td>v0.34</td>
     </tr>
     <tr>
       <td>v4.8</td>
       <td>2026 Mar 16</td>
       <td>2026 Sep 16</td>
       <td>2026 Dec 16</td>
-      <td>v0.33.0</td>
+      <td>v0.33</td>
     </tr>
     <tr>
       <td>v4.7</td>
       <td>2026 Feb 18</td>
       <td>2026 Aug 18</td>
       <td>2026 Nov 18</td>
-      <td>v0.32.0</td>
+      <td>v0.32</td>
     </tr>
     <tr>
       <td>v4.6</td>
       <td>2026 Jan 29</td>
       <td>2026 Jul 29</td>
       <td>2026 Oct 29</td>
-      <td>v0.31.0-rc.12<sup>&dagger;</sup></td>
+      <td>v0.31</sup></td>
     </tr>
     <tr>
       <td>v4.5</td>
       <td>2025 Oct 29</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
-      <td>v0.30.0</td>
+      <td>v0.30</td>
     </tr>
     <tr>
       <td colspan="5" align="center">
@@ -83,50 +83,46 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>2025 Sep 09</td>
       <td>2026 Mar 09</td>
       <td>2026 Jun 09</td>
-      <td>v0.28.0</td>
+      <td>v0.28</td>
     </tr>
     <tr>
       <td>v4.3</td>
       <td>2025 Jun 03</td>
       <td>2025 Dec 03</td>
       <td>2026 Mar 06</td>
-      <td>v0.25.0</td>
+      <td>v0.25</td>
     </tr>
     <tr>
       <td>v4.2</td>
       <td>2024 Dec 17</td>
       <td>2025 Sep 17</td>
       <td>2025 Dec 17</td>
-      <td>v0.21.2</td>
+      <td>v0.21</td>
     </tr>
     <tr>
       <td>v4.1</td>
       <td>2024 Nov 12</td>
       <td>2025 Feb 12</td>
       <td>2025 May 12</td>
-      <td>v0.21.0</td>
+      <td>v0.21</td>
     </tr>
     <tr>
       <td>v4.0</td>
       <td>2024 Oct 15</td>
       <td>2025 Jan 15</td>
       <td>2025 Apr 15</td>
-      <td>v0.20.1</td>
+      <td>v0.20</td>
     </tr>
     <tr>
       <td>v3.4</td>
       <td>2024 Feb 29</td>
       <td>2025 Apr 01<sup>*</sup></td>
       <td>2025 Jul 01</td>
-      <td>v0.19.3</td>
+      <td>v0.19</td>
     </tr>
   </tbody>
 </table>
 
 \* Due to the number of breaking changes from vCluster v0.19 to v0.20 and vCluster Platform v3.4 to v4.0, v3.4 has an extended EOS end date. Review the [migration guide](https://platform-v4-5--vcluster-docs-site.netlify.app/docs/platform/reference/migrations/4-0-migration) to upgrade your platform from v3.4 to v4.0.
-
-&dagger; v4.6.0 shipped defaulting to vCluster v0.31.0-rc.12, a pre-release build. This was corrected to v0.31.0 in the v4.6.1 patch release.
-
-The default vCluster version reflects the version pinned at the initial vX.Y.0 release of each Platform version, and does not account for changes made in later patch releases.
 
 <SupportTerminology />

--- a/docs/_partials/platform_supported_versions.mdx
+++ b/docs/_partials/platform_supported_versions.mdx
@@ -64,7 +64,7 @@ Any previous versions which are not on the following list, are no longer in any 
       <td>2026 Jan 29</td>
       <td>2026 Jul 29</td>
       <td>2026 Oct 29</td>
-      <td>v0.31</sup></td>
+      <td>v0.31</td>
     </tr>
     <tr>
       <td>v4.5</td>

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -62,14 +62,14 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
       <td>v1.35 (k8s)</td>
     </tr>
     <tr>
+      <td colspan="5" align="center"><i>Versions below are no longer supported</i></td>
+    </tr>
+    <tr>
       <td>v0.31</td>
       <td>2026 Jan 29</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
       <td>v1.34 (k8s)</td>
-    </tr>
-    <tr>
-      <td colspan="5" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.30</td>

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -10,10 +10,11 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
 
 <table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
   <colgroup>
-    <col style={{width: '15%'}} />
-    <col style={{width: '28%'}} />
-    <col style={{width: '28%'}} />
-    <col style={{width: '29%'}} />
+    <col style={{width: '13%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '17%'}} />
+    <col style={{width: '36%'}} />
   </colgroup>
   <thead>
     <tr>
@@ -21,6 +22,7 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
       <th>Released</th>
       <th>End of Support (EOS) Date</th>
       <th>End of Life (EOL) Date</th>
+      <th>Default Kubernetes Version</th>
     </tr>
   </thead>
   <tbody>
@@ -29,115 +31,135 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
       <td>2026 Jul 22</td>
       <td>2026 Oct 22</td>
       <td>2027 Jan 22</td>
+      <td>v1.36 (k8s)</td>
     </tr>
     <tr>
       <td>v0.35</td>
       <td>2026 Jun 16</td>
       <td>2026 Sep 16</td>
       <td>2026 Dec 16</td>
+      <td>v1.36 (k8s)</td>
     </tr>
     <tr>
       <td>v0.34</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
       <td>2026 Oct 29</td>
+      <td>v1.35 (k8s)</td>
     </tr>
     <tr>
       <td>v0.33</td>
       <td>2026 Mar 13</td>
       <td>2026 Jun 13</td>
       <td>2026 Sep 13</td>
+      <td>v1.35 (k8s)</td>
     </tr>
     <tr>
       <td>v0.32</td>
       <td>2026 Feb 18</td>
       <td>2026 May 18</td>
       <td>2026 Aug 18</td>
+      <td>v1.35 (k8s)</td>
     </tr>
     <tr>
       <td>v0.31</td>
       <td>2026 Jan 29</td>
       <td>2026 Apr 29</td>
       <td>2026 Jul 29</td>
+      <td>v1.34 (k8s)</td>
     </tr>
     <tr>
-      <td colspan="4" align="center"><i>Versions below are no longer supported</i></td>
+      <td colspan="5" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.30</td>
       <td>2025 Oct 28</td>
       <td>2026 Jan 28</td>
       <td>2026 Apr 28</td>
+      <td>v1.34 (k8s)</td>
     </tr>
     <tr>
       <td>v0.29</td>
       <td>2025 Oct 01</td>
       <td>2026 Jan 01</td>
       <td>2026 Apr 01</td>
+      <td>v1.33 (k8s)</td>
     </tr>
     <tr>
       <td>v0.28</td>
       <td>2025 Sep 08</td>
       <td>2025 Dec 08</td>
       <td>2026 Mar 08</td>
+      <td>v1.33 (k8s)</td>
     </tr>
     <tr>
       <td>v0.27</td>
       <td>2025 Aug 12</td>
       <td>2025 Nov 12</td>
       <td>2026 Feb 12</td>
+      <td>v1.33 (k8s)</td>
     </tr>
     <tr>
       <td>v0.26</td>
       <td>2025 Jun 26</td>
       <td>2025 Sep 26</td>
       <td>2025 Dec 26</td>
+      <td>v1.32 (k8s)</td>
     </tr>
     <tr>
       <td>v0.25</td>
       <td>2025 May 15</td>
       <td>2025 Aug 15</td>
       <td>2025 Nov 15</td>
+      <td>v1.32 (k8s)</td>
     </tr>
     <tr>
       <td>v0.24</td>
       <td>2025 Mar 18</td>
       <td>2025 Jun 16</td>
       <td>2025 Sep 14</td>
+      <td>v1.32 (k8s)</td>
     </tr>
     <tr>
       <td>v0.23</td>
       <td>2025 Feb 26</td>
       <td>2025 May 25</td>
       <td>2025 Aug 26</td>
+      <td>v1.32 (k8s)</td>
     </tr>
     <tr>
       <td>v0.22</td>
       <td>2024 Dec 18</td>
       <td>2025 Mar 18</td>
       <td>2025 Jun 18</td>
+      <td>v1.31 (k8s)</td>
     </tr>
     <tr>
       <td>v0.21</td>
       <td>2024 Nov 11</td>
       <td>2025 Feb 11</td>
       <td>2025 May 11</td>
+      <td>v1.31 (k8s)</td>
     </tr>
     <tr>
       <td>v0.20</td>
       <td>2024 Aug 14</td>
       <td>2024 Nov 14</td>
       <td>2025 Feb 14</td>
+      <td>v1.30 (k8s)</td>
     </tr>
     <tr>
       <td>v0.19</td>
       <td>2024 Feb 12</td>
       <td>2025 Apr 01<sup>*</sup></td>
       <td>2025 Jul 01</td>
+      <td>v1.29 (k3s)</td>
     </tr>
   </tbody>
 </table>
 
-\* **Extended support**: Due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 virtual clusters to v0.20.
+\* **Extended support**: Due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 tenant clusters to v0.20.
+
+The default Kubernetes version reflects the distro and version pinned at the initial vX.Y.0 release of each vCluster version, and does not account for changes made in later patch releases. vCluster's default distro changed from k3s to k8s in v0.20.
 
 <SupportTerminology />

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -8,18 +8,18 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
 
 ## vCluster releases
 
-<table style={{tableLayout: 'fixed', width: '100%', textAlign: 'center'}}>
+<table style={{tableLayout: 'fixed', width: '80%', textAlign: 'center'}}>
   <colgroup>
-    <col style={{width: '13%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '17%'}} />
-    <col style={{width: '36%'}} />
+    <col style={{width: '16%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
+    <col style={{width: '21%'}} />
   </colgroup>
   <thead>
     <tr>
       <th>Release</th>
-      <th>Released</th>
+      <th>Release Date</th>
       <th>End of Support (EOS) Date</th>
       <th>End of Life (EOL) Date</th>
       <th>Default Kubernetes Version</th>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -279,7 +279,7 @@ const config = {
             badge: true,
           },
           "0.34.0": {
-            label: "v0.34",
+            label: "v0.34 (EOS)",
             banner: "none",
             badge: true,
           },

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -14,7 +14,7 @@ export const platformHiddenVersions = [];
 export const vclusterEOLVersions = [
   { to: "https://vcluster.com/docs/v0.33", label: "v0.33 (EOS)" },
   { to: "https://vcluster.com/docs/v0.32", label: "v0.32 (EOS)" },
-  { to: "https://vcluster.com/docs/v0.31", label: "v0.31 (EOS)" },
+  { to: "https://vcluster.com/docs/v0.31", label: "v0.31 (EOL)" },
   { to: "https://vcluster.com/docs/v0.30", label: "v0.30 (EOL)" },
   { to: "https://vcluster.com/docs/v0.29", label: "v0.29 (EOL)" },
   { to: "https://vcluster.com/docs/v0.28", label: "v0.28 (EOL)" },
@@ -31,9 +31,9 @@ export const vclusterEOLVersions = [
 
 export const platformEOLVersions = [
   { to: "https://vcluster.com/docs/v4.7", label: "v4.7" },
-  { to: "https://vcluster.com/docs/v4.6", label: "v4.6" },
-  { to: "https://vcluster.com/docs/v4.5", label: "v4.5 (EOS)" },
-  { to: "https://vcluster.com/docs/v4.4", label: "v4.4 (EOS)" },
+  { to: "https://vcluster.com/docs/v4.6", label: "v4.6 (EOS)" },
+  { to: "https://vcluster.com/docs/v4.5", label: "v4.5 (EOL)" },
+  { to: "https://vcluster.com/docs/v4.4", label: "v4.4 (EOL)" },
   { to: "https://vcluster.com/docs/v4.3", label: "v4.3 (EOL)" },
   { to: "https://vcluster.com/docs/v4.2", label: "v4.2 (EOL)" },
   { to: "https://loft.sh/docs/getting-started/install", label: "v3.4 (EOL)" },

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -1,6 +1,6 @@
 {
   "product": "Platform",
-  "lastUpdated": "2026-07-28",
+  "lastUpdated": "2026-07-29",
   "versions": [
     {
       "version": "4.11.0",
@@ -40,14 +40,14 @@
     {
       "version": "4.6.0",
       "releaseDate": "2026-01-29",
-      "status": "active",
+      "status": "eos",
       "eosDate": "2026-07-29",
       "eolDate": "2026-10-29"
     },
     {
       "version": "4.5.0",
       "releaseDate": "2025-10-29",
-      "status": "eos",
+      "status": "eol",
       "eosDate": "2026-04-29",
       "eolDate": "2026-07-29"
     },

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -1,6 +1,6 @@
 {
   "product": "Platform",
-  "lastUpdated": "2026-07-15",
+  "lastUpdated": "2026-07-28",
   "versions": [
     {
       "version": "4.11.0",

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -1,6 +1,6 @@
 {
   "product": "vCluster",
-  "lastUpdated": "2026-07-15",
+  "lastUpdated": "2026-07-28",
   "versions": [
     {
       "version": "0.36.0",

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -1,6 +1,6 @@
 {
   "product": "vCluster",
-  "lastUpdated": "2026-07-28",
+  "lastUpdated": "2026-07-29",
   "versions": [
     {
       "version": "0.36.0",
@@ -19,7 +19,7 @@
     {
       "version": "0.34.0",
       "releaseDate": "2026-04-29",
-      "status": "active",
+      "status": "eos",
       "eosDate": "2026-07-29",
       "eolDate": "2026-10-29"
     },
@@ -40,7 +40,7 @@
     {
       "version": "0.31.0",
       "releaseDate": "2026-01-29",
-      "status": "eos",
+      "status": "eol",
       "eosDate": "2026-04-29",
       "eolDate": "2026-07-29"
     },


### PR DESCRIPTION
# Content Description
Adds a "Default vCluster Version" column to the Platform supported versions table and a "Default Kubernetes Version" column to the vCluster supported versions table. Values reflect what was pinned at each version's initial vX.Y.0 release only (patch-release changes are disregarded). Sourced from `DefaultVClusterVersion` in `loft-enterprise` and the pinned distro image in `vcluster`'s `chart/values.yaml` at each release tag.

This doesn't establish an official version-combination support policy (host cluster / platform / tenant Kubernetes version compatibility), which is the broader ask in DOC-1658. It's a smaller, verifiable step in that direction.

## Preview Link
- https://deploy-preview-2510--vcluster-docs-site.netlify.app/docs/vcluster/manage/upgrade/supported_versions
- https://deploy-preview-2510--vcluster-docs-site.netlify.app/docs/platform/maintenance/upgrade-migrate/lifecycle-policy


## Internal Reference
Relates to DOC-1658 (does not close it)


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs