### PR TITLE
docs: fix stale /next/ links across platform versioned docs

### DIFF
--- a/platform/how-to/product-control-plane.mdx
+++ b/platform/how-to/product-control-plane.mdx
@@ -7,7 +7,7 @@ description: Map your product's concepts to Platform resources, drive them throu
 
 When you build a product that provisions tenant clusters for your customers, your product's control plane is what customers interact with, not Platform directly. Your automation drives Platform through its API. This guide maps common product concepts to Platform resources, shows how to call and watch the API, and covers how to keep usage metering consistent across tenants.
 
-This pattern applies to any product built on Platform. For a managed Kubernetes service, see the [AI Cloud production path](/docs/vcluster/production-guide/ai-cloud). For a managed inference platform, see [Building an inference platform](/docs/vcluster/next/introduction/inference-platform).
+This pattern applies to any product built on Platform. For a managed Kubernetes service, see the [AI Cloud production path](/docs/vcluster/production-guide/ai-cloud). For a managed inference platform, see [Building an inference platform](/docs/vcluster/introduction/inference-platform).
 
 ## Map product concepts to Platform resources
 
@@ -41,4 +41,4 @@ Confirm which parts of the stack require Platform activation or a paid tier befo
 - [Use API](../api/use-api.mdx) — connect to the Platform management API
 - [Owned Access Key](../api/resources/ownedaccesskey.mdx) — create the internal key your automation uses
 - [End-to-end GitOps with ArgoCD](./gitops-end-to-end.mdx) — deliver platform and tenant resources declaratively
-- [Building an inference platform](/docs/vcluster/next/introduction/inference-platform) — the inference-specific version of this pattern
+- [Building an inference platform](/docs/vcluster/introduction/inference-platform) — the inference-specific version of this pattern

--- a/platform_versioned_docs/version-4.10.0/_fragments/cli-steps/connect-platform.mdx
+++ b/platform_versioned_docs/version-4.10.0/_fragments/cli-steps/connect-platform.mdx
@@ -1,4 +1,4 @@
-**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/next/administer/authentication/access-keys) for more details.
+**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/administer/authentication/access-keys) for more details.
 
 When you started the platform, you would have automatically connected to the platform when you ran `vcluster platform start`.
 

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/cluster-upgrades.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/cluster-upgrades.mdx
@@ -68,7 +68,7 @@ If the platform does not manage your agents, you can still manually upgrade them
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/advanced/multi-region/deploy.mdx
@@ -134,7 +134,7 @@ eksctl create addon --name aws-ebs-csi-driver \\
 />
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ## Step 2 - Install AWS load balancer controller
 

--- a/platform_versioned_docs/version-4.10.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/clusters/connect-cluster.mdx
@@ -58,7 +58,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/bcm.mdx
@@ -145,8 +145,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/vcluster/next/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
+The BCM node provider can use the [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -201,4 +201,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/kubevirt.mdx
@@ -649,7 +649,7 @@ The interface injection itself is a generic mechanism. Netris is one way to driv
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
+- [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
 - vCluster Platform license must include the Netris feature.
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the control plane cluster nodes.
 
@@ -743,4 +743,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.10.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/node-providers/terraform.mdx
@@ -133,7 +133,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/vcluster/next/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 

--- a/platform_versioned_docs/version-4.10.0/administer/templates/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/templates/overview.mdx
@@ -39,20 +39,20 @@ vCluster Platform includes templates for tenant clusters, applications, and name
 
 <br />
 
-You can [create templates](/docs/platform/next/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
+You can [create templates](/docs/platform/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
 
 
 ## Apply parameters and versioning
 
 Templates support optional parameterization and versioning. Optionally, you can apply:
 
-- [Parameters](/docs/platform/next/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
+- [Parameters](/docs/platform/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
 
-- [Versioning](/docs/platform/next/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
+- [Versioning](/docs/platform/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
 
 
 ## Next steps
 
-- [Create a template](/docs/platform/next/administer/templates/create-templates) to define a reusable configuration.
-- Optionally, [configure template parameters](/docs/platform/next/administer/templates/parameters) to allow user customization.
-- Optionally, [set up template versioning](/docs/platform/next/administer/templates/versioning) to manage template updates.
+- [Create a template](/docs/platform/administer/templates/create-templates) to define a reusable configuration.
+- Optionally, [configure template parameters](/docs/platform/administer/templates/parameters) to allow user customization.
+- Optionally, [set up template versioning](/docs/platform/administer/templates/versioning) to manage template updates.

--- a/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.10.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -188,5 +188,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for tenant clusters](/docs/vcluster/next/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for tenant clusters](/docs/vcluster/configure/vcluster-yaml/sleep)**
 :::

--- a/platform_versioned_docs/version-4.10.0/configure/agent-settings/overview.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/agent-settings/overview.mdx
@@ -67,7 +67,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.10.0/configure/installation-options/domain.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/installation-options/domain.mdx
@@ -29,7 +29,7 @@ Setting up the platform for access through a routable IP or domain name, and sec
 
 ## External access
 
-The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/next/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/next/manage/ingress-nginx-to-gateway-api).
+The platform, like any other service in Kubernetes, can be exposed in multiple ways. **The LoadBalancer method is recommended.** The NGINX ingress controller examples below are preserved for reference but the ingress-nginx project is deprecated upstream. Use a LoadBalancer or a Gateway API-compatible controller for new deployments. For tenant cluster endpoint planning, see [Gateway API](/docs/vcluster/key-features/gateway-api) and [Migrate from ingress-nginx to Gateway API](/docs/vcluster/manage/ingress-nginx-to-gateway-api).
 
 <details>
   <summary>

--- a/platform_versioned_docs/version-4.10.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.10.0/introduction/platform_intro.mdx
@@ -115,7 +115,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
   <figcaption>Sleeping tenant clusters remain visible in Platform and can be woken when users need them again.</figcaption>
 </figure>
 
-[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform_versioned_docs/version-4.10.0/understand/control-plane-outages.mdx
+++ b/platform_versioned_docs/version-4.10.0/understand/control-plane-outages.mdx
@@ -35,7 +35,7 @@ A connected control plane cluster is a Kubernetes cluster where Platform can dep
 | Tenant cluster reconciliation | Unavailable | Platform-managed reconciliation pauses or fails for tenant clusters on the unavailable cluster. |
 | Tenant workloads | Limited | Availability depends on whether their control planes and worker nodes are still running and reachable. |
 
-If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/next/understand/control-plane-outages).
+If tenant cluster control planes are hosted on the unavailable control plane cluster, tenant users can't reliably use those tenant cluster APIs until the control plane cluster recovers. For the tenant cluster view of this behavior, see [What happens during control plane outages?](/docs/vcluster/understand/control-plane-outages).
 
 ## Tenant cluster control plane outage
 

--- a/platform_versioned_docs/version-4.10.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.10.0/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Tenant cluster custom links
-For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -118,7 +118,7 @@ Organizations often have existing deployment pipelines using tools like Helm, Ar
 
 After deploying your vCluster using your existing tools, add it to <GlossaryTerm term="platform">the Platform</GlossaryTerm> and enable full management.
 
-First, login with the platform [access key](/docs/platform/next/administer/authentication/access-keys):
+First, login with the platform [access key](/docs/platform/administer/authentication/access-keys):
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
@@ -143,7 +143,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/next/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -285,8 +285,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -322,6 +322,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform_versioned_docs/version-4.10.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/next/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 

--- a/platform_versioned_docs/version-4.11.0/how-to/product-control-plane.mdx
+++ b/platform_versioned_docs/version-4.11.0/how-to/product-control-plane.mdx
@@ -7,7 +7,7 @@ description: Map your product's concepts to Platform resources, drive them throu
 
 When you build a product that provisions tenant clusters for your customers, your product's control plane is what customers interact with, not Platform directly. Your automation drives Platform through its API. This guide maps common product concepts to Platform resources, shows how to call and watch the API, and covers how to keep usage metering consistent across tenants.
 
-This pattern applies to any product built on Platform. For a managed Kubernetes service, see the [AI Cloud production path](/docs/vcluster/production-guide/ai-cloud). For a managed inference platform, see [Building an inference platform](/docs/vcluster/next/introduction/inference-platform).
+This pattern applies to any product built on Platform. For a managed Kubernetes service, see the [AI Cloud production path](/docs/vcluster/production-guide/ai-cloud). For a managed inference platform, see [Building an inference platform](/docs/vcluster/introduction/inference-platform).
 
 ## Map product concepts to Platform resources
 
@@ -41,4 +41,4 @@ Confirm which parts of the stack require Platform activation or a paid tier befo
 - [Use API](../api/use-api.mdx) — connect to the Platform management API
 - [Owned Access Key](../api/resources/ownedaccesskey.mdx) — create the internal key your automation uses
 - [End-to-end GitOps with ArgoCD](./gitops-end-to-end.mdx) — deliver platform and tenant resources declaratively
-- [Building an inference platform](/docs/vcluster/next/introduction/inference-platform) — the inference-specific version of this pattern
+- [Building an inference platform](/docs/vcluster/introduction/inference-platform) — the inference-specific version of this pattern

--- a/platform_versioned_docs/version-4.8.0/_fragments/cli-steps/connect-platform.mdx
+++ b/platform_versioned_docs/version-4.8.0/_fragments/cli-steps/connect-platform.mdx
@@ -1,4 +1,4 @@
-**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/next/administer/authentication/access-keys) for more details.
+**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/administer/authentication/access-keys) for more details.
 
 When you started the platform, you would have automatically connected to the platform when you ran `vcluster platform start`.
 

--- a/platform_versioned_docs/version-4.8.0/administer/clusters/advanced/cluster-upgrades.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/clusters/advanced/cluster-upgrades.mdx
@@ -67,7 +67,7 @@ If the platform does not manage your agents, you can still manually upgrade them
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.8.0/administer/clusters/advanced/multi-region.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/clusters/advanced/multi-region.mdx
@@ -165,7 +165,7 @@ eksctl create addon --name aws-ebs-csi-driver \
 ```
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ### Step 2 - Install AWS load balancer controller
 

--- a/platform_versioned_docs/version-4.8.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/clusters/connect-cluster.mdx
@@ -55,7 +55,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/bcm.mdx
@@ -144,8 +144,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/vcluster/next/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
+The BCM node provider can use the [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -200,4 +200,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/kubevirt.mdx
@@ -498,7 +498,7 @@ Specifies the Netris server cluster to use for this VM. When set, vCluster Platf
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration
+- [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration
 - vCluster Platform license must include the Netris feature
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the host cluster nodes
 
@@ -610,4 +610,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.8.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/node-providers/terraform.mdx
@@ -132,7 +132,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/vcluster/next/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 

--- a/platform_versioned_docs/version-4.8.0/administer/templates/overview.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/templates/overview.mdx
@@ -39,20 +39,20 @@ vCluster Platform includes templates for virtual clusters, applications, and nam
 
 <br />
 
-You can [create templates](/docs/platform/next/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
+You can [create templates](/docs/platform/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
 
 
 ## Apply parameters and versioning
 
 Templates support optional parameterization and versioning. Optionally, you can apply:
 
-- [Parameters](/docs/platform/next/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
+- [Parameters](/docs/platform/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
 
-- [Versioning](/docs/platform/next/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for virtual clusters based on versioned templates. Templates without versions do not support automatic updates.
+- [Versioning](/docs/platform/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for virtual clusters based on versioned templates. Templates without versions do not support automatic updates.
 
 
 ## Next steps
 
-- [Create a template](/docs/platform/next/administer/templates/create-templates) to define a reusable configuration.
-- Optionally, [configure template parameters](/docs/platform/next/administer/templates/parameters) to allow user customization.
-- Optionally, [set up template versioning](/docs/platform/next/administer/templates/versioning) to manage template updates.
+- [Create a template](/docs/platform/administer/templates/create-templates) to define a reusable configuration.
+- Optionally, [configure template parameters](/docs/platform/administer/templates/parameters) to allow user customization.
+- Optionally, [set up template versioning](/docs/platform/administer/templates/versioning) to manage template updates.

--- a/platform_versioned_docs/version-4.8.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.8.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -194,5 +194,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for virtual clusters](/docs/vcluster/next/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for virtual clusters](/docs/vcluster/configure/vcluster-yaml/sleep)**
 :::

--- a/platform_versioned_docs/version-4.8.0/configure/agent-settings/overview.mdx
+++ b/platform_versioned_docs/version-4.8.0/configure/agent-settings/overview.mdx
@@ -67,7 +67,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.8.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.8.0/introduction/platform_intro.mdx
@@ -82,7 +82,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
 
 {/* TODO: screenshot or GIF — Tenant cluster card showing sleep/wake toggle, or the sleep configuration panel with inactivity timeout and schedule fields */}
 
-[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.8.0/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform_versioned_docs/version-4.8.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.8.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Virtual cluster custom links
-For more information on configuring custom links for virtual clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+For more information on configuring custom links for virtual clusters, see the [Custom Links](/docs/vcluster/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -116,7 +116,7 @@ Organizations often have existing deployment pipelines using tools like Helm, Ar
 
 After deploying your vCluster using your existing tools, add it to <GlossaryTerm term="platform">the Platform</GlossaryTerm> and enable full management.
 
-First, login with the platform [access key](/docs/platform/next/administer/authentication/access-keys):
+First, login with the platform [access key](/docs/platform/administer/authentication/access-keys):
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
@@ -141,7 +141,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/next/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -283,8 +283,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -320,6 +320,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform_versioned_docs/version-4.8.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/multi-region-mode.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/next/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 

--- a/platform_versioned_docs/version-4.9.0/_fragments/cli-steps/connect-platform.mdx
+++ b/platform_versioned_docs/version-4.9.0/_fragments/cli-steps/connect-platform.mdx
@@ -1,4 +1,4 @@
-**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/next/administer/authentication/access-keys) for more details.
+**Connect to the Platform**: to use any `vcluster platform` command, you need to be connected to the platform. See [authentication documentation](/docs/platform/administer/authentication/access-keys) for more details.
 
 When you started the platform, you would have automatically connected to the platform when you ran `vcluster platform start`.
 

--- a/platform_versioned_docs/version-4.9.0/administer/clusters/advanced/cluster-upgrades.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/clusters/advanced/cluster-upgrades.mdx
@@ -68,7 +68,7 @@ If the platform does not manage your agents, you can still manually upgrade them
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.9.0/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/clusters/advanced/multi-region/deploy.mdx
@@ -133,7 +133,7 @@ eksctl create addon --name aws-ebs-csi-driver \\
 />
 
 For more details on EKS prerequisites for running tenant clusters, see the
-[EKS environment setup guide](/docs/vcluster/next/deploy/control-plane/kubernetes-pod/environment/eks).
+[EKS environment setup guide](/docs/vcluster/deploy/control-plane/kubernetes-pod/environment/eks).
 
 ## Step 2 - Install AWS load balancer controller
 

--- a/platform_versioned_docs/version-4.9.0/administer/clusters/connect-cluster.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/clusters/connect-cluster.mdx
@@ -55,7 +55,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.9.0/administer/node-providers/bcm.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/node-providers/bcm.mdx
@@ -144,8 +144,8 @@ Example: `10.0.0.20-10.0.0.30`
 
 ## Netris integration
 
-The BCM node provider can use the [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
-The following properties require the integration to be enabled and [configured](/vcluster/next/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
+The BCM node provider can use the [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) for automated network configuration and IP management.
+The following properties require the integration to be enabled and [configured](/docs/vcluster/configure/vcluster-yaml/integrations/netris#configure-netris-integration).
 
 ### `netris.vcluster.com/server-cluster`
 
@@ -200,4 +200,4 @@ privateNodes:
         netris.vcluster.com/server-cluster: vcluster-1
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.9.0/administer/node-providers/kubevirt.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/node-providers/kubevirt.mdx
@@ -589,7 +589,7 @@ The interface injection itself is a generic mechanism. Netris is one way to driv
 - `kubevirt.vcluster.com/network-nameservers`: DNS servers
 
 **Prerequisites:**
-- [Netris integration](/vcluster/next/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
+- [Netris integration](/docs/vcluster/configure/vcluster-yaml/integrations/netris) must be enabled and configured in the vCluster configuration.
 - vCluster Platform license must include the Netris feature.
 - Bridge with the `nbr-<vnet vxlan id>` must exist on the control plane cluster nodes.
 
@@ -701,4 +701,4 @@ integrations:
     connector: netris-credentials
 ```
 
-For more information on Netris integration, see the [Netris integration documentation](/vcluster/next/configure/vcluster-yaml/integrations/netris).
+For more information on Netris integration, see the [Netris integration documentation](/docs/vcluster/configure/vcluster-yaml/integrations/netris).

--- a/platform_versioned_docs/version-4.9.0/administer/node-providers/terraform.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/node-providers/terraform.mdx
@@ -132,7 +132,7 @@ Currently supported providers:
 - [Azure](https://github.com/loft-sh/vcluster-auto-nodes-azure/tree/v0.1.0)  
 - [GCP](https://github.com/loft-sh/vcluster-auto-nodes-gcp/tree/v0.1.0)  
 
-See the full [quick start deployment guide](/vcluster/next/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
+See the full [quick start deployment guide](/docs/vcluster/deploy/worker-nodes/private-nodes/auto-nodes/quick-start-templates) for more details.
 
 ### Available terraform vCluster variables
 

--- a/platform_versioned_docs/version-4.9.0/administer/templates/overview.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/templates/overview.mdx
@@ -39,20 +39,20 @@ vCluster Platform includes templates for tenant clusters, applications, and name
 
 <br />
 
-You can [create templates](/docs/platform/next/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
+You can [create templates](/docs/platform/administer/templates/create-templates) using the vCluster Platform UI for guided configuration or by applying manifests directly with `kubectl`, Helm, or ArgoCD. 
 
 
 ## Apply parameters and versioning
 
 Templates support optional parameterization and versioning. Optionally, you can apply:
 
-- [Parameters](/docs/platform/next/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
+- [Parameters](/docs/platform/administer/templates/parameters) - Enable dynamic customization of template fields, allowing users to specify values for CPU limits, labels, environment types, and other configuration options during vCluster provisioning.
 
-- [Versioning](/docs/platform/next/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
+- [Versioning](/docs/platform/administer/templates/versioning) - Manage and iterate template configurations across different releases, providing version control for your cluster templates. It allows for automatic updates for tenant clusters based on versioned templates. Templates without versions do not support automatic updates.
 
 
 ## Next steps
 
-- [Create a template](/docs/platform/next/administer/templates/create-templates) to define a reusable configuration.
-- Optionally, [configure template parameters](/docs/platform/next/administer/templates/parameters) to allow user customization.
-- Optionally, [set up template versioning](/docs/platform/next/administer/templates/versioning) to manage template updates.
+- [Create a template](/docs/platform/administer/templates/create-templates) to define a reusable configuration.
+- Optionally, [configure template parameters](/docs/platform/administer/templates/parameters) to allow user customization.
+- Optionally, [set up template versioning](/docs/platform/administer/templates/versioning) to manage template updates.

--- a/platform_versioned_docs/version-4.9.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.9.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -194,5 +194,5 @@ With access to a cluster, users can typically:
 
 vCluster Platform allows you to:
 
-- **[Configure sleep mode for tenant clusters](/docs/vcluster/next/configure/vcluster-yaml/sleep)**
+- **[Configure sleep mode for tenant clusters](/docs/vcluster/configure/vcluster-yaml/sleep)**
 :::

--- a/platform_versioned_docs/version-4.9.0/configure/agent-settings/overview.mdx
+++ b/platform_versioned_docs/version-4.9.0/configure/agent-settings/overview.mdx
@@ -67,7 +67,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/docs/platform/next/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/administer/authentication/access-keys#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform_versioned_docs/version-4.9.0/introduction/platform_intro.mdx
+++ b/platform_versioned_docs/version-4.9.0/introduction/platform_intro.mdx
@@ -113,7 +113,7 @@ Auto-delete works the same way. Tenant clusters idle beyond a configured thresho
   <figcaption>Sleeping tenant clusters remain visible in Platform and can be woken when users need them again.</figcaption>
 </figure>
 
-[Configure sleep mode →](/docs/vcluster/next/configure/vcluster-yaml/sleep)
+[Configure sleep mode →](/docs/vcluster/configure/vcluster-yaml/sleep)
 
 ## Access control
 

--- a/platform_versioned_docs/version-4.9.0/understand/externally-vs-platform-deployed.mdx
+++ b/platform_versioned_docs/version-4.9.0/understand/externally-vs-platform-deployed.mdx
@@ -38,7 +38,7 @@ When you add an externally deployed tenant cluster to Platform and connect it wi
 - Platform integrations (Argo CD, Vault secrets, and others)
 
 :::note
-Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/next/configure/vcluster-yaml/platform) are only available if the agent is installed.
+Features in the `platform:` [section of vcluster.yaml](/docs/vcluster/configure/vcluster-yaml/platform) are only available if the agent is installed.
 :::
 
 ## Choose a deployment model

--- a/platform_versioned_docs/version-4.9.0/use-platform/namespaces/key-features/custom-links.mdx
+++ b/platform_versioned_docs/version-4.9.0/use-platform/namespaces/key-features/custom-links.mdx
@@ -15,7 +15,7 @@ You can add custom links to namespaces that point to external resources such as 
 This allows team members to access all relevant resources directly from the namespace view.
 
 :::tip Tenant cluster custom links
-For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/next/key-features/custom-links) documentation.
+For more information on configuring custom links for tenant clusters, see the [Custom Links](/docs/vcluster/key-features/custom-links) documentation.
 :::
 
 <Tabs

--- a/platform_versioned_docs/version-4.9.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform_versioned_docs/version-4.9.0/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -116,7 +116,7 @@ Organizations often have existing deployment pipelines using tools like Helm, Ar
 
 After deploying your vCluster using your existing tools, add it to <GlossaryTerm term="platform">the Platform</GlossaryTerm> and enable full management.
 
-First, login with the platform [access key](/docs/platform/next/administer/authentication/access-keys):
+First, login with the platform [access key](/docs/platform/administer/authentication/access-keys):
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 ```
@@ -141,7 +141,7 @@ platform:
     secretName: vcluster-platform-api-key  # Defaults to vcluster-platform-api-key if undefined
     namespace: vcluster-namespace  # Namespace to search for the secret. If undefined, it searches the vCluster namespace. If different, vCluster needs access to the target namespace.
 ```
-The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/next/configure/vcluster-yaml/platform).
+The platform access key can only be provided as a Kubernetes Secret. You can find more information of how to create such Secret at the [`apiKey` configuration section of vCluster.](/docs/vcluster/configure/vcluster-yaml/platform).
 
 ### Helm wrapper for VirtualClusterInstance
 
@@ -283,8 +283,8 @@ Once `external: false` is set, the following Platform features become available:
 
 - **[Full lifecycle management](/docs/platform/use-platform/virtual-clusters/manage-access)**: Platform handles upgrades and configuration changes
 - **[Templates](../../administer/templates/create-templates.mdx)**: Use and enforce vCluster templates for consistency
-- **[Auto-delete](/docs/vcluster/next/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
-- **[Auto Sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
+- **[Auto-delete](/docs/vcluster/configure/vcluster-yaml/sleep#configure-auto-delete)**: Automatic cleanup after inactivity periods
+- **[Auto Sleep](/docs/vcluster/configure/vcluster-yaml/sleep)**: Automatic sleep/wake, to include the vCluster control plane, based on activity to save resources
 - **[Project assignment](/docs/platform/administer/projects/create)**: Organize tenant clusters into projects with quotas
 - **[SSO integration](../../configure/platform-configs/single-sign-on.mdx)**: <GlossaryTerm term="user">User</GlossaryTerm> access through Platform SSO providers
 - **[Audit logging](../../configure/platform-configs/audit.mdx)**: Centralized audit trails for compliance
@@ -320,6 +320,6 @@ For specific scenarios where full Platform management isn't suitable:
 ## Next steps
 
 - Learn about [managing tenant cluster access](/docs/platform/use-platform/virtual-clusters/manage-access)
-- Configure [auto sleep](/docs/vcluster/next/configure/vcluster-yaml/sleep) for cost optimization
+- Configure [auto sleep](/docs/vcluster/configure/vcluster-yaml/sleep) for cost optimization
 - Set up [templates](../../administer/templates/create-templates.mdx) for consistent deployments
 - Explore [GitOps integration](/docs/platform/install/gitops) for declarative management

--- a/platform_versioned_docs/version-4.9.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform_versioned_docs/version-4.9.0/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -28,7 +28,7 @@ If you have multiple tenant clusters with the same name, a sub-menu allows you t
 
 :::info
 If you have regional [cluster endpoints](../../administer/clusters/advanced/regional-cluster-endpoints.mdx) or
-[ingress endpoints for tenant clusters](/docs/vcluster/next/key-features/ingress-access)
+[ingress endpoints for tenant clusters](/docs/vcluster/key-features/ingress-access)
 enabled, the resulting kubeconfig will look different.
 :::
 


### PR DESCRIPTION
# Content Description
Fixes stale `/next/`-prefixed links found while restoring DOC-1692/DOC-1693 (backport-dropped files). These are unrelated, pre-existing broken links: `/docs/vcluster/next/...`, `/docs/platform/next/...`, and the malformed `/vcluster/next/...` (missing `/docs` prefix), all pointing at unreleased "next" docs instead of the stable or version-pinned path. Fixed on `main` (1 file) and across `platform_versioned_docs/version-4.8.0/`, `version-4.9.0/`, `version-4.10.0/`, and `version-4.11.0/` (48 files) — same pattern repeated in every version folder since none had ever been cleaned up.

Scoped strictly to the link substitution. Left alone: a separate volume of pre-existing vale warnings (old prose style — "Let's", "click on", Latinisms) in v4.8.0/v4.9.0 copies of a couple of these files, which predate the PR #2334/#2508 prose cleanup and would require a much larger rewrite outside this fix's scope.

## Preview Link


## Internal Reference
Related to DOC-1692, DOC-1693, and DEVOPS-1334 (found during that restoration work), but not itself tracked by a Linear ticket.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

@netlify /docs