### PR TITLE
docs: fix EOL redirect gap for 0.28.0-0.33.0 and archiver skill (DOC-1689)

### DIFF
--- a/.claude/skills/vcluster-docs-archiver/SKILL.md
+++ b/.claude/skills/vcluster-docs-archiver/SKILL.md
@@ -108,6 +108,20 @@ git checkout main
 git status  # Show staged changes to user
 ```
 
+### Step 5b: Add Long-Form Redirect in vcluster-docs (REQUIRED)
+
+This is a **separate redirect layer from Step 6** — easy to miss because it lives in this repo, not vcluster.com. Deleting the versioned folder in Step 5 removes the long-form `/docs/vcluster/X.Y.Z/*` URLs from the build; without this redirect, they 404 instead of falling back to latest.
+
+In this repo's `netlify.toml`, add a row to the "Removed vCluster versions — redirect to latest" block:
+```toml
+[[redirects]]
+  from = "/docs/vcluster/0.22.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+```
+
+Keep the block in ascending version order alongside the existing rows.
+
 ### Step 6: Add Redirects (REQUIRED)
 In `/home/decoder/loft/vcluster.com/themes/loft/static/_redirects`:
 ```
@@ -179,6 +193,7 @@ We archived vCluster vX.XX documentation to standalone Netlify branch deploys.
 | Real example | `references/platform-4.2-example.md` |
 | Netlify setup | Configure in Netlify dashboard, then empty commit |
 | Merge order | Redirects (vcluster.com) FIRST, then dropdown (vcluster-docs) |
+| Long-form URL redirect | Add row to `netlify.toml` "Removed vCluster versions" block (this repo) — separate from the vcluster.com redirects |
 
 ## Final Checklist (Copy-Paste for User)
 
@@ -199,12 +214,14 @@ Archive Complete! Final steps:
 
 □ 4. MERGE ORDER (critical!):
    a. FIRST: Merge redirects PR (vcluster.com)
-   b. THEN: Merge dropdown PR (vcluster-docs)
+   b. THEN: Merge dropdown PR (vcluster-docs) — confirm it includes the
+      netlify.toml row from Step 5b, not just the dropdown/version removal
 
 □ 5. Post to Slack (optional)
    - Use template from Step 7
 
 □ 6. Verify production
    - Check vcluster.com/docs/vX.XX redirects correctly
+   - Check vcluster.com/docs/vcluster/X.Y.Z/* (long-form URL) redirects to latest
    - Check dropdown shows new EOL version
 ```

--- a/.claude/skills/vcluster-docs-archiver/references/complete-checklist.md
+++ b/.claude/skills/vcluster-docs-archiver/references/complete-checklist.md
@@ -183,6 +183,14 @@ On the main branch:
     }
   ]}
   ```
+- [ ] Add a row to the "Removed vCluster versions — redirect to latest" block in this repo's `netlify.toml`:
+  ```toml
+  [[redirects]]
+    from = "/docs/vcluster/0.22.0/*"
+    to = "/docs/vcluster/:splat"
+    status = 301
+  ```
+  This is separate from the vcluster.com `_redirects` entries in step 7 above — it covers the long-form `/docs/vcluster/X.Y.Z/*` URL, which otherwise 404s once the versioned folder is deleted instead of falling back to latest.
 
 ## Common Issues & Quick Solutions
 

--- a/.claude/skills/vcluster-docs-archiver/references/quick-checklist.md
+++ b/.claude/skills/vcluster-docs-archiver/references/quick-checklist.md
@@ -79,6 +79,16 @@ Common patterns to fix:
 }
 ```
 
+**File:** `netlify.toml` (this repo — separate from the vcluster.com redirects in step 7)
+- [ ] Add a row to the "Removed vCluster versions — redirect to latest" block, in ascending version order:
+```toml
+[[redirects]]
+  from = "/docs/vcluster/0.XX.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+```
+- [ ] Without this, the long-form `/docs/vcluster/0.XX.0/*` URL 404s instead of falling back to latest — deleting the versioned folder in this step removes the build path, but doesn't redirect it.
+
 ## Verification
 - [ ] EOL branch builds successfully with only its version
 - [ ] Netlify deployment is accessible
@@ -86,6 +96,7 @@ Common patterns to fix:
 - [ ] A live response contains an `X-Robots-Tag` header with `noindex`
 - [ ] Redirects from vcluster.com work correctly
 - [ ] Version appears in main docs dropdown and redirects properly
+- [ ] Long-form URL `vcluster.com/docs/vcluster/0.XX.0/*` redirects to latest (not a 404)
 
 ## Notes
 - Each EOL branch is self-contained with only its version documentation

--- a/netlify.toml
+++ b/netlify.toml
@@ -900,6 +900,36 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   to = "/docs/vcluster/:splat"
   status = 301
 
+[[redirects]]
+  from = "/docs/vcluster/0.28.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/vcluster/0.29.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/vcluster/0.30.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/vcluster/0.31.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/vcluster/0.32.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/docs/vcluster/0.33.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+
 # =====================================================
 # Config restructure - sleep-mode renamed to sleep
 # =====================================================


### PR DESCRIPTION
# Content Description
Backfills the missing `0.28.0`-`0.33.0` rows in `netlify.toml`'s "Removed vCluster versions" block (customer hit a 404 on an archived `0.29.0` link instead of a redirect to latest), and adds a step to the `vcluster-docs-archiver` skill so future EOL archives don't drop this redirect layer again. The skill's redirect step only ever covered the separate vcluster.com short-alias redirects, not this repo's own long-form `netlify.toml` block.

## Preview Link 
N/A - no content pages changed (netlify.toml + internal skill docs only)

## Internal Reference
Closes DOC-1689

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs