### PR TITLE
docs(doc-1687): fix fleet observability quickstart gaps

### DIFF
--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -158,6 +158,10 @@ stringData:
 kubectl apply -f otel-otlp-auth.yaml
 ```
 
+Switch your `kubectl` context back to the cluster where Platform runs before continuing.
+The `ArgoCDApplication` you apply next, and its project namespace, are Platform custom
+resources that only exist on that cluster, not on the tenant cluster.
+
 Then deploy the collector to your tenant cluster. Edge collectors run inside the tenant
 cluster, which resolves DNS in its own zone, so `otlpEndpoint` needs to point somewhere
 the tenant cluster can actually reach. Which value to use depends on where the tenant
@@ -270,31 +274,57 @@ parameter list, see [Configure edge collectors](./configure-edge-collectors.mdx)
 
 ## 5. Verify
 
-Check that metrics are reaching the gateway. Run the port-forward in the background;
-without the trailing `&` it blocks the shell and `curl` never runs:
+Check that metrics are reaching the gateway. Run the port-forward in the background and
+capture its PID with `$!`; `--retry-connrefused` makes `curl` wait for the tunnel instead
+of racing it:
 
 ```bash
 GATEWAY_POD=$(kubectl get pod -n vcluster-platform -l app.kubernetes.io/name=gateway,app.kubernetes.io/instance=fleet-observability -o jsonpath='{.items[0].metadata.name}')
 kubectl port-forward -n vcluster-platform pod/$GATEWAY_POD 8889:8889 &
-curl http://127.0.0.1:8889/metrics
-kill %1
+PF_PID=$!
+curl --retry 5 --retry-connrefused --retry-delay 1 http://127.0.0.1:8889/metrics
+kill $PF_PID
 ```
 
 Gateway metrics only confirm a write request arrived, not that it reached the backend.
-Create a `metrics-reader` key scoped to the same tenant cluster, as described in
-[Create a reader key](./configure-metrics-access.mdx#create-a-reader-key), then query the
-Query Proxy for your first metric:
+Create a `metrics-reader` key scoped to the same tenant cluster and query the Query Proxy
+for your first metric. Match `PROJECT` and `TENANT_CLUSTER` to the values you used in step
+3; see [Create a reader key](./configure-metrics-access.mdx#create-a-reader-key) for the
+full parameter list:
 
 ```bash
+PROJECT=default
+TENANT_CLUSTER=my-vcluster
+METRICS_READER_TOKEN=$(head -c 20 /dev/urandom | od -An -tx1 | tr -d ' \n')
+kubectl apply -f - <<EOF
+apiVersion: storage.loft.sh/v1
+kind: AccessKey
+metadata:
+  name: "loft-metrics-reader-p-${PROJECT}-${TENANT_CLUSTER}"
+spec:
+  type: Other
+  key: "${METRICS_READER_TOKEN}"
+  subject: "loft:metrics-reader:p-${PROJECT}:${TENANT_CLUSTER}"
+  groups:
+    - loft:system:metrics-readers
+  scope:
+    roles:
+      - role: metrics-reader
+    virtualClusters:
+      - project: ${PROJECT}
+        virtualCluster: "${TENANT_CLUSTER}"
+EOF
+
 GATEWAY_POD=$(kubectl get pod -n vcluster-platform -l app.kubernetes.io/name=gateway,app.kubernetes.io/instance=fleet-observability -o jsonpath='{.items[0].metadata.name}')
 kubectl port-forward -n vcluster-platform pod/$GATEWAY_POD 8081:8081 &
-curl -k -G \
+PF_PID=$!
+curl -k -G --retry 5 --retry-connrefused --retry-delay 1 \
   -H "Authorization: Bearer $METRICS_READER_TOKEN" \
   -H "X-Vcluster-Platform-Project: $PROJECT" \
   -H "X-Vcluster-Platform-Instance: $TENANT_CLUSTER" \
   --data-urlencode 'query=up' \
   https://127.0.0.1:8081/api/v1/query
-kill %1
+kill $PF_PID
 ```
 
 A non-empty `result` array confirms the write reached the backend and is queryable.

--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -17,9 +17,9 @@ backend or targeting a control plane cluster.
 
 ## Prerequisites
 
-- The [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled, with a
-  connector registered on both the cluster where Platform is installed and the tenant
-  cluster you collect from. See
+- The [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled on both the
+  cluster where Platform is installed and the tenant cluster you collect from, each
+  referencing the same Argo CD connector. See
   [Connect to Argo CD](../../integrations/argocd/connect-argocd.mdx).
 - A vCluster Platform license that includes Fleet Observability.
 - `kubectl` access to a project namespace.

--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -6,6 +6,8 @@ description: Deploy the default Fleet Observability pipeline end to end with Arg
 ---
 
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 This walks through the default, out-of-the-box path. It deploys the bundled Prometheus
 backend and edge collectors with Argo CD to one tenant cluster, using YAML and `kubectl`
@@ -16,7 +18,8 @@ backend or targeting a control plane cluster.
 ## Prerequisites
 
 - The [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled, with a
-  connector registered on the target cluster. See
+  connector registered on both the cluster where Platform is installed and the tenant
+  cluster you collect from. See
   [Connect to Argo CD](../../integrations/argocd/connect-argocd.mdx).
 - A vCluster Platform license that includes Fleet Observability.
 - `kubectl` access to a project namespace.
@@ -56,7 +59,8 @@ For other backends, the Platform UI, and the full parameter list, see
 ## 2. Create the connector and deploy the gateway
 
 Create the observability connector Secret. These endpoints match the backend's default
-namespace from step 1:
+namespace from step 1. The Secret below also configures the connector for the bundled
+Grafana deployed in step 6, using that template's default certificate Secret name:
 
 ```yaml title="fleet-observability-connector.yaml"
 apiVersion: v1
@@ -72,6 +76,9 @@ stringData:
   metricsBackendOtlpEndpoint: https://prom-prometheus-server.vcluster-platform.svc.cluster.local/api/v1/otlp
   metricsBackendPromQLEndpoint: https://prom-prometheus-server.vcluster-platform.svc.cluster.local
   metricsBackendCertSecretName: metrics-backend-mtls
+  grafanaUrl: https://grafana.vcluster-platform.svc.cluster.local
+  grafanaCertSecretName: grafana-server-tls
+  fleetObservabilityDashboardUid: vcluster-fleet-observability
 ```
 
 ```bash
@@ -128,7 +135,13 @@ For control plane cluster keys, reader keys, and rotation, see
 
 ## 4. Deploy edge collectors
 
-Store the token from step 3 in a Secret in the collector namespace:
+The token from step 3 goes into a Secret inside the tenant cluster, in the namespace the
+collectors run in. Switch your `kubectl` context to the tenant cluster, then create the
+namespace and the Secret:
+
+```bash
+kubectl create namespace observability
+```
 
 ```yaml title="otel-otlp-auth.yaml"
 apiVersion: v1
@@ -145,13 +158,45 @@ stringData:
 kubectl apply -f otel-otlp-auth.yaml
 ```
 
-Then deploy the collector to your tenant cluster:
+Then deploy the collector to your tenant cluster. Edge collectors run inside the tenant
+cluster, which resolves DNS in its own zone, so `otlpEndpoint` needs to point somewhere
+the tenant cluster can actually reach. Which value to use depends on where the tenant
+cluster runs:
+
+<Tabs
+  defaultValue="same"
+  values={[
+    { label: "Same cluster as Platform", value: "same" },
+    { label: "A different cluster", value: "different" },
+  ]}
+>
+<TabItem value="same">
+
+If the tenant cluster runs on the same control plane cluster as Platform, map the
+gateway Service into the tenant cluster's DNS instead of exposing it externally. This
+requires shared nodes tenancy. Add this to the tenant cluster's `vcluster.yaml`:
+
+```yaml
+controlPlane:
+  coredns:
+    enabled: true
+    embedded: true
+networking:
+  resolveDNS:
+    - service: vcluster-platform/gateway-fleet-observability
+      target:
+        hostService: vcluster-platform/gateway-fleet-observability
+```
+
+See [Resolve DNS](/docs/vcluster/configure/vcluster-yaml/networking/resolve-dns) for how
+to apply `vcluster.yaml` changes and the full option reference. `otlpEndpoint` keeps using
+the gateway's in-cluster Service name:
 
 ```yaml title="fleet-edge-collectors.yaml"
 apiVersion: management.loft.sh/v1
 kind: ArgoCDApplication
 metadata:
-  name: fleet-edge-collectors
+  name: fleet-edge-collectors-my-vcluster   # include the tenant cluster name for uniqueness
   namespace: p-my-project          # replace with your project namespace
 spec:
   displayName: "Fleet edge collectors"
@@ -164,8 +209,57 @@ spec:
   parameters:
     destinationNamespace: observability
     otlpEndpoint: https://gateway-fleet-observability.vcluster-platform.svc.cluster.local:4318
+    otlpInsecureSkipVerify: "true"
     project: default
 ```
+
+</TabItem>
+<TabItem value="different">
+
+If the tenant cluster runs on a different cluster than Platform, it can't resolve or
+route to the gateway's in-cluster Service name. Expose the gateway with a `LoadBalancer`
+Service instead: add `serviceType: LoadBalancer` to the connector Secret from step 2 and
+reapply it, then retrieve the assigned address:
+
+```bash
+kubectl get svc -n vcluster-platform gateway-fleet-observability \
+  -o jsonpath='{range .status.loadBalancer.ingress[*]}{.hostname}{.ip}{"\n"}{end}'
+```
+
+The cloud provider assigns the address asynchronously, so wait until it's populated, then
+use it as `otlpEndpoint`:
+
+```yaml title="fleet-edge-collectors.yaml"
+apiVersion: management.loft.sh/v1
+kind: ArgoCDApplication
+metadata:
+  name: fleet-edge-collectors-my-vcluster   # include the tenant cluster name for uniqueness
+  namespace: p-my-project          # replace with your project namespace
+spec:
+  displayName: "Fleet edge collectors"
+  destination:
+    virtualCluster:
+      name: my-vcluster            # replace with your tenant cluster name
+      target: vCluster             # deploy into the tenant cluster
+  templateRef:
+    name: cluster-collector
+  parameters:
+    destinationNamespace: observability
+    otlpEndpoint: https://REPLACE_WITH_LOADBALANCER_ADDRESS:4318
+    otlpInsecureSkipVerify: "true"
+    project: default
+```
+
+See [Expose the gateway with a LoadBalancer](./install-observability-gateway.mdx#expose-the-gateway-with-a-loadbalancer)
+for certificate and Service annotation details.
+
+</TabItem>
+</Tabs>
+
+Both branches keep `otlpInsecureSkipVerify: "true"` to accept the gateway's self-signed
+certificate for this quickstart. For a production setup, distribute the gateway's
+`ca.crt` instead, as described in
+[Customize the gateway serving certificate](./install-observability-gateway.mdx#customize-the-gateway-serving-certificate).
 
 ```bash
 kubectl apply -f fleet-edge-collectors.yaml
@@ -176,13 +270,34 @@ parameter list, see [Configure edge collectors](./configure-edge-collectors.mdx)
 
 ## 5. Verify
 
-Check that metrics are reaching the gateway:
+Check that metrics are reaching the gateway. Run the port-forward in the background;
+without the trailing `&` it blocks the shell and `curl` never runs:
 
 ```bash
 GATEWAY_POD=$(kubectl get pod -n vcluster-platform -l app.kubernetes.io/name=gateway,app.kubernetes.io/instance=fleet-observability -o jsonpath='{.items[0].metadata.name}')
-kubectl port-forward -n vcluster-platform pod/$GATEWAY_POD 8889:8889
+kubectl port-forward -n vcluster-platform pod/$GATEWAY_POD 8889:8889 &
 curl http://127.0.0.1:8889/metrics
+kill %1
 ```
+
+Gateway metrics only confirm a write request arrived, not that it reached the backend.
+Create a `metrics-reader` key scoped to the same tenant cluster, as described in
+[Create a reader key](./configure-metrics-access.mdx#create-a-reader-key), then query the
+Query Proxy for your first metric:
+
+```bash
+GATEWAY_POD=$(kubectl get pod -n vcluster-platform -l app.kubernetes.io/name=gateway,app.kubernetes.io/instance=fleet-observability -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward -n vcluster-platform pod/$GATEWAY_POD 8081:8081 &
+curl -k -G \
+  -H "Authorization: Bearer $METRICS_READER_TOKEN" \
+  -H "X-Vcluster-Platform-Project: $PROJECT" \
+  -H "X-Vcluster-Platform-Instance: $TENANT_CLUSTER" \
+  --data-urlencode 'query=up' \
+  https://127.0.0.1:8081/api/v1/query
+kill %1
+```
+
+A non-empty `result` array confirms the write reached the backend and is queryable.
 
 If writes aren't showing up, see [Troubleshooting](./troubleshooting.mdx).
 
@@ -213,7 +328,10 @@ spec:
 kubectl apply -f fleet-grafana.yaml
 ```
 
-For the connector settings Grafana needs and how to sign in, see
+Once the Grafana pod is running, sign in at `https://<platform-host>/grafana/` with
+Platform SSO to see the pre-provisioned Fleet Observability, Cluster Metrics, and GPU
+Overview dashboards. For the connector settings Grafana needs and the full dashboard
+list, see
 [Deploy the bundled Grafana with Argo CD](./query-fleet-metrics.mdx#deploy-the-bundled-grafana-with-argo-cd).
 
 ## Next steps

--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -19,7 +19,7 @@ backend or targeting a control plane cluster.
 
 - The [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled on both the
   cluster where Platform is installed and the tenant cluster you collect from, each
-  referencing the same Argo CD connector. See
+  referencing an Argo CD connector. See
   [Connect to Argo CD](../../integrations/argocd/connect-argocd.mdx).
 - A vCluster Platform license that includes Fleet Observability.
 - `kubectl` access to a project namespace.
@@ -97,7 +97,7 @@ For connector keys, TLS options, and the Platform UI, see
 ## 3. Create a metrics-writer key
 
 Create a `metrics-writer` access key scoped to your tenant cluster. Set `PROJECT` and
-`TENANT_CLUSTER` to your tenant cluster's project and instance name; the command prints
+`TENANT_CLUSTER` to your tenant cluster's project and instance name. The command prints
 the generated token as `token: <value>` at the end.
 
 <InterpolatedCodeBlock
@@ -222,7 +222,7 @@ spec:
 
 If the tenant cluster runs on a different cluster than Platform, it can't resolve or
 route to the gateway's in-cluster Service name. Expose the gateway with a `LoadBalancer`
-Service instead: add `serviceType: LoadBalancer` to the connector Secret from step 2 and
+Service instead. Add `serviceType: LoadBalancer` to the connector Secret from step 2 and
 reapply it, then retrieve the assigned address:
 
 ```bash
@@ -275,7 +275,7 @@ parameter list, see [Configure edge collectors](./configure-edge-collectors.mdx)
 ## 5. Verify
 
 Check that metrics are reaching the gateway. Run the port-forward in the background and
-capture its PID with `$!`; `--retry-connrefused` makes `curl` wait for the tunnel instead
+capture its PID with `$!`. `--retry-connrefused` makes `curl` wait for the tunnel instead
 of racing it:
 
 ```bash
@@ -289,7 +289,7 @@ kill $PF_PID
 Gateway metrics only confirm a write request arrived, not that it reached the backend.
 Create a `metrics-reader` key scoped to the same tenant cluster and query the Query Proxy
 for your first metric. Match `PROJECT` and `TENANT_CLUSTER` to the values you used in step
-3; see [Create a reader key](./configure-metrics-access.mdx#create-a-reader-key) for the
+3. See [Create a reader key](./configure-metrics-access.mdx#create-a-reader-key) for the
 full parameter list:
 
 ```bash

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -104,6 +104,16 @@ If gateway pods start but can't write or query the backend:
   `tls.key`.
 - Use `metricsBackendInsecureSkipVerify: "true"` only as a temporary test setting.
 
+:::note `remote error: tls: certificate required`
+This error means the backend rejected the connection because the gateway didn't present a
+client certificate, not because the gateway distrusts the backend's certificate.
+`metricsBackendInsecureSkipVerify` only skips the gateway's verification of the backend's
+server certificate, so it can't fix this. Set `metricsBackendCertSecretName` instead. The
+bundled Prometheus backend enforces mTLS and expects this client certificate; when deployed
+with its default parameters, it's the auto-generated `metrics-backend-mtls` Secret. See
+[Deploy the metrics backend with Argo CD](./install-observability-gateway.mdx#deploy-the-metrics-backend-with-argo-cd).
+:::
+
 ## Gateway TLS failures
 
 The gateway always serves OTLP and query traffic over TLS. If collectors or query clients

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -109,7 +109,7 @@ This error means the backend rejected the connection because the gateway didn't 
 client certificate, not because the gateway distrusts the backend's certificate.
 `metricsBackendInsecureSkipVerify` only skips the gateway's verification of the backend's
 server certificate, so it can't fix this. Set `metricsBackendCertSecretName` instead. The
-bundled Prometheus backend enforces mTLS and expects this client certificate; when deployed
+bundled Prometheus backend enforces mTLS and expects this client certificate. When deployed
 with its default parameters, it's the auto-generated `metrics-backend-mtls` Secret. See
 [Deploy the metrics backend with Argo CD](./install-observability-gateway.mdx#deploy-the-metrics-backend-with-argo-cd).
 :::


### PR DESCRIPTION
# Content Description
Fixes the 10 issues from DOC-1687 feedback on the Fleet Observability quickstart: gateway reachability for edge collectors (DNS mapping for a tenant cluster co-located with Platform, or a LoadBalancer for a separate cluster), missing Grafana connector fields, Secret/namespace placement on the tenant cluster, unique naming for the collector `ArgoCDApplication`, a blocking `port-forward` in the verify step, and a real backend-reachability check via the Query Proxy. Also clarifies the mTLS `certificate required` error in troubleshooting.mdx.

## Preview Link
- https://deploy-preview-2580--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/observability/quickstart

## Internal Reference
Closes DOC-1687

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs