### PR TITLE
docs: fix kerberos free-tier sidebar label mismatch

### DIFF
--- a/src/data/features.yaml
+++ b/src/data/features.yaml
@@ -104,7 +104,7 @@ features:
     name: "External Database Kerberos Authentication"
     description: "Authenticate a tenant cluster's external PostgreSQL backing store using Kerberos/GSSAPI with a mounted keytab."
     category: "vCluster Pro Distro"
-    docs_url: "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external"
+    docs_url: "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external#authenticate-to-postgresql-with-kerberos-gssapi"
   connector-external-database:
     name: "Database Connector"
     description: "External Database Connector automates the provisioning, credential handling, and cleanup of databases for virtual clusters."

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -107,6 +107,10 @@ The tenant cluster must be [connected to the platform](/docs/vcluster/configure/
 
 ## Authenticate to PostgreSQL with Kerberos (GSSAPI)
 
+:::info Available on every tier
+Kerberos/GSSAPI authentication ships in the OSS `kine` binary and is available on every tier, including Free. Unlike the other methods on this page, it doesn't require an Enterprise license or a vCluster Platform connection.
+:::
+
 <PageVariables
   REALM="EXAMPLE.COM"
   KDC_HOST="kdc.example.com"


### PR DESCRIPTION
# Content Description
Fixes the sidebar-label mismatch flagged by DOC-1706: `external-database-kerberos` is Free tier (since PR #2264) but the shared external-database page's blanket `ProAdmonition` marked it Enterprise-only. Adds a scoped note on the Kerberos section instead of touching the page-wide badge/admonition, which is correct for the page's other three (genuinely Enterprise-only) features. Also anchors the feature's `docs_url` to its own section so `check-plans-sidebar-labels.js` stops re-flagging this page on every future plans-repo change — the script already skips anchored `docs_url` values for exactly this shared-page scenario.

## Preview Link


## Internal Reference
Closes DOC-1706


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs