### PR TITLE
docs(doc-1685): document service account token invalidation after standalone restore

### DIFF
--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -142,6 +142,16 @@ You can also restore from any external storage backend:
   language="bash"
 />
 
+:::warning Service account tokens invalidated with embedded etcd
+Restoring a standalone vCluster that uses the embedded etcd backing store can invalidate service account tokens for running system pods, such as CoreDNS, kube-proxy, and the konnectivity agent. The restored etcd data predates any tokens issued after the snapshot was taken, so the API server rejects them on the UID check. `kubectl get pods` still reports these pods as `Running`, but in-pod DNS resolution stops working.
+
+To restore full capability, manually restart the vCluster control plane again after the automatic restart from `vcluster restore --standalone` completes:
+
+```bash
+systemctl restart vcluster
+```
+:::
+
 :::tip Cross-node recovery
 Restoring to a different machine leaves stale node details in etcd that require manual cleanup. To make the snapshot available on another node, use an external storage backend (OCI, S3, or Azure Blob Storage). Plan to manually remove stale node resources after restore.
 :::
@@ -241,6 +251,10 @@ When taking snapshots and restoring tenant clusters, there are limitations:
 **vcluster.yaml configuration**
 
 - Although the vcluster.yaml configuration is backed up, it isn't automatically restored. After restoring a tenant cluster, you must manually reapply your vcluster.yaml configuration.
+
+**Standalone: service account tokens invalidated after restore**
+
+- Restoring a standalone vCluster that uses the embedded etcd backing store can invalidate service account tokens for system pods, breaking DNS resolution even though the affected pods report as `Running`. Manually restart the vCluster control plane after the restore completes. See [Restore a standalone vCluster](#restore-a-standalone-vcluster).
 
 **Standalone: restore to a new node**
 


### PR DESCRIPTION
# Content Description
Documents that restoring a standalone vCluster on the embedded etcd backing store can invalidate service account tokens for system pods (CoreDNS, kube-proxy, konnectivity agent), breaking in-pod DNS resolution even though pods report as `Running`, and the workaround of manually restarting the vCluster control plane after the automatic restart completes.

## Preview Link
https://deploy-preview-2597--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/restore#restore-a-standalone-vcluster

Scroll down a bit to the warning after two code blocks.


## Internal Reference
Closes DOC-1685

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs