### PR TITLE
docs(doc-1493): document KubeVirt OS images

### DIFF
--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -32,7 +32,7 @@ flowchart LR
         Destroy("delete VirtualMachine")
     end
 
-    subgraph host_cluster["KubeVirt Control Plane Cluster"]
+    subgraph host_cluster["KubeVirt control plane cluster"]
         direction TB
         KubeVirtVM["KubeVirt VirtualMachine"]
     end
@@ -496,7 +496,7 @@ The image configuration properties synthesize a root-disk `DataVolumeTemplate`, 
 **Type:** `string`
 
 <!-- vale Vale.Terms = NO -->
-References an [OSImage](../../use-platform/machines/os-images.mdx) resource by name. The OSImage's properties merge into the NodeClaim's properties. If the OSImage sets `kubevirt.vcluster.com/image-url` or `kubevirt.vcluster.com/image-datasource`, the NodeClaim's source-related fields (`image-url`, `image-checksum`, `image-datasource`) are discarded before the overlay to avoid mismatched sources.
+References a [KubeVirt OSImage](../../use-platform/machines/os-images.mdx#kubevirt) resource by name. The OSImage's properties merge into the NodeClaim's properties. If the OSImage sets `kubevirt.vcluster.com/image-url` or `kubevirt.vcluster.com/image-datasource`, the NodeClaim's source-related fields (`image-url`, `image-checksum`, `image-datasource`) are discarded before the overlay to avoid mismatched sources.
 <!-- vale Vale.Terms = YES -->
 
 #### `kubevirt.vcluster.com/image-url`
@@ -504,7 +504,7 @@ References an [OSImage](../../use-platform/machines/os-images.mdx) resource by n
 **Type:** `string` (HTTP(S) URL or `docker://` reference)
 
 <!-- vale Vale.Terms = NO -->
-URL of the OS image. HTTP and HTTPS URLs produce an `http` DataVolume source; `docker://` URLs produce a `registry` source. Mutually exclusive with `kubevirt.vcluster.com/image-datasource`.
+URL of the OS image. HTTP and HTTPS URLs produce an `http` DataVolume source; `docker://` URLs produce a `registry` source. Configure either this property or `kubevirt.vcluster.com/image-datasource`. If both are present, the provider uses the `DataSource`.
 <!-- vale Vale.Terms = YES -->
 
 #### `kubevirt.vcluster.com/image-checksum`
@@ -517,7 +517,7 @@ Checksum of the OS image, used only when `image-url` is an HTTP(S) URL.
 
 **Type:** `string` (`<name>` or `<namespace>/<name>`)
 
-References a CDI `DataSource`. The provider sets the DataVolume's `sourceRef` to this DataSource. If you only supply `<name>`, the provider looks up the DataSource in the same namespace as the VM. Mutually exclusive with `kubevirt.vcluster.com/image-url`.
+References a CDI `DataSource`. The provider sets the DataVolume's `sourceRef` to this DataSource. If you only supply `<name>`, the provider looks up the DataSource in the same namespace as the VM. Configure either this property or `kubevirt.vcluster.com/image-url`. If both are present, the provider uses the `DataSource` and ignores the URL and checksum.
 
 #### `kubevirt.vcluster.com/root-disk-size`
 

--- a/platform/administer/virtual-machines/overview.mdx
+++ b/platform/administer/virtual-machines/overview.mdx
@@ -16,7 +16,7 @@ import VirtualMachinesDiagram from '@site/static/media/diagrams/virtual-machines
 Virtual machine management is experimental. Breaking changes may occur between releases. The feature is enabled on a per-customer basis. Don't use it for production workloads without guidance from vCluster Labs.
 :::
 
-vCluster Platform integrates with [KubeVirt](https://kubevirt.io/) to manage virtual machines (VMs) on connected Control Plane Clusters.
+vCluster Platform integrates with [KubeVirt](https://kubevirt.io/) to manage virtual machines (VMs) on connected control plane clusters.
 Administrators can deploy KubeVirt, create reusable VM templates, and manage KubeVirt `VirtualMachine` resources from the platform UI.
 
 <figure>
@@ -47,7 +47,7 @@ spec:
     # Optional: reference a NodeEnvironment for network defaults.
     # vcluster.com/network-environment: [[VAR:NETWORK_ENVIRONMENT:default]]
   kubeVirt:
-    # Create VMs in this connected Control Plane Cluster.
+    # Create VMs in this connected control plane cluster.
     clusterRef:
       cluster: [[VAR:CLUSTER_NAME:my-kubevirt-cluster]]
       namespace: [[VAR:NAMESPACE:vcluster-platform]]
@@ -97,7 +97,7 @@ Virtual machines are a good fit when teams need VM-level isolation or guest oper
 
 Before managing virtual machines, you need:
 
-- A connected Control Plane Cluster where VMs should run.
+- A connected control plane cluster where VMs should run.
 - KubeVirt installed on that cluster, or a KubeVirt node provider configured with `spec.kubeVirt.deploy.kubevirt.enabled: true`.
 - Containerized disk images, Containerized Data Importer (CDI) data volumes, or data sources that KubeVirt can use for VM storage.
 - Optional [OS images](../../use-platform/machines/os-images.mdx) and [SSH keys](../../use-platform/machines/ssh-keys.mdx) for reusable provisioning configuration.
@@ -168,7 +168,7 @@ Common properties include:
 
 | Property | Description |
 |---|---|
-| `vcluster.com/os-image` | References an `OSImage` resource. Use this for reusable image defaults. |
+| `vcluster.com/os-image` | References a reusable [KubeVirt OSImage](../../use-platform/machines/os-images.mdx#kubevirt). |
 | `vcluster.com/ssh-keys` | References one or more `SSHKey` resources. |
 | `vcluster.com/network-environment` | References a `NodeEnvironment` whose properties merge into the Machine. |
 | `vcluster.com/user-data` | Provides inline cloud-init user data. |

--- a/platform/use-platform/machines/os-images.mdx
+++ b/platform/use-platform/machines/os-images.mdx
@@ -11,6 +11,7 @@ import PageVariables from '@site/src/components/PageVariables';
   IMAGE_URL="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
   IMAGE_CHECKSUM="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
   CHECKSUM_TYPE="sha256"
+  KUBEVIRT_ROOT_DISK_SIZE="20Gi"
 />
 
 An `OSImage` resource contains the information that a node provider needs to install an operating system on a Machine, stored as a reusable reference. Instead of specifying image URLs and checksums directly on every node type or Machine, you define them once in an OSImage and reference it by name.
@@ -46,6 +47,65 @@ For the [Metal3 node provider](../../administer/node-providers/metal3.mdx), the 
 | `metal3.vcluster.com/image-checksum` | Checksum for image verification. |
 | `metal3.vcluster.com/image-checksum-type` | Checksum algorithm: `md5`, `sha256`, or `sha512`. Optional — auto-detected if omitted. |
 
+### KubeVirt
+
+For the [KubeVirt node provider](../../administer/node-providers/kubevirt.mdx), an OS image defines the source and size of a VM's root disk.
+The provider adds a Containerized Data Importer (CDI) `DataVolume` template to the generated VM.
+
+| Property | Description |
+|---|---|
+| `machines.vcluster.com/os-image-type` | Classifies the image for provider filtering in the platform UI. Set this property to `kubevirt`. |
+| `kubevirt.vcluster.com/image-url` | HTTP, HTTPS, or `docker://` image source. Configure either this property or `kubevirt.vcluster.com/image-datasource`. |
+| `kubevirt.vcluster.com/image-checksum` | Optional checksum for an HTTP or HTTPS source. CDI receives the value unchanged. Include the algorithm prefix, for example `sha256:<digest>`. The provider ignores this property for `docker://` and CDI `DataSource` sources. |
+| `kubevirt.vcluster.com/image-datasource` | CDI `DataSource` in `<name>` or `<namespace>/<name>` format. A name without a namespace resolves in the VM namespace. |
+| `kubevirt.vcluster.com/root-disk-size` | Storage request for the root disk, expressed as a Kubernetes quantity such as `20Gi`. Required for every KubeVirt image source. |
+
+Configure one source for each image. If both `image-url` and `image-datasource` are present, the provider uses the `DataSource`.
+It discards the URL and checksum.
+
+#### Container registry image source
+
+Use a `docker://` URL to import an image from a container registry.
+A checksum doesn't apply to this source type.
+
+<InterpolatedCodeBlock
+  code={'apiVersion: management.loft.sh/v1\nkind: OSImage\nmetadata:\n  name: [[VAR:OS_IMAGE_NAME:ubuntu-container-disk]]\nspec:\n  displayName: "Ubuntu container disk"\n  properties:\n    # Show this image for KubeVirt providers in the platform UI.\n    machines.vcluster.com/os-image-type: kubevirt\n    # Import the root disk from this container registry image.\n    kubevirt.vcluster.com/image-url: "[[VAR:IMAGE_URL:docker://quay.io/containerdisks/ubuntu:22.04]]"\n    # Request this amount of storage for the root disk.\n    kubevirt.vcluster.com/root-disk-size: "[[GLOBAL:KUBEVIRT_ROOT_DISK_SIZE]]"'}
+  language="yaml"
+  title="kubevirt-registry-os-image.yaml"
+/>
+
+The provider creates a registry-backed `DataVolume` template and requests the configured root disk size.
+
+#### Import from a web address
+
+Use an HTTP or HTTPS source to let CDI import a disk image.
+The checksum is optional and applies only to this source type.
+
+<InterpolatedCodeBlock
+  code={'apiVersion: management.loft.sh/v1\nkind: OSImage\nmetadata:\n  name: [[VAR:OS_IMAGE_NAME:ubuntu-noble-http]]\nspec:\n  displayName: "Ubuntu Noble from HTTP"\n  properties:\n    # Show this image for KubeVirt providers in the platform UI.\n    machines.vcluster.com/os-image-type: kubevirt\n    # Import the root disk from this web address.\n    kubevirt.vcluster.com/image-url: "[[VAR:IMAGE_URL:https://example.com/images/ubuntu-noble.qcow2]]"\n    # Validate the downloaded image with its published checksum.\n    kubevirt.vcluster.com/image-checksum: "[[VAR:IMAGE_CHECKSUM:sha256:abc123]]"\n    # Request this amount of storage for the root disk.\n    kubevirt.vcluster.com/root-disk-size: "[[GLOBAL:KUBEVIRT_ROOT_DISK_SIZE]]"'}
+  language="yaml"
+  title="kubevirt-http-os-image.yaml"
+/>
+
+The provider creates an HTTP-backed `DataVolume` template and passes the checksum to CDI.
+Replace the example checksum with the checksum published for your image.
+If you omit the checksum property, CDI imports the image without checksum validation.
+
+#### Use a CDI data source
+
+Use a CDI `DataSource` when the source image already exists in the KubeVirt environment.
+Specify `<namespace>/<name>` to reference a `DataSource` outside the VM namespace.
+
+<InterpolatedCodeBlock
+  code={'apiVersion: management.loft.sh/v1\nkind: OSImage\nmetadata:\n  name: [[VAR:OS_IMAGE_NAME:ubuntu-noble-datasource]]\nspec:\n  displayName: "Ubuntu Noble DataSource"\n  properties:\n    # Show this image for KubeVirt providers in the platform UI.\n    machines.vcluster.com/os-image-type: kubevirt\n    # Reference an existing CDI DataSource by namespace and name.\n    kubevirt.vcluster.com/image-datasource: "[[VAR:DATA_SOURCE:os-images/ubuntu-noble]]"\n    # Request this amount of storage for the root disk.\n    kubevirt.vcluster.com/root-disk-size: "[[GLOBAL:KUBEVIRT_ROOT_DISK_SIZE]]"'}
+  language="yaml"
+  title="kubevirt-datasource-os-image.yaml"
+/>
+
+The provider creates a `DataVolume` template whose `sourceRef` points to the specified CDI `DataSource`.
+
+For advanced disk and `DataVolume` customization, see the [KubeVirt image configuration properties](../../administer/node-providers/kubevirt.mdx#image-configuration).
+
 ## Use an OSImage
 
 Reference an OSImage by name in node type properties or Machine properties:
@@ -57,6 +117,23 @@ properties:
 
 The platform resolves the OSImage and applies its properties during provisioning.
 On node providers that don't [support the property](#provider-specific-properties), it has no effect.
+
+## Resolve image problems
+
+Inspect the referenced image when a KubeVirt Machine doesn't provision:
+
+<InterpolatedCodeBlock
+  code={'kubectl get osimage [[VAR:OS_IMAGE_NAME:ubuntu-noble-http]] -o yaml'}
+  language="bash"
+/>
+
+| Problem | Resolution |
+|---|---|
+| The provider reports `failed to get OSImage` | The value of `vcluster.com/os-image` doesn't match an existing cluster-scoped `OSImage`. List the images with `kubectl get osimages`, then correct the reference. |
+| The image is missing from KubeVirt image selection in the platform UI | Check `machines.vcluster.com/os-image-type`. Set it to `kubevirt`. A missing or different value classifies the image as another provider type or as custom. |
+| The image defines both `image-url` and `image-datasource` | Remove the source that you don't intend to use. The provider gives `image-datasource` precedence and ignores `image-url` and `image-checksum`. |
+| Provisioning reports that `kubevirt.vcluster.com/root-disk-size` is required | Add the property to the OS image or another effective property source. Use a valid Kubernetes storage quantity such as `20Gi`. |
+| Provisioning reports an unsupported image URL scheme | Use a URL beginning with `http://`, `https://`, or `docker://`. |
 
 ## Access control
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds Kubevirt as an OSImage provider.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2515--vcluster-docs-site.netlify.app/docs/platform/next/use-platform/machines/os-images#kubevirt

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1493


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

