### PR TITLE
docs(observability): clarify project namespace naming in quickstart and reference pages

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -145,3 +145,11 @@ Google.Headings = NO
 BasedOnStyles = Loft, Google, Vale
 Google.Headings = NO
 Google.HeadingPunctuation = NO
+
+# Numbered step headings ("## 1. Deploy the metrics backend") are
+# sentence-tokenized with "1." as its own sentence, so Vale sees a heading
+# ending in a period even though the heading text itself doesn't. Same
+# misparse class as policies/README.mdx above; scope the rule off here too.
+[**/maintenance/observability/quickstart.mdx]
+BasedOnStyles = Loft, Google, Vale
+Google.HeadingPunctuation = NO

--- a/platform/_fragments/namespace/project-namespace-naming.mdx
+++ b/platform/_fragments/namespace/project-namespace-naming.mdx
@@ -1,0 +1,1 @@
+Platform creates a namespace named `p-<project-name>` for each project, so the default project's namespace is `p-default`.

--- a/platform/maintenance/observability/configure-edge-collectors.mdx
+++ b/platform/maintenance/observability/configure-edge-collectors.mdx
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
+import FragmentProjectNamespaceNaming from "../../_fragments/namespace/project-namespace-naming.mdx";
 
 Edge collectors are OpenTelemetry Collectors that scrape or receive metrics near the
 workloads, then send OTLP to the Write Gateway. Each collector request must include a bearer
@@ -62,6 +63,8 @@ described at the end of this section.
   ]}
 >
 <TabItem value="yaml">
+
+<FragmentProjectNamespaceNaming />
 
 Create the `ArgoCDApplication` object in your project namespace:
 

--- a/platform/maintenance/observability/install-observability-gateway.mdx
+++ b/platform/maintenance/observability/install-observability-gateway.mdx
@@ -11,6 +11,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 import NavStep from "@site/src/components/NavStep";
+import FragmentProjectNamespaceNaming from "../../_fragments/namespace/project-namespace-naming.mdx";
 
 The observability gateway runs in the vCluster Platform namespace. It contains two
 containers:
@@ -58,6 +59,8 @@ namespace on the local cluster.
   ]}
 >
 <TabItem value="yaml">
+
+<FragmentProjectNamespaceNaming />
 
 Create the `ArgoCDApplication` object in your project namespace:
 

--- a/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
+++ b/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
@@ -10,6 +10,7 @@ import TabItem from "@theme/TabItem";
 import Flow, { Step } from "@site/src/components/Flow";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
+import FragmentProjectNamespaceNaming from "../../_fragments/namespace/project-namespace-naming.mdx";
 
 [NVSentinel](https://github.com/NVIDIA/NVSentinel) is NVIDIA's open source, Kubernetes-native
 service for GPU fault handling. It detects hardware and software faults on GPU nodes through
@@ -99,6 +100,8 @@ with private GPU nodes, target the tenant cluster itself.
   ]}
 >
 <TabItem value="yaml">
+
+<FragmentProjectNamespaceNaming />
 
 Create the `ArgoCDApplication` object in your project namespace:
 

--- a/platform/maintenance/observability/query-fleet-metrics.mdx
+++ b/platform/maintenance/observability/query-fleet-metrics.mdx
@@ -11,6 +11,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 import NavStep from "@site/src/components/NavStep";
+import FragmentProjectNamespaceNaming from "../../_fragments/namespace/project-namespace-naming.mdx";
 
 Query fleet metrics through the bundled Grafana, the fastest path once it's deployed, or
 directly against the Query Proxy's Prometheus-compatible HTTP API for automation and your
@@ -33,6 +34,8 @@ Platform-authenticated access. If you use the
   ]}
 >
 <TabItem value="yaml">
+
+<FragmentProjectNamespaceNaming />
 
 Create the `ArgoCDApplication` object in your project namespace:
 

--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -22,7 +22,10 @@ backend or targeting a control plane cluster.
   referencing an Argo CD connector. See
   [Connect to Argo CD](../../integrations/argocd/connect-argocd.mdx).
 - A vCluster Platform license that includes Fleet Observability.
-- `kubectl` access to a project namespace.
+- `kubectl` access to a project namespace. Platform creates a namespace named
+  `p-<project-name>` for each project, so the default project's namespace is `p-default`.
+  Installations with a customized project namespace prefix, including installations
+  upgraded from older versions, can use a different namespace.
 - A tenant cluster to collect metrics from.
 
 ## 1. Deploy the metrics backend
@@ -52,6 +55,14 @@ spec:
 ```bash
 kubectl apply -f fleet-metrics-backend.yaml
 ```
+
+Confirm the application landed in your project's namespace:
+
+```bash
+kubectl get argocdapplications -n p-default
+```
+
+Substitute your project's namespace if you're not using the default project.
 
 For other backends, the Platform UI, and the full parameter list, see
 [Deploy the metrics backend with Argo CD](./install-observability-gateway.mdx#deploy-the-metrics-backend-with-argo-cd).


### PR DESCRIPTION
# Content Description
Clarifies the `p-<project-name>` project namespace naming convention in the Fleet Observability quickstart and its four Argo CD reference pages, which previously used `p-my-project` as an unexplained placeholder. Adds a shared fragment for the naming fact, a fuller explanation plus a verification step in the quickstart, and a `.vale.ini` scope fix for a pre-existing false-positive on the quickstart's numbered step headings.

## Preview Link
<!-- Netlify will post the deploy preview link on this PR -->
- https://deploy-preview-2595--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/observability/quickstart#prerequisites

## Internal Reference
Closes DOC-1709

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs