### PR TITLE
docs: add missing SELinux flags to private-nodes join flags table

### DIFF
--- a/vcluster/deploy/worker-nodes/private-nodes/join.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/join.mdx
@@ -118,6 +118,9 @@ The output of creating the token outputs a script to join the worker node to the
 | `--skip-join` | Installs all required components but skips joining node to the cluster. This can be useful if you want to update the kubeadm join config before joining the node to the cluster manually by executing `kubeadm join` | optional, defaults to `false` |
 | `--node-name` | Node name in the kubernetes cluster | optional, defaults to hostname |
 | `--force-join` | Force joining even when there is existing kubelet service running on the node.  | optional, defaults to `false` |
+| `--skip-selinux-rpm` | Skips installing the `vcluster-selinux` RPM on RHEL-family hosts with SELinux `Enforcing` or `Permissive`. Use when the RPM is already installed or SELinux is disabled. See [SELinux support](./security/selinux.mdx#install-offline) | optional, defaults to `false` |
+| `--selinux-rpm-url` | Overrides the default `vcluster-selinux` RPM source. Also settable with the `VCLUSTER_SELINUX_RPM_URL` environment variable. See [SELinux support](./security/selinux.mdx#install-offline) | optional, defaults to `rpm.vcluster.com/stable/el<version>/noarch` |
+| `--containerd-selinux` | Enables `enable_selinux = true` in containerd's config so tenant pods get per-pod MCS labels. Also settable with the `VCLUSTER_CONTAINERD_SELINUX` environment variable. See [SELinux support](./security/selinux.mdx#containerd-selinux) | optional, defaults to `false` |
 
 These flags can be passed to the script by appending `--` and then the flag:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds `--skip-selinux-rpm`, `--selinux-rpm-url`, and `--containerd-selinux` to the "Available flags" table on the private-nodes Join page, each linking to the relevant section of the SELinux support page for full detail.

## Preview Link 
<!-- The preview link or links to the documents-->
- https://deploy-preview-2626--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes/join#available-flags-to-use-in-the-script-to-join-nodes

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1529


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs