### PR TITLE
docs(doc-1692,doc-1693): restore files dropped from platform v4.10/v4.11 backports

### DIFF
--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -43,7 +43,7 @@ sure you are taking advantage of Projects when considering your RBAC strategy.
 ### 1. Create test user
 
 vCluster Platform lets you connect a variety of SSO providers for authentication but for the sake of
-simplicity, this guide manually creates a user to demonstrate vCluster Platform's cluster access features:
+simplicity, manually create a user to learn more about vCluster Platform's cluster access features:
 
 <Flow id="create-user">
   <Step>
@@ -53,13 +53,13 @@ simplicity, this guide manually creates a user to demonstrate vCluster Platform'
     Click the <Button>Add User</Button> button.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new user a name of{" "}
+    In the configuration sheet that opens, give your new user a name of{" "}
     <Input>Anna</Input>
     by replacing the 'my-user' placeholder name, or by updating the manifest YAML
     'metadata. name' field.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button> button.
+    Click the <Button>Save Changes</Button> button.
   </Step>
   <Step image="">
     Close the popup using the button <Button>Copy & Close</Button>
@@ -74,16 +74,15 @@ cluster and you could also manage these actions using kubectl or any kind of Git
 
 ### 2. Impersonate user
 
-vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. This section shows
-how vCluster Platform UI would look like for the newly created user:
+vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. This demonstrates
+how vCluster Platform UI appears for the newly created user:
 
 <Flow id="impersonate-user">
   <Step>
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    Find the user `Anna` in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click the{" "}
+    Find the user `Anna` in the list of users and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"
@@ -122,7 +121,7 @@ command while the impersonation is active.
 vcluster platform login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
 ```
 
-You can verify the login and print your user information using:
+You can verify the login and print your user information by running:
 
 ```bash
 vcluster platform login
@@ -130,30 +129,27 @@ vcluster platform login
 
 ### 3. Configure cluster access
 
-This section gives the test user Anna access to one of the clusters connected to this vCluster Platform instance:
+Give the test user Anna access to one of the clusters connected to this vCluster Platform instance:
 
 <PartialClusterAccessCreateUI />
 
 :::note Single Sign-On + Cluster Access
 You can connect a variety of SSO providers to vCluster Platform. To automatically give users access to
 clusters based on their SSO user groups, you can switch to the <Label>Team Members</Label> tab
-to grant cluster access for each member of a team (for example, for each member of a group in Active
-Directory, Okta, SAML, and so on), check out the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
+to grant cluster access for each member of a team (for example, a group in Active Directory, Okta, or SAML), see the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
 more details.
 :::
 
 ### 4. Verify cluster access
 
-After configuring the cluster access for test user Anna, verify that she can access the
-cluster:
+After configuring the cluster access for test user Anna, verify that she can access the cluster:
 
 <Flow id="impersonate-user-with-cluster-access">
   <Step>
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    Find the user Anna in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click the{" "}
+    Find the user Anna in the list of users and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"

--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/suspend.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/suspend.mdx
@@ -19,12 +19,9 @@ lock an user if you want to preserve the users environments without deleting the
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    In the user row you want to lock, hover over the blue drop down arrow and
-    select
-    <Label>Lock User</Label> from the menu options.
+    In the user row you want to lock, click the actions menu and select <Label>Lock User</Label>.
   </Step>
   <Step>
-    To unlock the user, select <Label>Unlock User</Label> from the same drop
-    down menu.
+    To unlock the user, click the actions menu and select <Label>Unlock User</Label>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/cluster.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/cluster.mdx
@@ -42,18 +42,18 @@ Cluster access lets you define access to certain clusters for your users or team
     Click the <NavStep>Cluster Access</NavStep> tab and then click <Button>Create Cluster Access</Button>.
   </Step>
   <Step>
-    In the drawer that appears from the right, give the access a name by replacing the auto-generated placeholder name, or by updating the manifest YAML 'metadata.name' field.
+    In the configuration sheet that opens, give the access a name by replacing the auto-generated placeholder name, or by updating the manifest YAML 'metadata.name' field.
   </Step>
   <Step>
-    In the <Label>Options</Label> configuration pane, choose the User or Team you wish to grant the access, from the <Label>Cluster Access ...</Label> drop down menu. Subsequently choose the cluster role to be assigned to the selected user or team from the <Label>Cluster Roles ...</Label> drop down menu.
+    In the <Label>Options</Label> tab, choose the user or team to grant access from the <Label>Cluster Access</Label> selector, then choose the cluster role from the <Label>Cluster Roles</Label> selector.
   </Step>
   <Step>
-    In the <Label>Clusters</Label> configuration pane, choose the cluster to which the User or Team should be granted access, from the <Label>Select Clusters ...</Label> drop down menu.
+    In the <Label>Clusters</Label> tab, choose the cluster to which the user or team should be granted access from the <Label>Select Clusters</Label> selector.
   </Step>
   <Step>
-    In the <Label>Access</Label> configuration pane, Select the User or Team that should have access to the underlying cluster access object, from the <Label>User & Teams ...</Label> drop down menu. Choose what actions they are allowed to perform on this object, from the <Label>Permissions ...</Label> drop down menu.
+    In the <Label>Access</Label> tab, select the user or team that can manage this cluster access object, then choose their allowed permissions.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button>  button to create the cluster access.
+    Click <Button>Save Changes</Button> to create the cluster access.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/namespace.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/namespace.mdx
@@ -12,7 +12,7 @@ import Button from '@site/src/components/Button'
 import PartialNamespaceShareUI from '../../../_partials/namespace/share-ui.mdx'
 import PartialNamespaceShareCLI from '../../../_partials/namespace/share-cli.mdx'
 
-Namespace access can be managed through the 'Permissions' section inside the namespace drawer. There are a couple of special cases:
+Namespace access can be managed through the 'Permissions' section inside the namespace configuration sheet. There are a couple of special cases:
 1. Global Admins & Project Admins have access and can change **all** namespaces within a project.
 2. Tenant Cluster owners always have access and can change their namespaces.
 3. Every user or team within the management cluster that has the RBAC permission on the resource "spaceinstances" in api group "management.loft.sh" for the verb "use" can access the namespace.

--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/project.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/permissions/project.mdx
@@ -54,7 +54,7 @@ spec:
     Click the <NavStep>Create Role</NavStep> button at the right bottom of the page.
   </Step>
   <Step>
-    If you created a project role, you can click the <NavStep>Project Settings</NavStep>, and then find the display name of the created project role in the dropdown menu of the role for each member under the Members and Roles section.
+    If you created a project role, click <NavStep>Project Settings</NavStep> and find the display name of the created project role in the role selector for each member under the <Label>Members and Roles</Label> section.
   </Step>
 </Flow>
 
@@ -67,13 +67,13 @@ remove them from the project.
 
 <Flow id="project-add-user">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Users</NavStep> tab.
+    Click the <NavStep>Users</NavStep> tab.
   </Step>
   <Step>
     Click the <Label>Users</Label> input and select the user to add. The table
@@ -96,13 +96,13 @@ Instead of adding every user, a special selection named `All Users` can be used 
 
 <Flow id="project-remove-user">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Users</NavStep> tab.
+    Click the <NavStep>Users</NavStep> tab.
   </Step>
   <Step>
     Click the trash can icon next to the user that you'd like to remove. If you wish to change this manually, you may edit the YAML directly.
@@ -122,13 +122,13 @@ Instead of having to assign individual users, teams can be used to assign multip
 
 <Flow id="project-add-team">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Teams</NavStep> tab.
+    Click the <NavStep>Teams</NavStep> tab.
   </Step>
   <Step>
     Click the <Label>Teams</Label> input and select the team to add. The table
@@ -148,13 +148,13 @@ Instead of having to assign individual users, teams can be used to assign multip
 
 <Flow id="project-remove-team">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Teams</NavStep> tab
+    Click the <NavStep>Teams</NavStep> tab
   </Step>
   <Step>
     Click the trash can icon next to the team that you'd like to remove. If you wish to change this manually, you may edit the YAML directly.

--- a/platform_versioned_docs/version-4.10.0/configure/agent-settings/agent-upgrade.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/agent-settings/agent-upgrade.mdx
@@ -74,12 +74,11 @@ Or you can finish this in vCluster Platform UI:
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click the drop down arrow next to the cluster name you wish to modify. In
-    the drop down menu click the <Label>Edit</Label> button.
+    Click the <Button>Edit</Button> option for the cluster you want to modify.
   </Step>
   <Step>
-    In the drawer that appears from the right, click the <Label>Agent</Label>{" "}
-    configuration pane and select the 'Ignore Agent' checkbox.
+    In the configuration sheet that opens, click the <Label>Agent</Label> tab
+    and enable <Label>Ignore Agent</Label>.
   </Step>
   <Step>
     Click the <Button>Save Changes</Button> button.

--- a/platform_versioned_docs/version-4.10.0/configure/agent-settings/customization.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/agent-settings/customization.mdx
@@ -19,7 +19,7 @@ As described in [installation modes][install-modes], the vCluster Platform Agent
 However, this means that all control plane clusters connecting to the platform will share the same configuration. If different connected control plane clusters require different agent configurations, there are two supported approaches.
 
 ## `loft.sh/agent-values` annotation {#loftsh-annotations}
-Add the `loft.sh/agent-values` annotation to a specific Cluster resource (using the UI or YAML). This annotation overrides the platform-level `agentValues`. The override applies only to the annotated Cluster. For example:
+Add the `loft.sh/agent-values` annotation to a specific Cluster resource (through the UI or YAML). This annotation overrides the platform-level `agentValues`. The override applies only to the annotated Cluster. For example:
   ```yaml
   loft.sh/agent-values: |
     replicaCount: 2
@@ -48,15 +48,13 @@ You can also update the agent settings in vCluster Platform UI.
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
 </Step>
 <Step>
-    Click the drop down arrow next to the cluster name you wish to modify. In
-    the drop down menu click the <Label>Edit</Label> button.
+    Click the <Button>Edit</Button> option for the cluster you want to modify.
 </Step>
 <Step>
-    In the drawer that appears from the right, click the <Label>Agent</Label>{" "}
-    configuration pane. Provide the values in the textarea under{" "}
-    <Label>Extra Agent Values</Label> in the YAML format.
+    In the configuration sheet that opens, click the <Label>Agent</Label> tab.
+    Provide the values in the <Label>Extra Agent Values</Label> field in YAML format.
 </Step>
 <Step>
-    Click on the <Button>Save Changes</Button> button.
+    Click the <Button>Save Changes</Button> button.
 </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/platform-configs/single-sign-on.mdx
@@ -113,22 +113,19 @@ the platform, they are going to be added to all matching Teams.
 <!-- vale off -->
 <Flow id="create-team-with-sso-group-membership">
   <Step>
-    Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
-  </Step>
-  <Step>
-    Click the <NavStep>Teams</NavStep> button on the User Management screen.
+    Go to <NavStep>Access & Secrets > Users & Roles</NavStep> and select the <NavStep>Teams</NavStep> tab.
   </Step>
   <Step>
     Click the <Button>Add Team</Button> button.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new team a name by
-    replacing the  'my-team' placeholder name, or by updating the manifest YAML
+    In the configuration sheet that opens, give your new team a name by
+    replacing the 'my-team' placeholder name, or by updating the manifest YAML
     'metadata.name' field.
   </Step>
   <Step>
     In the <Label>Team Members</Label> tab enter any desired groups into the{" "}
-    <Label>SSO Groups as Members</Label> field. You can add as many groups as
+    <Label>SSO groups</Label> field. You can add as many groups as
     you would like here. These group names must exactly match the group name
     that the SSO provider shares with the platform during SSO authentication.
   </Step>

--- a/platform_versioned_docs/version-4.10.0/how-to/disable-local-admin.mdx
+++ b/platform_versioned_docs/version-4.10.0/how-to/disable-local-admin.mdx
@@ -43,7 +43,7 @@ There are two steps to fully disable the local admin:
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    In the admin user row, hover over the blue drop down arrow and select <Label>Lock User</Label> from the menu options.
+    In the admin user row, click the actions menu and select <Label>Lock User</Label>.
   </Step>
 </Flow>
 
@@ -96,6 +96,6 @@ If SSO becomes unavailable and you need to regain access:
 3. Unlock the admin user:
    - Log in with the reset password
    - Go to <NavStep>Access & Secrets > Users & Roles</NavStep>
-   - Select **Unlock User** from the admin user's dropdown menu
+   - Click the actions menu on the admin user row and select **Unlock User**
 
 After regaining access, investigate the SSO issue, and fix it before re-locking the admin account.

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/connect-akuity.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/connect-akuity.mdx
@@ -7,6 +7,7 @@ sidebar_position: 3
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
@@ -60,18 +61,18 @@ See the [Akuity API key documentation](https://docs.akuity.io/organizations/api-
 
 <Flow>
   <Step>
-    Click <Label>Connectors</Label> and select the <Label>Argo CD</Label> tab.
+    Go to <NavStep>Infrastructure > Connectors</NavStep> and select the <Label>Argo CD</Label> tab.
   </Step>
   <Step>
-    Click <Button>Add ArgoCD Connector</Button>.
+    Click <Button>Connect Argo CD</Button>.
   </Step>
   <Step>
     In the <Label>Display name</Label> field, enter a human-readable name for the connector.
-    The <Label>ArgoCD Connector ID</Label> is auto-generated from the display name and is used to reference this connector from clusters.
+    The <Label>Argo CD Connector ID</Label> is auto-generated from the display name and is used to reference this connector from clusters.
   </Step>
   <Step>
     Enable the <Label>Use Akuity API</Label> toggle, then fill in:
-    - <Label>Organization ID</Label>: your Akuity organization ID
+    - <Label>Org ID</Label>: your Akuity organization ID
     - <Label>Argo CD Instance</Label>: the Argo CD instance ID within your organization
     - <Label>API Key ID</Label> and <Label>API Key Secret</Label>: your Akuity API key credentials
   </Step>
@@ -91,7 +92,7 @@ See the [Akuity API key documentation](https://docs.akuity.io/organizations/api-
     Optionally override <Label>Replicas</Label> and <Label>Memory</Label> for the `argocd-repo-server` (see [Agent sizing](#agent-sizing) below).
   </Step>
   <Step>
-    Click <Button>Create ArgoCD Connector</Button>.
+    Click <Button>Connect Argo CD</Button>.
   </Step>
 </Flow>
 
@@ -175,7 +176,7 @@ stringData:
 | `insecure` | No | Set to `"true"` to skip TLS verification. Defaults to `"false"` |
 | `akuityOrgId` | Yes | Akuity organization ID |
 | `akuityInstanceId` | Yes | Argo CD instance ID within your Akuity organization |
-| `akuityApiKeyId` | Yes | Akuity API key ID, used to register and manage clusters via the Akuity API |
+| `akuityApiKeyId` | Yes | Akuity API key ID, used to register and manage clusters using the Akuity API |
 | `akuityApiKeySecret` | Yes | Akuity API key secret |
 | `akuityAgentSize` | No | Agent size profile: `CLUSTER_SIZE_SMALL`, `CLUSTER_SIZE_MEDIUM` (default), or `CLUSTER_SIZE_LARGE`. See [Agent sizing](#agent-sizing). |
 | `akuityRepoServerReplicas` | No | Override the `argocd-repo-server` replica count. See [Agent sizing](#agent-sizing). |
@@ -220,7 +221,7 @@ integrations:
     connector: akuity-prod
 ```
 
-The connector can also be set directly in the `VirtualClusterInstance` manifest:
+The connector can also be set directly in the VirtualClusterInstance manifest:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -241,7 +242,7 @@ spec:
               connector: akuity-prod
 ```
 
-When the `VirtualClusterInstance` reconciles, Platform registers the tenant cluster with Akuity, retrieves the agent manifest, and installs the agent into the cluster.
+When the VirtualClusterInstance reconciles, Platform registers the tenant cluster with Akuity, retrieves the agent manifest, and installs the agent into the cluster.
 
 ### On a control plane cluster
 
@@ -259,7 +260,7 @@ spec:
 ```
 
 :::warning Disabling the integration
-Disabling the integration removes the cluster from Akuity, uninstalls the agent namespace from the cluster, and deletes all `ArgoCDApplication` objects managed by Platform. This applies whether the integration is configured via `vcluster.yaml`, a `VirtualClusterInstance` manifest, or a `Cluster` object. Any applications deployed by the integration will be removed from Argo CD.
+Disabling the integration removes the cluster from Akuity, uninstalls the agent namespace from the cluster, and deletes all `ArgoCDApplication` objects managed by Platform. This applies whether the integration is configured using `vcluster.yaml`, a VirtualClusterInstance manifest, or a Cluster object. Any applications deployed by the integration will be removed from Argo CD.
 :::
 
 ## Next step

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/deploy-applications.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/deploy-applications.mdx
@@ -7,6 +7,7 @@ sidebar_position: 4
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
@@ -31,21 +32,21 @@ An `ArgoCDApplicationTemplate` is a reusable Argo CD ApplicationSpec. Create one
 
 <Flow>
   <Step>
-    Click <Label>Argo CD Templates</Label> in the left sidebar.
+    Go to <NavStep>Tenant Management > Argo CD Templates</NavStep>.
   </Step>
   <Step>
-    Click <Button>Add ArgoCD Application Template</Button>.
+    Click <Button>Create Argo CD Template</Button>.
   </Step>
   <Step>
-    In the <Label>Basics</Label> section, enter a <Label>Display Name</Label> for the template.
-    The <Label>ArgoCD Application Template ID</Label> is auto-generated from the display name and is the identifier you reference in your applications.
+    In the <Label>Basics</Label> section, enter a <Label>Display name</Label> for the template.
+    The <Label>Argo CD Template ID</Label> is auto-generated from the display name and is the identifier you reference in your applications.
     Optionally add a <Label>Description</Label>.
   </Step>
   <Step>
-    In the <Label>ArgoCD Application Spec</Label> section, fill in the YAML editor with the Argo CD ApplicationSpec.
+    In the <Label>Config Options</Label> section, fill in the YAML editor with the Argo CD ApplicationSpec.
   </Step>
   <Step>
-    Click <Button>Create ArgoCD Application Template</Button>.
+    Click <Button>Add Argo CD Template</Button>.
   </Step>
 </Flow>
 
@@ -83,7 +84,7 @@ Platform checks explicitly defined names against existing `ArgoCDApplication` re
 
 `displayName` is the label shown in the Platform UI. `displayName` defined in `vcluster.yaml` must be unique across all the applications defined in the `vcluster.yaml`.
 
-### Naming modes
+### Name modes
 
 * **Set `name` explicitly:** Platform uses it as the Kubernetes resource name. If `displayName` is not set, it defaults to the value of `name`.
 * **Set `displayName` only:** Omit `name` and specify only `displayName`. Platform automatically generates a unique Kubernetes resource name.
@@ -122,7 +123,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
 
 <Flow>
   <Step>
-    Select your project from the projects dropdown at the top of the left navigation bar.
+    Select your project from the project selector at the top left.
   </Step>
   <Step>
     Navigate to <Label>Tenant Clusters</Label> and click <Button>Create Tenant Cluster</Button>.
@@ -154,7 +155,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
   </Step>
   <Step>
     Choose where to deploy:
-    - Select <Label>Deploy to vCluster</Label> to deploy into the tenant cluster itself.
+    - Select <Label>Deploy to tenant cluster</Label> to deploy into the tenant cluster itself.
     - Select <Label>Deploy to control plane cluster</Label> to deploy into the control plane cluster the tenant cluster runs on. The control plane cluster must already have an Argo CD connector configured.
   </Step>
   <Step>
@@ -180,7 +181,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
 
 <Flow>
   <Step>
-    Select your project from the projects dropdown at the top of the left navigation bar.
+    Select your project from the project selector at the top left.
   </Step>
   <Step>
     Navigate to <Label>Tenant Clusters</Label> and open the tenant cluster where you want to deploy an application.
@@ -197,7 +198,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
   </Step>
   <Step>
     Choose where to deploy:
-    - Select <Label>Deploy to vCluster</Label> to deploy into the tenant cluster itself.
+    - Select <Label>Deploy to tenant cluster</Label> to deploy into the tenant cluster itself.
     - Select <Label>Deploy to control plane cluster</Label> to deploy into the control plane cluster the tenant cluster runs on. The control plane cluster must already have an Argo CD connector configured.
   </Step>
   <Step>
@@ -276,7 +277,7 @@ deploy:
   </TabItem>
 </Tabs>
 
-### Deploying to the control plane cluster
+### Deploy to the control plane cluster
 
 Setting `target: host` deploys the application onto the control plane cluster rather than inside the tenant cluster. Use this for shared infrastructure — monitoring agents, logging collectors, or networking components — that belongs on the underlying cluster rather than inside a tenant cluster.
 
@@ -309,7 +310,7 @@ Applications deployed directly onto a control plane cluster are created as `Argo
 
 <Flow>
   <Step>
-    Click <Label>Clusters</Label> in the left sidebar under the infrastructure section.
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
     Click the name of the control plane cluster to open its detail page.

--- a/platform_versioned_docs/version-4.10.0/integrations/argocd/legacy.mdx
+++ b/platform_versioned_docs/version-4.10.0/integrations/argocd/legacy.mdx
@@ -38,10 +38,10 @@ of the speed and ease of creating tenant clusters, as well as the power of Argo 
 deploying applications within those tenant clusters.
 
 Argo CD Integration has three major components or levels, with each level adding additional
-integration touch points.
+integration capabilities.
 
 1. Sync tenant clusters to Argo CD
-2. Enable SSO Integration (sign in to Argo CD using vCluster Platform)
+2. Enable SSO integration (sign in to Argo CD using vCluster Platform)
 3. Create Argo CD [App Project](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/)
    per vCluster Platform Project
 
@@ -54,7 +54,7 @@ deleted cluster from Argo CD.
 
 The second integration level is enabling SSO integration. This is a project level setting that
 will configure Argo CD to allow users to authenticate using vCluster Platform. After enabling this setting
-users who browse to the Argo CD instance will see a button to login using vCluster Platform. All members of the
+users who browse to the Argo CD instance will see a button to log in using vCluster Platform. All members of the
 project will be able to log in using vCluster Platform and gain access to Argo CD.
 
 The final integration level is the App Project/Argo CD Project integration. This tier configures
@@ -85,11 +85,42 @@ under the 'Project Settings' button.
   <TabItem value="creation">
     <Flow id="enable-argocd-project-creation">
       <Step>
-        Select <Label>+ New Project</Label> from the projects dropdown at the top of the left navigation bar.
+        Select <Label>Create New Project</Label> from the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, create your project as
-        normal.
+        Create your project as normal, then click the <Label>Argo CD</Label> configuration tab.
+      </Step>
+      <Step>
+        Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
+      </Step>
+      <Step>
+        In the new configurations that appeared under the{" "}
+        <Label>Enable Argo CD Integration</Label> slider, select either{" "}
+        <Label>Clusters</Label> or
+        <Label>Tenant Clusters</Label> from the dropdown box in the <Label>
+          Where is Argo CD running
+        </Label> dropdown. This tells vCluster Platform if your Argo CD instance lives
+        in a connected physical cluster, or if it is running inside of a tenant cluster.
+      </Step>
+      <Step>
+        In the next dropdown to the right, select the name of the cluster or
+        tenant cluster that your Argo CD instance is deployed in.
+      </Step>
+      <Step>
+        If your Argo CD instance is deployed in a namespace other than `argocd`,
+        enter the name of the namespace in the <Label>Argo CD Namespace</Label>{" "}
+        box.
+      </Step>
+      <Step>
+        Finish configuring anything else you'd like on your project, then click{" "}
+        <Button>Save Changes</Button>.
+      </Step>
+    </Flow>
+  </TabItem>
+  <TabItem value="existing">
+    <Flow id="enable-argocd-project-existing">
+      <Step>
+        Click <Label>Settings</Label> for the appropriate project in the project selector dropdown (top left).
       </Step>
       <Step>
         Click the <Label>Argo CD</Label> configuration tab.
@@ -108,46 +139,7 @@ under the 'Project Settings' button.
         cluster.
       </Step>
       <Step>
-        In the next drop down to the right, select the name of the cluster or
-        tenant cluster that your Argo CD instance is deployed in.
-      </Step>
-      <Step>
-        If your Argo CD instance is deployed in a namespace other than `argocd`,
-        enter the name of the namespace in the <Label>Argo CD Namespace</Label>{" "}
-        box.
-      </Step>
-      <Step>
-        Finish configuring anything else you'd like on your project, then click
-        the
-        <Button>Save Changes</Button> button.
-      </Step>
-    </Flow>
-  </TabItem>
-  <TabItem value="existing">
-    <Flow id="enable-argocd-project-existing">
-      <Step>
-        Click on <Label>Settings</Label> for the appropriate project under the projects dropdown at the top of the left navigation bar.
-      </Step>
-      <Step>
-        In the drawer that appears from the right, click the{" "}
-        <Label>Argo CD</Label>
-        configuration tab.
-      </Step>
-      <Step>
-        Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
-      </Step>
-      <Step>
-        In the new configurations that appeared under the{" "}
-        <Label>Enable Argo CD Integration</Label> slider, select either{" "}
-        <Label>Clusters</Label> or
-        <Label>Tenant Clusters</Label> from the dropdown box in the <Label>
-          Where is Argo CD running
-        </Label> dropdown. This tells vCluster Platform if your Argo CD instance lives
-        in a connected physical cluster, or if it is running inside of a virtual
-        cluster.
-      </Step>
-      <Step>
-        In the next drop down to the right, select the name of the cluster or
+        In the next dropdown to the right, select the name of the cluster or
         tenant cluster that your Argo CD instance is deployed in.
       </Step>
       <Step>
@@ -162,14 +154,16 @@ under the 'Project Settings' button.
   </TabItem>
 </Tabs>
 
+<!-- vale Google.Headings = NO -->
 ### Enable Argo CD SSO integration
+<!-- vale Google.Headings = YES -->
 
 Projects may also enable SSO integration with Argo CD, which allows all members
 of the vCluster Platform project to log in to Argo CD using vCluster Platform.
 
 :::info Pre-Requisites
 The `loftHost` vCluster Platform configuration must be set to enable this integration. The `loftHost` can be
-configured using the Helm values, or in the `Platform` > `Platform Config` section of the UI on the `Config` pane.
+configured using Helm values, or in the `Admin` section of the UI on the `Config` pane.
 :::
 
 <Tabs
@@ -182,14 +176,10 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   <TabItem value="creation">
     <Flow id="enable-argocd-sso-project-creation">
       <Step>
-        Select <Label>+ New Project</Label> from the projects dropdown at the top of the left navigation bar.
+        Select <Label>Create New Project</Label> from the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, create your project as
-        normal.
-      </Step>
-      <Step>
-        Click the <Label>Argo CD</Label> configuration tab.
+        Create your project as normal, then click the <Label>Argo CD</Label> configuration tab.
       </Step>
       <Step>
         Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
@@ -205,7 +195,7 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
         cluster.
       </Step>
       <Step>
-        In the next drop down to the right, select the name of the cluster or
+        In the next dropdown to the right, select the name of the cluster or
         tenant cluster that your Argo CD instance is deployed in.
       </Step>
       <Step>
@@ -234,12 +224,10 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   <TabItem value="existing">
     <Flow id="enable-argocd-sso-project-existing">
       <Step>
-        Click on {" "}<Label>Settings</Label> for the appropriate project under the projects dropdown at the top of the left navigation bar.
+        Click <Label>Settings</Label> for the appropriate project in the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, click the{" "}
-        <Label>Argo CD</Label>
-        configuration tab.
+        Click the <Label>Argo CD</Label> configuration tab.
       </Step>
       <Step>
         Ensure that standard project Argo CD integration is configured.
@@ -264,7 +252,9 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   </TabItem>
 </Tabs>
 
+<!-- vale Google.Headings = NO -->
 ### Enable Argo CD App Project integration
+<!-- vale Google.Headings = YES -->
 
 App Project integration, can be enabled by editing a project manifest and setting the
 `argoCD.project.enabled` field of the project spec to 'true'. Additionally, users may

--- a/platform_versioned_docs/version-4.10.0/maintenance/monitoring/aggregating-metrics.mdx
+++ b/platform_versioned_docs/version-4.10.0/maintenance/monitoring/aggregating-metrics.mdx
@@ -32,13 +32,13 @@ Deploy Prometheus with OTLP receiver support using the Platform Apps UI.
 Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click on the cluster where you want to deploy Prometheus (for example, <code>local-cluster</code>).
+    Click the cluster where you want to deploy Prometheus (for example, <code>local-cluster</code>).
   </Step>
   <Step>
     Navigate to the <NavStep>Apps</NavStep> tab.
   </Step>
   <Step>
-    Click <Button>Deploy App</Button> and configure a Helm chart with the following settings.
+    Click <Button>Install App</Button> and configure a Helm chart with the following settings.
   </Step>
 </Flow>
 
@@ -100,13 +100,13 @@ The OpenTelemetry Collector Agent on each node pushes metrics about the workload
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click on the cluster where you are installing the OpenTelemetry Collector App.
+    Click the cluster where you are installing the OpenTelemetry Collector App.
   </Step>
   <Step>
     Navigate to the <NavStep>Apps</NavStep> tab.
   </Step>
   <Step>
-    Click on the <NavStep>OpenTelemetry Collector</NavStep> App.
+    Find and click the <b>OpenTelemetry Collector</b> App.
   </Step>
   <Step>
     Enter the Prometheus connection endpoint: <code>http://prometheus-server.observability.svc.cluster.local:80</code>
@@ -131,13 +131,13 @@ Deploy Grafana with a pre-configured Prometheus datasource and dashboard using t
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click on the cluster where you deployed Prometheus.
+    Click the cluster where you deployed Prometheus.
   </Step>
   <Step>
     Navigate to the <NavStep>Apps</NavStep> tab.
   </Step>
   <Step>
-    Click <Button>Deploy App</Button> and configure a Helm chart with the following settings.
+    Click <Button>Install App</Button> and configure a Helm chart with the following settings.
   </Step>
 </Flow>
 

--- a/platform_versioned_docs/version-4.10.0/maintenance/monitoring/fleet-monitoring-otel.mdx
+++ b/platform_versioned_docs/version-4.10.0/maintenance/monitoring/fleet-monitoring-otel.mdx
@@ -16,7 +16,7 @@ visibility into resource consumption and API health without deploying monitoring
 inside each tenant cluster. This guide explains how to configure OpenTelemetry
 Collectors to collect workload and control plane metrics from across multiple
 tenant clusters. All metrics are enriched with vCluster identity labels at
-collection time and pushed to a central Prometheus using `remote_write`.
+enrichment time and pushed to a central Prometheus using `remote_write`.
 
 :::note
 For a simpler setup using the built-in OpenTelemetry DaemonSet App, see
@@ -122,7 +122,7 @@ The architecture comprises the following:
 - Collector architecture:
   - A central Prometheus with the remote write receiver enabled.
   - One OTel Collector Deployment with Target Allocator per Control Plane Cluster (scrapes shared-nodes tenant clusters and their control planes using ServiceMonitors).
-  - One OTel Collector DaemonSet per private-nodes vCluster (scrapes local kubelet, cAdvisor, and API server metrics from inside the vCluster).
+  - One OTel Collector DaemonSet per private-nodes tenant cluster (scrapes local kubelet, cAdvisor, and API server metrics from inside the tenant cluster).
 
 ## How it works
 
@@ -160,7 +160,7 @@ node. The `groupbyattrs` processor splits the batch into per-pod resource scopes
 (by `namespace`, `pod`, `node`) so each pod is matched correctly.
 
 The `k8sattributes` processor resolves vCluster identity from Platform-managed
-namespace labels (`loft.sh/project`, `loft.sh/vcluster-instance-name`, and so on) and
+namespace labels (`loft.sh/project`, `loft.sh/vcluster-instance-name`, and others) and
 pod labels/annotations set by the vCluster syncer
 (`vcluster.loft.sh/namespace`, `vcluster.loft.sh/name`).
 
@@ -616,13 +616,13 @@ kubectl apply -f otel-collector-shared-nodes-app.yaml
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click on the cluster where you want to deploy the collector.
+    Click the cluster where you want to deploy the collector.
   </Step>
   <Step>
     Navigate to the <NavStep>Apps</NavStep> tab.
   </Step>
   <Step>
-    Click <Button>Deploy App</Button> and select the
+    Click <Button>Install App</Button> and select the
     **OTEL Collector - Shared Nodes** app.
   </Step>
   <Step>
@@ -1219,8 +1219,8 @@ This section assumes Grafana is already deployed. For setup instructions, see
 :::
 
 Two Grafana dashboards are provided for visualizing metrics collected by the
-OTel Collectors. Both dashboards use the identity labels enriched at
-collection time, so all panels use straightforward PromQL queries without joins.
+OTel Collectors. Both dashboards use the identity labels enriched at collection
+time, so all panels use straightforward PromQL queries without joins.
 
 ### Import a dashboard
 

--- a/platform_versioned_docs/version-4.10.0/use-platform/apps/updating.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/apps/updating.mdx
@@ -33,9 +33,8 @@ newer (or older!) version in the vCluster Platform UI.
       <Step>
         Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
       </Step>
-      <Step>From the Clusters sub-menu, select the Clusters option.</Step>
       <Step>
-        Find the cluster containing the App you would like ot upgrade, and click
+        Find the cluster containing the App you would like to upgrade and click
         on that cluster.
       </Step>
       <Step>
@@ -48,13 +47,12 @@ newer (or older!) version in the vCluster Platform UI.
         <Label>Outdated</Label> in the status column.
       </Step>
       <Step>
-        Either click on the <Label>Outdated</Label> button in the status column
-        of your target App (if the App is outdated), or click on the small drop
-        down button next to the App name and click on the <Button>Edit</Button>{" "}
-        button.
+        Either click the <Label>Outdated</Label> button in the status column
+        of your target App (if the App is outdated), or click the <Button>Edit</Button>{" "}
+        option for the App you want to modify.
       </Step>
       <Step>
-        From the <Label>App Version</Label> drop down box, select the desired
+        From the <Label>App Version</Label> selector, select the desired
         target App Version.
       </Step>
       <Step>
@@ -65,18 +63,11 @@ newer (or older!) version in the vCluster Platform UI.
   <TabItem value="vcluster">
     <Flow id="update-app-vcluster">
       <Step>
-        Select the <NavStep>Projects</NavStep> field on the left menu bar.
+        Select the project containing the tenant cluster using the project selector (top left), then click <NavStep>Tenant Clusters</NavStep>.
       </Step>
       <Step>
-        Select the project containing the tenant cluster that you'd like to
-        install the App in from the Project drop down menu.
-      </Step>
-      <Step>
-        From the Projects sub-menu, select the Tenant Clusters option.
-      </Step>
-      <Step>
-        Find the tenant cluster containing the App you would like to upgrade,
-        click on that tenant cluster.
+        Find the tenant cluster containing the App you would like to upgrade and
+        click that tenant cluster.
       </Step>
       <Step>
         In the Tenant Cluster Management view, click the <Button>Apps</Button>{" "}
@@ -89,13 +80,12 @@ newer (or older!) version in the vCluster Platform UI.
         <Label>Outdated</Label> in the status column.
       </Step>
       <Step>
-        Either click on the <Label>Outdated</Label> button in the status column
-        of your target App (if the App is outdated), or click on the small drop
-        down button next to the App name and click on the <Button>Edit</Button>{" "}
-        button.
+        Either click the <Label>Outdated</Label> button in the status column
+        of your target App (if the App is outdated), or click the <Button>Edit</Button>{" "}
+        option for the App you want to modify.
       </Step>
       <Step>
-        From the <Label>App Version</Label> drop down box, select the desired
+        From the <Label>App Version</Label> selector, select the desired
         target App Version.
       </Step>
       <Step>

--- a/platform_versioned_docs/version-4.10.0/use-platform/apps/use-in-templates.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/apps/use-in-templates.mdx
@@ -40,12 +40,8 @@ a template, that app will be deployed in the given resource upon creation.
     be deployed *in* the tenant cluster!
   </Step>
   <Step>
-    From the drop down menu <Label>Add a new App ...</Label> select an App
-    that you would like to be included as part of the template. You can
-    select as many Apps as you would like here by simply selecting another
-    App from the drop down menu. If you accidentally add one, or add one you
-    do not want, click the trash icon next to the Apps name to remove it
-    from the template.
+    Select an App from the <Label>Please select an App...</Label> selector to include it in the template. You can
+    add as many Apps as you like by selecting another. To remove one, click the trash icon next to the App name.
   </Step>
   <Step>
     For each App you added to the template, you can configure the default
@@ -64,12 +60,8 @@ a template, that app will be deployed in the given resource upon creation.
     in (not inside the tenant cluster itself).
   </Step>
   <Step>
-    From the drop down menu <Label>Add a new App ...</Label> select an App
-    that you would like to be included as part of the template. You can
-    select as many Apps as you would like here by simply selecting another
-    App from the drop down menu. If you accidentally add one, or add one you
-    do not want, click the trash icon next to the Apps name to remove it
-    from the template.
+    Select an App from the <Label>Please select an App...</Label> selector to include it in the template. You can
+    add as many Apps as you like by selecting another. To remove one, click the trash icon next to the App name.
   </Step>
   <Step>
     For each App you added to the template, you can any App parameters

--- a/platform_versioned_docs/version-4.10.0/use-platform/apps/use-on-demand.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/apps/use-on-demand.mdx
@@ -40,7 +40,7 @@ development, test, or even production, environments in a single easy to manage p
           tenant cluster in.
       </Step>
       <Step>
-        Click on <NavStep>Tenant Clusters</NavStep>.
+        Click <NavStep>Tenant Clusters</NavStep>.
       </Step>
       <Step>
         Click the <Button>New Tenant Cluster</Button> button. Do not select a template.
@@ -60,12 +60,9 @@ development, test, or even production, environments in a single easy to manage p
         be deployed *in* the tenant cluster.
       </Step>
       <Step>
-        From the drop down menu <Label>Please select an App...</Label>, select an
-        application that you would like to be deployed. You can
-        select as many as you would like by simply selecting another
-        application from the drop down menu. If you accidentally add one, or add one you
-        do not want, click the trash icon next to the names of the applications to remove it
-        from the configuration.
+        Select an application from the <Label>Please select an App...</Label> selector. You can
+        add as many as you like by selecting another. To remove one, click the trash icon
+        next to the application name.
       </Step>
       <Step>
         For each application that you added to the template, you can configure the default
@@ -103,7 +100,7 @@ development, test, or even production, environments in a single easy to manage p
       <Step>
         Select the App you would like to install from the App thumbnails, or, if
         there are no recommend Apps, click the <Button>Install App</Button> and
-        find the desired App in the <Label>Select an App</Label> drop down menu.
+        select the desired App from the <Label>Select an App</Label> selector.
       </Step>
       <Step>
         In the Install App screen enter the namespace to install the App to in

--- a/platform_versioned_docs/version-4.10.0/use-platform/apps/use-parameters.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/apps/use-parameters.mdx
@@ -11,7 +11,7 @@ import Label from "@site/src/components/Label";
 
 ## Create an app with parameters
 
-Create an app with parameters using the vCluster Platform UI.
+Apps with parameters can be created through the vCluster Platform UI.
 
 <Flow id="create-app-with-parameters">
   <Step>
@@ -21,7 +21,7 @@ Create an app with parameters using the vCluster Platform UI.
     Click <Button>Add App</Button>.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new app a name by
+    In the configuration sheet that opens, give your new app a name by
     replacing the 'my-app' placeholder name, or by updating the manifest YAML
     'metadata.name' field.
   </Step>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
@@ -10,15 +10,15 @@ import Expander from '@site/src/components/Expander'
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto-delete for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click the <Button>Edit</Button> option for the {props.name} you want to modify.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template, if you want to change the auto delete configuration for a {props.name} created by a template, please do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template. To change auto-delete for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
     Use the <Label>Delete After Inactivity</Label> field to specify the time to wait before deleting the {props.name} if there was no more user activity within this {props.name}
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/add-app-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/add-app-ui.mdx
@@ -4,26 +4,16 @@ import Button from '@site/src/components/Button'
 import Label from '@site/src/components/Label'
 
 <Step>
-    Select the <NavStep>Projects</NavStep> field on the left menu bar.
+    Select the project containing the namespace using the project selector (top left), then click <NavStep>Namespaces</NavStep>.
 </Step>
 <Step>
-    Select the project containing the namespace that you'd like to install
-    the App in from the Project drop down menu.
+    Find the namespace you would like to deploy an App to and click it.
 </Step>
 <Step>
-    From the Projects sub-menu, select the Namespaces option.
+    In the Namespace Management view, click <Button>Apps</Button>.
 </Step>
 <Step>
-    Find the namespace you would like to deploy an App to in the list of namespaces, and click on that
-    namespace.
-</Step>
-<Step>
-    In the Namespace Management view, click the <Button>Apps</Button> button.
-</Step>
-<Step>
-    Select the App you would like to install from the App thumbnails, or, if there
-    are no recommend Apps, click the <Button>Install App</Button> and find  the
-    desired App in the <Label>Select an App</Label> drop down menu.
+    Select the App you would like to install from the App thumbnails, or click <Button>Install App</Button> and select the desired App.
 </Step>
 <Step>
     Enter any other required parameters for your App -- this may vary depending on

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/delete-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/delete-ui.mdx
@@ -15,6 +15,6 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
     While hovering over the row, you will see buttons appear on the right in the <Label>Actions</Label> column
   </Step>
   <Step>
-    Click on the <Button><svg viewBox="64 64 896 896" focusable="false" data-icon="delete" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"></path></svg></Button> button to <Label>Delete</Label> the namespace
+    Click the <Button><svg viewBox="64 64 896 896" focusable="false" data-icon="delete" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"></path></svg></Button> button to <Label>Delete</Label> the namespace
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/share-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/namespace/share-ui.mdx
@@ -7,21 +7,21 @@ import Expander from '@site/src/components/Expander'
 
 <Flow id="namespace-share-ui">
   <Step>
-    Go to the <NavStep>Projects</NavStep> view using the menu on the left
+    Select the project using the project selector (top left), then click <NavStep>Namespaces</NavStep>.
   </Step>
   <Step>
-    Click on Namespaces and click on the Edit link on a namespace.
+    Find the namespace and click <Button>Edit</Button>.
   </Step>
   <Step>
-    In the drawer select the 'Permissions' section.
+    In the configuration sheet that opens, click the <Label>Permissions</Label> tab.
   </Step>
   <Step>
-    Select the user or team you want to grant permissions in the 'User or Team' select. If you don't see the user or team you want to grant access in there, make sure they have project access.
+    Select the user or team you want to grant permissions from the <Label>User or Team</Label> selector. If the user or team is not listed, make sure they have project access.
   </Step>
   <Step>
-    Specify the cluster-role you want to assign the user or team within the namespace.
+    Specify the cluster role you want to assign the user or team within the namespace.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button> button at the very bottom
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/sleep/configure-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/sleep/configure-ui.mdx
@@ -13,15 +13,15 @@ import CreateSpaceStep2 from '@site/static/media/ui/screenshots/spaces/create-sp
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click <Button>Edit</Button> on the {props.name}.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep</Expander> section. This only works for {props.name}s without a template, if you want to change the auto sleep configuration for a {props.name} created by a template, do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep</Expander> section. This only works for {props.name}s without a template. To change auto-sleep for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
-    Use the <Label>Sleep After Inactivity</Label> field to specify the time to wait before putting the {props.name} to sleep if there is no more user activity in this {props.name}
+    Use the <Label>Sleep After Inactivity</Label> field to specify the time to wait before putting the {props.name} to sleep if there is no more user activity.
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
@@ -10,18 +10,18 @@ import Expander from '@site/src/components/Expander'
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click <Button>Edit</Button> on the {props.name}.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep Mode</Expander> {props.name}. This only works for {props.name}s without a template, if you want to change the auto sleep configuration for a {props.name} created by a template, do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template. To change auto-sleep for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
-    Expand the <Expander>Sleep & Wake-Up Schedule</Expander> section
+    Expand the <Expander>Sleep &amp; Wake-Up Schedule</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Sleep Schedule</Label> field and/or the <Label>Wake-Up Schedule</Label> field to specify the <Input>Cronjob Times</Input> when the respective {props.name} should be put to sleep or woken up
+    Use the <Label>Sleep Schedule</Label> field and the <Label>Wake up Schedule</Label> field to specify when the {props.name} should be put to sleep or woken up.
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/space-constraints/create-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/space-constraints/create-ui.mdx
@@ -11,16 +11,16 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
 
 <Flow id="create-namespace-constraints-ui">
   <Step>
-    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Switch to the <Label>Namespace Constraints</Label> tab
+    Switch to the <Label>Namespace Constraints</Label> tab.
   </Step>
   <Step>
-    Click the <Button>Create Namespace Constraints</Button> button to create a new namespace constraints object
+    Click <Button>Create Namespace Constraints</Button>.
   </Step>
   <Step>
-    In the drawer that appears on the right, use the field <Label>Display Name</Label> to specify a <Input>Name</Input> for your namespace constraints object
+    In the configuration sheet that opens, use the <Label>Display Name</Label> field to specify a <Input>Name</Input> for your namespace constraints object.
   </Step>
   <Step>
     Expand the <Expander>Enforce Resources</Expander> section to specify manifests that should be deployed to and enforced in each namespace that is affected by these namespace constraints
@@ -29,6 +29,6 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
     Expand the <Expander>Enforce Namespace Settings</Expander> section to specify other namespace settings such as sleep mode, auto-delete, labels and annotations that should be enforced for each namespace that is affected by these namespace constraints
   </Step>
   <Step>
-    On the very bottom, click the <Button>Create</Button> button to create this namespace constraints object
+    Click <Button>Create</Button> to create this namespace constraints object.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/space-constraints/enforce-ui.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/_partials/space-constraints/enforce-ui.mdx
@@ -11,37 +11,37 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
 
 <Flow id="enforce-namespace-constraints-ui">
   <Step>
-    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Switch to the <Label>Cluster Access</Label> tab
+    Switch to the <Label>Cluster Access</Label> tab.
   </Step>
   <Step>
-    Hover over the cluster access that you want to apply these namespace constraints to and click the <Button><svg viewBox="64 64 896 896" focusable="false" class="" data-icon="setting" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"></path></svg></Button> button to <Label>Edit</Label> the cluster access
+    Click <Button>Edit</Button> on the cluster access you want to apply these namespace constraints to.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Restrictions</Expander> section
+    In the configuration sheet that opens, expand the <Expander>Restrictions</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Enforce Namespace Constraints</Label> field to select the <Input>Namespace Constraint</Input> that you want to enforce for all namespaces created using this cluster access
+    Use the <Label>Enforce Namespace Constraints</Label> field to select the namespace constraint you want to enforce for all namespaces created using this cluster access.
   </Step>
   <Step>
-    On the very bottom, click the <Button>Update</Button> or <Button>Create</Button> button to save the changes
+    Click <Button>Update</Button> or <Button>Create</Button> to save the changes.
   </Step>
   <Step>
-    Switch to the <Label>Cluster Access</Label> tab
+    Switch to the <Label>Cluster Access</Label> tab.
   </Step>
   <Step>
-    Hover over the cluster access of the user or team that you want to configure automatic sleep mode for and click the <Button><svg viewBox="64 64 896 896" focusable="false" class="" data-icon="setting" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"></path></svg></Button> button to <Label>Edit</Label> the cluster access
+    Click <Button>Edit</Button> on the cluster access for the user or team you want to configure.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Restrictions</Expander> section
+    In the configuration sheet that opens, expand the <Expander>Restrictions</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Enforce Namespace Constraints</Label> field to select the <Input>Namespace Constraint</Input> you edited or created in Step 3 above
+    Use the <Label>Enforce Namespace Constraints</Label> field to select the namespace constraint you edited or created above.
   </Step>
   <Step>
-    On the very bottom, click the <Button>Update</Button> button to save the changes
+    Click <Button>Update</Button> to save the changes.
   </Step>
 </Flow>
 

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -33,13 +33,13 @@ For more information on configuring custom links for tenant clusters, see the [C
         Edit an existing Namespace or create a new one.
       </Step>
       <Step>
-        Click <Label>Add Link</Label> to add a new link or <Label>Change</Label> to edit an existing one.
+        Click the edit icon next to the links section to open the links editor. Click <Button>Add</Button> to add a new link.
       </Step>
       <Step>
         Enter a URL and optionally a label for your link.
       </Step>
       <Step>
-        Click <Label>Save</Label>.
+        Click <Button>Save</Button>.
       </Step>
       <Step>
         Click <Button>Create Namespace</Button>,

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/prevent-deletion.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/prevent-deletion.mdx
@@ -44,7 +44,7 @@ spec:
 
 <Flow id="namespace-prevent-deletion-ui">
 <Step>
-  Navigate to the <NavStep>Projects</NavStep> section using the menu on the left.
+  Go to <NavStep>Projects</NavStep>.
 </Step>
 
 <Step>
@@ -52,8 +52,7 @@ spec:
 </Step>
 
 <Step>
-  Either click on the <Button>Create Namespace</Button> button or select the
-  dropdown next to an existing namespace and select the <Label>Edit</Label> option.
+  Either click the <Button>Create Namespace</Button> button or click the <Button>Edit</Button> option for the namespace you want to modify.
 </Step>
 
 <Step>
@@ -61,13 +60,12 @@ spec:
 </Step>
 
 <Step>
-  Select the <Expander>Prevent Deletion</Expander> expander and tick the "enable
-  deletion prevention" checkbox.
+  Select the <Expander>Prevent Deletion</Expander> expander and enable <Label>Prevent Deletion</Label>.
 </Step>
 
 <Step>
-  Click on the <Button>Save</Button> button to save the changes or the{" "}
-  <Button>Create</Button> button, when creating a new namespace.
+  Click the <Button>Save</Button> button to save the changes, or the{" "}
+  <Button>Create</Button> button when creating a new namespace.
 </Step>
 
 </Flow>

--- a/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/key-features/custom-links.mdx
@@ -9,6 +9,7 @@ import TabItem from "@theme/TabItem";
 import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
+import Flow, { Step } from "@site/src/components/Flow";
 
 vCluster Platform lets you associate custom links to tenant cluster instances, for example to point to a github pull request or jira issue.
 
@@ -19,12 +20,11 @@ vCluster Platform lets you associate custom links to tenant cluster instances, f
         {label: 'CLI', value: 'cli'},
     ]}>
     <TabItem value="ui">
-    1. Go to the <NavStep>Tenant Clusters</NavStep> view using the menu on the left
-    1. Edit an existing Tenant Cluster or create a new one
-    1. Click <Label>Add Link</Label> to add a new link or <Label>Change</Label> to edit existing ones.
+    1. Select your project from the project selector, then click <NavStep>Tenant Clusters</NavStep>.
+    1. Edit an existing tenant cluster or create a new one.
+    1. Click the edit icon next to the links section to open the links editor. Click <Button>Add</Button> to add a new link.
     1. Enter a URL and optionally a label for your link.
-    1. Save your links by clicking <Label>Save</Label>.
-    1. Click on the <Button>Create Tenant Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing tenant cluster, to apply all changes.
+    1. Click <Button>Create Tenant Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing tenant cluster, to apply all changes.
     </TabItem>
 <TabItem value="cli">
 

--- a/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
@@ -53,20 +53,20 @@ spec:
     tenant cluster in.
   </Step>
   <Step>
-    Click on <NavStep>Tenant Clusters</NavStep>.
+    Click <NavStep>Tenant Clusters</NavStep>.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
+    Click the <Button>Edit</Button> option for the tenant cluster you want to modify.
   </Step>
   <Step>
     Navigate to <Label>Advanced</Label> section on the left.
   </Step>
   <Step>
-    Select the <Expander>Prevent Deletion</Expander> expander and tick the <Label>Enabled</Label> checkbox.
+    Select the <Expander>Prevent Deletion</Expander> expander and enable <Label>Enabled</Label>.
   </Step>
 
 <Step>
-  Click on the <Button>Save</Button> button to save the changes.
+  Click the <Button>Save</Button> button to save the changes.
 </Step>
 
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -43,7 +43,7 @@ sure you are taking advantage of Projects when considering your RBAC strategy.
 ### 1. Create test user
 
 vCluster Platform lets you connect a variety of SSO providers for authentication but for the sake of
-simplicity, this guide manually creates a user to explore vCluster Platform's cluster access features:
+simplicity, manually create a user to learn more about vCluster Platform's cluster access features:
 
 <Flow id="create-user">
   <Step>
@@ -53,7 +53,7 @@ simplicity, this guide manually creates a user to explore vCluster Platform's cl
     Click the <Button>Add User</Button> button.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new user a name of{" "}
+    In the configuration sheet that opens, give your new user a name of{" "}
     <Input>Anna</Input>
     by replacing the 'my-user' placeholder name, or by updating the manifest YAML
     'metadata. name' field.
@@ -74,16 +74,15 @@ cluster and you could also manage these actions using kubectl or any kind of Git
 
 ### 2. Impersonate user
 
-vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. Try this to see
-how vCluster Platform UI would look like for the newly created user:
+vCluster Platform allows admins with appropriate RBAC permissions to impersonate users. This demonstrates
+how vCluster Platform UI appears for the newly created user:
 
 <Flow id="impersonate-user">
   <Step>
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    Find the user `Anna` in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click the{" "}
+    Find the user `Anna` in the list of users and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"
@@ -122,7 +121,7 @@ command while the impersonation is active.
 vcluster platform login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
 ```
 
-You can verify the login and print your user information using:
+You can verify the login and print your user information by running:
 
 ```bash
 vcluster platform login
@@ -137,23 +136,20 @@ Give the test user Anna access to one of the clusters connected to this vCluster
 :::note Single Sign-On + Cluster Access
 You can connect a variety of SSO providers to vCluster Platform. To automatically give users access to
 clusters based on their SSO user groups, you can switch to the <Label>Team Members</Label> tab
-to grant cluster access for each member of a team (for example, for each member of a group in Active
-Directory, Okta, or SAML), check out the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
+to grant cluster access for each member of a team (for example, a group in Active Directory, Okta, or SAML), see the [SSO Group Sync](../../../configure/platform-configs/single-sign-on.mdx#sso-group-sync) section for
 more details.
 :::
 
 ### 4. Verify cluster access
 
-After configuring the cluster access for test user Anna, verify that she can access the
-cluster:
+After configuring the cluster access for test user Anna, verify that she can access the cluster:
 
 <Flow id="impersonate-user-with-cluster-access">
   <Step>
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    Find the user Anna in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click the{" "}
+    Find the user Anna in the list of users and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/suspend.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/suspend.mdx
@@ -19,12 +19,9 @@ lock an user if you want to preserve the users environments without deleting the
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    In the user row you want to lock, hover over the blue drop down arrow and
-    select
-    <Label>Lock User</Label> from the menu options.
+    In the user row you want to lock, click the actions menu and select <Label>Lock User</Label>.
   </Step>
   <Step>
-    To unlock the user, select <Label>Unlock User</Label> from the same drop
-    down menu.
+    To unlock the user, click the actions menu and select <Label>Unlock User</Label>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/cluster.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/cluster.mdx
@@ -42,18 +42,18 @@ Cluster access lets you define access to certain clusters for your users or team
     Click the <NavStep>Cluster Access</NavStep> tab and then click <Button>Create Cluster Access</Button>.
   </Step>
   <Step>
-    In the drawer that appears from the right, give the access a name by replacing the auto-generated placeholder name, or by updating the manifest YAML 'metadata.name' field.
+    In the configuration sheet that opens, give the access a name by replacing the auto-generated placeholder name, or by updating the manifest YAML 'metadata.name' field.
   </Step>
   <Step>
-    In the <Label>Options</Label> configuration pane, choose the User or Team you wish to grant the access, from the <Label>Cluster Access ...</Label> drop down menu. Subsequently choose the cluster role to be assigned to the selected user or team from the <Label>Cluster Roles ...</Label> drop down menu.
+    In the <Label>Options</Label> tab, choose the user or team to grant access from the <Label>Cluster Access</Label> selector, then choose the cluster role from the <Label>Cluster Roles</Label> selector.
   </Step>
   <Step>
-    In the <Label>Clusters</Label> configuration pane, choose the cluster to which the User or Team should be granted access, from the <Label>Select Clusters ...</Label> drop down menu.
+    In the <Label>Clusters</Label> tab, choose the cluster to which the user or team should be granted access from the <Label>Select Clusters</Label> selector.
   </Step>
   <Step>
-    In the <Label>Access</Label> configuration pane, Select the User or Team that should have access to the underlying cluster access object, from the <Label>User & Teams ...</Label> drop down menu. Choose what actions they are allowed to perform on this object, from the <Label>Permissions ...</Label> drop down menu.
+    In the <Label>Access</Label> tab, select the user or team that can manage this cluster access object, then choose their allowed permissions.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button>  button to create the cluster access.
+    Click <Button>Save Changes</Button> to create the cluster access.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/namespace.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/namespace.mdx
@@ -12,7 +12,7 @@ import Button from '@site/src/components/Button'
 import PartialNamespaceShareUI from '../../../_partials/namespace/share-ui.mdx'
 import PartialNamespaceShareCLI from '../../../_partials/namespace/share-cli.mdx'
 
-Namespace access can be managed through the 'Permissions' section inside the namespace drawer. There are a couple of special cases:
+Namespace access can be managed through the 'Permissions' section inside the namespace configuration sheet. There are a couple of special cases:
 1. Global Admins & Project Admins have access and can change **all** namespaces within a project.
 2. Tenant Cluster owners always have access and can change their namespaces.
 3. Every user or team within the management cluster that has the RBAC permission on the resource "spaceinstances" in api group "management.loft.sh" for the verb "use" can access the namespace.

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/project.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/permissions/project.mdx
@@ -54,7 +54,7 @@ spec:
     Click the <NavStep>Create Role</NavStep> button at the right bottom of the page.
   </Step>
   <Step>
-    If you created a project role, you can click the <NavStep>Project Settings</NavStep>, and then find the display name of the created project role in the dropdown menu of the role for each member under the Members and Roles section.
+    If you created a project role, click <NavStep>Project Settings</NavStep> and find the display name of the created project role in the role selector for each member under the <Label>Members and Roles</Label> section.
   </Step>
 </Flow>
 
@@ -67,13 +67,13 @@ remove them from the project.
 
 <Flow id="project-add-user">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Users</NavStep> tab.
+    Click the <NavStep>Users</NavStep> tab.
   </Step>
   <Step>
     Click the <Label>Users</Label> input and select the user to add. The table
@@ -96,13 +96,13 @@ Instead of adding every user, a special selection named `All Users` can be used 
 
 <Flow id="project-remove-user">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Users</NavStep> tab.
+    Click the <NavStep>Users</NavStep> tab.
   </Step>
   <Step>
     Click the trash can icon next to the user that you'd like to remove. If you wish to change this manually, you may edit the YAML directly.
@@ -122,13 +122,13 @@ Instead of having to assign individual users, teams can be used to assign multip
 
 <Flow id="project-add-team">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Teams</NavStep> tab.
+    Click the <NavStep>Teams</NavStep> tab.
   </Step>
   <Step>
     Click the <Label>Teams</Label> input and select the team to add. The table
@@ -148,13 +148,13 @@ Instead of having to assign individual users, teams can be used to assign multip
 
 <Flow id="project-remove-team">
   <Step>
-    Select the project you'd like to configure using the drop down menu. Click on <Label>Settings</Label>.
+    Select the project you'd like to configure using the project selector dropdown. Click <Label>Settings</Label>.
   </Step>
   <Step>
-    Click on <NavStep>Members</NavStep>.
+    Click <NavStep>Members</NavStep>.
   </Step>
   <Step>
-    Click on the <NavStep>Teams</NavStep> tab
+    Click the <NavStep>Teams</NavStep> tab
   </Step>
   <Step>
     Click the trash can icon next to the team that you'd like to remove. If you wish to change this manually, you may edit the YAML directly.

--- a/platform_versioned_docs/version-4.11.0/configure/agent-settings/agent-upgrade.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/agent-settings/agent-upgrade.mdx
@@ -74,12 +74,11 @@ Or you can finish this in vCluster Platform UI:
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Click the drop down arrow next to the cluster name you wish to modify. In
-    the drop down menu click the <Label>Edit</Label> button.
+    Click the <Button>Edit</Button> option for the cluster you want to modify.
   </Step>
   <Step>
-    In the drawer that appears from the right, click the <Label>Agent</Label>{" "}
-    configuration pane and select the 'Ignore Agent' checkbox.
+    In the configuration sheet that opens, click the <Label>Agent</Label> tab
+    and enable <Label>Ignore Agent</Label>.
   </Step>
   <Step>
     Click the <Button>Save Changes</Button> button.

--- a/platform_versioned_docs/version-4.11.0/configure/agent-settings/customization.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/agent-settings/customization.mdx
@@ -19,7 +19,7 @@ As described in [installation modes][install-modes], the vCluster Platform Agent
 However, this means that all control plane clusters connecting to the platform will share the same configuration. If different connected control plane clusters require different agent configurations, there are two supported approaches.
 
 ## `loft.sh/agent-values` annotation {#loftsh-annotations}
-Add the `loft.sh/agent-values` annotation to a specific Cluster resource (using the UI or YAML). This annotation overrides the platform-level `agentValues`. The override applies only to the annotated Cluster. For example:
+Add the `loft.sh/agent-values` annotation to a specific Cluster resource (through the UI or YAML). This annotation overrides the platform-level `agentValues`. The override applies only to the annotated Cluster. For example:
   ```yaml
   loft.sh/agent-values: |
     replicaCount: 2
@@ -48,15 +48,13 @@ You can also update the agent settings in vCluster Platform UI.
     Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
 </Step>
 <Step>
-    Click the drop down arrow next to the cluster name you wish to modify. In
-    the drop down menu click the <Label>Edit</Label> button.
+    Click the <Button>Edit</Button> option for the cluster you want to modify.
 </Step>
 <Step>
-    In the drawer that appears from the right, click the <Label>Agent</Label>{" "}
-    configuration pane. Provide the values in the textarea under{" "}
-    <Label>Extra Agent Values</Label> in the YAML format.
+    In the configuration sheet that opens, click the <Label>Agent</Label> tab.
+    Provide the values in the <Label>Extra Agent Values</Label> field in YAML format.
 </Step>
 <Step>
-    Click on the <Button>Save Changes</Button> button.
+    Click the <Button>Save Changes</Button> button.
 </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/platform-configs/single-sign-on.mdx
@@ -113,22 +113,19 @@ the platform, they are going to be added to all matching Teams.
 <!-- vale off -->
 <Flow id="create-team-with-sso-group-membership">
   <Step>
-    Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
-  </Step>
-  <Step>
-    Click the <NavStep>Teams</NavStep> button on the User Management screen.
+    Go to <NavStep>Access & Secrets > Users & Roles</NavStep> and select the <NavStep>Teams</NavStep> tab.
   </Step>
   <Step>
     Click the <Button>Add Team</Button> button.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new team a name by
-    replacing the  'my-team' placeholder name, or by updating the manifest YAML
+    In the configuration sheet that opens, give your new team a name by
+    replacing the 'my-team' placeholder name, or by updating the manifest YAML
     'metadata.name' field.
   </Step>
   <Step>
     In the <Label>Team Members</Label> tab enter any desired groups into the{" "}
-    <Label>SSO Groups as Members</Label> field. You can add as many groups as
+    <Label>SSO groups</Label> field. You can add as many groups as
     you would like here. These group names must exactly match the group name
     that the SSO provider shares with the platform during SSO authentication.
   </Step>

--- a/platform_versioned_docs/version-4.11.0/how-to/disable-local-admin.mdx
+++ b/platform_versioned_docs/version-4.11.0/how-to/disable-local-admin.mdx
@@ -43,7 +43,7 @@ There are two steps to fully disable the local admin:
     Go to <NavStep>Access & Secrets > Users & Roles</NavStep>.
   </Step>
   <Step>
-    In the admin user row, hover over the blue drop down arrow and select <Label>Lock User</Label> from the menu options.
+    In the admin user row, click the actions menu and select <Label>Lock User</Label>.
   </Step>
 </Flow>
 
@@ -96,6 +96,6 @@ If SSO becomes unavailable and you need to regain access:
 3. Unlock the admin user:
    - Log in with the reset password
    - Go to <NavStep>Access & Secrets > Users & Roles</NavStep>
-   - Select **Unlock User** from the admin user's dropdown menu
+   - Click the actions menu on the admin user row and select **Unlock User**
 
 After regaining access, investigate the SSO issue, and fix it before re-locking the admin account.

--- a/platform_versioned_docs/version-4.11.0/integrations/argocd/connect-akuity.mdx
+++ b/platform_versioned_docs/version-4.11.0/integrations/argocd/connect-akuity.mdx
@@ -7,6 +7,7 @@ sidebar_position: 3
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
@@ -60,18 +61,18 @@ See the [Akuity API key documentation](https://docs.akuity.io/organizations/api-
 
 <Flow>
   <Step>
-    Click <Label>Connectors</Label> and select the <Label>Argo CD</Label> tab.
+    Go to <NavStep>Infrastructure > Connectors</NavStep> and select the <Label>Argo CD</Label> tab.
   </Step>
   <Step>
-    Click <Button>Add ArgoCD Connector</Button>.
+    Click <Button>Connect Argo CD</Button>.
   </Step>
   <Step>
     In the <Label>Display name</Label> field, enter a human-readable name for the connector.
-    The <Label>ArgoCD Connector ID</Label> is auto-generated from the display name and is used to reference this connector from clusters.
+    The <Label>Argo CD Connector ID</Label> is auto-generated from the display name and is used to reference this connector from clusters.
   </Step>
   <Step>
     Enable the <Label>Use Akuity API</Label> toggle, then fill in:
-    - <Label>Organization ID</Label>: your Akuity organization ID
+    - <Label>Org ID</Label>: your Akuity organization ID
     - <Label>Argo CD Instance</Label>: the Argo CD instance ID within your organization
     - <Label>API Key ID</Label> and <Label>API Key Secret</Label>: your Akuity API key credentials
   </Step>
@@ -91,7 +92,7 @@ See the [Akuity API key documentation](https://docs.akuity.io/organizations/api-
     Optionally override <Label>Replicas</Label> and <Label>Memory</Label> for the `argocd-repo-server` (see [Agent sizing](#agent-sizing) below).
   </Step>
   <Step>
-    Click <Button>Create ArgoCD Connector</Button>.
+    Click <Button>Connect Argo CD</Button>.
   </Step>
 </Flow>
 
@@ -175,7 +176,7 @@ stringData:
 | `insecure` | No | Set to `"true"` to skip TLS verification. Defaults to `"false"` |
 | `akuityOrgId` | Yes | Akuity organization ID |
 | `akuityInstanceId` | Yes | Argo CD instance ID within your Akuity organization |
-| `akuityApiKeyId` | Yes | Akuity API key ID, used to register and manage clusters via the Akuity API |
+| `akuityApiKeyId` | Yes | Akuity API key ID, used to register and manage clusters using the Akuity API |
 | `akuityApiKeySecret` | Yes | Akuity API key secret |
 | `akuityAgentSize` | No | Agent size profile: `CLUSTER_SIZE_SMALL`, `CLUSTER_SIZE_MEDIUM` (default), or `CLUSTER_SIZE_LARGE`. See [Agent sizing](#agent-sizing). |
 | `akuityRepoServerReplicas` | No | Override the `argocd-repo-server` replica count. See [Agent sizing](#agent-sizing). |
@@ -220,7 +221,7 @@ integrations:
     connector: akuity-prod
 ```
 
-The connector can also be set directly in the `VirtualClusterInstance` manifest:
+The connector can also be set directly in the VirtualClusterInstance manifest:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -241,7 +242,7 @@ spec:
               connector: akuity-prod
 ```
 
-When the `VirtualClusterInstance` reconciles, Platform registers the tenant cluster with Akuity, retrieves the agent manifest, and installs the agent into the cluster.
+When the VirtualClusterInstance reconciles, Platform registers the tenant cluster with Akuity, retrieves the agent manifest, and installs the agent into the cluster.
 
 ### On a control plane cluster
 
@@ -259,7 +260,7 @@ spec:
 ```
 
 :::warning Disabling the integration
-Disabling the integration removes the cluster from Akuity, uninstalls the agent namespace from the cluster, and deletes all `ArgoCDApplication` objects managed by Platform. This applies whether the integration is configured via `vcluster.yaml`, a `VirtualClusterInstance` manifest, or a `Cluster` object. Any applications deployed by the integration will be removed from Argo CD.
+Disabling the integration removes the cluster from Akuity, uninstalls the agent namespace from the cluster, and deletes all `ArgoCDApplication` objects managed by Platform. This applies whether the integration is configured using `vcluster.yaml`, a VirtualClusterInstance manifest, or a Cluster object. Any applications deployed by the integration will be removed from Argo CD.
 :::
 
 ## Next step

--- a/platform_versioned_docs/version-4.11.0/integrations/argocd/deploy-applications.mdx
+++ b/platform_versioned_docs/version-4.11.0/integrations/argocd/deploy-applications.mdx
@@ -7,6 +7,7 @@ sidebar_position: 4
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
@@ -31,21 +32,21 @@ An `ArgoCDApplicationTemplate` is a reusable Argo CD ApplicationSpec. Create one
 
 <Flow>
   <Step>
-    Click <Label>Argo CD Templates</Label> in the left sidebar.
+    Go to <NavStep>Tenant Management > Argo CD Templates</NavStep>.
   </Step>
   <Step>
-    Click <Button>Add ArgoCD Application Template</Button>.
+    Click <Button>Create Argo CD Template</Button>.
   </Step>
   <Step>
-    In the <Label>Basics</Label> section, enter a <Label>Display Name</Label> for the template.
-    The <Label>ArgoCD Application Template ID</Label> is auto-generated from the display name and is the identifier you reference in your applications.
+    In the <Label>Basics</Label> section, enter a <Label>Display name</Label> for the template.
+    The <Label>Argo CD Template ID</Label> is auto-generated from the display name and is the identifier you reference in your applications.
     Optionally add a <Label>Description</Label>.
   </Step>
   <Step>
-    In the <Label>ArgoCD Application Spec</Label> section, fill in the YAML editor with the Argo CD ApplicationSpec.
+    In the <Label>Config Options</Label> section, fill in the YAML editor with the Argo CD ApplicationSpec.
   </Step>
   <Step>
-    Click <Button>Create ArgoCD Application Template</Button>.
+    Click <Button>Add Argo CD Template</Button>.
   </Step>
 </Flow>
 
@@ -83,7 +84,7 @@ Platform checks explicitly defined names against existing `ArgoCDApplication` re
 
 `displayName` is the label shown in the Platform UI. `displayName` defined in `vcluster.yaml` must be unique across all the applications defined in the `vcluster.yaml`.
 
-### Naming modes
+### Name modes
 
 * **Set `name` explicitly:** Platform uses it as the Kubernetes resource name. If `displayName` is not set, it defaults to the value of `name`.
 * **Set `displayName` only:** Omit `name` and specify only `displayName`. Platform automatically generates a unique Kubernetes resource name.
@@ -122,7 +123,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
 
 <Flow>
   <Step>
-    Select your project from the projects dropdown at the top of the left navigation bar.
+    Select your project from the project selector at the top left.
   </Step>
   <Step>
     Navigate to <Label>Tenant Clusters</Label> and click <Button>Create Tenant Cluster</Button>.
@@ -154,7 +155,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
   </Step>
   <Step>
     Choose where to deploy:
-    - Select <Label>Deploy to vCluster</Label> to deploy into the tenant cluster itself.
+    - Select <Label>Deploy to tenant cluster</Label> to deploy into the tenant cluster itself.
     - Select <Label>Deploy to control plane cluster</Label> to deploy into the control plane cluster the tenant cluster runs on. The control plane cluster must already have an Argo CD connector configured.
   </Step>
   <Step>
@@ -180,7 +181,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
 
 <Flow>
   <Step>
-    Select your project from the projects dropdown at the top of the left navigation bar.
+    Select your project from the project selector at the top left.
   </Step>
   <Step>
     Navigate to <Label>Tenant Clusters</Label> and open the tenant cluster where you want to deploy an application.
@@ -197,7 +198,7 @@ Applications deployed to a tenant cluster are declared in the cluster's `vcluste
   </Step>
   <Step>
     Choose where to deploy:
-    - Select <Label>Deploy to vCluster</Label> to deploy into the tenant cluster itself.
+    - Select <Label>Deploy to tenant cluster</Label> to deploy into the tenant cluster itself.
     - Select <Label>Deploy to control plane cluster</Label> to deploy into the control plane cluster the tenant cluster runs on. The control plane cluster must already have an Argo CD connector configured.
   </Step>
   <Step>
@@ -276,7 +277,7 @@ deploy:
   </TabItem>
 </Tabs>
 
-### Deploying to the control plane cluster
+### Deploy to the control plane cluster
 
 Setting `target: host` deploys the application onto the control plane cluster rather than inside the tenant cluster. Use this for shared infrastructure — monitoring agents, logging collectors, or networking components — that belongs on the underlying cluster rather than inside a tenant cluster.
 
@@ -309,7 +310,7 @@ Applications deployed directly onto a control plane cluster are created as `Argo
 
 <Flow>
   <Step>
-    Click <Label>Clusters</Label> in the left sidebar under the infrastructure section.
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
     Click the name of the control plane cluster to open its detail page.

--- a/platform_versioned_docs/version-4.11.0/integrations/argocd/legacy.mdx
+++ b/platform_versioned_docs/version-4.11.0/integrations/argocd/legacy.mdx
@@ -38,10 +38,10 @@ of the speed and ease of creating tenant clusters, as well as the power of Argo 
 deploying applications within those tenant clusters.
 
 Argo CD Integration has three major components or levels, with each level adding additional
-integration touch points.
+integration capabilities.
 
 1. Sync tenant clusters to Argo CD
-2. Enable SSO Integration (sign in to Argo CD using vCluster Platform)
+2. Enable SSO integration (sign in to Argo CD using vCluster Platform)
 3. Create Argo CD [App Project](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/)
    per vCluster Platform Project
 
@@ -54,7 +54,7 @@ deleted cluster from Argo CD.
 
 The second integration level is enabling SSO integration. This is a project level setting that
 will configure Argo CD to allow users to authenticate using vCluster Platform. After enabling this setting
-users who browse to the Argo CD instance will see a button to login using vCluster Platform. All members of the
+users who browse to the Argo CD instance will see a button to log in using vCluster Platform. All members of the
 project will be able to log in using vCluster Platform and gain access to Argo CD.
 
 The final integration level is the App Project/Argo CD Project integration. This tier configures
@@ -85,11 +85,42 @@ under the 'Project Settings' button.
   <TabItem value="creation">
     <Flow id="enable-argocd-project-creation">
       <Step>
-        Select <Label>+ New Project</Label> from the projects dropdown at the top of the left navigation bar.
+        Select <Label>Create New Project</Label> from the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, create your project as
-        normal.
+        Create your project as normal, then click the <Label>Argo CD</Label> configuration tab.
+      </Step>
+      <Step>
+        Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
+      </Step>
+      <Step>
+        In the new configurations that appeared under the{" "}
+        <Label>Enable Argo CD Integration</Label> slider, select either{" "}
+        <Label>Clusters</Label> or
+        <Label>Tenant Clusters</Label> from the dropdown box in the <Label>
+          Where is Argo CD running
+        </Label> dropdown. This tells vCluster Platform if your Argo CD instance lives
+        in a connected physical cluster, or if it is running inside of a tenant cluster.
+      </Step>
+      <Step>
+        In the next dropdown to the right, select the name of the cluster or
+        tenant cluster that your Argo CD instance is deployed in.
+      </Step>
+      <Step>
+        If your Argo CD instance is deployed in a namespace other than `argocd`,
+        enter the name of the namespace in the <Label>Argo CD Namespace</Label>{" "}
+        box.
+      </Step>
+      <Step>
+        Finish configuring anything else you'd like on your project, then click{" "}
+        <Button>Save Changes</Button>.
+      </Step>
+    </Flow>
+  </TabItem>
+  <TabItem value="existing">
+    <Flow id="enable-argocd-project-existing">
+      <Step>
+        Click <Label>Settings</Label> for the appropriate project in the project selector dropdown (top left).
       </Step>
       <Step>
         Click the <Label>Argo CD</Label> configuration tab.
@@ -108,46 +139,7 @@ under the 'Project Settings' button.
         cluster.
       </Step>
       <Step>
-        In the next drop down to the right, select the name of the cluster or
-        tenant cluster that your Argo CD instance is deployed in.
-      </Step>
-      <Step>
-        If your Argo CD instance is deployed in a namespace other than `argocd`,
-        enter the name of the namespace in the <Label>Argo CD Namespace</Label>{" "}
-        box.
-      </Step>
-      <Step>
-        Finish configuring anything else you'd like on your project, then click
-        the
-        <Button>Save Changes</Button> button.
-      </Step>
-    </Flow>
-  </TabItem>
-  <TabItem value="existing">
-    <Flow id="enable-argocd-project-existing">
-      <Step>
-        Click on <Label>Settings</Label> for the appropriate project under the projects dropdown at the top of the left navigation bar.
-      </Step>
-      <Step>
-        In the drawer that appears from the right, click the{" "}
-        <Label>Argo CD</Label>
-        configuration tab.
-      </Step>
-      <Step>
-        Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
-      </Step>
-      <Step>
-        In the new configurations that appeared under the{" "}
-        <Label>Enable Argo CD Integration</Label> slider, select either{" "}
-        <Label>Clusters</Label> or
-        <Label>Tenant Clusters</Label> from the dropdown box in the <Label>
-          Where is Argo CD running
-        </Label> dropdown. This tells vCluster Platform if your Argo CD instance lives
-        in a connected physical cluster, or if it is running inside of a virtual
-        cluster.
-      </Step>
-      <Step>
-        In the next drop down to the right, select the name of the cluster or
+        In the next dropdown to the right, select the name of the cluster or
         tenant cluster that your Argo CD instance is deployed in.
       </Step>
       <Step>
@@ -162,14 +154,16 @@ under the 'Project Settings' button.
   </TabItem>
 </Tabs>
 
+<!-- vale Google.Headings = NO -->
 ### Enable Argo CD SSO integration
+<!-- vale Google.Headings = YES -->
 
 Projects may also enable SSO integration with Argo CD, which allows all members
 of the vCluster Platform project to log in to Argo CD using vCluster Platform.
 
 :::info Pre-Requisites
 The `loftHost` vCluster Platform configuration must be set to enable this integration. The `loftHost` can be
-configured using the Helm values, or in the `Platform` > `Platform Config` section of the UI on the `Config` pane.
+configured using Helm values, or in the `Admin` section of the UI on the `Config` pane.
 :::
 
 <Tabs
@@ -182,14 +176,10 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   <TabItem value="creation">
     <Flow id="enable-argocd-sso-project-creation">
       <Step>
-        Select <Label>+ New Project</Label> from the projects dropdown at the top of the left navigation bar.
+        Select <Label>Create New Project</Label> from the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, create your project as
-        normal.
-      </Step>
-      <Step>
-        Click the <Label>Argo CD</Label> configuration tab.
+        Create your project as normal, then click the <Label>Argo CD</Label> configuration tab.
       </Step>
       <Step>
         Slide the <Label>Enable Argo CD Integration</Label> slider to enabled.
@@ -205,7 +195,7 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
         cluster.
       </Step>
       <Step>
-        In the next drop down to the right, select the name of the cluster or
+        In the next dropdown to the right, select the name of the cluster or
         tenant cluster that your Argo CD instance is deployed in.
       </Step>
       <Step>
@@ -234,12 +224,10 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   <TabItem value="existing">
     <Flow id="enable-argocd-sso-project-existing">
       <Step>
-        Click on {" "}<Label>Settings</Label> for the appropriate project under the projects dropdown at the top of the left navigation bar.
+        Click <Label>Settings</Label> for the appropriate project in the project selector dropdown (top left).
       </Step>
       <Step>
-        In the drawer that appears from the right, click the{" "}
-        <Label>Argo CD</Label>
-        configuration tab.
+        Click the <Label>Argo CD</Label> configuration tab.
       </Step>
       <Step>
         Ensure that standard project Argo CD integration is configured.
@@ -264,7 +252,9 @@ configured using the Helm values, or in the `Platform` > `Platform Config` secti
   </TabItem>
 </Tabs>
 
+<!-- vale Google.Headings = NO -->
 ### Enable Argo CD App Project integration
+<!-- vale Google.Headings = YES -->
 
 App Project integration, can be enabled by editing a project manifest and setting the
 `argoCD.project.enabled` field of the project spec to 'true'. Additionally, users may

--- a/platform_versioned_docs/version-4.11.0/maintenance/monitoring/fleet-monitoring-otel.mdx
+++ b/platform_versioned_docs/version-4.11.0/maintenance/monitoring/fleet-monitoring-otel.mdx
@@ -160,7 +160,7 @@ node. The `groupbyattrs` processor splits the batch into per-pod resource scopes
 (by `namespace`, `pod`, `node`) so each pod is matched correctly.
 
 The `k8sattributes` processor resolves vCluster identity from Platform-managed
-namespace labels (`loft.sh/project`, `loft.sh/vcluster-instance-name`, and so on) and
+namespace labels (`loft.sh/project`, `loft.sh/vcluster-instance-name`, and others) and
 pod labels/annotations set by the vCluster syncer
 (`vcluster.loft.sh/namespace`, `vcluster.loft.sh/name`).
 
@@ -622,7 +622,7 @@ kubectl apply -f otel-collector-shared-nodes-app.yaml
     Navigate to the <NavStep>Apps</NavStep> tab.
   </Step>
   <Step>
-    Click <Button>Install App</Button> and click the
+    Click <Button>Install App</Button> and select the
     **OTEL Collector - Shared Nodes** app.
   </Step>
   <Step>
@@ -645,7 +645,7 @@ Repeat these steps for each Control Plane Cluster.
 ## Deploy the private nodes collector
 <!-- vale on -->
 
-Deploy one private-nodes collector into each private-nodes tenant cluster. All
+Deploy one private-nodes collector into each private-nodes vCluster. All
 vCluster identity labels are injected automatically by the Platform using
 `{{ .Values.loft.* }}`.
 

--- a/platform_versioned_docs/version-4.11.0/use-platform/apps/updating.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/apps/updating.mdx
@@ -33,9 +33,8 @@ newer (or older!) version in the vCluster Platform UI.
       <Step>
         Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
       </Step>
-      <Step>From the Clusters sub-menu, select the Clusters option.</Step>
       <Step>
-        Find the cluster containing the App you would like ot upgrade, and click
+        Find the cluster containing the App you would like to upgrade and click
         on that cluster.
       </Step>
       <Step>
@@ -48,13 +47,12 @@ newer (or older!) version in the vCluster Platform UI.
         <Label>Outdated</Label> in the status column.
       </Step>
       <Step>
-        Either click on the <Label>Outdated</Label> button in the status column
-        of your target App (if the App is outdated), or click on the small drop
-        down button next to the App name and click on the <Button>Edit</Button>{" "}
-        button.
+        Either click the <Label>Outdated</Label> button in the status column
+        of your target App (if the App is outdated), or click the <Button>Edit</Button>{" "}
+        option for the App you want to modify.
       </Step>
       <Step>
-        From the <Label>App Version</Label> drop down box, select the desired
+        From the <Label>App Version</Label> selector, select the desired
         target App Version.
       </Step>
       <Step>
@@ -65,18 +63,11 @@ newer (or older!) version in the vCluster Platform UI.
   <TabItem value="vcluster">
     <Flow id="update-app-vcluster">
       <Step>
-        Select the <NavStep>Projects</NavStep> field on the left menu bar.
+        Select the project containing the tenant cluster using the project selector (top left), then click <NavStep>Tenant Clusters</NavStep>.
       </Step>
       <Step>
-        Select the project containing the tenant cluster that you'd like to
-        install the App in from the Project drop down menu.
-      </Step>
-      <Step>
-        From the Projects sub-menu, select the Tenant Clusters option.
-      </Step>
-      <Step>
-        Find the tenant cluster containing the App you would like to upgrade,
-        click on that tenant cluster.
+        Find the tenant cluster containing the App you would like to upgrade and
+        click that tenant cluster.
       </Step>
       <Step>
         In the Tenant Cluster Management view, click the <Button>Apps</Button>{" "}
@@ -89,13 +80,12 @@ newer (or older!) version in the vCluster Platform UI.
         <Label>Outdated</Label> in the status column.
       </Step>
       <Step>
-        Either click on the <Label>Outdated</Label> button in the status column
-        of your target App (if the App is outdated), or click on the small drop
-        down button next to the App name and click on the <Button>Edit</Button>{" "}
-        button.
+        Either click the <Label>Outdated</Label> button in the status column
+        of your target App (if the App is outdated), or click the <Button>Edit</Button>{" "}
+        option for the App you want to modify.
       </Step>
       <Step>
-        From the <Label>App Version</Label> drop down box, select the desired
+        From the <Label>App Version</Label> selector, select the desired
         target App Version.
       </Step>
       <Step>

--- a/platform_versioned_docs/version-4.11.0/use-platform/apps/use-in-templates.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/apps/use-in-templates.mdx
@@ -40,12 +40,8 @@ a template, that app will be deployed in the given resource upon creation.
     be deployed *in* the tenant cluster!
   </Step>
   <Step>
-    From the drop down menu <Label>Add a new App ...</Label> select an App
-    that you would like to be included as part of the template. You can
-    select as many Apps as you would like here by simply selecting another
-    App from the drop down menu. If you accidentally add one, or add one you
-    do not want, click the trash icon next to the Apps name to remove it
-    from the template.
+    Select an App from the <Label>Please select an App...</Label> selector to include it in the template. You can
+    add as many Apps as you like by selecting another. To remove one, click the trash icon next to the App name.
   </Step>
   <Step>
     For each App you added to the template, you can configure the default
@@ -64,12 +60,8 @@ a template, that app will be deployed in the given resource upon creation.
     in (not inside the tenant cluster itself).
   </Step>
   <Step>
-    From the drop down menu <Label>Add a new App ...</Label> select an App
-    that you would like to be included as part of the template. You can
-    select as many Apps as you would like here by simply selecting another
-    App from the drop down menu. If you accidentally add one, or add one you
-    do not want, click the trash icon next to the Apps name to remove it
-    from the template.
+    Select an App from the <Label>Please select an App...</Label> selector to include it in the template. You can
+    add as many Apps as you like by selecting another. To remove one, click the trash icon next to the App name.
   </Step>
   <Step>
     For each App you added to the template, you can any App parameters

--- a/platform_versioned_docs/version-4.11.0/use-platform/apps/use-on-demand.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/apps/use-on-demand.mdx
@@ -40,7 +40,7 @@ development, test, or even production, environments in a single easy to manage p
           tenant cluster in.
       </Step>
       <Step>
-        Click on <NavStep>Tenant Clusters</NavStep>.
+        Click <NavStep>Tenant Clusters</NavStep>.
       </Step>
       <Step>
         Click the <Button>New Tenant Cluster</Button> button. Do not select a template.
@@ -60,12 +60,9 @@ development, test, or even production, environments in a single easy to manage p
         be deployed *in* the tenant cluster.
       </Step>
       <Step>
-        From the drop down menu <Label>Please select an App...</Label>, select an
-        application that you would like to be deployed. You can
-        select as many as you would like by simply selecting another
-        application from the drop down menu. If you accidentally add one, or add one you
-        do not want, click the trash icon next to the names of the applications to remove it
-        from the configuration.
+        Select an application from the <Label>Please select an App...</Label> selector. You can
+        add as many as you like by selecting another. To remove one, click the trash icon
+        next to the application name.
       </Step>
       <Step>
         For each application that you added to the template, you can configure the default
@@ -103,7 +100,7 @@ development, test, or even production, environments in a single easy to manage p
       <Step>
         Select the App you would like to install from the App thumbnails, or, if
         there are no recommend Apps, click the <Button>Install App</Button> and
-        find the desired App in the <Label>Select an App</Label> drop down menu.
+        select the desired App from the <Label>Select an App</Label> selector.
       </Step>
       <Step>
         In the Install App screen enter the namespace to install the App to in

--- a/platform_versioned_docs/version-4.11.0/use-platform/apps/use-parameters.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/apps/use-parameters.mdx
@@ -11,7 +11,7 @@ import Label from "@site/src/components/Label";
 
 ## Create an app with parameters
 
-Create an app with parameters using the vCluster Platform UI.
+Apps with parameters can be created through the vCluster Platform UI.
 
 <Flow id="create-app-with-parameters">
   <Step>
@@ -21,7 +21,7 @@ Create an app with parameters using the vCluster Platform UI.
     Click <Button>Add App</Button>.
   </Step>
   <Step>
-    In the drawer that appears from the right, give your new app a name by
+    In the configuration sheet that opens, give your new app a name by
     replacing the 'my-app' placeholder name, or by updating the manifest YAML
     'metadata.name' field.
   </Step>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/auto-delete/configure-ui.mdx
@@ -10,15 +10,15 @@ import Expander from '@site/src/components/Expander'
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto-delete for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click the <Button>Edit</Button> option for the {props.name} you want to modify.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template, if you want to change the auto delete configuration for a {props.name} created by a template, please do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template. To change auto-delete for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
     Use the <Label>Delete After Inactivity</Label> field to specify the time to wait before deleting the {props.name} if there was no more user activity within this {props.name}
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/add-app-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/add-app-ui.mdx
@@ -4,26 +4,16 @@ import Button from '@site/src/components/Button'
 import Label from '@site/src/components/Label'
 
 <Step>
-    Select the <NavStep>Projects</NavStep> field on the left menu bar.
+    Select the project containing the namespace using the project selector (top left), then click <NavStep>Namespaces</NavStep>.
 </Step>
 <Step>
-    Select the project containing the namespace that you'd like to install
-    the App in from the Project drop down menu.
+    Find the namespace you would like to deploy an App to and click it.
 </Step>
 <Step>
-    From the Projects sub-menu, select the Namespaces option.
+    In the Namespace Management view, click <Button>Apps</Button>.
 </Step>
 <Step>
-    Find the namespace you would like to deploy an App to in the list of namespaces, and click on that
-    namespace.
-</Step>
-<Step>
-    In the Namespace Management view, click the <Button>Apps</Button> button.
-</Step>
-<Step>
-    Select the App you would like to install from the App thumbnails, or, if there
-    are no recommend Apps, click the <Button>Install App</Button> and find  the
-    desired App in the <Label>Select an App</Label> drop down menu.
+    Select the App you would like to install from the App thumbnails, or click <Button>Install App</Button> and select the desired App.
 </Step>
 <Step>
     Enter any other required parameters for your App -- this may vary depending on

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/delete-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/delete-ui.mdx
@@ -15,6 +15,6 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
     While hovering over the row, you will see buttons appear on the right in the <Label>Actions</Label> column
   </Step>
   <Step>
-    Click on the <Button><svg viewBox="64 64 896 896" focusable="false" data-icon="delete" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"></path></svg></Button> button to <Label>Delete</Label> the namespace
+    Click the <Button><svg viewBox="64 64 896 896" focusable="false" data-icon="delete" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"></path></svg></Button> button to <Label>Delete</Label> the namespace
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/share-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/namespace/share-ui.mdx
@@ -7,21 +7,21 @@ import Expander from '@site/src/components/Expander'
 
 <Flow id="namespace-share-ui">
   <Step>
-    Go to the <NavStep>Projects</NavStep> view using the menu on the left
+    Select the project using the project selector (top left), then click <NavStep>Namespaces</NavStep>.
   </Step>
   <Step>
-    Click on Namespaces and click on the Edit link on a namespace.
+    Find the namespace and click <Button>Edit</Button>.
   </Step>
   <Step>
-    In the drawer select the 'Permissions' section.
+    In the configuration sheet that opens, click the <Label>Permissions</Label> tab.
   </Step>
   <Step>
-    Select the user or team you want to grant permissions in the 'User or Team' select. If you don't see the user or team you want to grant access in there, make sure they have project access.
+    Select the user or team you want to grant permissions from the <Label>User or Team</Label> selector. If the user or team is not listed, make sure they have project access.
   </Step>
   <Step>
-    Specify the cluster-role you want to assign the user or team within the namespace.
+    Specify the cluster role you want to assign the user or team within the namespace.
   </Step>
   <Step>
-    Click on the <Button>Save Changes</Button> button at the very bottom
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/sleep/configure-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/sleep/configure-ui.mdx
@@ -13,15 +13,15 @@ import CreateSpaceStep2 from '@site/static/media/ui/screenshots/spaces/create-sp
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over the {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click <Button>Edit</Button> on the {props.name}.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep</Expander> section. This only works for {props.name}s without a template, if you want to change the auto sleep configuration for a {props.name} created by a template, do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep</Expander> section. This only works for {props.name}s without a template. To change auto-sleep for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
-    Use the <Label>Sleep After Inactivity</Label> field to specify the time to wait before putting the {props.name} to sleep if there is no more user activity in this {props.name}
+    Use the <Label>Sleep After Inactivity</Label> field to specify the time to wait before putting the {props.name} to sleep if there is no more user activity.
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/sleep/schedule-ui.mdx
@@ -10,18 +10,18 @@ import Expander from '@site/src/components/Expander'
     In the <NavStep>Projects > {props.name === "tenant cluster" ? "Tenant Clusters" : "Namespaces"}</NavStep> view, hover over {props.name} that you want to configure auto sleep for
   </Step>
   <Step>
-    Click on the <Label>Edit</Label> button to <Label>Edit</Label> the {props.name}
+    Click <Button>Edit</Button> on the {props.name}.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Sleep Mode</Expander> {props.name}. This only works for {props.name}s without a template, if you want to change the auto sleep configuration for a {props.name} created by a template, do the changes in the Templates view
+    In the configuration sheet that opens, expand the <Expander>Sleep Mode</Expander> section. This only works for {props.name}s without a template. To change auto-sleep for a {props.name} created by a template, make the changes in the Templates view.
   </Step>
   <Step>
-    Expand the <Expander>Sleep & Wake-Up Schedule</Expander> section
+    Expand the <Expander>Sleep &amp; Wake-Up Schedule</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Sleep Schedule</Label> field and/or the <Label>Wake-Up Schedule</Label> field to specify the <Input>Cronjob Times</Input> when the respective {props.name} should be put to sleep or woken up
+    Use the <Label>Sleep Schedule</Label> field and the <Label>Wake up Schedule</Label> field to specify when the {props.name} should be put to sleep or woken up.
   </Step>
   <Step>
-    On the very bottom, click on the <Button>Save Changes</Button> button to save the changes
+    Click <Button>Save Changes</Button>.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/space-constraints/create-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/space-constraints/create-ui.mdx
@@ -11,16 +11,16 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
 
 <Flow id="create-namespace-constraints-ui">
   <Step>
-    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Switch to the <Label>Namespace Constraints</Label> tab
+    Switch to the <Label>Namespace Constraints</Label> tab.
   </Step>
   <Step>
-    Click the <Button>Create Namespace Constraints</Button> button to create a new namespace constraints object
+    Click <Button>Create Namespace Constraints</Button>.
   </Step>
   <Step>
-    In the drawer that appears on the right, use the field <Label>Display Name</Label> to specify a <Input>Name</Input> for your namespace constraints object
+    In the configuration sheet that opens, use the <Label>Display Name</Label> field to specify a <Input>Name</Input> for your namespace constraints object.
   </Step>
   <Step>
     Expand the <Expander>Enforce Resources</Expander> section to specify manifests that should be deployed to and enforced in each namespace that is affected by these namespace constraints
@@ -29,6 +29,6 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
     Expand the <Expander>Enforce Namespace Settings</Expander> section to specify other namespace settings such as sleep mode, auto-delete, labels and annotations that should be enforced for each namespace that is affected by these namespace constraints
   </Step>
   <Step>
-    On the very bottom, click the <Button>Create</Button> button to create this namespace constraints object
+    Click <Button>Create</Button> to create this namespace constraints object.
   </Step>
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/space-constraints/enforce-ui.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/_partials/space-constraints/enforce-ui.mdx
@@ -11,37 +11,37 @@ import CreateNamespaceStep2 from '@site/static/media/ui/screenshots/spaces/creat
 
 <Flow id="enforce-namespace-constraints-ui">
   <Step>
-    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>
+    Go to <NavStep>Infrastructure > Control Plane Clusters</NavStep>.
   </Step>
   <Step>
-    Switch to the <Label>Cluster Access</Label> tab
+    Switch to the <Label>Cluster Access</Label> tab.
   </Step>
   <Step>
-    Hover over the cluster access that you want to apply these namespace constraints to and click the <Button><svg viewBox="64 64 896 896" focusable="false" class="" data-icon="setting" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"></path></svg></Button> button to <Label>Edit</Label> the cluster access
+    Click <Button>Edit</Button> on the cluster access you want to apply these namespace constraints to.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Restrictions</Expander> section
+    In the configuration sheet that opens, expand the <Expander>Restrictions</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Enforce Namespace Constraints</Label> field to select the <Input>Namespace Constraint</Input> that you want to enforce for all namespaces created using this cluster access
+    Use the <Label>Enforce Namespace Constraints</Label> field to select the namespace constraint you want to enforce for all namespaces created using this cluster access.
   </Step>
   <Step>
-    On the very bottom, click the <Button>Update</Button> or <Button>Create</Button> button to save the changes
+    Click <Button>Update</Button> or <Button>Create</Button> to save the changes.
   </Step>
   <Step>
-    Switch to the <Label>Cluster Access</Label> tab
+    Switch to the <Label>Cluster Access</Label> tab.
   </Step>
   <Step>
-    Hover over the cluster access of the user or team that you want to configure automatic sleep mode for and click the <Button><svg viewBox="64 64 896 896" focusable="false" class="" data-icon="setting" width="1em" height="1em" fill="currentColor" aria-hidden="true"><path d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"></path></svg></Button> button to <Label>Edit</Label> the cluster access
+    Click <Button>Edit</Button> on the cluster access for the user or team you want to configure.
   </Step>
   <Step>
-    In the drawer that appears on the right, expand the <Expander>Restrictions</Expander> section
+    In the configuration sheet that opens, expand the <Expander>Restrictions</Expander> section.
   </Step>
   <Step>
-    Use the <Label>Enforce Namespace Constraints</Label> field to select the <Input>Namespace Constraint</Input> you edited or created in Step 3 above
+    Use the <Label>Enforce Namespace Constraints</Label> field to select the namespace constraint you edited or created above.
   </Step>
   <Step>
-    On the very bottom, click the <Button>Update</Button> button to save the changes
+    Click <Button>Update</Button> to save the changes.
   </Step>
 </Flow>
 

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -33,13 +33,13 @@ For more information on configuring custom links for tenant clusters, see the [C
         Edit an existing Namespace or create a new one.
       </Step>
       <Step>
-        Click <Label>Add Link</Label> to add a new link or <Label>Change</Label> to edit an existing one.
+        Click the edit icon next to the links section to open the links editor. Click <Button>Add</Button> to add a new link.
       </Step>
       <Step>
         Enter a URL and optionally a label for your link.
       </Step>
       <Step>
-        Click <Label>Save</Label>.
+        Click <Button>Save</Button>.
       </Step>
       <Step>
         Click <Button>Create Namespace</Button>,

--- a/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/prevent-deletion.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/namespaces/key-features/prevent-deletion.mdx
@@ -44,7 +44,7 @@ spec:
 
 <Flow id="namespace-prevent-deletion-ui">
 <Step>
-  Navigate to the <NavStep>Projects</NavStep> section using the menu on the left.
+  Go to <NavStep>Projects</NavStep>.
 </Step>
 
 <Step>
@@ -52,8 +52,7 @@ spec:
 </Step>
 
 <Step>
-  Either click on the <Button>Create Namespace</Button> button or select the
-  dropdown next to an existing namespace and select the <Label>Edit</Label> option.
+  Either click the <Button>Create Namespace</Button> button or click the <Button>Edit</Button> option for the namespace you want to modify.
 </Step>
 
 <Step>
@@ -61,13 +60,12 @@ spec:
 </Step>
 
 <Step>
-  Select the <Expander>Prevent Deletion</Expander> expander and tick the "enable
-  deletion prevention" checkbox.
+  Select the <Expander>Prevent Deletion</Expander> expander and enable <Label>Prevent Deletion</Label>.
 </Step>
 
 <Step>
-  Click on the <Button>Save</Button> button to save the changes or the{" "}
-  <Button>Create</Button> button, when creating a new namespace.
+  Click the <Button>Save</Button> button to save the changes, or the{" "}
+  <Button>Create</Button> button when creating a new namespace.
 </Step>
 
 </Flow>

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/key-features/custom-links.mdx
@@ -9,6 +9,7 @@ import TabItem from "@theme/TabItem";
 import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
+import Flow, { Step } from "@site/src/components/Flow";
 
 vCluster Platform lets you associate custom links to tenant cluster instances, for example to point to a github pull request or jira issue.
 
@@ -19,12 +20,11 @@ vCluster Platform lets you associate custom links to tenant cluster instances, f
         {label: 'CLI', value: 'cli'},
     ]}>
     <TabItem value="ui">
-    1. Go to the <NavStep>Tenant Clusters</NavStep> view using the menu on the left
-    1. Edit an existing Tenant Cluster or create a new one
-    1. Click <Label>Add Link</Label> to add a new link or <Label>Change</Label> to edit existing ones.
+    1. Select your project from the project selector, then click <NavStep>Tenant Clusters</NavStep>.
+    1. Edit an existing tenant cluster or create a new one.
+    1. Click the edit icon next to the links section to open the links editor. Click <Button>Add</Button> to add a new link.
     1. Enter a URL and optionally a label for your link.
-    1. Save your links by clicking <Label>Save</Label>.
-    1. Click on the <Button>Create Tenant Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing tenant cluster, to apply all changes.
+    1. Click <Button>Create Tenant Cluster</Button>, or <Button>Save Changes</Button> if you're editing an existing tenant cluster, to apply all changes.
     </TabItem>
 <TabItem value="cli">
 

--- a/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
+++ b/platform_versioned_docs/version-4.11.0/use-platform/virtual-clusters/key-features/prevent-deletion.mdx
@@ -53,20 +53,20 @@ spec:
     tenant cluster in.
   </Step>
   <Step>
-    Click on <NavStep>Tenant Clusters</NavStep>.
+    Click <NavStep>Tenant Clusters</NavStep>.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the tenant cluster that you want to edit.
+    Click the <Button>Edit</Button> option for the tenant cluster you want to modify.
   </Step>
   <Step>
     Navigate to <Label>Advanced</Label> section on the left.
   </Step>
   <Step>
-    Select the <Expander>Prevent Deletion</Expander> expander and tick the <Label>Enabled</Label> checkbox.
+    Select the <Expander>Prevent Deletion</Expander> expander and enable <Label>Enabled</Label>.
   </Step>
 
 <Step>
-  Click on the <Button>Save</Button> button to save the changes.
+  Click the <Button>Save</Button> button to save the changes.
 </Step>
 
 </Flow>


### PR DESCRIPTION
# Content Description
Restores the 31 files silently dropped by the docs-backport-action pagination bug (DEVOPS-1334) from source PR #2334's v4.10 backport (#2458) and v4.11 backport (#2459) — secrets/connect-cluster UI-drift and prose fixes across users-permissions, agent settings, SSO, Argo CD integrations, monitoring, apps, and namespace docs.

Ported via a 3-way merge (base = PR #2334's parent commit, theirs = PR #2334's merge commit, ours = current versioned file) rather than a blind overwrite, so independent changes already made to these files since the dropped backport — PR #2508's nav-path fixes, the fleet observability phase 1 guide, an Argo CD sync-permission addition — are preserved instead of reverted. 21 of 31 files merged with no conflicts; 10 needed manual conflict resolution where PR #2508 had already partially re-applied some of the same nav-label text as a stopgap.

30 files changed in version-4.10.0, 29 in version-4.11.0 (2 files were already at full parity via unrelated later fixes).

Verified: byte-for-byte parity against PR #2334's content for all 31 files in both versions (remaining diffs are only intentional version-pinned links or later independent improvements), 0 vale errors, no broken relative links introduced.

## Preview Link


## Internal Reference
Closes DOC-1692
Closes DOC-1693

References #2334, #2458, #2459, and DEVOPS-1334.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs