### PR TITLE
fix(platform generator): normalize schema required arrays from +optional

### DIFF
--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -81,9 +81,10 @@ func generateSchema(configInstance interface{}) *jsonschema.Schema {
 	// than from explicit `jsonschema:"required"` tags, which those structs do
 	// not carry. renderField then derives the "required" badge from that array,
 	// so a field is only flagged required when the upstream type genuinely
-	// requires it within its parent object. The `+optional` comment override in
-	// renderField further demotes fields that lack `,omitempty` but are
-	// annotated optional.
+	// requires it within its parent object. normalizeRequired below reconciles
+	// the array with the `+optional` markers the fields document, and the same
+	// override in renderField keeps the badge correct for schemas that never go
+	// through reflection.
 	r.RequiredFromJSONSchemaTags = false
 	r.ExpandedStruct = true
 
@@ -140,7 +141,130 @@ func generateSchema(configInstance interface{}) *jsonschema.Schema {
 		r.CommentMap[k] = strings.ReplaceAll(r.CommentMap[k], ">", ")")
 	}
 
-	return r.Reflect(configInstance)
+	schema := r.Reflect(configInstance)
+	normalizeRequired(schema)
+
+	return schema
+}
+
+// normalizeRequired drops properties documented with a standalone Kubernetes
+// `+optional` marker from their parent object's `required` array.
+//
+// The reflector derives `required` from the absence of `,omitempty` in a field's
+// json tag (see generateSchema), which is not the same thing as Kubernetes
+// requiredness. Some loft-sh/api fields are deliberately `+optional` yet cannot
+// carry `,omitempty` because omitting an explicitly empty value would change its
+// meaning. ProjectSpec.AllowedNodeTypes is the canonical case: nil allows every
+// node type while an empty list allows none, so `,omitempty` would silently turn
+// "allow none" into "allow all". Reconciling the array here keeps the reflected
+// schema itself honest instead of leaving every consumer to re-derive
+// requiredness from the description.
+func normalizeRequired(schema *jsonschema.Schema) {
+	walkSchema(schema, map[*jsonschema.Schema]bool{}, func(s *jsonschema.Schema) {
+		if len(s.Required) == 0 || s.Properties == nil {
+			return
+		}
+
+		required := make([]string, 0, len(s.Required))
+		for _, name := range s.Required {
+			if property, ok := s.Properties.Get(name); ok && isOptional(property) {
+				continue
+			}
+
+			required = append(required, name)
+		}
+
+		if len(required) == 0 {
+			s.Required = nil
+			return
+		}
+
+		s.Required = required
+	})
+}
+
+// isOptional reports whether a property documents itself as optional. Nullable
+// fields (`jsonschema:"nullable"`) are reflected as a oneOf wrapper whose own
+// description is empty, with the documentation left on the non-null member, so
+// fall back to that member. renderField resolves the description the same way.
+func isOptional(property *jsonschema.Schema) bool {
+	if property == nil {
+		return false
+	}
+
+	if hasOptionalMarker(property.Description) {
+		return true
+	}
+	if property.Description != "" {
+		return false
+	}
+
+	for _, member := range property.OneOf {
+		if member == nil || member.Type == "null" {
+			continue
+		}
+		if hasOptionalMarker(member.Description) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasOptionalMarker(description string) bool {
+	for _, line := range strings.Split(description, "\n") {
+		if strings.TrimSpace(line) == "+optional" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// walkSchema calls visit on schema and on every subschema reachable from it.
+// The visited set keeps a self-referential schema from recursing forever, and a
+// shape this does not know about is simply not descended into, so an unexpected
+// upstream schema degrades to a no-op rather than breaking generation.
+func walkSchema(schema *jsonschema.Schema, visited map[*jsonschema.Schema]bool, visit func(*jsonschema.Schema)) {
+	if schema == nil || visited[schema] {
+		return
+	}
+	visited[schema] = true
+
+	visit(schema)
+
+	for _, definition := range schema.Definitions {
+		walkSchema(definition, visited, visit)
+	}
+	if schema.Properties != nil {
+		for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+			walkSchema(pair.Value, visited, visit)
+		}
+	}
+	for _, property := range schema.PatternProperties {
+		walkSchema(property, visited, visit)
+	}
+	for _, dependent := range schema.DependentSchemas {
+		walkSchema(dependent, visited, visit)
+	}
+	for _, group := range [][]*jsonschema.Schema{schema.AllOf, schema.AnyOf, schema.OneOf, schema.PrefixItems} {
+		for _, member := range group {
+			walkSchema(member, visited, visit)
+		}
+	}
+	for _, nested := range []*jsonschema.Schema{
+		schema.Items,
+		schema.Contains,
+		schema.AdditionalProperties,
+		schema.PropertyNames,
+		schema.ContentSchema,
+		schema.Not,
+		schema.If,
+		schema.Then,
+		schema.Else,
+	} {
+		walkSchema(nested, visited, visit)
+	}
 }
 
 func runInDir(dir string, fn func()) {
@@ -506,8 +630,9 @@ func buildContent(prefix string, schema *jsonschema.Schema, definitions jsonsche
 
 // requiredSet returns the set of property names that the schema marks as
 // required. For reflected types this comes from the Kubernetes `,omitempty`
-// convention (see generateSchema); for schemas loaded from a values.schema.json
-// file it comes from the `required` arrays already present in the file.
+// convention narrowed by the `+optional` markers (see generateSchema and
+// normalizeRequired); for schemas loaded from a values.schema.json file it comes
+// from the `required` arrays already present in the file.
 func requiredSet(schema *jsonschema.Schema) map[string]bool {
 	set := map[string]bool{}
 	for _, name := range schema.Required {

--- a/hack/platform/util/schema_test.go
+++ b/hack/platform/util/schema_test.go
@@ -3,8 +3,51 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/invopop/jsonschema"
 )
+
+// normalizeRequiredFixture mirrors the loft-sh/api shapes that motivated
+// normalizeRequired. The two slices deliberately omit `,omitempty` even though
+// they document `+optional`, because nil and an explicitly empty list mean
+// different things: nil allows everything, an empty list allows nothing. Adding
+// `,omitempty` would serialize an empty list as absent and so turn "allow none"
+// into "allow all", which is why the fix has to happen in the generator.
+type normalizeRequiredFixture struct {
+	DisplayName      string   `json:"displayName"`
+	AllowedNodeTypes []string `json:"allowedNodeTypes" jsonschema:"nullable"`
+	AllowedProfiles  []string `json:"allowedProfiles"`
+	Owner            string   `json:"owner,omitempty"`
+}
+
+// seedFixtureComments installs comments for fixture's fields into the package
+// comment map, keyed the way the reflector looks them up, and restores the
+// previous map afterwards. Seeding directly keeps the test off the vendor
+// extraction path, which needs a `vendor` directory relative to the working
+// directory. Unknown field names fail loudly so a rename cannot quietly turn
+// these assertions into no-ops.
+func seedFixtureComments(t *testing.T, fixture interface{}, comments map[string]string) {
+	t.Helper()
+
+	fixtureType := reflect.TypeOf(fixture)
+	for fixtureType.Kind() == reflect.Ptr {
+		fixtureType = fixtureType.Elem()
+	}
+
+	seeded := map[string]string{}
+	for field, comment := range comments {
+		if _, ok := fixtureType.FieldByName(field); !ok {
+			t.Fatalf("%s has no field %s", fixtureType.Name(), field)
+		}
+		seeded[fixtureType.PkgPath()+"."+fixtureType.Name()+"."+field] = comment
+	}
+
+	previous := commentMap
+	commentMap = seeded
+	t.Cleanup(func() { commentMap = previous })
+}
 
 func TestWriteGeneratedFileUsesNonExecutablePermissions(t *testing.T) {
 	for _, test := range []struct {
@@ -38,4 +81,117 @@ func TestWriteGeneratedFileUsesNonExecutablePermissions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateSchemaNormalizesRequiredFromOptionalMarkers(t *testing.T) {
+	seedFixtureComments(t, &normalizeRequiredFixture{}, map[string]string{
+		"DisplayName":      "DisplayName is the display name shown in the UI.",
+		"AllowedNodeTypes": "If unset (nil), all NodeTypes are allowed; an empty list disallows all NodeTypes.\n+optional",
+		"AllowedProfiles":  "AllowedProfiles holds the profiles this project may use.\n+optional",
+		"Owner":            "Owner describes the owner of the project.\n+optional",
+	})
+
+	required := requiredSet(generateSchema(&normalizeRequiredFixture{}))
+
+	for _, name := range []string{"allowedNodeTypes", "allowedProfiles"} {
+		if required[name] {
+			t.Errorf("%s is required, want optional: it documents +optional and omits ,omitempty deliberately", name)
+		}
+	}
+	if !required["displayName"] {
+		t.Error("displayName is optional, want required: it documents no +optional marker and omits ,omitempty")
+	}
+	if required["owner"] {
+		t.Error("owner is required, want optional: its json tag carries ,omitempty")
+	}
+}
+
+func TestGenerateSchemaNormalizesNullableOneOfDescription(t *testing.T) {
+	seedFixtureComments(t, &normalizeRequiredFixture{}, map[string]string{
+		"AllowedNodeTypes": "If unset (nil), all NodeTypes are allowed; an empty list disallows all NodeTypes.\n+optional",
+	})
+
+	schema := generateSchema(&normalizeRequiredFixture{})
+
+	// Guard the shape this test exists for: a `jsonschema:"nullable"` field is
+	// reflected as a oneOf of the real type plus null, which leaves the property
+	// itself undocumented and moves the marker onto the non-null member. If the
+	// reflector ever stops doing that, the assertion below would pass for the
+	// wrong reason.
+	property, ok := schema.Properties.Get("allowedNodeTypes")
+	if !ok {
+		t.Fatal("allowedNodeTypes is missing from the reflected properties")
+	}
+	if property.Description != "" {
+		t.Fatalf("allowedNodeTypes carries its own description %q, so this no longer covers the nullable oneOf shape", property.Description)
+	}
+	if len(property.OneOf) == 0 {
+		t.Fatal("allowedNodeTypes has no oneOf members, so this no longer covers the nullable oneOf shape")
+	}
+
+	documented := false
+	for _, member := range property.OneOf {
+		if member.Type != "null" && member.Description != "" {
+			documented = true
+		}
+	}
+	if !documented {
+		t.Fatal("no non-null oneOf member carries the description")
+	}
+
+	if requiredSet(schema)["allowedNodeTypes"] {
+		t.Error("allowedNodeTypes is required, want optional: the +optional marker on its non-null oneOf member was not honored")
+	}
+}
+
+func TestNormalizeRequiredClearsFullyOptionalObjects(t *testing.T) {
+	seedFixtureComments(t, &normalizeRequiredFixture{}, map[string]string{
+		"DisplayName":      "DisplayName is the display name shown in the UI.\n+optional",
+		"AllowedNodeTypes": "AllowedNodeTypes holds the allowed node types.\n+optional",
+		"AllowedProfiles":  "AllowedProfiles holds the allowed profiles.\n+optional",
+	})
+
+	// An object with nothing left to require must drop `required` entirely rather
+	// than emit an empty array.
+	if got := generateSchema(&normalizeRequiredFixture{}).Required; got != nil {
+		t.Errorf("required = %v, want nil", got)
+	}
+}
+
+func TestNormalizeRequiredToleratesUnusualSchemas(t *testing.T) {
+	t.Run("nil schema", func(t *testing.T) {
+		normalizeRequired(nil)
+	})
+
+	t.Run("required without properties", func(t *testing.T) {
+		schema := &jsonschema.Schema{Type: "object", Required: []string{"name"}}
+
+		normalizeRequired(schema)
+
+		if len(schema.Required) != 1 || schema.Required[0] != "name" {
+			t.Errorf("required = %v, want [name]: requiredness cannot be disproved without a property to read", schema.Required)
+		}
+	})
+
+	t.Run("required naming an absent property", func(t *testing.T) {
+		seedFixtureComments(t, &normalizeRequiredFixture{}, map[string]string{
+			"DisplayName": "DisplayName is the display name shown in the UI.",
+		})
+		schema := generateSchema(&normalizeRequiredFixture{})
+		schema.Required = append(schema.Required, "absent")
+
+		normalizeRequired(schema)
+
+		if !requiredSet(schema)["absent"] {
+			t.Error("absent was dropped from required, want kept: an unresolvable name says nothing about optionality")
+		}
+	})
+
+	t.Run("self referential schema", func(t *testing.T) {
+		schema := &jsonschema.Schema{Type: "object"}
+		schema.Not = schema
+		schema.AllOf = []*jsonschema.Schema{schema}
+
+		normalizeRequired(schema)
+	})
 }


### PR DESCRIPTION
# Content Description

Normalizes the Platform reference generator's reflected `required` arrays against the Kubernetes `+optional` markers, so the schema itself is correct rather than relying on the renderer to re-derive requiredness. No generated content changes.

## Summary

The reflector infers requiredness from the absence of `,omitempty` in a field's json tag, which is not the same thing as Kubernetes requiredness. `ProjectSpec.AllowedNodeTypes` and `ProjectSpec.AllowedNodeProfiles` are the reproducible case: both document `+optional`, and neither can carry `,omitempty`, because nil means "allow every node type" while an empty list means "allow none". Serializing an empty list as absent would widen "allow none" into "allow all", which is why the source-side fix in ENGCP-969 was canceled.

This adds a normalization pass right after reflection: for every object, a property documenting a standalone `+optional` marker is dropped from its parent's `required` array.

Nothing was broken on the docs site. #2321 already taught `renderField` to demote `+optional` fields, so the published badge was correct. What was wrong was the schema underneath it, and the fact that correctness depended on the renderer re-deriving requiredness from the description. This is hardening, not a user-visible fix.

## Key Changes

`hack/platform/util/schema.go`

- `generateSchema` now runs `normalizeRequired` on the reflected schema before returning it.
- `normalizeRequired` walks the root plus every reachable subschema and strips `+optional` properties from each object's `required` array. An object left with nothing required drops `required` entirely instead of emitting an empty array.
- Nullable fields are handled: `jsonschema:"nullable"` reflects as a `oneOf` of the real type plus null, which leaves the property's own description empty and moves the marker onto the non-null member, so the check falls back to that member. This reuses the shape `renderField` already established in #2321.
- The walk is deliberately lenient. A cycle terminates via a visited set, a `required` entry naming a property that cannot be resolved is kept rather than guessed at, and an unrecognized schema shape is simply not descended into. Given how often this generator has been broken by upstream `loft-sh/api` churn, an unexpected shape should degrade to a no-op instead of failing generation.

`hack/platform/util/schema_test.go`

Four new tests. The file previously had no schema-generation coverage at all, so this adds the fixture scaffolding too. Comments are seeded directly into the package comment map, keyed the way the reflector looks them up, which keeps the tests off the vendor extraction path (it needs a `vendor` directory relative to the working directory, which does not exist under the package dir). Unknown field names fail loudly, so a rename cannot quietly turn the assertions into no-ops.

- `TestGenerateSchemaNormalizesRequiredFromOptionalMarkers`: an optional slice where nil and empty differ is demoted, and a genuinely required field stays required.
- `TestGenerateSchemaNormalizesNullableOneOfDescription`: asserts the reflector really does produce the nullable `oneOf` shape before asserting the demotion, so the test cannot pass for the wrong reason.
- `TestNormalizeRequiredClearsFullyOptionalObjects`: a fully optional object emits no `required` key.
- `TestNormalizeRequiredToleratesUnusualSchemas`: nil schema, `required` without properties, `required` naming an absent property, and a self-referential schema.

### On the renderer fallback

Issue step 5 asked whether to keep or simplify the `renderField` demotion. It stays, and it is not redundant. The vcluster generator enters this package through `RenderFromPath` with a schema loaded from `values.schema.json`, which never passes through `generateSchema` and so is never normalized. Removing the fallback would make correctness depend on the normalization pass reaching every render path, which it does not. The marker-stripping loop in `renderField` also has to stay regardless, since it removes `+` lines from the rendered prose.

## Verification

Acceptance criteria, all checked against the artifact rather than reasoned about:

- `AllowedNodeTypes` and `AllowedNodeProfiles` absent from the reflected `ProjectSpec.required`. Confirmed by reflecting the real `storagev1.ProjectSpec` at the current `go.mod` pin (v4.11.0). Before: `required = [allowedNodeTypes allowedNodeProfiles]`. After: `required = []`.
- Source json tags unchanged. No `,omitempty` added anywhere; this PR touches two files, both under `hack/platform/util`.
- Regression test for an optional slice where nil and `[]` differ. Covered.
- Test for the nullable `oneOf` description shape. Covered.
- Genuinely required fields still required. Covered.
- Generated output still marks both fields optional. Yes, and unchanged.
- No unrelated requiredness changes. Confirmed the strong way: a baseline regeneration on `main` produces zero content changes, proving the checked-in partials already match the current generator, and a regeneration with this change also produces zero content changes across all 158 files. So no field anywhere changed requiredness in the rendered output, which is the expected result given #2321.

The three behavioral tests were verified to fail with the normalization call disabled and pass with it, so they are not vacuous.

One caveat on that, worth a reviewer's attention: no workflow in this repo runs `go test` on pull requests, so these tests were run locally (`go test ./hack/platform/util/`, plus `go build ./hack/...`, `go vet`, and `gofmt`) and CI will not re-run them here or guard against a future regression. Wiring up a Go test job is separate scope and not attempted in this PR, but it does limit what the green checks below actually prove about `hack/`.

Note on file modes: regenerating rewrites 158 partials from mode 755 to 644, because the checked-in copies predate the `writeGeneratedFile` permission fix. That drift is pre-existing and unrelated to this issue, so it is deliberately not included here. Worth a separate cleanup.

## Preview Link

This PR changes no `.mdx` files, so there are no changed documents to preview. The page whose badges the change concerns, expected to be identical to production:

- https://deploy-preview-2528--vcluster-docs-site.netlify.app/docs/platform/next/api/resources/project/project

## Backporting

Not applicable. The generator source is single-copy on `main`, and the rendered output does not change, so there is nothing to apply to `platform_versioned_docs/`.

## Dependencies

None. Self-contained in one package.

## TODO

- [x] Normalization pass
- [x] Regression tests, verified non-vacuous
- [x] Regeneration diff measured against a baseline
- [ ] Review

## Internal Reference

Closes DOC-1659

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs