### PR TITLE
docs(doc-1479): clarify Free tier is a vCluster Platform plan, not OSS

### DIFF
--- a/src/components/FeatureTable/__tests__/index.test.jsx
+++ b/src/components/FeatureTable/__tests__/index.test.jsx
@@ -41,6 +41,8 @@ jest.mock('@site/src/data/products.yaml', () => ({
     free: {
       name: 'Free',
       enterprise: false,
+      docs_url: '/docs/vcluster/introduction/oss-vs-free#overview',
+      header_note: 'Requires vCluster Platform, unlike OSS',
       features: ['test-feature-free', 'test-feature-no-url'],
     },
     dev: {
@@ -98,6 +100,40 @@ describe('FeatureTable Component', () => {
       render(<FeatureTable names="test-feature-free" showEnterpriseHeader={false} />);
 
       expect(screen.queryByText('Enterprise')).not.toBeInTheDocument();
+    });
+
+    test('links the Free column header to the OSS-vs-Free overview', () => {
+      render(<FeatureTable names="test-feature-free" />);
+
+      const freeLink = screen.getByRole('link', { name: 'Free' });
+      expect(freeLink).toHaveAttribute('href', '/docs/vcluster/introduction/oss-vs-free#overview');
+    });
+
+    test('renders exactly one info icon, on the Free header, when only Free has a header_note', () => {
+      render(<FeatureTable names="test-feature-free" />);
+
+      const headerRow = screen.getByText('Available in these plans').closest('tr');
+      const icons = headerRow.querySelectorAll('[title]');
+
+      expect(icons).toHaveLength(1);
+      expect(icons[0]).toHaveAttribute('title', 'Requires vCluster Platform, unlike OSS');
+      expect(icons[0].closest('th')).toHaveTextContent('Free');
+    });
+
+    test('the info icon is a link to the same docs_url as the Free header text', () => {
+      render(<FeatureTable names="test-feature-free" />);
+
+      const icon = screen.getByRole('link', { name: 'Requires vCluster Platform, unlike OSS' });
+      expect(icon.tagName).toBe('A');
+      expect(icon).toHaveAttribute('href', '/docs/vcluster/introduction/oss-vs-free#overview');
+    });
+
+    test('renders a footnote linking to the OSS-vs-Free overview when a product has a header_note', () => {
+      render(<FeatureTable names="test-feature-free" />);
+
+      expect(screen.getByText(/vCluster Platform license plans/)).toBeInTheDocument();
+      const footnoteLink = screen.getByRole('link', { name: 'Compare open source and free tiers' });
+      expect(footnoteLink).toHaveAttribute('href', '/docs/vcluster/introduction/oss-vs-free#overview');
     });
 
     test('renders multiple features', () => {

--- a/src/components/FeatureTable/index.jsx
+++ b/src/components/FeatureTable/index.jsx
@@ -8,6 +8,11 @@ import featuresData from '@site/src/data/features.yaml';
  * Displays a table of vCluster features with product tier availability.
  * Shows 4 tiers: Free | Dev | Prod | Scale
  * Dev, Prod, Scale are Enterprise tiers (optionally shown with Enterprise header)
+ * A product entry with a `header_note` in products.yaml renders an inline info
+ * icon next to its column header (adds no line/row height), linking to that
+ * product's docs_url, plus a footnote below the table with the same
+ * explanation. The table header is sticky so it (and the icon/link) stays
+ * visible while scrolling a long table, e.g. the full names="all" listing.
  *
  * @param {string} names - Comma-separated list of feature IDs to display, or "all" for all features
  * @param {string} tenancy - Filter features by tenancy model (e.g., "private", "shared", "standalone")
@@ -121,10 +126,16 @@ const FeatureTable = ({ names, tenancy, showEnterpriseHeader = true }) => {
     return 'Available in these plans';
   };
 
+  // A product with a header_note (currently just Free) gets a footnote below
+  // the table pointing to the OSS-vs-Free explanation, in addition to the
+  // inline linked icon on its column header.
+  const productWithNote = products.find(product => product.header_note);
+
   // Use compact layout when showing specific features (not "all")
-  const wrapperClass = showAll
-    ? styles.featureTableWrapper
-    : `${styles.featureTableWrapper} ${styles.featureTableWrapperCompact}`;
+  const wrapperClasses = [styles.featureTableWrapper];
+  if (!showAll) wrapperClasses.push(styles.featureTableWrapperCompact);
+  if (productWithNote) wrapperClasses.push(styles.featureTableWrapperWithFootnote);
+  const wrapperClass = wrapperClasses.join(' ');
 
   return (
     <>
@@ -152,6 +163,18 @@ const FeatureTable = ({ names, tenancy, showEnterpriseHeader = true }) => {
                     </a>
                   ) : (
                     product.name
+                  )}
+                  {product.header_note && (
+                    <a
+                      href={product.docs_url}
+                      className={styles.headerNoteIcon}
+                      title={product.header_note}
+                      aria-label={product.header_note}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" height="14px" viewBox="0 -960 960 960" width="14px" fill="currentColor">
+                        <path d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"/>
+                      </svg>
+                    </a>
                   )}
                 </th>
               ))}
@@ -199,6 +222,19 @@ const FeatureTable = ({ names, tenancy, showEnterpriseHeader = true }) => {
           </tbody>
         </table>
       </div>
+      {productWithNote && (
+        <p className={styles.footnote}>
+          Free, Dev, Prod, and Scale are vCluster Platform license plans. Open source does not need a license or a Platform connection.
+          {productWithNote.docs_url && (
+            <>
+              {' '}See{' '}
+              <a href={productWithNote.docs_url} className={styles.productLink}>
+                Compare open source and free tiers
+              </a>.
+            </>
+          )}
+        </p>
+      )}
     </>
   );
 };

--- a/src/components/FeatureTable/styles.module.css
+++ b/src/components/FeatureTable/styles.module.css
@@ -18,6 +18,23 @@
   margin-right: auto;
 }
 
+.featureTableWrapperWithFootnote {
+  margin-bottom: 0.5em;
+}
+
+.footnote {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 0 2em;
+}
+
+.featureTableWrapperCompact + .footnote {
+  max-width: 70%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .featureTable {
   margin: 0;
   display: table;
@@ -56,6 +73,24 @@
   font-weight: 600;
   font-size: 13px;
   color: var(--ifm-table-head-color);
+}
+
+.headerNoteIcon {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: 4px;
+  color: var(--ifm-color-emphasis-500);
+}
+
+.headerNoteIcon:hover {
+  color: var(--ifm-color-primary);
+}
+
+.headerNoteIcon:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .featureTable th {
@@ -247,6 +282,10 @@
 /* Responsive design for mobile */
 @media (max-width: 768px) {
   .featureTableWrapperCompact {
+    max-width: 100%;
+  }
+
+  .featureTableWrapperCompact + .footnote {
     max-width: 100%;
   }
 

--- a/src/data/products.yaml
+++ b/src/data/products.yaml
@@ -17,7 +17,8 @@ products:
     enterprise: false
     description: "Free tier with enhanced features for development and testing"
     pricing_url: "https://www.vcluster.com/pricing"
-    docs_url: "/docs/vcluster/introduction/oss-vs-free#activate-the-free-tier"
+    docs_url: "/docs/vcluster/introduction/oss-vs-free#overview"
+    header_note: "Requires vCluster Platform. Open source users do not need Platform."
     features:
       - "cluster-access"
       - "cluster-roles"

--- a/vcluster/introduction/oss-vs-free.mdx
+++ b/vcluster/introduction/oss-vs-free.mdx
@@ -25,7 +25,7 @@ Documentation pages show tier badges in the sidebar: **FREE** (black) requires P
 
 ## Feature comparison by license plan
 
-This table compares the vCluster Platform license plans, Free, Dev, Prod, and Scale. It does not show open source features, which do not need a license or a Platform connection.
+This table compares the vCluster license plans, Free, Dev, Prod, and Scale. It does not show open source features, which do not need a license or a Platform connection.
 
 <!--
   FeatureTable names="all" renders every feature defined in features.yaml.

--- a/vcluster/introduction/oss-vs-free.mdx
+++ b/vcluster/introduction/oss-vs-free.mdx
@@ -23,9 +23,9 @@ Beyond the Free tier, paid Enterprise tiers (Dev, Prod, Scale) add features like
 Documentation pages show tier badges in the sidebar: **FREE** (black) requires Platform activation, **ENTERPRISE** (orange) requires a paid license. Pages without badges are OSS features available to everyone.
 :::
 
-## Feature comparison
+## Feature comparison by license plan
 
-The following table lists tier-gated features and the plans they apply to. Open source features are not shown here because they are available in all tiers without restriction.
+This table compares the vCluster Platform license plans, Free, Dev, Prod, and Scale. It does not show open source features, which do not need a license or a Platform connection.
 
 <!--
   FeatureTable names="all" renders every feature defined in features.yaml.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Prospects have repeatedly misread the feature table's "Free" column as "free as in open source," confusing the licensed vCluster Platform Free tier with unlicensed OSS use. This PR clarifies the distinction in three places:

- The "Free" column header link now points to the OSS-vs-Free `## Overview` section (`#overview`) instead of the activation how-to steps (`#activate-the-free-tier`).
- The Free column header carries an info icon that links to the same overview.
- A footnote below every `FeatureTable` instance states plainly that Free/Dev/Prod/Scale are vCluster Platform plans, distinct from open source.
- The `oss-vs-free.mdx` page's own "Feature comparison" section intro was tightened to state the same distinction directly above the table.

## Preview Link
<!-- The preview link or links to the documents-->
- [OSS vs Free table](https://deploy-preview-2598--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/oss-vs-free#feature-comparison-by-license-plan) - there's a new "i" icon on the Free header to indicate a click, scroll to the bottom of the table to see the footnote, too
- [Air gapped with offline license key](https://deploy-preview-2598--vcluster-docs-site.netlify.app/docs/platform/install/air-gapped) - an example of the feature table with just one row

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1479


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs