### PR TITLE
Update 4.7 and 0.32 versions to EOS

### DIFF
--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -55,14 +55,14 @@ Versions not listed under End of Support (EOS) or End of Life (EOL) are consider
       <td>v1.35 (k8s)</td>
     </tr>
     <tr>
+      <td colspan="5" align="center"><i>Versions below are no longer supported</i></td>
+    </tr>
+    <tr>
       <td>v0.32</td>
       <td>2026 Feb 18</td>
       <td>2026 May 18</td>
       <td>2026 Aug 18</td>
       <td>v1.35 (k8s)</td>
-    </tr>
-    <tr>
-      <td colspan="5" align="center"><i>Versions below are no longer supported</i></td>
     </tr>
     <tr>
       <td>v0.31</td>

--- a/src/config/versionConfig.js
+++ b/src/config/versionConfig.js
@@ -13,7 +13,7 @@ export const platformHiddenVersions = [];
 
 export const vclusterEOLVersions = [
   { to: "https://vcluster.com/docs/v0.33", label: "v0.33 (EOS)" },
-  { to: "https://vcluster.com/docs/v0.32", label: "v0.32 (EOS)" },
+  { to: "https://vcluster.com/docs/v0.32", label: "v0.32 (EOL)" },
   { to: "https://vcluster.com/docs/v0.31", label: "v0.31 (EOL)" },
   { to: "https://vcluster.com/docs/v0.30", label: "v0.30 (EOL)" },
   { to: "https://vcluster.com/docs/v0.29", label: "v0.29 (EOL)" },
@@ -30,7 +30,7 @@ export const vclusterEOLVersions = [
 ];
 
 export const platformEOLVersions = [
-  { to: "https://vcluster.com/docs/v4.7", label: "v4.7" },
+  { to: "https://vcluster.com/docs/v4.7", label: "v4.7 (EOS)" },
   { to: "https://vcluster.com/docs/v4.6", label: "v4.6 (EOS)" },
   { to: "https://vcluster.com/docs/v4.5", label: "v4.5 (EOL)" },
   { to: "https://vcluster.com/docs/v4.4", label: "v4.4 (EOL)" },

--- a/static/api/lifecycle/platform.json
+++ b/static/api/lifecycle/platform.json
@@ -1,6 +1,6 @@
 {
   "product": "Platform",
-  "lastUpdated": "2026-07-29",
+  "lastUpdated": "2026-08-18",
   "versions": [
     {
       "version": "4.11.0",
@@ -33,7 +33,7 @@
     {
       "version": "4.7.0",
       "releaseDate": "2026-02-18",
-      "status": "active",
+      "status": "eos",
       "eosDate": "2026-08-18",
       "eolDate": "2026-11-18"
     },

--- a/static/api/lifecycle/vcluster.json
+++ b/static/api/lifecycle/vcluster.json
@@ -1,6 +1,6 @@
 {
   "product": "vCluster",
-  "lastUpdated": "2026-07-29",
+  "lastUpdated": "2026-08-18",
   "versions": [
     {
       "version": "0.36.0",
@@ -33,7 +33,7 @@
     {
       "version": "0.32.0",
       "releaseDate": "2026-02-18",
-      "status": "eos",
+      "status": "eol",
       "eosDate": "2026-05-18",
       "eolDate": "2026-08-18"
     },


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Platform 4.7 reached end of support and vCluster 0.32 reached end of life. This updates the links in the version switcher to reflect those changes.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

