### PR TITLE
fix(doc-1625): remove doubled /vcluster prefix in backing-store category slugs

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -25,7 +25,7 @@ vCluster doesn't support changing the backing store type after initial deploymen
 The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
 :::
 
-:::warning vCluster Standalone 
+:::warning vCluster Standalone
 vCluster Standalone has limited backing store options. For single control plane nodes setup,
 * Embedded database (sqlite)
 * Embedded etcd

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/database
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: etcd
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/etcd
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -12,8 +12,8 @@ import BackingStore from '../../../../../_partials/config/controlPlane/backingSt
 
 Each tenant cluster requires a backing store and vCluster provides two different types of backing store options:
 
-* [etcd](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd)
-* [database](/vcluster/next/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database)
+* [etcd](./etcd/README.mdx)
+* [database](./database/README.mdx)
 
 There are different ways to deploy the type of backing store.
 

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/database
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
+++ b/vcluster_versioned_docs/version-0.34.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: etcd
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/etcd
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -25,7 +25,7 @@ vCluster doesn't support changing the backing store type after initial deploymen
 The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
 :::
 
-:::warning vCluster Standalone 
+:::warning vCluster Standalone
 vCluster Standalone has limited backing store options. For single control plane nodes setup,
 * Embedded database (sqlite)
 * Embedded etcd

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/database
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: etcd
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/etcd
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -25,7 +25,7 @@ vCluster doesn't support changing the backing store type after initial deploymen
 The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
 :::
 
-:::warning vCluster Standalone 
+:::warning vCluster Standalone
 vCluster Standalone has limited backing store options. For single control plane nodes setup,
 * Embedded database (sqlite)
 * Embedded etcd

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/database/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/database
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: etcd
 description: Backing store deployment options
-slug: /vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd
+slug: /configure/vcluster-yaml/control-plane/components/backing-store/etcd
 sidebar_class_name: host-nodes private-nodes standalone
 ---
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

The `etcd` and `database` category index pages under `backing-store/` had a `slug:` frontmatter that redundantly repeated `/vcluster` on top of the docs plugin's `routeBasePath: "vcluster"`, doubling the built route to `/vcluster/vcluster/...` instead of `/vcluster/...`. This dropped the category index pages from the build at their expected URL and broke the links from `backing-store/README.mdx`.

Fixed the slug in main and all three versioned snapshots (0.34.0, 0.35.0, 0.36.0), which had the identical bug baked in from when they were cut. Also replaced a stale hardcoded absolute link in 0.34.0's `backing-store/README.mdx` that pointed at the old, buggy URL, with a relative link matching 0.35.0/0.36.0.

Verified with a full clean `npm run build`: passes, and `etcd/index.html` + `database/index.html` now exist at the correct route for all four versions.

## Preview Link
<!-- Netlify will post the preview link on this PR -->

## Internal Reference
Closes DOC-1625

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs