### PR TITLE
ci: follow the docs backport action v1 tag

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Backport Docusaurus Changes
-        uses: loft-sh/docs-backport-action@v1.3.1
+        uses: loft-sh/docs-backport-action@v1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Updates the docs backport workflow to follow the floating `docs-backport-action` v1 tag.

The action release workflow moves `v1` after each compatible `v1.x.x` release, so future fixes do not require another consumer pin update.

This PR depends on loft-sh/docs-backport-action#130 merging and its release moving `v1`. Do not merge it before both conditions are met.

## Preview Link 
Not applicable. This changes workflow configuration only.

## Internal Reference
References DEVOPS-1334


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
