### PR TITLE
docs(doc-1683): clarify AWS_SESSION_TOKEN requirement for S3-compatible storage

### DIFF
--- a/vcluster/_fragments/snapshots-s3-aws.mdx
+++ b/vcluster/_fragments/snapshots-s3-aws.mdx
@@ -46,6 +46,9 @@ Alternatively, you can create a Kubernetes secret with your AWS credentials.
   * `AWS_SECRET_ACCESS_KEY`
   * `AWS_SESSION_TOKEN`
 
+:::info AWS_SESSION_TOKEN with static credentials
+`AWS_SESSION_TOKEN` must be present in the secret even if you don't use one. This applies to long-term static credentials and to S3-compatible storage that doesn't issue session tokens, such as MinIO, Ceph, or Dell ECS. If you don't have a session token, set the key to an empty string.
+:::
 
   ```bash title="Create AWS credentials secret"
   kubectl create -f - <<EOF
@@ -58,7 +61,7 @@ Alternatively, you can create a Kubernetes secret with your AWS credentials.
   data:
     AWS_ACCESS_KEY_ID: "id"
     AWS_SECRET_ACCESS_KEY: "key"
-    AWS_SESSION_TOKEN: "token"
+    AWS_SESSION_TOKEN: ""
   EOF
   ```
 </Step>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Clarifies that `AWS_SESSION_TOKEN` must be present as a key in the S3 credentials secret even when no session token is used (for example, static credentials or non-AWS S3-compatible storage like MinIO, Ceph, or Dell ECS), and that it can be set to an empty string in that case.

## Preview Link 
<!-- The preview link or links to the documents-->
https://deploy-preview-2596--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/snapshots#aws-s3-bucket-example

You'll need to expand the collapsed section, then see the note under step 1.


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1683


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs