### PR TITLE
docs(snapshots-ga): remove beta language and document external db/deployed-etcd restore behavior

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/README.mdx
@@ -10,7 +10,7 @@ slug: /configure/vcluster-yaml/control-plane/components/backing-store
 
 import BackingStore from '../../../../../_partials/config/controlPlane/backingStore.mdx'
 
-Each tenant cluster requires a backing store and vCluster provides two different types of backing store options:
+Each tenant cluster requires a backing store and <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> provides two different types of backing store options:
 
 * [etcd](./etcd/README.mdx)
 * [database](./database/README.mdx)
@@ -19,18 +19,18 @@ There are different ways to deploy the type of backing store.
 
 By default, vCluster uses an embedded SQLite database as the backing store. This option is great for smaller sandbox tenant clusters, but for production, it's recommended to use a different backing store option.
 
-:::warning Backing store migration isn't supported
-vCluster doesn't support changing the backing store type after initial deployment. This includes migrating between database and etcd backing stores, between embedded and external databases, or using snapshot and restore to do so. Choose a backing store type before you deploy to production.
+:::warning Backing store migration has limited support
+vCluster doesn't support changing the backing store type after initial deployment by editing configuration in place. A tenant cluster that already runs on deployed etcd also has no [snapshot or restore support](./etcd/deploy.mdx#back-up-and-restore) for backing itself up or recovering in place, so choose a backing store type before you deploy to production.
 
-The only supported exception is migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
+Two exceptions exist:
+- Migration from [deployed etcd to embedded etcd](../../../../../manage/migrate-etcd-backing-store.mdx). Both modes use etcd as the backing store technology.
+- Restoring an embedded etcd snapshot onto a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> configured with an embedded database, external database, or deployed etcd backing store. vCluster converts the snapshot automatically before restoring it. See [Migrate from embedded etcd to a different backing store](../../../../../manage/backup-restore/restore.mdx#migrate-from-embedded-etcd-to-a-different-backing-store).
+
+Migrating in other directions, such as from a database backing store to <GlossaryTerm term="etcd">etcd</GlossaryTerm>, isn't documented or tested.
 :::
 
-:::warning Snapshots aren't supported with deployed etcd
-[vCluster snapshots](../../../../../manage/backup-restore/backup.mdx) aren't supported with [deployed etcd](./etcd/deploy.mdx) (`controlPlane.backingStore.etcd.deploy`). Because the backing store type can't be changed after deployment, choose one that matches your recovery requirements.
-:::
-
-:::warning vCluster Standalone
-vCluster Standalone has limited backing store options. For single control plane nodes setup,
+:::note vCluster Standalone
+vCluster Standalone has limited backing store options. For single <GlossaryTerm term="control-plane">control plane</GlossaryTerm> nodes setup,
 * Embedded database (sqlite)
 * Embedded etcd
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -25,7 +25,7 @@ import PageVariables from "@site/src/components/PageVariables";
 
 ## Introduction
 
-This guide explains how to configure an external database as the backing store for a tenant cluster. A backing store is a persistent storage solution that maintains the state and data of the tenant cluster. Using an external database can provide better performance, scalability, and data persistence compared to the default embedded storage.
+This guide explains how to configure an external database as the backing store for a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. A backing store is a persistent storage solution that maintains the state and data of the tenant cluster. Using an external database can provide better performance, scalability, and data persistence compared to the default embedded storage.
 
 Configure this feature to use an external database such as MySQL or PostgreSQL for your tenant cluster's backing store.
 
@@ -52,7 +52,7 @@ Before configuring an external database for your tenant cluster, ensure you have
 ### Connector (platform-managed)
 
 :::important Platform Setup Required
-The connector method requires the vCluster Platform to be installed and properly configured. This must be completed by an administrator before using external databases.
+The connector method requires the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform to be installed and properly configured. This must be completed by an administrator before using external databases.
 :::
 
 1. [**vCluster Platform installation**](/platform/install/quick-start-guide): The platform must be installed and accessible in your Kubernetes cluster
@@ -67,7 +67,7 @@ The **connector** option provides automatic database provisioning, credential ma
 
 There are two mutually exclusive options for using an external backing store.
 
-`dataSource`: assign a connection string to `dataSource` that the tenant cluster uses for its control plane backing store.
+`dataSource`: assign a connection string to `dataSource` that the tenant cluster uses for its <GlossaryTerm term="control-plane">control plane</GlossaryTerm> backing store.
 
 `connector`: assign a name of a [connector secret](/platform/administer/connector/database) that exists in an instance of the platform in the installed namespace. The platform uses the secret to automatically provision a separate database within the database server for the tenant cluster. It also creates a non-privileged user that can only interact with the tenant cluster's database. The tenant cluster receives a connection string built from the user and database.
 
@@ -78,6 +78,10 @@ There are two mutually exclusive options for using an external backing store.
 | Share Across tenant clusters  | Yes       | No         |
 | Automatic DB Cleanup          | Yes       | No         |
 | Credential stored in secret   | Yes       | No         |
+
+:::warning Snapshot and restore
+`vcluster snapshot create` and `vcluster restore` work with an external database, whether configured with `dataSource` or `connector`, but they operate on the tenant cluster's Kubernetes key/value data through kine, not as a native database backup. vCluster doesn't back up or roll back the external database itself. See [Restore limitations](../../../../../../manage/backup-restore/restore.mdx#limitations).
+:::
 
 ### Datasource configuration
 
@@ -135,7 +139,7 @@ Before you begin, ensure you have:
 - An existing **Kerberos environment**:
   - A KDC and realm (for example `EXAMPLE.COM`).
   - A **client principal** for the tenant cluster, for example `krb5-db-user@EXAMPLE.COM`, that you can export to a keytab.
-- A **PostgreSQL server built with GSSAPI support**, reachable from the control plane cluster at a stable fully qualified domain name (FQDN), with:
+- A **PostgreSQL server built with GSSAPI support**, reachable from the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm> at a stable fully qualified domain name (FQDN), with:
   - The service principal `postgres/<postgres-fqdn>@REALM` present in the server's keytab and referenced by `krb_server_keyfile`.
   - A `pg_hba.conf` rule that authenticates the connection with `gss`.
   - A login role and database that the client principal maps to (see [Step 2](#step-2---create-the-postgresql-role-and-database)).

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
@@ -23,7 +23,7 @@ controlPlane:
 ```
 
 :::warning Snapshots aren't supported with deployed etcd
-`vcluster snapshot create`, `vcluster restore`, and [scheduled snapshots](../../../../snapshots.mdx) aren't supported with this backing store. See [Back up and restore](#back-up-and-restore).
+`vcluster snapshot create`, `vcluster restore`, and [scheduled snapshots](../../../../snapshots.mdx) aren't supported for backing up or restoring a tenant cluster that already runs on this backing store. Deployed etcd is a supported *target* when migrating an embedded etcd snapshot. See [Back up and restore](#back-up-and-restore).
 :::
 
 ## Customize the resources
@@ -81,7 +81,9 @@ controlPlane:
 
 ## Back up and restore
 
-vCluster snapshot and restore aren't supported with deployed etcd. `vcluster snapshot create` isn't blocked and can appear to succeed, but the result isn't validated, so don't rely on it to recover a tenant cluster. The same applies to `vcluster restore` and [scheduled snapshots](../../../../snapshots.mdx).
+vCluster snapshot and restore aren't supported for backing up or restoring a tenant cluster that already runs on deployed etcd. `vcluster snapshot create` isn't blocked and can appear to succeed, but the result isn't validated, so don't rely on it to recover a tenant cluster. The same applies to `vcluster restore` and [scheduled snapshots](../../../../snapshots.mdx).
+
+Deployed etcd is, however, a supported target when migrating an embedded etcd snapshot onto a new tenant cluster. See [Migrate from embedded etcd to a different backing store](../../../../../../manage/backup-restore/restore.mdx#migrate-from-embedded-etcd-to-a-different-backing-store).
 
 To move off this backing store, see [Migration options](#migration-options).
 

--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -27,7 +27,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 # Snapshots
 
-vCluster Platform allows you to configure taking snapshots of the vCluster at specific intervals.
+<GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform allows you to configure taking snapshots of the vCluster at specific intervals.
 
 :::info Manual snapshots with the vCluster CLI
 For on-demand snapshot creation and restore operations, see the [vCluster Snapshot and Restore](/docs/vcluster/manage/backup-restore/backup) documentation.
@@ -43,12 +43,12 @@ Snapshots aren't supported with [deployed etcd](./control-plane/components/backi
 :::
 
 In the `vcluster.yaml`, it is configured under `snapshots`. Using the UI, you
-can configure the management of snapshots in the config options of a tenant cluster under **Snapshots**. Though
+can configure the management of snapshots in the config options of a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> under **Snapshots**. Though
 snapshot configuration is configured on the tenant cluster itself, the capability and logic of scheduling snapshots
 is in vCluster Platform.
 
 :::note
-Auto Snapshot is currently in beta (platform v4.4.0 and later).
+Auto Snapshot requires platform v4.4.0 or later.
 :::
 
 ## Configure

--- a/vcluster/manage/backup-restore/backup.mdx
+++ b/vcluster/manage/backup-restore/backup.mdx
@@ -12,19 +12,19 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
+There are multiple ways to back up and restore a tenant cluster. <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> provides a built-in method to create and restore snapshots using its CLI.
 
 :::tip Scheduled snapshots with vCluster Platform
 Need automated, scheduled snapshots? [vCluster Platform AutoSnapshots](../../configure/vcluster-yaml/snapshots.mdx) lets you configure automatic snapshot creation on a cron schedule with retention policies. No need to write custom Kubernetes jobs.
 :::
 
 :::warning
-External databases such as MySQL or PostgreSQL that run outside the vCluster namespace require a separate backup. Refer to the relevant database documentation.
+`vcluster snapshot create` exports the tenant cluster's Kubernetes key/value data through kine, including when kine uses an external MySQL or PostgreSQL database. This isn't a native database backup, and vCluster can't back up or roll back that external database if a later restore fails. Take a native database backup before you rely on `vcluster restore` with an external database. Refer to the relevant database documentation.
 :::
 
 ## Create a snapshot
 
-We recommend using the vCluster CLI `vcluster snapshot create` command to back up the etcd datastore.
+We recommend using the vCluster CLI `vcluster snapshot create` command to back up the <GlossaryTerm term="etcd">etcd</GlossaryTerm> datastore.
 
 :::info
 The vCluster snapshot feature does not back up persistent volumes. To back up persistent volumes, use the [Velero backup method](./velero.mdx).
@@ -50,7 +50,7 @@ vcluster snapshot get myvcluster "container:///data/my-snapshot.tar.gz"
 
 The vCluster snapshot controller automatically determines the configured backing store and saves the snapshot at the specified location. The snapshot includes:
 
-- Backing store data (for example, etcd or SQLite)
+- Backing store data (such as etcd or SQLite)
 - vCluster Helm release information
 - vCluster configuration (for example, `vcluster.yaml`)
 
@@ -163,7 +163,7 @@ Alternatively, you can pass options directly in the snapshot URL. The following 
 | `secret-access-key`         | Base64-encoded S3 secret access key for authentication | Yes, when not using local credentials |
 | `session-token`             | Base64-encoded temporary session token for authentication | Yes, when not using local credentials |
 | `region`                    | Region of the S3-compatible bucket | No |
-| `url`                       | Base64-encoded custom endpoint URL for S3-compatible providers (e.g. MinIO, Ceph) | No |
+| `url`                       | Base64-encoded custom endpoint URL for S3-compatible providers (such as MinIO or Ceph) | No |
 | `force-path-style`          | Use path-style addressing (`endpoint/bucket`) instead of virtual-hosted-style. Required for most S3-compatible providers. | No, defaults to `false` |
 | `profile`                   | AWS profile to use for authentication | No |
 | `skip-client-credentials`   | Skips use of local credentials for authentication | No, defaults to `false` |
@@ -384,16 +384,16 @@ vcluster snapshot create [[VAR:VCLUSTER_NAME:my-vcluster]] "container://[[VAR:SN
 When taking snapshots and restoring tenant clusters, there are limitations:
 
 **Sleeping tenant clusters**
-- Snapshots require a running vCluster control plane and don't work with sleeping tenant clusters.
+- Snapshots require a running vCluster <GlossaryTerm term="control-plane">control plane</GlossaryTerm> and don't work with sleeping tenant clusters.
 
 **Tenant clusters using an external database**
-- Tenant clusters with an external database handle backup and restore outside of vCluster. A database administrator must back up or restore the external database according to the database documentation. Avoid using the vCluster CLI backup and restore commands for clusters with an external database.
+- vCluster snapshots export the tenant cluster's Kubernetes key/value data through kine, whether the external database is configured with `dataSource` or `connector`. This isn't a native database backup, and vCluster doesn't back up or roll back the external database itself, so take a native database backup before restoring. See [Restore limitations](./restore.mdx#limitations).
 
 **Tenant clusters using deployed etcd**
 - Snapshots aren't supported with deployed etcd (`controlPlane.backingStore.etcd.deploy`), even though `vcluster snapshot create` can still complete against it. Back up etcd with its own tooling instead. See [Back up and restore](../../configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx#back-up-and-restore).
 
 **Distribution**
-- Snapshots work only with K8s.
+- Snapshots work only with <GlossaryTerm term="k8s">K8s</GlossaryTerm>.
 
 **Cluster Certificates**
 - vCluster doesn't include cluster certificates in snapshots.

--- a/vcluster/manage/backup-restore/restore.mdx
+++ b/vcluster/manage/backup-restore/restore.mdx
@@ -12,11 +12,11 @@ import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 
 <TenancySupport hostNodes="true" privateNodes="true" />
 
-There are multiple ways to back up and restore a tenant cluster. vCluster provides a built-in method to create and restore snapshots using its CLI.
+There are multiple ways to back up and restore a tenant cluster. <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> provides a built-in method to create and restore snapshots using its CLI.
 
 A vCluster snapshot includes:
 
-- Backing store data (for example, etcd or SQLite)
+- Backing store data (such as <GlossaryTerm term="etcd">etcd</GlossaryTerm> or SQLite)
 - vCluster Helm release information
 - vCluster configuration (for example, `vcluster.yaml`)
 
@@ -29,7 +29,7 @@ For tenant clusters with private nodes, you may need to follow [additional steps
 Restoring from a snapshot pauses the vCluster, scales down all workload pods to 0, and launches a temporary restore pod. Once the restore completes, vCluster resumes and scales all workload pods back up. This process results in temporary downtime while the restore is in progress.
 
 :::warning Failed Restore
-If the restore fails while using `vcluster restore` commands, the process stops. You must retry the restore to avoid leaving the tenant cluster in an inconsistent or broken state.
+If the restore fails while using `vcluster restore` commands, the process stops. You must retry the restore to avoid leaving the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> in an inconsistent or broken state.
 :::
 
 Restore a vCluster using the following commands. You can use any snapshot option and set the snapshot URL with different credentials.
@@ -143,9 +143,9 @@ You can also restore from any external storage backend:
 />
 
 :::warning Service account tokens invalidated with embedded etcd
-Restoring a standalone vCluster that uses the embedded etcd backing store can invalidate service account tokens for running system pods, such as CoreDNS, kube-proxy, and the konnectivity agent. The restored etcd data predates any tokens issued after the snapshot was taken, so the API server rejects them on the UID check. `kubectl get pods` still reports these pods as `Running`, but in-pod DNS resolution stops working.
+Restoring a standalone vCluster that uses the embedded etcd backing store can invalidate service account tokens for running system pods, such as CoreDNS, kube-proxy, and the konnectivity agent. The restored etcd data predates any tokens issued after the snapshot was taken, so the <GlossaryTerm term="api-server">API server</GlossaryTerm> rejects them on the UID check. `kubectl get pods` still reports these pods as `Running`, but in-pod DNS resolution stops working.
 
-To restore full capability, manually restart the vCluster control plane again after the automatic restart from `vcluster restore --standalone` completes:
+To restore full capability, manually restart the vCluster <GlossaryTerm term="control-plane">control plane</GlossaryTerm> again after the automatic restart from `vcluster restore --standalone` completes:
 
 ```bash
 systemctl restart vcluster
@@ -217,7 +217,9 @@ vCluster certificates change when you create a tenant cluster with a new name or
 
 ## Migrate and override vCluster configuration options to create a new tenant cluster
 
-When upgrading tenant clusters, there are a couple of configuration options that aren't supported to change on an existing tenant cluster. For example, changing the backing store type isn't supported, including through snapshot and restore. See [Backing store](../../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx) for details. To change other options, migrate the tenant cluster by creating a new one from a snapshot and applying updated configuration.
+When upgrading tenant clusters, there are a couple of configuration options that aren't supported to change on an existing tenant cluster. For example, changing the backing store type in place isn't supported. See [Backing store](../../configure/vcluster-yaml/control-plane/components/backing-store/README.mdx) for details. To change other options, migrate the tenant cluster by creating a new one from a snapshot and applying updated configuration.
+
+The one exception is restoring an embedded etcd snapshot onto a different backing store type, which doubles as a migration path. See [Migrate from embedded etcd to a different backing store](#migrate-from-embedded-etcd-to-a-different-backing-store).
 
 When creating a new tenant cluster from a snapshot, it also restores all workloads in the tenant cluster.
 
@@ -236,6 +238,26 @@ vcluster create [[VAR:VCLUSTER_NAME:my-vcluster]] --upgrade -f vcluster.yaml --r
 vCluster certificates change when you create a tenant cluster with a new name or namespace. This is expected, as tenant clusters shouldn't share certificates.
 :::
 
+### Migrate from embedded etcd to a different backing store
+
+Restoring an embedded etcd snapshot onto a tenant cluster configured with a different backing store type converts the snapshot automatically. This lets you move a tenant cluster off embedded etcd onto an embedded database, [external database](../../configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx), or [deployed etcd](../../configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx), using the same snapshot and restore workflow as any other migration.
+
+This migration path is separate from deployed etcd's own snapshot and restore support. Deployed etcd is a supported *target* for a converted embedded-etcd snapshot, but taking a snapshot of a tenant cluster that already runs on deployed etcd, to back up or restore that same cluster, isn't validated. See [Back up and restore](../../configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx#back-up-and-restore).
+
+vCluster can't change a tenant cluster's backing store type in place. Restore this into a new tenant cluster (a different name, namespace, or both) rather than the original one:
+
+<InterpolatedCodeBlock
+  code={`# Take a snapshot of the source tenant cluster, which uses embedded etcd.
+vcluster snapshot create [[VAR:SOURCE_VCLUSTER_NAME:my-vcluster]] "oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]"
+
+# Restore it into a new tenant cluster whose vcluster.yaml configures a different backing store.
+# vCluster detects the etcd snapshot and converts it before restoring.
+vcluster create [[VAR:NEW_VCLUSTER_NAME:my-vcluster-external-db]] --namespace [[VAR:NEW_NAMESPACE:vcluster-my-vcluster-external-db]] -f vcluster.yaml --restore oci://[[VAR:OCI_REGISTRY:ghcr.io]]/[[VAR:OCI_USER:my-user]]/[[VAR:OCI_REPO:my-repo]]:[[VAR:OCI_TAG:my-tag]]`}
+  language="bash"
+/>
+
+This guide covers migrating from embedded etcd only. Migrating in the other direction, such as from a database backing store to etcd, isn't documented or tested.
+
 ### Limitations
 
 When taking snapshots and restoring tenant clusters, there are limitations:
@@ -246,11 +268,11 @@ When taking snapshots and restoring tenant clusters, there are limitations:
 
 **Tenant clusters using an external database**
 
-- Restoring onto an external database deletes the existing data before replaying the snapshot, and vCluster does not back up or roll back the external database. Before running `vcluster restore`, the database owner or administrator must take a native database backup so that a native external database restore can be triggered if the restore fails.
+- Restoring onto an external database, whether configured with `dataSource` or `connector`, deletes the existing tenant-cluster key/value records (through kine, key by key) before replaying the snapshot. vCluster doesn't back up or roll back the external database itself. Before running `vcluster restore`, the database owner or administrator must take a native database backup so that a native external database restore can be triggered if the restore fails.
 
 **Tenant clusters using deployed etcd**
 
-- Restore isn't supported with deployed etcd (`controlPlane.backingStore.etcd.deploy`). Restore etcd with its own tooling instead. See [Back up and restore](../../configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx#back-up-and-restore).
+- Restoring a tenant cluster that already runs on deployed etcd (`controlPlane.backingStore.etcd.deploy`) isn't supported. Restore etcd with its own tooling instead. See [Back up and restore](../../configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx#back-up-and-restore). Deployed etcd is a supported target when migrating an embedded etcd snapshot onto a new tenant cluster; see [Migrate from embedded etcd to a different backing store](#migrate-from-embedded-etcd-to-a-different-backing-store).
 
 **vcluster.yaml configuration**
 

--- a/vcluster/manage/migrate-etcd-backing-store.mdx
+++ b/vcluster/manage/migrate-etcd-backing-store.mdx
@@ -16,7 +16,7 @@ This guide explains how to migrate your <GlossaryTerm term="vcluster">vCluster</
 If you're currently using deployed <GlossaryTerm term="etcd">etcd</GlossaryTerm> and want to simplify your deployment, reduce resource consumption, or streamline operations, migrating to embedded etcd is a straightforward process that preserves all your data.
 
 :::important Scope of this guide
-This guide covers migration between two etcd deployment modes only. vCluster doesn't support migrating between backing store types, such as etcd to database, database to etcd, or embedded to external database. Snapshot and restore across backing store types isn't supported either.
+This guide covers migration between two etcd deployment modes using the `migrateFromDeployedEtcd` flag. vCluster doesn't support changing the backing store type by editing configuration in place, such as etcd to database or database to etcd. The one other supported migration path is restoring an embedded etcd snapshot onto a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> configured with an embedded database, external database, or deployed etcd backing store. See [Migrate from embedded etcd to a different backing store](./backup-restore/restore.mdx#migrate-from-embedded-etcd-to-a-different-backing-store).
 :::
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Removes beta language now that Auto Snapshot is GA, and documents actual snapshot/restore behavior for external database backing stores (kine key/value export, key-by-key delete on restore, no native backup/rollback) and for restoring an embedded etcd snapshot onto a different backing store as a supported migration path.

## Preview Link 
- [Backing store overview](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store) — consolidated warnings, migration exceptions
- [External database](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/database/external#connector-and-data-source) — new snapshot/restore warning
- [Deployed etcd](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy#back-up-and-restore) — narrowed unsupported-restore scope
- [Snapshots (vcluster.yaml)](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/snapshots) — beta language removed
- [Create snapshots](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/backup#limitations) — external database limitation reworded
- [Restore snapshots](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/backup-restore/restore#migrate-from-embedded-etcd-to-a-different-backing-store) — new migration section
- [Migrate etcd backing store](https://deploy-preview-2605--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/migrate-etcd-backing-store) — scope callout updated

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1649
Closes DOC-1713


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
