### PR TITLE
docs: add archive noindex checks

### DIFF
--- a/.claude/skills/vcluster-docs-archiver/references/quick-checklist.md
+++ b/.claude/skills/vcluster-docs-archiver/references/quick-checklist.md
@@ -18,17 +18,29 @@ This checklist guides the process of preparing End-of-Life (EOL) documentation b
 
 ### 2. Configure Docusaurus Build
 **File:** `docusaurus.config.js`
+- [ ] Set `noIndex: true` at the top level of the config
 - [ ] Set vCluster `lastVersion` to the EOL version (e.g., `"0.24.0"`)
 - [ ] Set vCluster `onlyIncludeVersions` to only this version: `["0.24.0"]`
 - [ ] Set platform plugin `lastVersion` to latest platform version (e.g., `"4.3.0"`)
 - [ ] Add platform plugin `onlyIncludeVersions: ["4.3.0"]`
 
-### 3. Clean Version Dropdowns
+### 3. Configure crawler response headers
+**File:** `netlify.toml`
+- [ ] Add `X-Robots-Tag: noindex` to every response:
+```toml
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"
+```
+- [ ] Do not block the archive in `robots.txt`. Crawlers must fetch a page to read its `noindex` signal.
+
+### 4. Clean Version Dropdowns
 **File:** `src/theme/DocSidebar/Desktop/Content/index.js`
 - [ ] Set `dropdownItemsAfter={[]}` for both vCluster and platform selectors
 - [ ] This removes all external version links from the dropdown
 
-### 4. Fix Broken Links
+### 5. Fix Broken Links
 Common patterns to fix:
 - [ ] Replace `@site` imports with relative paths in versioned docs
 - [ ] Fix fragment imports (must use absolute paths when imported across directories)
@@ -37,12 +49,12 @@ Common patterns to fix:
 - [ ] Clear cache: `rm -rf .docusaurus build node_modules/.cache`
 - [ ] Run build to verify: `npm run build`
 
-### 5. Deploy to Netlify
+### 6. Deploy to Netlify
 - [ ] Add branch to Netlify deployments
 - [ ] Branch URL format: `vcluster-v0-XX--vcluster-docs-site.netlify.app`
 - [ ] Verify deployment succeeds
 
-### 6. Add Redirects to vcluster.com
+### 7. Add Redirects to vcluster.com
 **File:** `/themes/loft/static/_redirects` in vcluster.com repo
 - [ ] Add redirect entries for the new EOL version:
 ```
@@ -51,7 +63,7 @@ Common patterns to fix:
 /docs/v0.XX/*       https://vcluster-v0-XX--vcluster-docs-site.netlify.app/docs/vcluster/:splat   302!
 ```
 
-### 7. Update Main Branch Documentation Menu
+### 8. Update Main Branch Documentation Menu
 **In main/master branch of vcluster-docs:**
 
 **File:** `docusaurus.config.js`
@@ -70,6 +82,8 @@ Common patterns to fix:
 ## Verification
 - [ ] EOL branch builds successfully with only its version
 - [ ] Netlify deployment is accessible
+- [ ] A live HTML response contains a robots meta tag with `noindex`
+- [ ] A live response contains an `X-Robots-Tag` header with `noindex`
 - [ ] Redirects from vcluster.com work correctly
 - [ ] Version appears in main docs dropdown and redirects properly
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Add page-level and response-level `noindex` controls to the archive checklist, including post-deploy verification.


## Preview Link 
<!-- The preview link or links to the documents-->

No rendered documentation page changes.


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-1675


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
