### PR TITLE
fix(docs): prevent platform v4.4 archive indexing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -51,6 +51,7 @@ const config = {
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
+  noIndex: true,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,11 @@ command = """
 [build.processing.html]
   pretty_urls = true
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"
+
 # Redirects - Order matters (first match wins)
 # Specific paths before wildcards, /next/ stays in /next/
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Prevent search engines from indexing the Platform v4.4 archive. Add page-level and response-level `noindex` signals without changing `robots.txt`.


## Preview Link 
<!-- The preview link or links to the documents-->

Netlify deploy preview is attached by the status check.


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-1675


**AI review:** mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs
