### PR TITLE
docs(doc-1697): fix stale UI element names and paths in join.mdx

### DIFF
--- a/.claude/skills/platform-ui-drift/SKILL.md
+++ b/.claude/skills/platform-ui-drift/SKILL.md
@@ -106,6 +106,12 @@ longer exist as separate entries. Instead:
   (literally no space, unlike the "Argo CD" prose spelling elsewhere) and
   `Helm Apps`.
 
+Both layouts hide the tab bar entirely when only one of the two sibling
+features is enabled (`tabs: visibleTabs.length > 1 ? visibleTabs : undefined`)
+and redirect straight to the single remaining page instead — no tab bar
+renders, so there's nothing to click. Never write a bare "click the X tab"
+for these two pages; see "Conditionally hidden tabs" under Fix patterns below.
+
 So `Go to <NavStep>Tenant Management > Cluster Templates</NavStep>` becomes
 `Go to <NavStep>Management > Templates</NavStep> and click the
 <Label>Tenant Clusters</Label> tab`, and similarly for Namespaces and
@@ -204,6 +210,33 @@ Exception: the `Apps` page tab is literally labeled `ArgoCD Apps` (no space) in
 text, keep it as `ArgoCD Apps` — changing it to `Argo CD Apps` would itself be
 drift, since it wouldn't match what the tab says on screen.
 
+### Conditionally hidden tabs (Templates/Apps)
+
+`TemplatesPageLayout.tsx` and `AppsPageLayout.tsx` only render a tab bar when
+both sibling features are enabled; with just one enabled, the page redirects
+straight there and no tab exists to click. Any instruction that tells a user
+to click `Tenant Clusters`/`Namespaces` (Templates) or `ArgoCD Apps`/`Helm Apps`
+(Apps) needs the click to be conditional:
+
+```mdx
+<!-- Before -->
+Go to <NavStep>Management > Templates</NavStep> and click the
+<Label>Tenant Clusters</Label> tab.
+
+<!-- After -->
+Go to <NavStep>Management > Templates</NavStep> and, if shown, click the
+<Label>Tenant Clusters</Label> tab.
+```
+
+For a step that references both tabs of a page in one sentence (for example
+a shared "find your template" step spanning Templates and Apps), use "If a
+tab bar is shown, click the tab for..." instead of stapling "if shown" onto
+each label individually.
+
+Check for this same collapse-to-redirect pattern on any other page layout
+gated by two mutually exclusive feature flags — look for a `.length > 1 ? ... : undefined`
+guard on the `tabs:` prop before writing a bare tab-click instruction.
+
 ## After fixing: Vale
 
 Run Vale on every file you touch and fix all warnings — not just the drift-related lines.
@@ -223,6 +256,8 @@ Common warnings triggered by drift fixes:
 After the Management/Templates/Apps sidebar restructuring sweep, the report stands at 10 unmatched tokens (all in the "known expected" table above) and 0 instruction phrases. Any new findings above this baseline represent genuine drift introduced since that date.
 
 This sweep found a real restructuring the script's multi-part `NavStep` matching had masked for some time: `Tenant Management` was renamed `Management`, and the `Cluster Templates`/`Namespace Templates`/`Argo CD Templates` nav items were merged into two items (`Templates` with `Tenant Clusters`/`Namespaces` tabs, and `Apps` with `ArgoCD Apps`/`Helm Apps` tabs). Fixed across `_partials/namespace-template/create-ui.mdx`, `administer/templates/create-templates.mdx`, `administer/templates/versioning.mdx`, `integrations/argocd/deploy-applications.mdx`, `use-platform/apps/use-in-templates.mdx`, and `use-platform/apps/use-parameters.mdx`. Also fixed along the way: a stale `<Button>Add App</Button>` (now `Create App Template`), a stale bold `**Add Namespace Template**` (now the `<Button>` component with the correct `Create Namespace Template` text), and a stale `<Label>Recommended App</Label>` (the UI label is `Recommend App`, no "-ed").
+
+A PR review on the same sweep caught a further issue the drift script can't detect at all: the `Templates`/`Apps` tab-click steps assumed the tab bar always renders, but it collapses away when only one sibling feature is enabled (see "Conditionally hidden tabs" under Fix patterns). Reworded all 8 affected steps across the same six files to make the click conditional.
 
 Previously (2026-07-28, after the fleet observability sweep): 10 unmatched tokens, 0 instruction phrases. Previously (2026-06-26, after the DOC-1574 sweep): 4 unmatched tokens, 0 instruction phrases. The six fleet observability tokens added since then are all Argo CD Application Template names/parameters (dynamic content, not literal UI strings) — see the known-expected table. One genuine drift item from that sweep, a stale `<Label>Deploy to vCluster</Label>` in `configure-edge-collectors.mdx` that should have read `Deploy to tenant cluster`, was found and fixed rather than added to the known-expected list.
 

--- a/.claude/skills/platform-ui-drift/SKILL.md
+++ b/.claude/skills/platform-ui-drift/SKILL.md
@@ -85,16 +85,34 @@ cat ../loft-enterprise/ui/src/Layout/Sidebar/config/sections.tsx
 cat ../loft-enterprise/ui/src/views/Clusters/hooks/useClusterTabs.tsx
 ```
 
-**Current sidebar structure (as of 2026-06):**
+**Current sidebar structure (as of 2026-08-13):**
 
 | Section label | Key items |
 |---|---|
-| Infrastructure | Infra Providers, Control Plane Clusters, Connectors, Bare Metal Servers |
-| Tenant Management | Cluster Templates, Namespace Templates, Argo CD Templates, Apps |
-| Access & Secrets | Users & Roles, SSH Keys, Global Secrets |
-| Platform | Logs & Activity, Cost Control, Platform Config |
+| Infrastructure | Nodes & Providers, Control Plane Clusters, Connectors, Bare Metal Servers, KubeVirt, Operating System, VPN |
+| Management | Templates, Apps |
+| Access & Secrets | Users & Roles, Global Secrets |
+| Platform | Fleet Observability, Logs & Activity, Cost Control, Platform Config |
 
 Control Plane Clusters sub-tabs: Host Clusters, Cluster Access, Cluster Roles, VPN.
+
+The `Tenant Management` section was renamed `Management` and consolidated: the
+old `Cluster Templates`/`Namespace Templates`/`Argo CD Templates` nav items no
+longer exist as separate entries. Instead:
+
+- `Templates` (`ui/src/views/Templates/TemplatesPageLayout.tsx`) has two tabs:
+  `Tenant Clusters` and `Namespaces`.
+- `Apps` (`ui/src/views/Templates/AppsPageLayout.tsx`) has two tabs: `ArgoCD Apps`
+  (literally no space, unlike the "Argo CD" prose spelling elsewhere) and
+  `Helm Apps`.
+
+So `Go to <NavStep>Tenant Management > Cluster Templates</NavStep>` becomes
+`Go to <NavStep>Management > Templates</NavStep> and click the
+<Label>Tenant Clusters</Label> tab`, and similarly for Namespaces and
+Argo CD Templates/Apps. This is a **common false negative**: the script
+matched `Tenant Management > *` paths for years because "tenant" and
+"management" each exist elsewhere in the UI source, not because the section
+still exists. Multi-part `NavStep` matches are leads, not proof — see above.
 
 ### Button and label text
 
@@ -179,7 +197,12 @@ In the configuration sheet that opens, click the <Label>Agent</Label> tab.
 
 ### Argo CD
 
-The UI uses a space: "Argo CD" not "ArgoCD". The script normalizes this so it matches, but fix prose spelling when you touch the file.
+The UI generally uses a space: "Argo CD" not "ArgoCD". The script normalizes this so it matches, but fix prose spelling when you touch the file.
+
+Exception: the `Apps` page tab is literally labeled `ArgoCD Apps` (no space) in
+`AppsPageLayout.tsx`. When a `<Label>` or `<NavStep>` represents that exact tab
+text, keep it as `ArgoCD Apps` — changing it to `Argo CD Apps` would itself be
+drift, since it wouldn't match what the tab says on screen.
 
 ## After fixing: Vale
 
@@ -195,11 +218,13 @@ Common warnings triggered by drift fixes:
 - Title-case headings → sentence case
 - `via` → `using`
 
-## Drift baseline (as of 2026-07-28)
+## Drift baseline (as of 2026-08-13)
 
-After the fleet observability sweep, the report stands at 10 unmatched tokens (all in the "known expected" table above) and 0 instruction phrases. Any new findings above this baseline represent genuine drift introduced since that date.
+After the Management/Templates/Apps sidebar restructuring sweep, the report stands at 10 unmatched tokens (all in the "known expected" table above) and 0 instruction phrases. Any new findings above this baseline represent genuine drift introduced since that date.
 
-Previously (2026-06-26, after the DOC-1574 sweep): 4 unmatched tokens, 0 instruction phrases. The six fleet observability tokens added since then are all Argo CD Application Template names/parameters (dynamic content, not literal UI strings) — see the known-expected table. One genuine drift item from that sweep, a stale `<Label>Deploy to vCluster</Label>` in `configure-edge-collectors.mdx` that should have read `Deploy to tenant cluster`, was found and fixed rather than added to the known-expected list.
+This sweep found a real restructuring the script's multi-part `NavStep` matching had masked for some time: `Tenant Management` was renamed `Management`, and the `Cluster Templates`/`Namespace Templates`/`Argo CD Templates` nav items were merged into two items (`Templates` with `Tenant Clusters`/`Namespaces` tabs, and `Apps` with `ArgoCD Apps`/`Helm Apps` tabs). Fixed across `_partials/namespace-template/create-ui.mdx`, `administer/templates/create-templates.mdx`, `administer/templates/versioning.mdx`, `integrations/argocd/deploy-applications.mdx`, `use-platform/apps/use-in-templates.mdx`, and `use-platform/apps/use-parameters.mdx`. Also fixed along the way: a stale `<Button>Add App</Button>` (now `Create App Template`), a stale bold `**Add Namespace Template**` (now the `<Button>` component with the correct `Create Namespace Template` text), and a stale `<Label>Recommended App</Label>` (the UI label is `Recommend App`, no "-ed").
+
+Previously (2026-07-28, after the fleet observability sweep): 10 unmatched tokens, 0 instruction phrases. Previously (2026-06-26, after the DOC-1574 sweep): 4 unmatched tokens, 0 instruction phrases. The six fleet observability tokens added since then are all Argo CD Application Template names/parameters (dynamic content, not literal UI strings) — see the known-expected table. One genuine drift item from that sweep, a stale `<Label>Deploy to vCluster</Label>` in `configure-edge-collectors.mdx` that should have read `Deploy to tenant cluster`, was found and fixed rather than added to the known-expected list.
 
 ## Release checklist use
 

--- a/platform/_partials/namespace-template/create-ui.mdx
+++ b/platform/_partials/namespace-template/create-ui.mdx
@@ -11,7 +11,7 @@ import CreateSpaceStep2 from '@site/static/media/ui/screenshots/spaces/create-sp
 
 <Flow id="create-space-template-ui">
   <Step>
-    Go to <NavStep>Tenant Management > Namespace Templates</NavStep>.
+    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Namespaces</Label> tab.
   </Step>
   <Step>
     Click <Button>Create Namespace Template</Button>.

--- a/platform/_partials/namespace-template/create-ui.mdx
+++ b/platform/_partials/namespace-template/create-ui.mdx
@@ -11,7 +11,7 @@ import CreateSpaceStep2 from '@site/static/media/ui/screenshots/spaces/create-sp
 
 <Flow id="create-space-template-ui">
   <Step>
-    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Namespaces</Label> tab.
+    Go to <NavStep>Management > Templates</NavStep> and, if shown, click the <Label>Namespaces</Label> tab.
   </Step>
   <Step>
     Click <Button>Create Namespace Template</Button>.

--- a/platform/administer/templates/create-templates.mdx
+++ b/platform/administer/templates/create-templates.mdx
@@ -28,7 +28,7 @@ You can create templates directly in the UI:
 
 <Flow id="create-vcluster-template-ui">
   <Step>
-   Go to <NavStep>Tenant Management > Cluster Templates</NavStep>.
+   Go to <NavStep>Management > Templates</NavStep> and click the <Label>Tenant Clusters</Label> tab.
   </Step>
   <Step>Click <Button>Create Tenant Cluster Template</Button>.</Step>
   <Step>
@@ -54,10 +54,10 @@ App templates can be created through the UI.
 
 <Flow id="create-app">
   <Step>
-    Go to <NavStep>Tenant Management > Apps</NavStep>.
+    Go to <NavStep>Management > Apps</NavStep> and click the <Label>Helm Apps</Label> tab.
   </Step>
   <Step>
-    Click <Button>Add App</Button>.
+    Click <Button>Create App Template</Button>.
   </Step>
   <Step>
     Provide your tenant cluster template with a name by replacing the `my-template` placeholder name, or by
@@ -70,7 +70,7 @@ App templates can be created through the UI.
     <b>[Optional]</b> Use the <Label>Display Options</Label> tab to upload an app icon, which appears in the UI.
   </Step>
   <Step>
-    <b>[Optional]</b> Use the <Label>Recommended App</Label> list to choose whether the app appears as recommended in the UI.
+    <b>[Optional]</b> Use the <Label>Recommend App</Label> list to choose whether the app appears as recommended in the UI.
   </Step>
   <Step>
     Click <Button>Create App</Button>.
@@ -84,10 +84,10 @@ Namespace templates can be created directly in the UI to define default labels, 
 
 <Flow id="create-namespace-template-ui">
   <Step>
-    Go to <NavStep>Tenant Management > Namespace Templates</NavStep>.
+    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Namespaces</Label> tab.
   </Step>
   <Step>
-    Click **Add Namespace Template**.
+    Click <Button>Create Namespace Template</Button>.
   </Step>
   <Step>
     Provide your tenant cluster template with a name by replacing the `my-template` placeholder name, or by
@@ -260,7 +260,7 @@ To make changes, you must manually update the corresponding custom resource by e
 
 <Flow>
   <Step>
-    Go to <NavStep>Tenant Management</NavStep> and select the template type (Cluster Templates, Namespace Templates, or Apps).
+    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep> and click the tab for the template type (<Label>Tenant Clusters</Label>, <Label>Namespaces</Label>, <Label>ArgoCD Apps</Label>, or <Label>Helm Apps</Label>).
   </Step>
   <Step>
     Find the template you want to delete.

--- a/platform/administer/templates/create-templates.mdx
+++ b/platform/administer/templates/create-templates.mdx
@@ -28,7 +28,7 @@ You can create templates directly in the UI:
 
 <Flow id="create-vcluster-template-ui">
   <Step>
-   Go to <NavStep>Management > Templates</NavStep> and click the <Label>Tenant Clusters</Label> tab.
+   Go to <NavStep>Management > Templates</NavStep> and, if shown, click the <Label>Tenant Clusters</Label> tab.
   </Step>
   <Step>Click <Button>Create Tenant Cluster Template</Button>.</Step>
   <Step>
@@ -54,7 +54,7 @@ App templates can be created through the UI.
 
 <Flow id="create-app">
   <Step>
-    Go to <NavStep>Management > Apps</NavStep> and click the <Label>Helm Apps</Label> tab.
+    Go to <NavStep>Management > Apps</NavStep> and, if shown, click the <Label>Helm Apps</Label> tab.
   </Step>
   <Step>
     Click <Button>Create App Template</Button>.
@@ -84,7 +84,7 @@ Namespace templates can be created directly in the UI to define default labels, 
 
 <Flow id="create-namespace-template-ui">
   <Step>
-    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Namespaces</Label> tab.
+    Go to <NavStep>Management > Templates</NavStep> and, if shown, click the <Label>Namespaces</Label> tab.
   </Step>
   <Step>
     Click <Button>Create Namespace Template</Button>.
@@ -260,7 +260,7 @@ To make changes, you must manually update the corresponding custom resource by e
 
 <Flow>
   <Step>
-    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep> and click the tab for the template type (<Label>Tenant Clusters</Label>, <Label>Namespaces</Label>, <Label>ArgoCD Apps</Label>, or <Label>Helm Apps</Label>).
+    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep>. If a tab bar is shown, click the tab for the template type (<Label>Tenant Clusters</Label>, <Label>Namespaces</Label>, <Label>ArgoCD Apps</Label>, or <Label>Helm Apps</Label>).
   </Step>
   <Step>
     Find the template you want to delete.

--- a/platform/administer/templates/versioning.mdx
+++ b/platform/administer/templates/versioning.mdx
@@ -77,7 +77,7 @@ whether to indicate if a template has a newer version available.
 
 <Flow id="create-template-version">
   <Step>
-    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep> and click the tab for the template type you want to version.
+    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep>. If a tab bar is shown, click the tab for the template type you want to version.
   </Step>
   <Step>
     Find the template you want to add a new version to in

--- a/platform/administer/templates/versioning.mdx
+++ b/platform/administer/templates/versioning.mdx
@@ -77,7 +77,7 @@ whether to indicate if a template has a newer version available.
 
 <Flow id="create-template-version">
   <Step>
-    Go to <NavStep>Tenant Management</NavStep> and select the template type you want to version.
+    Go to <NavStep>Management > Templates</NavStep> or <NavStep>Management > Apps</NavStep> and click the tab for the template type you want to version.
   </Step>
   <Step>
     Find the template you want to add a new version to in

--- a/platform/integrations/argocd/deploy-applications.mdx
+++ b/platform/integrations/argocd/deploy-applications.mdx
@@ -32,7 +32,7 @@ An `ArgoCDApplicationTemplate` is a reusable Argo CD ApplicationSpec. Create one
 
 <Flow>
   <Step>
-    Go to <NavStep>Tenant Management > Argo CD Templates</NavStep>.
+    Go to <NavStep>Management > Apps</NavStep> and click the <Label>ArgoCD Apps</Label> tab.
   </Step>
   <Step>
     Click <Button>Create Argo CD Template</Button>.

--- a/platform/integrations/argocd/deploy-applications.mdx
+++ b/platform/integrations/argocd/deploy-applications.mdx
@@ -32,7 +32,7 @@ An `ArgoCDApplicationTemplate` is a reusable Argo CD ApplicationSpec. Create one
 
 <Flow>
   <Step>
-    Go to <NavStep>Management > Apps</NavStep> and click the <Label>ArgoCD Apps</Label> tab.
+    Go to <NavStep>Management > Apps</NavStep> and, if shown, click the <Label>ArgoCD Apps</Label> tab.
   </Step>
   <Step>
     Click <Button>Create Argo CD Template</Button>.

--- a/platform/use-platform/apps/use-in-templates.mdx
+++ b/platform/use-platform/apps/use-in-templates.mdx
@@ -27,7 +27,7 @@ a template, that app will be deployed in the given resource upon creation.
 
 <Flow id="add-app-vcluster-template">
   <Step>
-    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Tenant Clusters</Label> tab.
+    Go to <NavStep>Management > Templates</NavStep> and, if shown, click the <Label>Tenant Clusters</Label> tab.
   </Step>
   <Step>
     Edit an existing template, or create a new tenant cluster template.

--- a/platform/use-platform/apps/use-in-templates.mdx
+++ b/platform/use-platform/apps/use-in-templates.mdx
@@ -27,7 +27,7 @@ a template, that app will be deployed in the given resource upon creation.
 
 <Flow id="add-app-vcluster-template">
   <Step>
-    Go to <NavStep>Tenant Management > Cluster Templates</NavStep>.
+    Go to <NavStep>Management > Templates</NavStep> and click the <Label>Tenant Clusters</Label> tab.
   </Step>
   <Step>
     Edit an existing template, or create a new tenant cluster template.

--- a/platform/use-platform/apps/use-parameters.mdx
+++ b/platform/use-platform/apps/use-parameters.mdx
@@ -15,10 +15,10 @@ Apps with parameters can be created through the vCluster Platform UI.
 
 <Flow id="create-app-with-parameters">
   <Step>
-    Go to <NavStep>Tenant Management > Apps</NavStep>.
+    Go to <NavStep>Management > Apps</NavStep> and click the <Label>Helm Apps</Label> tab.
   </Step>
   <Step>
-    Click <Button>Add App</Button>.
+    Click <Button>Create App Template</Button>.
   </Step>
   <Step>
     In the configuration sheet that opens, give your new app a name by

--- a/platform/use-platform/apps/use-parameters.mdx
+++ b/platform/use-platform/apps/use-parameters.mdx
@@ -15,7 +15,7 @@ Apps with parameters can be created through the vCluster Platform UI.
 
 <Flow id="create-app-with-parameters">
   <Step>
-    Go to <NavStep>Management > Apps</NavStep> and click the <Label>Helm Apps</Label> tab.
+    Go to <NavStep>Management > Apps</NavStep> and, if shown, click the <Label>Helm Apps</Label> tab.
   </Step>
   <Step>
     Click <Button>Create App Template</Button>.

--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -8,6 +8,8 @@ sidebar_class_name: private-nodes
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
+import Button from '@site/src/components/Button'
+import Label from '@site/src/components/Label'
 
 <TenancySupport privateNodes="true" standalone="true"/>
 
@@ -20,7 +22,7 @@ import TabItem from '@theme/TabItem'
 ## Create token
 
 To join worker nodes, a token from the vCluster must be created to provide access and permissions. A single token
-can be used for any node(s) to join, or if you wanted to, you could create a token for each node.
+can be used for any nodes to join, or if you wanted to, you could create a token for each node.
 
 By default, the token expires within 1 hour. The token is stored as a secret prefixed with `bootstrap-token-` in the `kube-system` namespace.
 The expiry timestamp is stored under the `expiration` key in the secret.
@@ -88,10 +90,10 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward. Node profiles require vCluster 0.36 or later.
 
-1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
-2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
+1. Open the tenant cluster instance in the platform UI, go to the <Label>Status</Label> tab, and click <Button>Join Node...</Button>.
+2. In the dialog that opens, optionally select a profile from the <Label>Node Profile</Label> dropdown. It lists the profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 
 The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/join.mdx
@@ -8,6 +8,8 @@ sidebar_class_name: private-nodes
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
+import Button from '@site/src/components/Button'
+import Label from '@site/src/components/Label'
 
 <TenancySupport privateNodes="true" standalone="true"/>
 
@@ -20,7 +22,7 @@ import TabItem from '@theme/TabItem'
 ## Create token
 
 To join worker nodes, a token from the vCluster must be created to provide access and permissions. A single token
-can be used for any node(s) to join, or if you wanted to, you could create a token for each node.
+can be used for any nodes to join, or if you wanted to, you could create a token for each node.
 
 By default, the token expires within 1 hour. The token is stored as a secret prefixed with `bootstrap-token-` in the `kube-system` namespace.
 The expiry timestamp is stored under the `expiration` key in the secret.
@@ -88,10 +90,10 @@ Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 
 ## Join with a node profile
 
-If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward.
+If the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is connected to vCluster Platform, you can attach a [node profile](/docs/platform/administer/node-profiles/overview) to a node as part of the join. This saves you from joining the node bare and configuring it by hand afterward. Node profiles require vCluster 0.36 or later.
 
-1. Open the tenant cluster instance in the platform UI and click **Attach Node Directly**.
-2. Optionally select a profile from the list of profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
+1. Open the tenant cluster instance in the platform UI, go to the <Label>Status</Label> tab, and click <Button>Join Node...</Button>.
+2. In the dialog that opens, optionally select a profile from the <Label>Node Profile</Label> dropdown. It lists the profiles allowed in the project. If you don't select one, the node falls back to the tenant cluster's or project's default profile, when configured.
 3. Copy the returned curl command and run it on the target node, as described in [Join each worker node](#join-each-worker-node). Changing the selected profile regenerates the command.
 
 The node joins carrying the profile's labels and taints, plus a `vcluster.com/node-profile=<name>` back-reference label. From then on, the platform continuously reconciles the profile onto the node, so later edits to the profile converge automatically without rejoining the node. See [Assignment and precedence](/docs/platform/administer/node-profiles/overview#assignment-and-precedence) for how the fallback chain resolves.


### PR DESCRIPTION
# Content Description
Fixes DOC-1697: corrects stale UI element names/paths in join.mdx (button, tab, and dropdown labels no longer match the platform UI), backported to the version-0.36.0 snapshot. Also fixes separate platform nav drift (Management sidebar consolidation) found while auditing, scoped to the unreleased v4.12 platform docs only.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
Closes DOC-1697

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs