### PR TITLE
fix(docs): prevent v0.22 archive indexing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,6 +50,7 @@ const config = {
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
+  noIndex: true,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,11 @@ command = """
   NODE_VERSION = "20"
   NODE_OPTIONS = "--max-old-space-size=8192"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"
+
 [[redirects]]
   from = "/docs/architecture/*"
   to = "/docs/vcluster/introduction/architecture/"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Prevent search engines from indexing the vCluster v0.22 archive. Add page-level and response-level `noindex` signals without changing `robots.txt`.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Document Preview](https://deploy-preview-2534--vcluster-docs-site.netlify.app/docs)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-1675
