### PR TITLE
docs: reposition platform/introduction pages beyond kubernetes-only framing

### DIFF
--- a/platform/introduction/architecture.mdx
+++ b/platform/introduction/architecture.mdx
@@ -12,7 +12,7 @@ import PlatformEntryPoints from '@site/static/media/platform/diagrams/platform-e
 
 vCluster Platform is the management plane for your <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> fleet. It runs in Kubernetes and exposes UI, CLI, and API entry points. It reconciles Platform resources into connected <GlossaryTerm term="control-plane-cluster">control plane clusters</GlossaryTerm>.
 
-Platform is where admins define projects, specify who can create tenant clusters, and set which templates and policies apply. Platform controllers reconcile those decisions into connected clusters, where vCluster runs each tenant cluster control plane.
+Platform is where admins define projects, specify who can create tenant clusters, and set which templates and policies apply. Platform controllers reconcile those decisions into connected clusters, where vCluster runs each tenant cluster control plane. That control plane delivers managed Kubernetes directly, or serves as the foundation for other cluster types like Slurm, Ray, and inference.
 
 <figure>
   <PlatformIntroOverview style={{width: '100%', height: 'auto'}} role="img" aria-label="vCluster Platform connects admins and automation to projects, policies, connected clusters, and tenant clusters" />
@@ -27,7 +27,7 @@ The management plane runs as the `vcluster-platform` Helm chart, deployed into t
 - **Web UI.** Browser interface for the Platform API, running as part of the management API process.
 - **Management API.** Serves Platform resources: projects, clusters, VirtualClusterInstances, templates, users, and access keys.
 - **Platform manager.** Controllers that reconcile Platform resources into connected clusters.
-- **Operational services.** Audit, metrics, cost data, sleep and wake behavior, snapshots, and integrations.
+- **Operational services.** Audit, metrics, cost data, snapshots, integrations, and sleep/wake behavior.
 
 Platform uses Kubernetes custom resources for all management state. The default single-replica deployment uses an embedded database. High-availability deployments can connect to an [external relational database](../administer/clusters/advanced/external-database/external-database.mdx) through Kine, which provides an etcd-compatible API over MySQL or PostgreSQL.
 

--- a/platform/introduction/how-platform-works.mdx
+++ b/platform/introduction/how-platform-works.mdx
@@ -10,7 +10,7 @@ import PlatformEntryPoints from '@site/static/media/platform/diagrams/platform-e
 import PlatformTenantLifecycle from '@site/static/media/platform/diagrams/platform-tenant-lifecycle.svg';
 import PlatformNetworkPaths from '@site/static/media/platform/diagrams/platform-network-paths.svg';
 
-Platform follows the Kubernetes controller model. Users and automation create or update API resources expressing desired state. Controllers in the management plane compare that state against connected clusters and reconcile the difference. The connected cluster agent applies changes locally and reports status back to Platform. vCluster then runs the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> control plane within the connected cluster.
+Platform follows the Kubernetes controller model. Users and automation create or update API resources expressing desired state. Controllers in the management plane compare that state against connected clusters and reconcile the difference. The connected cluster agent applies changes locally and reports status back to Platform. vCluster then runs the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> control plane within the connected cluster. That control plane delivers managed Kubernetes directly, or serves as the foundation for other cluster types like Slurm, Ray, and inference running on top.
 
 For the structural components, see [Platform architecture](./architecture.mdx).
 

--- a/platform/introduction/vcluster_intro.mdx
+++ b/platform/introduction/vcluster_intro.mdx
@@ -8,13 +8,15 @@ hide_table_of_contents: false
 
 import GlossaryTerm from '@site/src/components/GlossaryTerm';
 
-vCluster provisions fully isolated Kubernetes environments, called <GlossaryTerm term="tenant-cluster">tenant clusters</GlossaryTerm>, on your existing infrastructure. Each tenant cluster has a dedicated API server, its own RBAC and CRDs, and a cluster experience indistinguishable from a dedicated Kubernetes cluster. Tenant clusters do not require dedicated physical nodes.
+vCluster helps AI cloud providers deliver highly scalable, resilient compute clusters as self-service tenant products, including managed Kubernetes, Slurm, inference, Ray, and other cluster types. Each tenant gets a dedicated <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> on your existing infrastructure, with its own API server, RBAC, and CRDs.
 
 ## What a tenant cluster looks like
 
-From the perspective of a user or workload, a tenant cluster is a full Kubernetes cluster. They receive a `kubeconfig` scoped to their cluster and interact with it using any conformant tool: `kubectl`, Helm, Argo CD, `Crossplane`, and others. They cannot see or reach other tenant clusters or the underlying <GlossaryTerm term="control-plane-cluster">Control Plane Cluster</GlossaryTerm>.
+From the perspective of a user or workload, a tenant cluster is a full Kubernetes cluster. They receive a `kubeconfig` scoped to their cluster and interact with it using tools built for the standard Kubernetes API, such as `kubectl`, Helm, Argo CD, and Crossplane. They cannot see other tenant clusters or the underlying <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm> through the Kubernetes API. Network-level isolation between tenants depends on the worker node model you choose.
 
-From the platform operator's perspective, the tenant cluster control plane runs as a pod in a namespace on the Control Plane Cluster. Creating one requires no additional infrastructure.
+That same Kubernetes foundation is what higher-level cluster types like Slurm, Ray, and inference-serving stacks run on as workloads.
+
+From the platform operator's perspective, the tenant cluster control plane runs as a pod in a namespace on the control plane cluster. Creating one requires no additional infrastructure.
 
 ## Isolation model
 
@@ -29,7 +31,7 @@ vCluster Platform is the management layer for your tenant cluster fleet. It hand
 - **Provisioning** — create tenant clusters from the UI, CLI, or API, with optional templates that enforce configuration baselines
 - **Access control** — RBAC at the platform, project, and individual cluster level; SSO integration with any OIDC provider
 - **Lifecycle** — sleep, wake, auto-delete, and version upgrades coordinated across the fleet
-- **Multi-cluster** — manage tenant clusters across multiple Control Plane Clusters from a single Platform instance
+- **Multi-cluster** — manage tenant clusters across multiple control plane clusters from a single Platform instance
 
 [Learn how Platform works →](./platform_intro.mdx)
 


### PR DESCRIPTION
# Content Description
Realign `platform/introduction/vcluster_intro.mdx`, `architecture.mdx`, and `how-platform-works.mdx` with the suite-level repositioning already shipped on the landing pages and on `vcluster/introduction/` (DOC-1667/#2547, DOC-1717/#2609): lead with cluster-type breadth (managed Kubernetes, Slurm, inference, Ray) and frame Kubernetes as the implementation detail underneath, not vCluster's core identity. Also separates API-level tenant visibility from network isolation on `vcluster_intro.mdx` and fixes control plane cluster casing.

## Preview Link
- https://deploy-preview-2610--vcluster-docs-site.netlify.app/docs/platform/next/introduction/vcluster_intro
- https://deploy-preview-2610--vcluster-docs-site.netlify.app/docs/platform/next/introduction/architecture
- https://deploy-preview-2610--vcluster-docs-site.netlify.app/docs/platform/next/introduction/how-platform-works

## Internal Reference
Closes DOC-1718

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs