### PR TITLE
Add Free tag to the fromHost customResources sidebar item

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -3,7 +3,7 @@ title: Custom resources
 sidebar_label: customResources
 sidebar_position: 1
 toc_max_heading_level: 3
-sidebar_class_name: host-nodes
+sidebar_class_name: free host-nodes
 description: Configuration for syncing custom resources from host
 ---
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adding the same Free tag [as we have on the toHost customResources](https://github.com/loft-sh/vcluster-docs/blob/main/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx?plain=1#L6C21-L6C25) sidebar item.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
N/A
Reported by a community member here - https://github.com/loft-sh/vcluster/issues/4119#issuecomment-5347966541
