### PR TITLE
docs: document ingress-nginx admission webhook caBundle race

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
@@ -45,6 +45,19 @@ sync:
       enabled: true
 ```
 
+### Admission webhook rejects synced Ingress
+
+The ingress-nginx chart's cert-gen Helm hook nulls the ValidatingWebhookConfiguration's `caBundle` in a pre-upgrade job and regenerates it in a post-upgrade job. If the control plane cluster's ingress-nginx upgrade is interrupted between those two hooks, `caBundle` stays empty.
+
+When vCluster then creates a synced Ingress on the control plane cluster, the webhook rejects it, returning `tls: failed to verify certificate: x509: certificate signed by unknown authority`. From the tenant's side, the Ingress exists but never appears on the control plane cluster. The syncer log shows the TLS rejection against the translated Ingress name.
+
+Two ways to work around it:
+
+- For debugging only, set `controller.admissionWebhooks.enabled: false` on the ingress-nginx chart. This disables admission validation. The controller still routes traffic.
+- For a lasting fix, set `admissionWebhooks.certManager.enabled: true` so cert-manager manages the `caBundle` instead of the chart's Helm hook job. This removes the race entirely.
+
+This is an ingress-nginx webhook lifecycle issue, not a vCluster sync defect, and one more reason to plan a move to [Gateway API sync](./gateway-api.mdx).
+
 ## Patches
 
 Use `sync.toHost.ingresses.patches` to transform Ingress fields, such as `spec.rules[*].host`, while syncing to the control plane cluster. See [Patching synced resources](../../patching/README.mdx) for syntax, directionality, and examples.

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
@@ -47,14 +47,14 @@ sync:
 
 ### Admission webhook rejects synced Ingress
 
-The ingress-nginx chart's cert-gen Helm hook nulls the ValidatingWebhookConfiguration's `caBundle` in a pre-upgrade job and regenerates it in a post-upgrade job. If the control plane cluster's ingress-nginx upgrade is interrupted between those two hooks, `caBundle` stays empty.
+During an ingress-nginx Helm upgrade on the control plane cluster, the chart applies the ValidatingWebhookConfiguration with no `caBundle` set. A post-upgrade job then patches the `caBundle` onto it using the webhook's certificate secret. If the upgrade is interrupted before that job completes, the webhook config is left with an empty `caBundle`.
 
 When vCluster then creates a synced Ingress on the control plane cluster, the webhook rejects it, returning `tls: failed to verify certificate: x509: certificate signed by unknown authority`. From the tenant's side, the Ingress exists but never appears on the control plane cluster. The syncer log shows the TLS rejection against the translated Ingress name.
 
 Two ways to work around it:
 
 - For debugging only, set `controller.admissionWebhooks.enabled: false` on the ingress-nginx chart. This disables admission validation. The controller still routes traffic.
-- For a lasting fix, set `admissionWebhooks.certManager.enabled: true` so cert-manager manages the `caBundle` instead of the chart's Helm hook job. This removes the race entirely.
+- For a lasting fix, set `controller.admissionWebhooks.certManager.enabled: true` so cert-manager manages the `caBundle` instead of the chart's Helm hook jobs. This requires cert-manager already installed in the cluster, and removes the race entirely.
 
 This is an ingress-nginx webhook lifecycle issue, not a vCluster sync defect, and one more reason to plan a move to [Gateway API sync](./gateway-api.mdx).
 


### PR DESCRIPTION
# Content Description
Adds a subsection to the Ingress sync config page explaining the ingress-nginx admission webhook caBundle race: an interrupted helm upgrade can leave the webhook's caBundle empty, causing synced tenant Ingresses to be rejected on the control plane cluster with a TLS verification error. Includes the debug-only and production workarounds.

## Preview Link
<!-- Netlify will post the deploy preview link on this PR -->
https://deploy-preview-2625--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/networking/ingresses#admission-webhook-rejects-synced-ingress

## Internal Reference
Closes DOC-1519

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs