### PR TITLE
docs(platform/observability): requests/limits for pods

### DIFF
--- a/.claude/skills/vcluster-docs-writer/references/style-guide.md
+++ b/.claude/skills/vcluster-docs-writer/references/style-guide.md
@@ -78,14 +78,18 @@ Kubernetes object or the infrastructure behind it.
 Pick the verb based on what's actually being destroyed:
 
 - **"delete"** for a Kubernetes API object, matching the literal `kubectl delete` verb:
-  deleting a pod, PVC, namespace, or other resource. The object's `status.phase` becomes
-  `Terminating` while it's being removed. That's Kubernetes' own field/status name, not a
-  style choice, so leave it as-is even though it contains "terminat-".
+  deleting a pod, PVC, namespace, or other resource. kubectl displays `Terminating` for an
+  object once its `metadata.deletionTimestamp` is set and removal is pending. That's not an
+  actual `status.phase` value (Pod phases are `Pending`, `Running`, `Succeeded`, `Failed`, or
+  `Unknown`), but it's still Kubernetes' own display convention, not a style choice, so
+  leave `Terminating` as-is even though it contains "terminat-".
 - **"terminate"** for a controller or component destroying the underlying cloud instance or
   VM behind a node, for example a cloud autoscaler or a remediation controller calling a
-  provider API (`ec2:TerminateInstances`, `compute.instances.reset`). Don't substitute
-  "delete" here: it blurs the distinction from `kubectl delete`, and it doesn't match the
-  actual API being described.
+  provider API that actually destroys the instance, like `ec2:TerminateInstances`. Don't use
+  it for a reboot-only API such as `compute.instances.reset`, which restarts the VM without
+  destroying it. Call that a reboot, not a termination. Don't substitute "delete" for a real
+  termination either: it blurs the distinction from `kubectl delete`, and it doesn't match
+  the actual API being described.
 
 If a page's prose legitimately needs "terminate" in the cloud-instance sense throughout and
 Vale keeps flagging it, don't hand-edit around individual warnings; scope `Google.WordList

--- a/.claude/skills/vcluster-docs-writer/references/style-guide.md
+++ b/.claude/skills/vcluster-docs-writer/references/style-guide.md
@@ -68,6 +68,31 @@ Do not delete the vCluster pod.
 :::
 ```
 
+## Word Choice: "delete" vs. "terminate"
+
+Google.WordList flags "terminate" (along with "kill" and "abort") and suggests "stop",
+"exit", "cancel", or "end" instead. That rule assumes "terminate" means ending a session,
+process, or request. It doesn't hold for the other sense of the word: destroying a
+Kubernetes object or the infrastructure behind it.
+
+Pick the verb based on what's actually being destroyed:
+
+- **"delete"** for a Kubernetes API object, matching the literal `kubectl delete` verb:
+  deleting a pod, PVC, namespace, or other resource. The object's `status.phase` becomes
+  `Terminating` while it's being removed. That's Kubernetes' own field/status name, not a
+  style choice, so leave it as-is even though it contains "terminat-".
+- **"terminate"** for a controller or component destroying the underlying cloud instance or
+  VM behind a node, for example a cloud autoscaler or a remediation controller calling a
+  provider API (`ec2:TerminateInstances`, `compute.instances.reset`). Don't substitute
+  "delete" here: it blurs the distinction from `kubectl delete`, and it doesn't match the
+  actual API being described.
+
+If a page's prose legitimately needs "terminate" in the cloud-instance sense throughout and
+Vale keeps flagging it, don't hand-edit around individual warnings; scope `Google.WordList
+= NO` for that page in `.vale.ini` instead, with a comment explaining why. Double-check the
+glob matches the file's **current** name: a page rename after the override was added leaves
+a dead glob that silently stops applying, and the warnings resurface with no obvious cause.
+
 ## Oxford Comma
 
 Use the Oxford comma (serial comma) before the last item when listing 3 or more items in a sentence.

--- a/.vale.ini
+++ b/.vale.ini
@@ -95,7 +95,7 @@ Google.Headings = NO
 # whole rule off for this page rather than editing the shared word list, since inline
 # per-instance vale toggles proved unreliable across this page's wrapped list items
 # and table cells.
-[**/observability/nvsentinel-gpu-monitoring.mdx]
+[**/observability/nvsentinel-gpu-observability.mdx]
 BasedOnStyles = Loft, Google, Vale
 Google.WordList = NO
 

--- a/platform/maintenance/observability/configure-edge-collectors.mdx
+++ b/platform/maintenance/observability/configure-edge-collectors.mdx
@@ -126,27 +126,11 @@ spec:
 | `bearerToken` | _(empty)_ | `metrics-writer` bearer token. When empty, the collectors read the `otel-otlp-auth` Secret. |
 | `otlpCaData` | _(empty)_ | PEM CA data used to verify the gateway serving certificate. |
 | `otlpInsecureSkipVerify` | `false` | Skip gateway TLS verification. Use only for test gateways. |
-| `otelDaemonResources` | _(empty)_ | Resource requests and limits for the `otel-daemon` collector container, as a YAML block. When empty, the chart default applies. |
-| `otelDeployResources` | _(empty)_ | Resource requests and limits for the `otel-deploy` collector container, as a YAML block. When empty, the chart default applies. |
+| `otelDaemonResources` | _(empty)_ | Resource requests and limits for the `otel-daemon` collector container, as a multiline YAML block. See the example below. When empty, the chart default applies, which sets no requests or limits. |
+| `otelDeployResources` | _(empty)_ | Resource requests and limits for the `otel-deploy` collector container, in the same format as `otelDaemonResources`. When empty, the chart default applies, which sets no requests or limits. |
 
-### Set collector resource requests and limits
-
-The template deploys two collectors, sized independently: `otel-daemon` runs with
-`mode: daemonset` and scrapes each node, and `otel-deploy` runs with `mode: deployment` and
-one replica, collecting cluster-scoped metrics. Each value is the contents of a Kubernetes
-`resources` field, not a full YAML document.
-
-<Tabs
-  defaultValue="ui"
-  values={[
-    { label: "Platform UI", value: "ui" },
-    { label: "YAML", value: "yaml" },
-  ]}
->
-<TabItem value="yaml">
-
-Add the parameters to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for
-each value:
+Both resource parameters are multiline parameters that take the contents of a Kubernetes
+`resources` field.
 
 ```yaml title="fleet-edge-collectors.yaml"
 spec:
@@ -164,41 +148,6 @@ spec:
       limits:
         memory: 512Mi
 ```
-
-</TabItem>
-<TabItem value="ui">
-
-<Flow>
-  <Step>
-    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
-  </Step>
-  <Step>
-    In the <Label>OTel Daemon collector resources</Label> field, enter the resources for the `otel-daemon` collector. Enter only the field contents, without the parameter name:
-
-    ```yaml
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 256Mi
-    ```
-  </Step>
-  <Step>
-    In the <Label>OTel Deploy collector resources</Label> field, enter the resources for the `otel-deploy` collector.
-  </Step>
-  <Step>
-    Click <Button>Save</Button>. Argo CD syncs the change and restarts the collector pods.
-  </Step>
-</Flow>
-
-</TabItem>
-</Tabs>
-
-:::note
-The collector containers run without an explicit `resources` block until you set these
-parameters, so they get the `BestEffort` QoS class and are evicted first under node
-pressure. Set at least a memory request for production fleets.
-:::
 
 The collectors stamp the request scope from the destination, so target a tenant cluster
 for tenant-scoped writes or a control plane cluster for cluster-scoped writes. Set

--- a/platform/maintenance/observability/configure-edge-collectors.mdx
+++ b/platform/maintenance/observability/configure-edge-collectors.mdx
@@ -126,6 +126,79 @@ spec:
 | `bearerToken` | _(empty)_ | `metrics-writer` bearer token. When empty, the collectors read the `otel-otlp-auth` Secret. |
 | `otlpCaData` | _(empty)_ | PEM CA data used to verify the gateway serving certificate. |
 | `otlpInsecureSkipVerify` | `false` | Skip gateway TLS verification. Use only for test gateways. |
+| `otelDaemonResources` | _(empty)_ | Resource requests and limits for the `otel-daemon` collector container, as a YAML block. When empty, the chart default applies. |
+| `otelDeployResources` | _(empty)_ | Resource requests and limits for the `otel-deploy` collector container, as a YAML block. When empty, the chart default applies. |
+
+### Set collector resource requests and limits
+
+The template deploys two collectors, sized independently: `otel-daemon` runs with
+`mode: daemonset` and scrapes each node, and `otel-deploy` runs with `mode: deployment` and
+one replica, collecting cluster-scoped metrics. Each value is the contents of a Kubernetes
+`resources` field, not a full YAML document.
+
+<Tabs
+  defaultValue="ui"
+  values={[
+    { label: "Platform UI", value: "ui" },
+    { label: "YAML", value: "yaml" },
+  ]}
+>
+<TabItem value="yaml">
+
+Add the parameters to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for
+each value:
+
+```yaml title="fleet-edge-collectors.yaml"
+spec:
+  parameters:
+    otelDaemonResources: |
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 256Mi
+    otelDeployResources: |
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 512Mi
+```
+
+</TabItem>
+<TabItem value="ui">
+
+<Flow>
+  <Step>
+    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
+  </Step>
+  <Step>
+    In the <Label>OTel Daemon collector resources</Label> field, enter the resources for the `otel-daemon` collector. Enter only the field contents, without the parameter name:
+
+    ```yaml
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 256Mi
+    ```
+  </Step>
+  <Step>
+    In the <Label>OTel Deploy collector resources</Label> field, enter the resources for the `otel-deploy` collector.
+  </Step>
+  <Step>
+    Click <Button>Save</Button>. Argo CD syncs the change and restarts the collector pods.
+  </Step>
+</Flow>
+
+</TabItem>
+</Tabs>
+
+:::note
+The collector containers run without an explicit `resources` block until you set these
+parameters, so they get the `BestEffort` QoS class and are evicted first under node
+pressure. Set at least a memory request for production fleets.
+:::
 
 The collectors stamp the request scope from the destination, so target a tenant cluster
 for tenant-scoped writes or a control plane cluster for cluster-scoped writes. Set

--- a/platform/maintenance/observability/gpu-observability-templates.mdx
+++ b/platform/maintenance/observability/gpu-observability-templates.mdx
@@ -98,9 +98,9 @@ within a few restarts. No action is needed.
 
 If you deploy edge collectors with the `cluster-collector` template, described in
 [Deploy collectors with Argo CD](./configure-edge-collectors.mdx#deploy-collectors-with-argo-cd),
-it also scrapes the GPU stack. No extra collector configuration is needed. Alongside its
-per-node DaemonSet, the template deploys a cluster-singleton collector preconfigured with
-scrape jobs for:
+it also scrapes the GPU stack. No extra collector configuration is needed. Alongside the
+per-node `otel-daemon` collector, the template deploys the `otel-deploy` collector,
+preconfigured with scrape jobs for:
 
 - The Fleet Intelligence Agent, in the `fleet-intelligence` namespace.
 - The NVIDIA GPU Operator's dcgm-exporter, in the `gpu-operator` namespace.

--- a/platform/maintenance/observability/install-observability-gateway.mdx
+++ b/platform/maintenance/observability/install-observability-gateway.mdx
@@ -115,25 +115,10 @@ spec:
 | `version` | `29.14.0` | Prometheus Helm chart version. |
 | `prometheusStorageSize` | `20Gi` | Persistent volume size for Prometheus storage. |
 | `metricsBackendTLSSecret` | _(empty)_ | Existing mTLS Secret for the backend. When empty, Platform self-signs a Secret named `metrics-backend-mtls`. |
-| `resources` | _(empty)_ | Resource requests and limits for the Prometheus server container, as a YAML block. When empty, the chart default applies. |
+| `resources` | _(empty)_ | Resource requests and limits for the Prometheus server container, as a multiline YAML block. See the example below. When empty, the chart default applies, which sets no requests or limits. |
 
-### Set Prometheus resource requests and limits
-
-Prometheus memory scales with the number of active series it holds, which grows with fleet
-size and metric cardinality. The `resources` value is the contents of a Kubernetes
-`resources` field, not a full YAML document.
-
-<Tabs
-  defaultValue="ui"
-  values={[
-    { label: "Platform UI", value: "ui" },
-    { label: "YAML", value: "yaml" },
-  ]}
->
-<TabItem value="yaml">
-
-Add the parameter to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for the
-value:
+`resources` is a multiline parameter that takes the contents of a Kubernetes `resources`
+field.
 
 ```yaml title="fleet-metrics-backend.yaml"
 spec:
@@ -145,38 +130,6 @@ spec:
       limits:
         memory: 2Gi
 ```
-
-</TabItem>
-<TabItem value="ui">
-
-<Flow>
-  <Step>
-    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
-  </Step>
-  <Step>
-    In the <Label>Pod resources</Label> field, enter the resources for the Prometheus server container. Enter only the field contents, without the parameter name:
-
-    ```yaml
-    requests:
-      cpu: 500m
-      memory: 2Gi
-    limits:
-      memory: 2Gi
-    ```
-  </Step>
-  <Step>
-    Click <Button>Save</Button>. Argo CD syncs the change and restarts the Prometheus pod.
-  </Step>
-</Flow>
-
-</TabItem>
-</Tabs>
-
-:::note
-The Prometheus container runs without an explicit `resources` block until you set this
-parameter, so it gets the `BestEffort` QoS class and is evicted first under node pressure.
-Set at least a memory request before you point production fleets at this backend.
-:::
 
 The connector you create below must use these endpoints when the template is deployed in
 its default namespace:

--- a/platform/maintenance/observability/install-observability-gateway.mdx
+++ b/platform/maintenance/observability/install-observability-gateway.mdx
@@ -115,6 +115,68 @@ spec:
 | `version` | `29.14.0` | Prometheus Helm chart version. |
 | `prometheusStorageSize` | `20Gi` | Persistent volume size for Prometheus storage. |
 | `metricsBackendTLSSecret` | _(empty)_ | Existing mTLS Secret for the backend. When empty, Platform self-signs a Secret named `metrics-backend-mtls`. |
+| `resources` | _(empty)_ | Resource requests and limits for the Prometheus server container, as a YAML block. When empty, the chart default applies. |
+
+### Set Prometheus resource requests and limits
+
+Prometheus memory scales with the number of active series it holds, which grows with fleet
+size and metric cardinality. The `resources` value is the contents of a Kubernetes
+`resources` field, not a full YAML document.
+
+<Tabs
+  defaultValue="ui"
+  values={[
+    { label: "Platform UI", value: "ui" },
+    { label: "YAML", value: "yaml" },
+  ]}
+>
+<TabItem value="yaml">
+
+Add the parameter to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for the
+value:
+
+```yaml title="fleet-metrics-backend.yaml"
+spec:
+  parameters:
+    resources: |
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        memory: 2Gi
+```
+
+</TabItem>
+<TabItem value="ui">
+
+<Flow>
+  <Step>
+    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
+  </Step>
+  <Step>
+    In the <Label>Pod resources</Label> field, enter the resources for the Prometheus server container. Enter only the field contents, without the parameter name:
+
+    ```yaml
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      memory: 2Gi
+    ```
+  </Step>
+  <Step>
+    Click <Button>Save</Button>. Argo CD syncs the change and restarts the Prometheus pod.
+  </Step>
+</Flow>
+
+</TabItem>
+</Tabs>
+
+:::note
+The Prometheus container runs without an explicit `resources` block until you set this
+parameter, so it gets the `BestEffort` QoS class and is evicted first under node pressure.
+Set at least a memory request before you point production fleets at this backend.
+:::
 
 The connector you create below must use these endpoints when the template is deployed in
 its default namespace:

--- a/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
+++ b/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
@@ -14,7 +14,7 @@ import Label from "@site/src/components/Label";
 [NVSentinel](https://github.com/NVIDIA/NVSentinel) is NVIDIA's open source, Kubernetes-native
 service for GPU fault handling. It detects hardware and software faults on GPU nodes through
 DCGM, system logs, and cloud provider maintenance events. It can respond by cordoning nodes,
-draining workloads, and triggering node reboots or deletions.
+draining workloads, and triggering node reboots or terminations.
 
 When the [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled, vCluster
 Platform ships an `ArgoCDApplicationTemplate` for NVSentinel alongside the other
@@ -49,7 +49,7 @@ NVSentinel is composed of independent components that you enable per deployment:
 | Fault Quarantine | `false` | Cordons and taints nodes with detected faults. |
 | Node Drainer | `false` | Evicts workloads from quarantined nodes. |
 | Fault Remediation | `false` | Creates maintenance resources to recover failing nodes after drain completes. |
-| Janitor | `false` | Executes the node reboots and deletions that Fault Remediation requests. |
+| Janitor | `false` | Executes the node reboots and terminations that Fault Remediation requests. |
 | Health Events Analyzer | `false` | Analyzes patterns across health events and produces recommended actions. |
 | MongoDB Store | `false` | Persistent event storage; the coordination layer for the remediation components. |
 
@@ -64,9 +64,9 @@ automatically, so the deployed application can differ from the toggles you set:
   or Health Events Analyzer is enabled, even if you leave **Enable MongoDB Store** off.
   Those components coordinate through MongoDB change streams and crash without it.
 - **Janitor** turns on whenever Fault Remediation is enabled, because Fault Remediation
-  can't reboot or delete nodes without it.
+  can't reboot or terminate nodes without it.
 - The Janitor's default provider is `kind`, which only **simulates** reboots and
-  deletions. Set the **Janitor Provider** parameter to your cloud provider (or
+  terminations. Set the **Janitor Provider** parameter to your cloud provider (or
   `generic` for bare metal) before relying on real remediation. See
   [Janitor provider parameters](#janitor-provider-parameters).
 
@@ -172,13 +172,13 @@ During a dry run, NVSentinel doesn't:
 
 - Cordon the node. `kubectl get node <name> -o jsonpath='{.spec.unschedulable}'` stays empty and the node keeps accepting workloads.
 - Evict workloads.
-- Reboot or delete nodes.
+- Reboot or terminate nodes.
 
 Because the metrics increment but nodes are not cordoned or evicted during a dry run, both the node object and the dashboard can look like a genuine quarantine happened.
 
 Use dry run to validate detection end to end. Inject or wait for a health event, confirm the logs, node annotations, and metrics, and then set `dryRun: "false"` to let NVSentinel cordon, drain, and remediate for real.
 
-Before turning dry run off, make sure the Janitor provider is set to a real provider, since the default `kind` provider only simulates reboots and deletions.
+Before turning dry run off, make sure the Janitor provider is set to a real provider, since the default `kind` provider only simulates reboots and terminations.
 
 ## Uninstall and cleanup
 
@@ -243,7 +243,7 @@ The template groups parameters by component. All boolean parameters are passed a
 | `enableFaultQuarantine` | `false` | Cordon and taint faulty nodes. Turns on the MongoDB store automatically. |
 | `enableNodeDrainer` | `false` | Evict workloads from quarantined nodes. Turns on the MongoDB store automatically, but not Fault Quarantine. [Enable that yourself too](#component-dependencies-the-template-resolves-for-you). |
 | `enableFaultRemediation` | `false` | Create maintenance resources to recover failing nodes. Turns on the MongoDB store and the Janitor automatically. |
-| `enableJanitor` | `false` | Execute reboots and deletions. Turns on automatically with Fault Remediation. |
+| `enableJanitor` | `false` | Execute reboots and terminations. Turns on automatically with Fault Remediation. |
 | `enableHealthEventsAnalyzer` | `false` | Analyze patterns across health events. Turns on the MongoDB store automatically. |
 
 ### MongoDB store parameters
@@ -273,7 +273,7 @@ The template groups parameters by component. All boolean parameters are passed a
 
 ### Janitor provider parameters
 
-The Janitor talks to your infrastructure provider to reboot and delete nodes. Pick the
+The Janitor talks to your infrastructure provider to reboot and terminate nodes. Pick the
 provider with `janitorProvider` and fill the matching provider section. The `kind` and
 `kwok` providers only simulate actions and are meant for test clusters.
 
@@ -345,7 +345,7 @@ Select the tab for your Janitor provider:
 <TabItem value="generic">
 
 The `generic` provider reboots nodes with a privileged Job scheduled onto the node. It
-can't delete instances.
+can't terminate instances.
 
 | Parameter | Default | Description |
 |---|---|---|

--- a/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
+++ b/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
@@ -14,7 +14,7 @@ import Label from "@site/src/components/Label";
 [NVSentinel](https://github.com/NVIDIA/NVSentinel) is NVIDIA's open source, Kubernetes-native
 service for GPU fault handling. It detects hardware and software faults on GPU nodes through
 DCGM, system logs, and cloud provider maintenance events. It can respond by cordoning nodes,
-draining workloads, and triggering node reboots or terminations.
+draining workloads, and triggering node reboots or deletions.
 
 When the [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled, vCluster
 Platform ships an `ArgoCDApplicationTemplate` for NVSentinel alongside the other
@@ -49,7 +49,7 @@ NVSentinel is composed of independent components that you enable per deployment:
 | Fault Quarantine | `false` | Cordons and taints nodes with detected faults. |
 | Node Drainer | `false` | Evicts workloads from quarantined nodes. |
 | Fault Remediation | `false` | Creates maintenance resources to recover failing nodes after drain completes. |
-| Janitor | `false` | Executes the node reboots and terminations that Fault Remediation requests. |
+| Janitor | `false` | Executes the node reboots and deletions that Fault Remediation requests. |
 | Health Events Analyzer | `false` | Analyzes patterns across health events and produces recommended actions. |
 | MongoDB Store | `false` | Persistent event storage; the coordination layer for the remediation components. |
 
@@ -64,9 +64,9 @@ automatically, so the deployed application can differ from the toggles you set:
   or Health Events Analyzer is enabled, even if you leave **Enable MongoDB Store** off.
   Those components coordinate through MongoDB change streams and crash without it.
 - **Janitor** turns on whenever Fault Remediation is enabled, because Fault Remediation
-  can't reboot or terminate nodes without it.
+  can't reboot or delete nodes without it.
 - The Janitor's default provider is `kind`, which only **simulates** reboots and
-  terminations. Set the **Janitor Provider** parameter to your cloud provider (or
+  deletions. Set the **Janitor Provider** parameter to your cloud provider (or
   `generic` for bare metal) before relying on real remediation. See
   [Janitor provider parameters](#janitor-provider-parameters).
 
@@ -172,13 +172,13 @@ During a dry run, NVSentinel doesn't:
 
 - Cordon the node. `kubectl get node <name> -o jsonpath='{.spec.unschedulable}'` stays empty and the node keeps accepting workloads.
 - Evict workloads.
-- Reboot or terminate nodes.
+- Reboot or delete nodes.
 
 Because the metrics increment but nodes are not cordoned or evicted during a dry run, both the node object and the dashboard can look like a genuine quarantine happened.
 
 Use dry run to validate detection end to end. Inject or wait for a health event, confirm the logs, node annotations, and metrics, and then set `dryRun: "false"` to let NVSentinel cordon, drain, and remediate for real.
 
-Before turning dry run off, make sure the Janitor provider is set to a real provider, since the default `kind` provider only simulates reboots and terminations.
+Before turning dry run off, make sure the Janitor provider is set to a real provider, since the default `kind` provider only simulates reboots and deletions.
 
 ## Uninstall and cleanup
 
@@ -243,7 +243,7 @@ The template groups parameters by component. All boolean parameters are passed a
 | `enableFaultQuarantine` | `false` | Cordon and taint faulty nodes. Turns on the MongoDB store automatically. |
 | `enableNodeDrainer` | `false` | Evict workloads from quarantined nodes. Turns on the MongoDB store automatically, but not Fault Quarantine. [Enable that yourself too](#component-dependencies-the-template-resolves-for-you). |
 | `enableFaultRemediation` | `false` | Create maintenance resources to recover failing nodes. Turns on the MongoDB store and the Janitor automatically. |
-| `enableJanitor` | `false` | Execute reboots and terminations. Turns on automatically with Fault Remediation. |
+| `enableJanitor` | `false` | Execute reboots and deletions. Turns on automatically with Fault Remediation. |
 | `enableHealthEventsAnalyzer` | `false` | Analyze patterns across health events. Turns on the MongoDB store automatically. |
 
 ### MongoDB store parameters
@@ -273,7 +273,7 @@ The template groups parameters by component. All boolean parameters are passed a
 
 ### Janitor provider parameters
 
-The Janitor talks to your infrastructure provider to reboot and terminate nodes. Pick the
+The Janitor talks to your infrastructure provider to reboot and delete nodes. Pick the
 provider with `janitorProvider` and fill the matching provider section. The `kind` and
 `kwok` providers only simulate actions and are meant for test clusters.
 
@@ -345,7 +345,7 @@ Select the tab for your Janitor provider:
 <TabItem value="generic">
 
 The `generic` provider reboots nodes with a privileged Job scheduled onto the node. It
-can't terminate instances.
+can't delete instances.
 
 | Parameter | Default | Description |
 |---|---|---|

--- a/platform/maintenance/observability/query-fleet-metrics.mdx
+++ b/platform/maintenance/observability/query-fleet-metrics.mdx
@@ -89,6 +89,70 @@ spec:
 | `platformHost` | Platform host | Platform host used to authenticate Grafana users. |
 | `grafanaAdminGroup` | _(empty)_ | Group mapped to the Grafana admin role. |
 | `grafanaCertSecret` | _(empty)_ | TLS Secret for Grafana serving. When empty, Platform self-signs a Secret named `grafana-server-tls`. |
+| `resources` | _(empty)_ | Resource requests and limits for the Grafana container, as a YAML block. When empty, the chart default applies. |
+
+### Set Grafana resource requests and limits
+
+The `resources` value is the contents of a Kubernetes `resources` field, not a full YAML
+document.
+
+<Tabs
+  defaultValue="ui"
+  values={[
+    { label: "Platform UI", value: "ui" },
+    { label: "YAML", value: "yaml" },
+  ]}
+>
+<TabItem value="yaml">
+
+Add the parameter to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for the
+value:
+
+```yaml title="fleet-grafana.yaml"
+spec:
+  parameters:
+    resources: |
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 256Mi
+```
+
+</TabItem>
+<TabItem value="ui">
+
+<Flow>
+  <Step>
+    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
+  </Step>
+  <Step>
+    In the <Label>Pod resources</Label> field, enter the resources for the Grafana container. Enter only the field contents, without the parameter name:
+
+    ```yaml
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 256Mi
+    ```
+  </Step>
+  <Step>
+    Click <Button>Save</Button>. Argo CD syncs the change and restarts the Grafana pod.
+  </Step>
+</Flow>
+
+</TabItem>
+</Tabs>
+
+Grafana memory scales with concurrent users and the panel count of the dashboards they
+open, not with fleet size. Raise the memory request when many operators query the same
+dashboards at once.
+
+:::note
+The Grafana container runs without an explicit `resources` block until you set this
+parameter, so it gets the `BestEffort` QoS class and is evicted first under node pressure.
+:::
 
 Configure the fleet observability connector so Platform can proxy and embed the bundled
 Grafana dashboards. These values match the template defaults:

--- a/platform/maintenance/observability/query-fleet-metrics.mdx
+++ b/platform/maintenance/observability/query-fleet-metrics.mdx
@@ -89,24 +89,10 @@ spec:
 | `platformHost` | Platform host | Platform host used to authenticate Grafana users. |
 | `grafanaAdminGroup` | _(empty)_ | Group mapped to the Grafana admin role. |
 | `grafanaCertSecret` | _(empty)_ | TLS Secret for Grafana serving. When empty, Platform self-signs a Secret named `grafana-server-tls`. |
-| `resources` | _(empty)_ | Resource requests and limits for the Grafana container, as a YAML block. When empty, the chart default applies. |
+| `resources` | _(empty)_ | Resource requests and limits for the Grafana container, as a multiline YAML block. See the example below. When empty, the chart default applies, which sets no requests or limits. |
 
-### Set Grafana resource requests and limits
-
-The `resources` value is the contents of a Kubernetes `resources` field, not a full YAML
-document.
-
-<Tabs
-  defaultValue="ui"
-  values={[
-    { label: "Platform UI", value: "ui" },
-    { label: "YAML", value: "yaml" },
-  ]}
->
-<TabItem value="yaml">
-
-Add the parameter to the `ArgoCDApplication` object, using a YAML block scalar (`|`) for the
-value:
+`resources` is a multiline parameter that takes the contents of a Kubernetes `resources`
+field.
 
 ```yaml title="fleet-grafana.yaml"
 spec:
@@ -118,41 +104,6 @@ spec:
       limits:
         memory: 256Mi
 ```
-
-</TabItem>
-<TabItem value="ui">
-
-<Flow>
-  <Step>
-    Open the Argo CD Application and find the <Label>Template Parameters</Label> section.
-  </Step>
-  <Step>
-    In the <Label>Pod resources</Label> field, enter the resources for the Grafana container. Enter only the field contents, without the parameter name:
-
-    ```yaml
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 256Mi
-    ```
-  </Step>
-  <Step>
-    Click <Button>Save</Button>. Argo CD syncs the change and restarts the Grafana pod.
-  </Step>
-</Flow>
-
-</TabItem>
-</Tabs>
-
-Grafana memory scales with concurrent users and the panel count of the dashboards they
-open, not with fleet size. Raise the memory request when many operators query the same
-dashboards at once.
-
-:::note
-The Grafana container runs without an explicit `resources` block until you set this
-parameter, so it gets the `BestEffort` QoS class and is evicted first under node pressure.
-:::
 
 Configure the fleet observability connector so Platform can proxy and embed the bundled
 Grafana dashboards. These values match the template defaults:

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -134,13 +134,12 @@ kubectl describe pod -n vcluster-platform <pod> | grep -A3 "Last State"
 If you see `OOMKilled` or `Evicted`, set resource requests and limits on the affected
 template:
 
-- Prometheus: the `resources` parameter. See [Set Prometheus resource requests and
-  limits](./install-observability-gateway.mdx#set-prometheus-resource-requests-and-limits).
-- Grafana: the `resources` parameter. See [Set Grafana resource requests and
-  limits](./query-fleet-metrics.mdx#set-grafana-resource-requests-and-limits).
-- Collectors: the `otelDaemonResources` and `otelDeployResources` parameters. See [Set
-  collector resource requests and
-  limits](./configure-edge-collectors.mdx#set-collector-resource-requests-and-limits).
+- Prometheus: the `resources` parameter. See [Deploy the metrics backend with Argo
+  CD](./install-observability-gateway.mdx#deploy-the-metrics-backend-with-argo-cd).
+- Grafana: the `resources` parameter. See [Deploy the bundled Grafana with Argo
+  CD](./query-fleet-metrics.mdx#deploy-the-bundled-grafana-with-argo-cd).
+- Collectors: the `otelDaemonResources` and `otelDeployResources` parameters. See [Deploy
+  collectors with Argo CD](./configure-edge-collectors.mdx#deploy-collectors-with-argo-cd).
 
 Prometheus is the most likely to be OOMKilled, because its memory grows with active series
 count.

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -136,11 +136,27 @@ kubectl get pod -n vcluster-platform <pod> -o jsonpath='{.status.message}'
 The fix depends on which failure you see:
 
 - `OOMKilled`: the container exceeded its memory limit, or the node ran out of memory.
-  Measure actual usage with `kubectl top pod -n vcluster-platform` and set or raise the
-  memory limit accordingly. A limit that is too low causes this on its own.
-- `Evicted` under memory or CPU pressure: set memory and CPU requests so the kubelet
-  ranks the pod above pods that exceed their requests. The status message names the
-  pressure signal that triggered the eviction.
+  `kubectl top pod -n vcluster-platform <pod> --containers` only shows current per-container
+  usage. A restarted container resets to a fresh baseline, so it won't show the memory spike
+  that preceded the restart. Check historical usage instead. The bundled [golden signals
+  queries](../monitoring/fleet-monitoring-otel.mdx#golden-signals-queries) filter on tenant
+  workload labels that these platform pods don't carry, so query the platform namespace
+  directly in the bundled Prometheus or Grafana. Scope the query to the specific container
+  the resource parameter targets, since a pod can run more than one:
+
+  ```promql
+  max(max_over_time(container_memory_working_set_bytes{namespace="vcluster-platform", pod="<pod>", container="<container>"}[1h]))
+  ```
+
+  Use the peak this returns to size a limit that covers it. A limit that is too low causes
+  this on its own.
+- `Evicted` under memory pressure: set memory requests so the kubelet ranks the pod above
+  pods that exceed their requests. The status message names the pressure signal that
+  triggered the eviction. CPU pressure isn't one of the eviction signals. The kubelet
+  handles CPU contention through throttling, not eviction, so a CPU request affects
+  scheduling but won't prevent an eviction. `DiskPressure` and
+  `PIDPressure` evictions need the underlying node condition resolved (free disk space or
+  process count), not a requests or limits change on this pod.
 
 Set requests and limits on the affected template:
 

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -121,18 +121,28 @@ can't connect:
 ## Observability pods are OOMKilled or evicted
 
 The bundled templates deploy Prometheus, Grafana, and the collectors without an explicit
-`resources` block, so those containers get the `BestEffort` QoS class and the kubelet
-evicts them first under node pressure.
+`resources` block, so those pods likely end up in the `BestEffort` QoS class, which the
+kubelet evicts first under node pressure.
 
-Check the restart reason:
+Check the QoS class, the container termination reason, and the pod status message:
 
 ```bash
 kubectl get pods -n vcluster-platform -o wide
+kubectl get pod -n vcluster-platform <pod> -o jsonpath='{.status.qosClass}'
 kubectl describe pod -n vcluster-platform <pod> | grep -A3 "Last State"
+kubectl get pod -n vcluster-platform <pod> -o jsonpath='{.status.message}'
 ```
 
-If you see `OOMKilled` or `Evicted`, set resource requests and limits on the affected
-template:
+The fix depends on which failure you see:
+
+- `OOMKilled`: the container exceeded its memory limit, or the node ran out of memory.
+  Measure actual usage with `kubectl top pod -n vcluster-platform` and set or raise the
+  memory limit accordingly. A limit that is too low causes this on its own.
+- `Evicted` under memory or CPU pressure: set memory and CPU requests so the kubelet
+  ranks the pod above pods that exceed their requests. The status message names the
+  pressure signal that triggered the eviction.
+
+Set requests and limits on the affected template:
 
 - Prometheus: the `resources` parameter. See [Deploy the metrics backend with Argo
   CD](./install-observability-gateway.mdx#deploy-the-metrics-backend-with-argo-cd).

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -118,6 +118,33 @@ can't connect:
 - If the gateway uses a `LoadBalancer` Service and a Platform-managed certificate, wait for
   the LoadBalancer address before expecting the gateway Deployment to become available.
 
+## Observability pods are OOMKilled or evicted
+
+The bundled templates deploy Prometheus, Grafana, and the collectors without an explicit
+`resources` block, so those containers get the `BestEffort` QoS class and the kubelet
+evicts them first under node pressure.
+
+Check the restart reason:
+
+```bash
+kubectl get pods -n vcluster-platform -o wide
+kubectl describe pod -n vcluster-platform <pod> | grep -A3 "Last State"
+```
+
+If you see `OOMKilled` or `Evicted`, set resource requests and limits on the affected
+template:
+
+- Prometheus: the `resources` parameter. See [Set Prometheus resource requests and
+  limits](./install-observability-gateway.mdx#set-prometheus-resource-requests-and-limits).
+- Grafana: the `resources` parameter. See [Set Grafana resource requests and
+  limits](./query-fleet-metrics.mdx#set-grafana-resource-requests-and-limits).
+- Collectors: the `otelDaemonResources` and `otelDeployResources` parameters. See [Set
+  collector resource requests and
+  limits](./configure-edge-collectors.mdx#set-collector-resource-requests-and-limits).
+
+Prometheus is the most likely to be OOMKilled, because its memory grows with active series
+count.
+
 ## Platform API outage
 
 The gateway and query proxy fail closed when Platform authorization is unavailable.

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -124,39 +124,19 @@ The bundled templates deploy Prometheus, Grafana, and the collectors without an 
 `resources` block, so those pods likely end up in the `BestEffort` QoS class, which the
 kubelet evicts first under node pressure.
 
-Check the QoS class, the container termination reason, and the pod status message:
+Check the QoS class, last container state, and status message:
 
 ```bash
-kubectl get pods -n vcluster-platform -o wide
-kubectl get pod -n vcluster-platform <pod> -o jsonpath='{.status.qosClass}'
-kubectl describe pod -n vcluster-platform <pod> | grep -A3 "Last State"
-kubectl get pod -n vcluster-platform <pod> -o jsonpath='{.status.message}'
+kubectl describe pod -n vcluster-platform <pod>
 ```
+
+Look for `QoS Class`, `Last State`, and `Message` in the output.
 
 The fix depends on which failure you see:
 
-- `OOMKilled`: the container exceeded its memory limit, or the node ran out of memory.
-  `kubectl top pod -n vcluster-platform <pod> --containers` only shows current per-container
-  usage. A restarted container resets to a fresh baseline, so it won't show the memory spike
-  that preceded the restart. Check historical usage instead. The bundled [golden signals
-  queries](../monitoring/fleet-monitoring-otel.mdx#golden-signals-queries) filter on tenant
-  workload labels that these platform pods don't carry, so query the platform namespace
-  directly in the bundled Prometheus or Grafana. Scope the query to the specific container
-  the resource parameter targets, since a pod can run more than one:
-
-  ```promql
-  max(max_over_time(container_memory_working_set_bytes{namespace="vcluster-platform", pod="<pod>", container="<container>"}[1h]))
-  ```
-
-  Use the peak this returns to size a limit that covers it. A limit that is too low causes
-  this on its own.
-- `Evicted` under memory pressure: set memory requests so the kubelet ranks the pod above
-  pods that exceed their requests. The status message names the pressure signal that
-  triggered the eviction. CPU pressure isn't one of the eviction signals. The kubelet
-  handles CPU contention through throttling, not eviction, so a CPU request affects
-  scheduling but won't prevent an eviction. `DiskPressure` and
-  `PIDPressure` evictions need the underlying node condition resolved (free disk space or
-  process count), not a requests or limits change on this pod.
+- `OOMKilled`: raise the memory limit on the affected template's `resources` parameter.
+- `Evicted`: set memory requests so the kubelet ranks the pod above pods that exceed their
+  own requests. Only memory, disk, and PID pressure trigger eviction, not CPU.
 
 Set requests and limits on the affected template:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Add new resources parameter for Grafana, Prometheus and OTEL Collector, introduced by loft-sh/loft-enterprise#7617

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2519--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/observability/install-observability-gateway#deploy-the-metrics-backend-with-argo-cd
https://deploy-preview-2519--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/observability/troubleshooting#observability-pods-are-oomkilled-or-evicted

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Part of ENGPLAT-798

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

