### PR TITLE
ci: grant checks and statuses read to the auto-approve caller

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -4,6 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# checks/statuses are what the shared workflow's CI poll reads. They must be
+# granted here, not there: a reusable workflow can only downgrade the caller's
+# GITHUB_TOKEN permissions, never elevate them, and anything omitted defaults to
+# none. GITHUB_TOKEN is scoped strictly by this block whatever the repository's
+# visibility, so omitting them makes the poll fail and the bot silently never
+# approve, while both the check and the job still report success.
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+  statuses: read
+
 jobs:
   auto-approve:
     uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main


### PR DESCRIPTION
## What

Adds a caller-side `permissions` block to the auto-approve workflow, granting `contents: read`, `pull-requests: write`, `checks: read`, and `statuses: read`.

## Why

The shared reusable workflow declares `checks: read` and `statuses: read` on its job. A reusable workflow can only downgrade the caller's `GITHUB_TOKEN`, never elevate it, and this caller has no `permissions` block at all — so every scope defaults to `none` and the workflow file is invalid:

```
Error calling workflow '...auto-approve-bot-prs.yaml@main'. The nested job 'auto-approve'
is requesting 'checks: read, statuses: read', but is only allowed
'checks: none, statuses: none'.
```

That is a startup failure, not a failing run. It surfaces the next time a bot opens a PR here — Renovate, Dependabot, or loft-bot — and the PR simply never gets approved, with nothing turning red where anyone would look.

Note this caller is pinned to `@main` of the shared workflow rather than a release tag, so it picks up shared-workflow changes immediately. The same fix already landed on `loft-sh/vcluster-pro`, `loft-sh/vcluster`, and `loft-sh/loft-enterprise`.

Ref: DEVOPS-1254
