### PR TITLE
docs(doc-1472): document that backing store migration is unsupported

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -20,7 +20,7 @@ There are different ways to deploy the type of backing store.
 By default, vCluster uses an embedded SQLite database as the backing store. This option is great for smaller sandbox tenant clusters, but for production, it's recommended to use a different backing store option.
 
 :::warning Backing store migration isn't supported
-vCluster doesn't support changing the backing store type after initial deployment. This includes migrating between database and etcd backing stores, or using snapshot and restore to do so. Choose a backing store type before you deploy to production.
+vCluster doesn't support changing the backing store type after initial deployment. This includes migrating between database and etcd backing stores, between embedded and external databases, or using snapshot and restore to do so. Choose a backing store type before you deploy to production.
 
 The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
 :::

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -19,6 +19,12 @@ There are different ways to deploy the type of backing store.
 
 By default, vCluster uses an embedded SQLite database as the backing store. This option is great for smaller sandbox tenant clusters, but for production, it's recommended to use a different backing store option.
 
+:::warning Backing store migration isn't supported
+vCluster doesn't support changing the backing store type after initial deployment. This includes migrating between database and etcd backing stores, or using snapshot and restore to do so. Choose a backing store type before you deploy to production.
+
+The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
+:::
+
 :::warning vCluster Standalone 
 vCluster Standalone has limited backing store options. For single control plane nodes setup,
 * Embedded database (sqlite)

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -53,7 +53,7 @@ Embedded etcd starts the etcd binary with the Kubernetes control plane inside th
 vCluster fully manages embedded etcd and provides these capabilities:
 
 - **Dynamic scaling**: Scales the etcd cluster up or down based on vCluster replica count.
-- **Seamless migration**: Migrates from SQLite or [deployed etcd](../../../../../../manage/migrate-etcd-backing-store.mdx) to embedded etcd automatically.
+- **Migration from deployed etcd**: Migrates from [deployed etcd](../../../../../../manage/migrate-etcd-backing-store.mdx) to embedded etcd using the `migrateFromDeployedEtcd` flag. vCluster doesn't support changing to other backing store types, including through snapshot and restore.
 - **Simplified deployment**: Requires no additional `StatefulSets` or `Deployments`.
 
 <!-- vale off -->

--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -207,7 +207,7 @@ vCluster certificates change when you create a tenant cluster with a new name or
 
 ## Migrate and override vCluster configuration options to create a new tenant cluster
 
-When upgrading tenant clusters, there are a couple of configuration options that aren't supported to change on an existing tenant cluster. For example, the backing store can't be changed. To change other options, migrate the tenant cluster by creating a new one from a snapshot and applying updated configuration.
+When upgrading tenant clusters, there are a couple of configuration options that aren't supported to change on an existing tenant cluster. For example, changing the backing store type isn't supported, including through snapshot and restore. See [Backing store](../../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx) for details. To change other options, migrate the tenant cluster by creating a new one from a snapshot and applying updated configuration.
 
 When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
 
@@ -225,19 +225,6 @@ vcluster create [[VAR:VCLUSTER_NAME:my-vcluster]] --upgrade -f vcluster.yaml --r
 :::info New name or namespace updates certificates
 vCluster certificates change when you create a tenant cluster with a new name or namespace. This is expected, as tenant clusters shouldn't share certificates.
 :::
-
-### Supported migration options
-
-vCluster supports migration paths based on your setup. The following migration options are available for Kubernetes distributions and backing stores.
-
-#### Change the backing store
-
-Change your data store to improve efficiency, scalability, and Kubernetes compatibility. You can migrate between the following data stores:
-
-- Embedded database (SQLite) -> Embedded database (etcd)
-- Embedded database (SQLite) -> External database
-
-vCluster overrides all other configuration options, similar to upgrading a tenant cluster and applying changes.
 
 ### Limitations
 

--- a/vcluster/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster/manage/migrate-etcd-backing-store.mdx
@@ -13,9 +13,12 @@ import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 
 This guide explains how to migrate your <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> from [deployed (external) etcd](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy) to [embedded etcd](/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded) without data loss. 
 
-:::info Why migrate?
 If you're currently using deployed <GlossaryTerm term="etcd">etcd</GlossaryTerm> and want to simplify your deployment, reduce resource consumption, or streamline operations, migrating to embedded etcd is a straightforward process that preserves all your data.
+
+:::important Scope of this guide
+This guide covers migration between two etcd deployment modes only. vCluster doesn't support migrating between backing store types, such as etcd to database or database to etcd. Snapshot and restore across backing store types isn't supported either.
 :::
+
 
 ## Overview
 
@@ -94,7 +97,7 @@ controlPlane:
 ```
 
 :::warning Admission controllers
-If your cluster uses admission controllers (Kyverno, OPA Gatekeeper, etc.), ensure they allow StatefulSet spec modifications and volume claim changes. You may need to add temporary exceptions for the vCluster namespace during migration.
+If your cluster uses admission controllers (such as Kyverno or OPA Gatekeeper), ensure they allow StatefulSet spec modifications and volume claim changes. You may need to add temporary exceptions for the vCluster namespace during migration.
 :::
 
 </Step>

--- a/vcluster/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster/manage/migrate-etcd-backing-store.mdx
@@ -16,7 +16,7 @@ This guide explains how to migrate your <GlossaryTerm term="vcluster">vCluster</
 If you're currently using deployed <GlossaryTerm term="etcd">etcd</GlossaryTerm> and want to simplify your deployment, reduce resource consumption, or streamline operations, migrating to embedded etcd is a straightforward process that preserves all your data.
 
 :::important Scope of this guide
-This guide covers migration between two etcd deployment modes only. vCluster doesn't support migrating between backing store types, such as etcd to database or database to etcd. Snapshot and restore across backing store types isn't supported either.
+This guide covers migration between two etcd deployment modes only. vCluster doesn't support migrating between backing store types, such as etcd to database, database to etcd, or embedded to external database. Snapshot and restore across backing store types isn't supported either.
 :::
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Documents that changing the backing store type (etcd <-> database) after initial deployment isn't supported, including via snapshot and restore. Adds this guidance to the backing store overview and the etcd migration guide, and removes existing content that contradicted it: a restore-guide section advertising SQLite -> etcd and SQLite -> external database as supported migrations, and a "seamless migration" claim in the embedded etcd docs describing the same unsupported SQLite path as a capability.

## Preview Link 
<!-- The preview link or links to the documents-->
- https://deploy-preview-2518--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store
- https://deploy-preview-2518--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded#how-embedded-etcd-works
- https://deploy-preview-2518--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/restore#migrate-and-override-vcluster-configuration-options-to-create-a-new-tenant-cluster
- https://deploy-preview-2518--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/migrate-etcd-backing-store


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1472

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs