### PR TITLE
Update metal3 provider docs

### DIFF
--- a/platform/administer/node-providers/metal3-network-integration.mdx
+++ b/platform/administer/node-providers/metal3-network-integration.mdx
@@ -10,7 +10,7 @@ The Metal3 provider provisions bare metal servers, but on its own it does not is
 The provider selects a network integration through a family of network providers. A provider is chosen with the `metal3.vcluster.com/network-provider` property on the network environment (a [`NodeEnvironment`](./overview.mdx#node-environments) resource).
 
 :::info Requires private nodes
-The Neutron and Netris modes on this page require [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/overview). They provision servers as private nodes for a tenant cluster and select their network through a network environment. The default mode (no network integration) has no such requirement.
+The Neutron and Netris modes on this page require [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes). They provision servers as private nodes for a tenant cluster and select their network through a network environment. The default mode (no network integration) has no such requirement.
 :::
 
 ## Choose a network integration mode

--- a/platform/administer/node-providers/metal3-network-integration.mdx
+++ b/platform/administer/node-providers/metal3-network-integration.mdx
@@ -1,0 +1,169 @@
+---
+title: Metal3 Network Integration
+sidebar_label: Network Integration
+sidebar_position: 5.5
+sidebar_class_name: pro
+---
+
+The Metal3 provider provisions bare metal servers, but on its own it does not isolate the network those servers run on. Network integration determines how strongly each tenant's traffic is separated on the metal fabric and how the platform manages addresses for provisioned servers. The right choice depends on how much you trust the tenants that share your hardware: a single trusted team can run on a flat provisioning network, while untrusted or external tenants need isolation enforced in the physical network.
+
+The provider selects a network integration through a family of network providers. A provider is chosen with the `metal3.vcluster.com/network-provider` property on the network environment (a [`NodeEnvironment`](./overview.mdx#node-environments) resource).
+
+:::info Requires private nodes
+The Neutron and Netris modes on this page require [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes/overview). They provision servers as private nodes for a tenant cluster and select their network through a network environment. The default mode (no network integration) has no such requirement.
+:::
+
+## Choose a network integration mode
+
+There are three modes, from a flat shared network to full isolation in hardware.
+
+| Mode | Isolation level | IPAM | When to use |
+|---|---|---|---|
+| No network integration (default) | None. The provisioning network is the tenant network. | Platform IPAM leases on the shared flat network. | A single trusted tenant, or a lab where the provisioning network is the only network. |
+| Neutron (flat network) | None at the fabric. The network stays flat and shared; Ironic owns the port lifecycle. | Platform IPAM, per tenant network. | You want Ironic to drive ports through its neutron interface, but do not need hardware isolation. |
+| Netris | Hardware. Per-server L2 isolation through Netris. | Platform IPAM; the subnet is derived from the Netris server cluster unless a CIDR is pinned. | Untrusted, external, or regulated tenants that must be isolated at the physical network layer. |
+
+The two flat modes give control-plane, API, and address isolation between tenant clusters, but every server still shares the same layer 2 network. Only Netris moves the isolation boundary into the hardware fabric.
+
+## No network integration (default)
+
+With no network provider set, the provisioning network is also the tenant network. The platform's built-in IPAM leases an address on that shared flat network and writes it, together with the gateway and DNS servers, directly onto the `BareMetalHost` as DHCP annotations. This is the default Metal3 behavior and requires no additional configuration.
+
+Addresses come from the existing network properties documented on the [Metal3 provider page](./metal3.mdx#network-configuration):
+
+- `metal3.vcluster.com/network-cidr` sets the gateway and subnet to allocate from.
+- `metal3.vcluster.com/network-ip-range` restricts allocation to explicit ranges.
+- `metal3.vcluster.com/network-data` supplies a complete custom network-data document.
+
+Because all servers share one network, use this mode only where the tenants sharing the hardware are trusted.
+
+## Neutron (flat network)
+
+In this mode Ironic drives its `neutron` network interface instead of writing addresses straight onto the `BareMetalHost`. The platform allocates the address for each port and Ironic manages the port lifecycle across provisioning, cleaning, and inspection.
+
+:::warning Neutron does not isolate the network
+Neutron changes how ports are managed, not how the network is segmented. The underlying network is still flat and shared across tenants. For isolation enforced in hardware, use Netris.
+:::
+
+Enable Neutron by setting the NodeProvider field `metal3.neutronEnabled: true`:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: metal3-provider
+spec:
+  metal3:
+    neutronEnabled: true
+```
+
+Then supply the externally provisioned network names that Ironic requests through the metal3 chart `helmValues`:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: metal3-provider
+spec:
+  metal3:
+    deploy:
+      metal3:
+        enabled: true
+        helmValues: |
+          neutron:
+            enabled: true
+            networks:
+              provisioning: provisioning
+              cleaning: cleaning
+              inspection: inspection
+```
+
+When `cleaning` or `inspection` are left empty, they fall back to the provisioning network. Servers provisioned in this mode select their network through a network environment, so a network environment is required.
+
+## Netris (hardware network isolation)
+
+Netris provides true network isolation in hardware. On provisioning, the platform attaches each server to a Netris server cluster, which gives that server per-server L2 isolation. Tenants are then isolated from each other at the physical network layer rather than only at the control plane, which is what external, resale, or regulated tenants require.
+
+Requires [Neutron mode](#neutron-flat-network). Netris builds on Neutron and adds per-server L2 isolation on top, so it also requires a network environment.
+
+### Provide Netris API credentials
+
+Reference a Secret holding the Netris API `url`, `username`, and `password` on the NodeProvider. The `metal3.neutronEnabled: true` field is repeated here to show the complete provider configuration:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: metal3-provider
+spec:
+  metal3:
+    neutronEnabled: true
+    netris:
+      secretRef:
+        name: netris-credentials
+        namespace: metal3-system
+```
+
+### Select and configure the Netris provider
+
+The Netris provider is selected and configured through properties on the network environment. Set them under `spec.properties`.
+
+| Property | Required | Description |
+|---|---|---|
+| `metal3.vcluster.com/network-provider` | Yes | Set to `netris` to select the Netris network provider. |
+| `netris.vcluster.com/server-cluster` | Yes | Name of the Netris server cluster to attach each server to. Also the subnet source when no CIDR is pinned. |
+| `netris.vcluster.com/server-cluster-template` | Conditional | Name of a Netris server-cluster template. The platform creates the server cluster from it when the cluster does not already exist. |
+| `netris.vcluster.com/server-cluster-template-json` | Conditional | JSON body used to create the template when a template of that name does not already exist. |
+| `netris.vcluster.com/admin` | Conditional | Netris tenant that owns the created server cluster. Required when the platform creates the server cluster. |
+| `netris.vcluster.com/site` | Conditional | Netris site the created server cluster belongs to. Required when the platform creates the server cluster. |
+| `netris.vcluster.com/vpc` | No | VPC for the created server cluster. |
+
+When the named server cluster already exists, the platform adopts it and never marks it managed, so `server-cluster-template`, `admin`, and `site` are only needed when the platform must create the server cluster itself.
+
+When the platform creates a server cluster or template, it records what it created on the network environment so it can remove exactly those resources on teardown:
+
+- `netris.vcluster.com/managed-server-cluster`
+- `netris.vcluster.com/managed-server-cluster-template`
+
+These annotations are managed by the platform. Do not set them by hand.
+
+:::warning Shared Netris resources are deleted with their creator
+The platform only deletes the Netris server cluster and template that a network environment created. If several network environments reference the same Netris server cluster or VPC, deleting the network environment that created those Netris resources deletes them for every network environment that still references them, breaking the others. Give each network environment its own server cluster, or have only environments that adopt a pre-existing, externally managed server cluster share one.
+:::
+
+The subnet for each server is derived from the Netris server cluster's network unless `metal3.vcluster.com/network-cidr` pins it, in which case the pinned CIDR always wins.
+
+### Override the Netris server name
+
+By default a server is registered in Netris under its `BareMetalHost` name. To register it under a different name, set the following annotation on the `BareMetalHost`:
+
+```yaml
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: server-01
+  annotations:
+    netris.vcluster.com/server-name: rack1-server-01
+```
+
+### Example
+
+This network environment selects the Netris provider and points at a server cluster that the platform creates from a template if it does not already exist:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeEnvironment
+metadata:
+  name: tenant-a-network
+  namespace: metal3-system
+spec:
+  providerRef: metal3-provider
+  properties:
+    metal3.vcluster.com/network-provider: netris
+    netris.vcluster.com/server-cluster: tenant-a
+    netris.vcluster.com/server-cluster-template: default-template
+    netris.vcluster.com/admin: tenant-a-admin
+    netris.vcluster.com/site: datacenter-1
+```
+
+Servers select this network environment through the `vcluster.com/network-environment` property, described on the [Metal3 provider page](./metal3.mdx#network-environment). Any server provisioned into it is attached to the `tenant-a` Netris server cluster and given per-server L2 isolation.

--- a/platform/administer/node-providers/metal3-network-integration.mdx
+++ b/platform/administer/node-providers/metal3-network-integration.mdx
@@ -5,12 +5,12 @@ sidebar_position: 5.5
 sidebar_class_name: pro
 ---
 
-The Metal3 provider provisions bare metal servers, but on its own it does not isolate the network those servers run on. Network integration determines how strongly each tenant's traffic is separated on the metal fabric and how the platform manages addresses for provisioned servers. The right choice depends on how much you trust the tenants that share your hardware: a single trusted team can run on a flat provisioning network, while untrusted or external tenants need isolation enforced in the physical network.
+The Metal3 provider provisions bare metal servers, but on its own it doesn't isolate the network those servers run on. Network integration determines how strongly each tenant's traffic is separated on the metal fabric and how the platform manages addresses for provisioned servers. The right choice depends on how much you trust the tenants that share your hardware. A single trusted team can run on a flat provisioning network, while untrusted or external tenants need isolation enforced in the physical network.
 
-The provider selects a network integration through a family of network providers. A provider is chosen with the `metal3.vcluster.com/network-provider` property on the network environment (a [`NodeEnvironment`](./overview.mdx#node-environments) resource).
+The `metal3.neutronEnabled` NodeProvider field enables Neutron integration. Within Neutron mode, the `metal3.vcluster.com/network-provider` property selects an optional fabric provider on a network environment (a [`NodeEnvironment`](./overview.mdx#node-environments) resource). Set the property to `netris` for Netris, or leave it empty for a flat network.
 
-:::info Requires private nodes
-The Neutron and Netris modes on this page require [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes). They provision servers as private nodes for a tenant cluster and select their network through a network environment. The default mode (no network integration) has no such requirement.
+:::info Requires a network environment
+Neutron and Netris require a network environment. They support Machines provisioned independently or used as [private nodes](/docs/vcluster/deploy/worker-nodes/private-nodes) for a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. Use private nodes and a separate Netris server cluster for each network environment when tenants are untrusted.
 :::
 
 ## Choose a network integration mode
@@ -19,15 +19,17 @@ There are three modes, from a flat shared network to full isolation in hardware.
 
 | Mode | Isolation level | IPAM | When to use |
 |---|---|---|---|
-| No network integration (default) | None. The provisioning network is the tenant network. | Platform IPAM leases on the shared flat network. | A single trusted tenant, or a lab where the provisioning network is the only network. |
-| Neutron (flat network) | None at the fabric. The network stays flat and shared; Ironic owns the port lifecycle. | Platform IPAM, per tenant network. | You want Ironic to drive ports through its neutron interface, but do not need hardware isolation. |
-| Netris | Hardware. Per-server L2 isolation through Netris. | Platform IPAM; the subnet is derived from the Netris server cluster unless a CIDR is pinned. | Untrusted, external, or regulated tenants that must be isolated at the physical network layer. |
+| No network integration (default) | None. The provisioning network is the tenant network. | Optional. Platform IPAM allocates addresses when a network CIDR is configured. | A single trusted tenant, or a lab where the provisioning network is the only network. |
+| Neutron (flat network) | None at the fabric. The network stays flat and shared; Ironic owns the port lifecycle. | Platform IPAM, per tenant network. | You want Ironic to drive ports through its neutron interface, but don't need hardware isolation. |
+| Netris | Hardware. Environment-level L2 isolation through Netris. | Platform IPAM; the subnet is derived from the Netris server cluster unless a CIDR is pinned. | Untrusted, external, or regulated tenants that must be isolated at the physical network layer. |
 
-The two flat modes give control-plane, API, and address isolation between tenant clusters, but every server still shares the same layer 2 network. Only Netris moves the isolation boundary into the hardware fabric.
+The two flat modes keep tenant cluster control planes and APIs separate and manage their addresses independently. Every server still shares the same layer 2 network, so these modes don't provide network isolation. Only Netris moves that isolation boundary into the hardware fabric.
 
 ## No network integration (default)
 
-With no network provider set, the provisioning network is also the tenant network. The platform's built-in IPAM leases an address on that shared flat network and writes it, together with the gateway and DNS servers, directly onto the `BareMetalHost` as DHCP annotations. This is the default Metal3 behavior and requires no additional configuration.
+With `metal3.neutronEnabled` set to `false`, the provisioning network is also the tenant network. When `metal3.vcluster.com/network-cidr` is configured, the platform's built-in IPAM allocates an address on that shared network. It writes the address, gateway, and DNS servers directly onto the `BareMetalHost` as DHCP annotations.
+
+Without a network CIDR, the platform doesn't allocate an address or write managed DHCP annotations. The bundled DHCP server can't serve a PXE client unless another system supplies the required IP address annotation on its `BareMetalHost`. Alternatively, use external DHCP. You can provide custom network data to configure the installed operating system, but it doesn't replace provisioning DHCP.
 
 Addresses come from the existing network properties documented on the [Metal3 provider page](./metal3.mdx#network-configuration):
 
@@ -41,11 +43,13 @@ Because all servers share one network, use this mode only where the tenants shar
 
 In this mode Ironic drives its `neutron` network interface instead of writing addresses straight onto the `BareMetalHost`. The platform allocates the address for each port and Ironic manages the port lifecycle across provisioning, cleaning, and inspection.
 
-:::warning Neutron does not isolate the network
+:::warning Neutron doesn't isolate the network
 Neutron changes how ports are managed, not how the network is segmented. The underlying network is still flat and shared across tenants. For isolation enforced in hardware, use Netris.
 :::
 
-Enable Neutron by setting the NodeProvider field `metal3.neutronEnabled: true`:
+Enable Neutron and supply the externally provisioned network names that Ironic requests. The platform derives the chart's `neutron.enabled` value from `metal3.neutronEnabled`.
+
+Flat Neutron also requires `metal3.vcluster.com/network-cidr` in the effective properties of every NodeClaim. The platform can't allocate the tenant port without this CIDR. The following example defines the CIDR on a node type and binds its NodeClaims to a network environment in their management-plane namespace:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -54,41 +58,50 @@ metadata:
   name: metal3-provider
 spec:
   metal3:
+    clusterRef:
+      cluster: bare-metal-cluster
+      namespace: metal3-system
+    # Enables the platform network controller and the chart's Neutron support.
     neutronEnabled: true
-```
-
-Then supply the externally provisioned network names that Ironic requests through the metal3 chart `helmValues` (chart `v0.6.0`):
-
-```yaml
-apiVersion: management.loft.sh/v1
-kind: NodeProvider
-metadata:
-  name: metal3-provider
-spec:
-  metal3:
     deploy:
       metal3:
         enabled: true
         helmValues: |
           neutron:
-            enabled: true
             networks:
               provisioning: provisioning
               cleaning: cleaning
               inspection: inspection
+    nodeTypes:
+      - name: compute
+        properties:
+          # Flat Neutron can't derive a subnet, so configure one explicitly.
+          metal3.vcluster.com/network-cidr: 192.168.100.1/24
+          # Resolve this NodeEnvironment from each NodeClaim's namespace.
+          vcluster.com/network-environment: tenant-a-network
+---
+apiVersion: management.loft.sh/v1
+kind: NodeEnvironment
+metadata:
+  name: tenant-a-network
+  namespace: tenant-a
+spec:
+  providerRef: metal3-provider
 ```
 
 When `cleaning` or `inspection` are left empty, they fall back to the provisioning network. Servers provisioned in this mode select their network through a network environment, so a network environment is required.
 
 ## Netris (hardware network isolation)
 
-Netris provides true network isolation in hardware. On provisioning, the platform attaches each server to a Netris server cluster, which gives that server per-server L2 isolation. Tenants are then isolated from each other at the physical network layer rather than only at the control plane, which is what external, resale, or regulated tenants require.
+Netris provides network isolation in hardware. On provisioning, the platform attaches each server in a network environment to that environment's Netris server cluster. Give each tenant network environment its own server cluster to isolate tenant traffic at the physical network layer.
 
-Requires [Neutron mode](#neutron-flat-network). Netris builds on Neutron and adds per-server L2 isolation on top, so it also requires a network environment.
+Requires [Neutron mode](#neutron-flat-network). Netris builds on Neutron and adds environment-level L2 isolation, so it also requires a network environment.
 
 ### Provide Netris API credentials
 
-Reference a Secret holding the Netris API `url`, `username`, and `password` on the NodeProvider. The `metal3.neutronEnabled: true` field is repeated here to show the complete provider configuration:
+Create a Secret on the management cluster that contains the Netris API `url`, `username`, and `password`. Reference its management-plane namespace on the NodeProvider. This namespace is independent of the namespace in `metal3.clusterRef`, which identifies where Metal3 resources run on the connected <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>.
+
+Add the following Netris settings to the provider configuration from the preceding Neutron section. The fragment configures the credentials and binds the node type to the network environment shown later on this page:
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -101,7 +114,12 @@ spec:
     netris:
       secretRef:
         name: netris-credentials
-        namespace: metal3-system
+        namespace: vcluster-platform
+    nodeTypes:
+      - name: compute
+        properties:
+          # Resolve this NodeEnvironment from each NodeClaim's namespace.
+          vcluster.com/network-environment: tenant-a-network
 ```
 
 ### Select and configure the Netris provider
@@ -112,23 +130,25 @@ The Netris provider is selected and configured through properties on the network
 |---|---|---|
 | `metal3.vcluster.com/network-provider` | Yes | Set to `netris` to select the Netris network provider. |
 | `netris.vcluster.com/server-cluster` | Yes | Name of the Netris server cluster to attach each server to. Also the subnet source when no CIDR is pinned. |
-| `netris.vcluster.com/server-cluster-template` | Conditional | Name of a Netris server-cluster template. The platform creates the server cluster from it when the cluster does not already exist. |
-| `netris.vcluster.com/server-cluster-template-json` | Conditional | JSON body used to create the template when a template of that name does not already exist. |
+| `netris.vcluster.com/server-cluster-template` | Conditional | Name of a Netris server-cluster template. The platform creates the server cluster from it when the cluster doesn't already exist. |
+| `netris.vcluster.com/server-cluster-template-json` | Conditional | JSON array used as the template's `vnets` array when a template of that name doesn't already exist. |
 | `netris.vcluster.com/admin` | Conditional | Netris tenant that owns the created server cluster. Required when the platform creates the server cluster. |
 | `netris.vcluster.com/site` | Conditional | Netris site the created server cluster belongs to. Required when the platform creates the server cluster. |
-| `netris.vcluster.com/vpc` | No | VPC for the created server cluster. |
+| `netris.vcluster.com/vpc` | No | Name of an existing VPC for the created server cluster. When empty, Netris creates a VPC implicitly as part of server-cluster creation. |
 
-When the named server cluster already exists, the platform adopts it and never marks it managed, so `server-cluster-template`, `admin`, and `site` are only needed when the platform must create the server cluster itself.
+When the named server cluster already exists, the platform adopts it and never marks it managed. In that case, `server-cluster-template`, `admin`, and `site` are unneeded.
 
 When the platform creates a server cluster or template, it records what it created on the network environment so it can remove exactly those resources on teardown:
 
 - `netris.vcluster.com/managed-server-cluster`
 - `netris.vcluster.com/managed-server-cluster-template`
 
-These annotations are managed by the platform. Do not set them by hand.
+These annotations are managed by the platform. Don't set them by hand.
 
-:::warning Shared Netris resources are deleted with their creator
-The platform only deletes the Netris server cluster and template that a network environment created. If several network environments reference the same Netris server cluster or VPC, deleting the network environment that created those Netris resources deletes them for every network environment that still references them, breaking the others. Give each network environment its own server cluster, or have only environments that adopt a pre-existing, externally managed server cluster share one.
+:::warning Don't share managed Netris resources
+The platform deletes only the server cluster and template recorded as managed by a network environment. It doesn't delete a VPC specified by `netris.vcluster.com/vpc`.
+
+If other network environments reference a managed server cluster or template, deleting its creator can remove the shared resource or fail while the resource is still in use. Give each network environment its own server cluster and template. Share only pre-existing resources that the platform adopts instead of manages.
 :::
 
 The subnet for each server is derived from the Netris server cluster's network unless `metal3.vcluster.com/network-cidr` pins it, in which case the pinned CIDR always wins.
@@ -148,14 +168,15 @@ metadata:
 
 ### Example
 
-This network environment selects the Netris provider and points at a server cluster that the platform creates from a template if it does not already exist:
+This network environment selects the Netris provider and points at a server cluster that the platform creates from a template if it doesn't already exist:
 
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: NodeEnvironment
 metadata:
   name: tenant-a-network
-  namespace: metal3-system
+  # NodeEnvironment must use the same management-plane namespace as its NodeClaims.
+  namespace: tenant-a
 spec:
   providerRef: metal3-provider
   properties:
@@ -166,4 +187,4 @@ spec:
     netris.vcluster.com/site: datacenter-1
 ```
 
-Servers select this network environment through the `vcluster.com/network-environment` property, described on the [Metal3 provider page](./metal3.mdx#network-environment). Any server provisioned into it is attached to the `tenant-a` Netris server cluster and given per-server L2 isolation.
+Servers select this network environment through the `vcluster.com/network-environment` property, described on the [Metal3 provider page](./metal3.mdx#network-environment). Any server provisioned into it is attached to the `tenant-a` Netris server cluster. The server cluster forms the hardware-backed network boundary for this environment.

--- a/platform/administer/node-providers/metal3-network-integration.mdx
+++ b/platform/administer/node-providers/metal3-network-integration.mdx
@@ -57,7 +57,7 @@ spec:
     neutronEnabled: true
 ```
 
-Then supply the externally provisioned network names that Ironic requests through the metal3 chart `helmValues`:
+Then supply the externally provisioned network names that Ironic requests through the metal3 chart `helmValues` (chart `v0.6.0`):
 
 ```yaml
 apiVersion: management.loft.sh/v1

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -15,7 +15,7 @@ import Flow, {Step} from "@site/src/components/Flow";
 The Metal3 provider allows you to provision bare metal servers as Machines using [Metal3](https://metal3.io/) and [Ironic](https://ironicbaremetal.org/).
 When a Machine is requested, the platform claims an available `BareMetalHost` resource, configures it with the requested OS image and user data, and Ironic handles the PXE boot and OS installation on the physical server.
 
-This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a Control Plane Cluster. Machines can be used as private nodes for tenant clusters or provisioned independently.
+This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a control plane cluster. Machines can be used as private nodes for tenant clusters or provisioned independently.
 
 ```mermaid
 flowchart LR
@@ -43,7 +43,7 @@ flowchart LR
 
 ## Overview
 
-The Metal3 provider works by selecting available BareMetalHost resources on a Control Plane Cluster and provisioning them with an OS image and user data configuration.
+The Metal3 provider works by selecting available BareMetalHost resources on a control plane cluster and provisioning them with an OS image and user data configuration.
 Node types let you organize bare metal servers based on type, location, or other criteria. When a Machine is created, the platform:
 
 1. Selects an available BareMetalHost matching the node type's label selector and resource requirements
@@ -57,7 +57,7 @@ When the Machine is deleted, the platform powers the server off, removes the pro
 
 When a Machine is created, the platform provisions the bare metal server through the following steps:
 
-1. The platform generates a user data configuration and stores it in a Kubernetes Secret on the Control Plane Cluster.
+1. The platform generates a user data configuration and stores it in a Kubernetes Secret on the control plane cluster.
 2. The provider sets the BareMetalHost's `userData` reference to this Secret and the image information from the configured [OSImage](../../use-platform/machines/os-images.mdx) or direct image properties.
 3. Ironic provisions the server through a series of steps: power management, PXE boot, and an in-memory installer that writes the OS to disk.
 4. The server boots into the provisioned OS and is initialized with the user data configuration.
@@ -66,27 +66,43 @@ When a Machine is used as a private node for a tenant cluster, the user data inc
 
 ## Infrastructure deployment
 
-The Metal3 provider can deploy the required infrastructure components on the Control Plane Cluster. Each component can be individually enabled and customized with Helm values. Metal3 and Ironic may also be managed yourself. Disable the respective component and the provider uses whatever is already deployed.
+The Metal3 provider can deploy the required infrastructure components on the control plane cluster. Each component can be individually enabled and customized with Helm values. Metal3 and Ironic may also be managed yourself. Disable the respective component and the provider uses whatever is already deployed.
 
 <Tabs>
 <TabItem value="metal3" label="Metal3 & Ironic">
 
-Bare metal provisioning and lifecycle management. Deploys the Bare Metal Operator and Ironic.
+Bare metal provisioning and lifecycle management. Deploys the Bare Metal Operator, Ironic, an IPA image server, and MariaDB as separate workloads behind a cert-manager mTLS mesh.
 
 :::note Requires cert-manager
-The Bare Metal Operator uses admission webhooks that require [cert-manager](https://cert-manager.io/) on the Control Plane Cluster. Install cert-manager before enabling this component. The platform pre-checks for it and warns when it is missing.
+The Bare Metal Operator uses admission webhooks and the components authenticate over mutual TLS, both of which require [cert-manager](https://cert-manager.io/) on the control plane cluster. Install cert-manager before enabling this component. The platform pre-checks for it and warns when it is missing.
+:::
+
+:::note How the components run
+Ironic runs active/active: conductors shard host ownership over a consistent hash ring and coordinate through JSON-RPC between replicas. MariaDB is a single-replica StatefulSet. For highly available MariaDB, run your own and set `mariadb.mode: external`.
 :::
 
 **Helm values:**
 
 | Value | Description | Default |
 |---|---|---|
+| `ironic.replicas` | Number of Ironic conductors. Values greater than `1` run them active/active. | `2` |
+| `ironic.ipaAdvertiseIP` | Ironic LoadBalancer VIP advertised to the in-memory agent (IPA). Set it to enable real provisioning against physical hosts; empty keeps the Ironic API in-cluster only (for scale-out testing without a real host cycle). | `""` |
+| `ironic.service` | Applied as the Ironic Service spec, so any field can be set (for example `type: LoadBalancer`, `loadBalancerClass`, and a nested `metadata` map for annotations and labels). `name`, `namespace`, `selector`, and `ports` are managed by the chart. Empty leaves a default ClusterIP Service. | `{}` |
 | `ironic.image.repository` | Ironic container image | `quay.io/metal3-io/ironic` |
-| `ironic.image.tag` | Ironic image tag | `release-32.0` |
-| `ipaDownloader.image.repository` | IPA ramdisk downloader image | `quay.io/metal3-io/ironic-ipa-downloader` |
-| `ipaDownloader.image.tag` | IPA ramdisk downloader tag | `latest` |
+| `ironic.image.tag` | Ironic image tag | `release-35.0` |
+| `ipaImages.replicas` | Replicas of the IPA image server that serves the IPA kernel and initramfs. | `2` |
+| `mariadb.mode` | Database backend for Ironic: `statefulset` (single-replica managed MariaDB StatefulSet with its own PVC and cert-manager TLS) or `external` (connect to your own MariaDB). | `statefulset` |
+| `mariadb.externalHost` | Host Ironic connects to in `external` mode. Ignored otherwise. | `""` |
+| `mariadb.database` | Database name. | `ironic` |
+| `mariadb.username` / `mariadb.password` | Credentials Ironic uses. In `statefulset` mode an unset password is generated on first install and preserved across upgrades. | `""` |
+| `mariadb.caCertSecretName` / `mariadb.caCertSecretKey` | `external` mode only. Secret and key holding the CA certificate used to verify the external MariaDB over TLS. When set, Ironic connects over TLS. | `""` / `ca.crt` |
+| `mariadb.persistence.size` | PVC size for the managed MariaDB in `statefulset` mode. | `10Gi` |
 | `bareMetalOperator.image.repository` | Bare Metal Operator image | `quay.io/metal3-io/baremetal-operator` |
-| `bareMetalOperator.image.tag` | Bare Metal Operator tag | `v0.12.0` |
+| `bareMetalOperator.image.tag` | Bare Metal Operator tag | `v0.13.1` |
+| `ipaDownloader.image.repository` | IPA image downloader init container | `ghcr.io/loft-sh/vcluster-platform-ipa-images` |
+| `ipaDownloader.image.tag` | IPA image downloader tag | `v0.2.2` |
+
+Set `ironic.ipaAdvertiseIP` to the VIP of the Ironic LoadBalancer Service so bare metal hosts can reach the Ironic agent endpoint during provisioning:
 
 ```yaml
 deploy:
@@ -94,8 +110,25 @@ deploy:
     enabled: true
     helmValues: |
       ironic:
-        image:
-          tag: release-32.0
+        replicas: 2
+        ipaAdvertiseIP: 192.168.100.10
+        service:
+          type: LoadBalancer
+```
+
+For highly available MariaDB, run your own database and point Ironic at it:
+
+```yaml
+deploy:
+  metal3:
+    enabled: true
+    helmValues: |
+      mariadb:
+        mode: external
+        externalHost: mariadb.example.internal
+        database: ironic
+        username: ironic
+        password: <MARIADB-PASSWORD>
 ```
 
 </TabItem>
@@ -122,6 +155,7 @@ Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ir
 | `image.tag` | Container image tag. | Chart app version |
 | `image.pullPolicy` | Image pull policy. | `Always` |
 | `imagePullSecrets` | Pull secrets for the image. | `[]` |
+| `replicas` | Number of DHCP server replicas. Only supported with a DHCP relay in front of the server, since without one every replica answers the same broadcast. Replies are stateless (addresses come from the BareMetalHost, not a lease database), so any replica can serve any client. Incompatible with `networkAttachmentDefinition.enabled`; run under `hostNetwork` or plain pod networking. | `1` |
 | `hostNetwork` | Run the pod on the host network. When `true`, the pod also runs as root and the Multus NetworkAttachmentDefinition is not attached. | `false` |
 | `podAnnotations` / `podLabels` | Extra pod metadata. | `{}` |
 | `resources` | Container resource requests and limits. | `{}` |
@@ -129,17 +163,22 @@ Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ir
 | `securityContext` | Container security context. Overridden to `runAsUser: 0` when `hostNetwork` is `true`. | `NET_BIND_SERVICE` capability, `runAsNonRoot: true`, `runAsUser: 1000` |
 | `extraArgs` | Extra arguments appended to the server binary. Use to set the IPA inspector and installer kernel parameters. | `[]` |
 | `extraEnv` | Extra environment variables on the server container. | `[]` |
+| `networkAttachmentDefinition.enabled` | Attach a Multus secondary interface so the pod sits on the provisioning L2 and can answer broadcast DHCP. Ignored under `hostNetwork`. Set to `false` for ordinary pod networking with no Multus dependency; this only works behind a DHCP relay, and you must set `dhcp.serverIP` and `http.advertiseUrl` to an address clients can reach (typically the `provisioningService` load balancer). | `true` |
 | `networkAttachmentDefinition.vip` | Virtual IP with prefix for the DHCP server. Injected into the NetworkAttachmentDefinition under `ipam.static`. Ignored when `hostNetwork: true`. | `192.168.100.3/24` |
-| `networkAttachmentDefinition.config` | CNI configuration JSON for the NetworkAttachmentDefinition. Use `bridge` if Control Plane Cluster nodes have a bridge attached to the provisioning network. Use `macvlan` if the bare metal servers are on the same network as the control plane cluster nodes. | bridge `br0` |
+| `networkAttachmentDefinition.resourceName` | Device-plugin resource the NetworkAttachmentDefinition binds to, stamped as the `k8s.v1.cni.cncf.io/resourceName` annotation so Multus passes the allocated device ID to the CNI plugin (for SR-IOV or other device-plugin interfaces). Empty leaves the annotation off. | `""` |
+| `networkAttachmentDefinition.config` | CNI configuration JSON for the NetworkAttachmentDefinition. Use `bridge` if control plane cluster nodes have a bridge attached to the provisioning network. Use `macvlan` if the bare metal servers are on the same network as the control plane cluster nodes. | bridge `br0` |
 | `dhcp.serverIP` | IP the DHCP server advertises as itself. | `$(SERVER_IP)` (pod env) |
 | `dhcp.port` | DHCP listen port. | `67` |
 | `dhcp.listenAddr` | DHCP listen address. Set to `$(SERVER_IP):{{ .Values.dhcp.port }}` under `hostNetwork` to avoid answering on shared bridges. Rendered with `tpl`. | `0.0.0.0:67` |
 | `tftp.port` | TFTP listen port. | `69` |
 | `tftp.listenAddr` | TFTP listen address. Set to `""` to disable TFTP entirely (HTTP Boot still works). Rendered with `tpl`. | `$(SERVER_IP):69` |
-| `http.port` / `http.listenAddr` / `http.advertiseUrl` | HTTP boot file server config. Rendered with `tpl`. | `8080` |
+| `http.port` / `http.listenAddr` / `http.advertiseUrl` | HTTP boot file server config. `advertiseUrl` is also the default for `proxy.apiAdvertiseUrl`. Rendered with `tpl`. | `8080` |
+| `provisioningService.type` | Service type exposing the DHCP, TFTP, and HTTP ports so a DHCP relay can unicast to one address instead of relying on broadcast. Usually `LoadBalancer`. Empty leaves the Service out entirely. Needed for `replicas > 1`. | `""` |
+| `provisioningService` (spec) | Interpreted as the Service spec, so any field can be set (`loadBalancerClass`, `externalTrafficPolicy`, and so on). A nested `metadata` map is lifted out and applied to the object's metadata. `ports` defaults to the DHCP, TFTP, and HTTP ports and may be overridden, but an override replaces the defaults wholesale, so it must repeat every port; `name`, `namespace`, and `selector` are always the chart's. | `{}` |
 | `proxy.callbackPort` / `proxy.callbackListenAddr` / `proxy.callbackAdvertiseUrl` | IPA callback proxy config. Rendered with `tpl`. | `8081` |
-| `proxy.ironicHttpUrl` | Ironic HTTP endpoint for image serving. | Auto-configured when Metal3 is enabled |
-| `proxy.ironicApiUrl` | Ironic API endpoint. | Auto-configured when Metal3 is enabled |
+| `proxy.apiAdvertiseUrl` | Ironic API base URL written into the IPA kernel parameters. Empty defaults to `http.advertiseUrl`, which routes IPA through this proxy. Set it to a reachable Ironic API root (a literal `IP:port`, not a cluster DNS name) to have IPA reach Ironic directly, which makes `proxy.ironicApiUrl` unnecessary. Rendered with `tpl`. | `""` |
+| `proxy.ironicHttpUrl` | Ironic HTTP endpoint the proxy forwards image and boot-file requests to. Always required. | Auto-configured when Metal3 is enabled |
+| `proxy.ironicApiUrl` | Ironic API endpoint the proxy forwards to. Optional when `proxy.apiAdvertiseUrl` is set. | Auto-configured when Metal3 is enabled |
 
 **Server flags (via `extraArgs`):**
 
@@ -149,6 +188,9 @@ Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ir
 | `--inspector-extra-kernel-param` | Extra kernel parameter appended to the inspector iPXE script. May be specified multiple times. |
 | `--installer-extra-kernel-param` | Extra kernel parameter appended to the installer iPXE script. May be specified multiple times. |
 | `--callback-insecure-skip-verify` | Skip TLS verification when the callback proxy forwards to IPA. |
+| `--api-advertise-url` | Ironic API base URL written into the IPA kernel parameters. Corresponds to `proxy.apiAdvertiseUrl`; defaults to the HTTP advertise URL. |
+| `--leader-election-id` | Name of the Lease electing which replica manages the proxy certificate Secret. Required when `replicas > 1`, otherwise replicas race to create the Secret. The DHCP, TFTP, HTTP, and callback servers keep serving in every replica. |
+| `--tftp-single-port` | EXPERIMENTAL. Serve every TFTP transfer from the listen port instead of a per-transfer ephemeral port, so replies survive Service NAT. Required when TFTP traffic is reached through a Service. Some client firmware may reject replies from port 69, so it is off by default. |
 
 **Per-BareMetalHost DHCP annotations:**
 
@@ -179,7 +221,7 @@ deploy:
           }
 ```
 
-Example with macvlan (bare metal servers on the same network as the Control Plane Cluster nodes):
+Example with macvlan (bare metal servers on the same network as the control plane cluster nodes):
 
 ```yaml
 deploy:
@@ -210,6 +252,40 @@ deploy:
       extraArgs:
         - --inspector-extra-kernel-param=console=ttyS0,115200n8
         - --installer-extra-kernel-param=console=ttyS0,115200n8
+```
+
+#### High availability and DHCP relay
+
+By default the DHCP server runs a single replica attached to the provisioning L2 through Multus, where it answers broadcast DHCP directly. This mode does not scale past one active answerer.
+
+To run more than one replica, place a DHCP relay in front of the server and expose it through a Service:
+
+- Set `replicas` greater than `1`.
+- Set `provisioningService.type: LoadBalancer` so the relay has a single unicast target that also serves boot files.
+- Point the relay at the `provisioningService` address, and set `dhcp.serverIP` and `http.advertiseUrl` to that same address so clients boot through the Service instead of from whichever replica answered.
+- Set `--leader-election-id` (required for more than one replica) and add the experimental `--tftp-single-port` so TFTP replies survive the Service NAT.
+- Disable Multus with `networkAttachmentDefinition.enabled: false`, since its static IPAM would hand the same VIP to every pod.
+
+```yaml
+deploy:
+  dhcp:
+    enabled: true
+    helmValues: |
+      replicas: 2
+      networkAttachmentDefinition:
+        enabled: false
+      dhcp:
+        serverIP: 192.168.100.20
+      http:
+        advertiseUrl: http://192.168.100.20:8080
+      provisioningService:
+        type: LoadBalancer
+        metadata:
+          annotations:
+            metallb.universe.tf/loadBalancerIPs: 192.168.100.20
+      extraArgs:
+        - --leader-election-id=vcluster-platform-dhcp-server
+        - --tftp-single-port
 ```
 
 </TabItem>
@@ -245,15 +321,15 @@ A Metal3 `NodeProvider` configuration consists of a cluster reference, optional 
 
 ### Cluster reference
 
-The `clusterRef` specifies the Control Plane Cluster where the platform installs Metal3 components and where the BareMetalHost resources live. This cluster must be connected to vCluster Platform.
+The `clusterRef` specifies the control plane cluster where the platform installs Metal3 components and where the BareMetalHost resources live. This cluster must be connected to vCluster Platform.
 
 | Field | Description | Required |
 |---|---|---|
-| `clusterRef.cluster` | Name of the connected Control Plane Cluster | Yes |
-| `clusterRef.namespace` | Namespace on the Control Plane Cluster for Metal3 components and BareMetalHost resources | Yes |
+| `clusterRef.cluster` | Name of the connected control plane cluster | Yes |
+| `clusterRef.namespace` | Namespace on the control plane cluster for Metal3 components and BareMetalHost resources | Yes |
 
 :::info Ironic network access
-Ironic must have network access to the BMC addresses of the bare metal servers. Ensure the Control Plane Cluster where Ironic is deployed can reach the BMC network (Redfish/IPMI endpoints).
+Ironic must have network access to the BMC addresses of the bare metal servers. Ensure the control plane cluster where Ironic is deployed can reach the BMC network (Redfish/IPMI endpoints).
 :::
 
 ### Example
@@ -299,13 +375,13 @@ spec:
 
 ## Get started
 
-This walkthrough covers the essential steps to go from a connected Control Plane Cluster to a provisioned bare metal server.
+This walkthrough covers the essential steps to go from a connected control plane cluster to a provisioned bare metal server.
 
 <Flow>
 <Step>
 Apply the NodeProvider.
 
-Create a NodeProvider that references your Control Plane Cluster and defines at least one node type. The node type's label selector determines which BareMetalHosts it can claim.
+Create a NodeProvider that references your control plane cluster and defines at least one node type. The node type's label selector determines which BareMetalHosts it can claim.
 
 ```yaml
 apiVersion: management.loft.sh/v1
@@ -341,7 +417,7 @@ spec:
 kubectl apply -f metal3-provider.yaml
 ```
 
-Wait for Metal3 and Ironic to be running on the Control Plane Cluster before creating BareMetalHost resources. The Metal3 webhook must be ready to validate them.
+Wait for Metal3 and Ironic to be running on the control plane cluster before creating BareMetalHost resources. The Metal3 webhook must be ready to validate them.
 </Step>
 
 <Step>
@@ -532,13 +608,13 @@ Complete custom network-data configuration. When set, this overrides automatic n
 
 References a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) by name. The provider renders the template's `networkDataTemplate` into a cloud-init `network-config` document when `metal3.vcluster.com/network-data` is not set. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
 
-### Node environment selection
+### Network environment
 
 #### `vcluster.com/network-environment`
 
 **Type:** `string`
 
-Names the [NodeEnvironment](./overview.mdx#node-environments) whose properties are merged into the NodeClaim's effective property set. The platform resolves this from the merged properties of NodeProvider, NodeType, and NodeClaim. When set, this property takes precedence over the typed `NodeClaim.spec.environmentRef` field.
+Names the network environment, a [NodeEnvironment](./overview.mdx#node-environments) resource whose properties are merged into the NodeClaim's effective property set. The platform resolves this from the merged properties of NodeProvider, NodeType, and NodeClaim. When set, this property takes precedence over the typed `NodeClaim.spec.environmentRef` field.
 
 ### Server pinning
 

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -9,6 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FeatureTable from '@site/src/components/FeatureTable';
 import Flow, {Step} from "@site/src/components/Flow";
+import Metal3ProvisioningFlow from '@site/static/media/diagrams/metal3-provisioning-flow.svg';
 
 <FeatureTable names="auto-nodes-metal3" />
 
@@ -17,50 +18,25 @@ When a Machine is requested, the platform claims an available `BareMetalHost` re
 
 This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>. Machines can be used as private nodes for tenant clusters or provisioned independently.
 
-```mermaid
-flowchart LR
-    subgraph platform["vCluster Platform"]
-        direction LR
-        Machine["Machine"]
-        Select("Select BareMetalHost")
-        Configure("Configure image & userData")
-    end
-
-    subgraph host_cluster["Control Plane Cluster"]
-        direction TB
-        BMH["BareMetalHost"]
-        Ironic["Ironic"]
-        Server["Physical Server"]
-    end
-
-    Machine -- "Triggers" --> Select
-    Select -- "Claims" --> BMH
-    Configure -- "Sets image & userData" --> BMH
-    BMH -- "Provisions via" --> Ironic
-    Ironic -- "PXE boot & OS install" --> Server
-    Server -- "Joins as Node" --> Machine
-```
+<figure>
+  <Metal3ProvisioningFlow style={{width: '100%', height: 'auto'}} role="img" aria-label="A Machine request causes the Metal3 provider to select and configure an available BareMetalHost on the control plane cluster. Bare Metal Operator reconciles it, and Ironic powers the external physical server and installs its operating system. For private nodes, user data registers the server with a tenant cluster. Deleting the Machine clears provisioning data and returns the host to the available pool." />
+  <figcaption>The platform writes the requested state to an available BareMetalHost. Metal3 and Ironic provision the external server, which joins a tenant cluster only when requested as a private node. Deleting the Machine returns the host to the available pool.</figcaption>
+</figure>
 
 ## Overview
 
-The Metal3 provider works by selecting available BareMetalHost resources on a control plane cluster and provisioning them with an OS image and user data configuration.
-Node types let you organize bare metal servers based on type, location, or other criteria. When a Machine is created, the platform:
-
-1. Selects an available BareMetalHost matching the node type's label selector and resource requirements
-2. Configures the BareMetalHost with the OS image, user data, and optional network configuration
-3. Ironic provisions the server through a series of steps (power management, PXE boot, in-memory installer)
-4. The server boots into the provisioned OS and is initialized
+The Metal3 provider works by selecting available BareMetalHost resources on a control plane cluster and provisioning them with an OS image and user data configuration. Node types let you organize bare metal servers based on type, location, or other criteria.
 
 When the Machine is deleted, the platform powers the server off and clears its image, user data, and network data references. It restores pre-existing managed DHCP annotations and makes the BareMetalHost available for reuse.
 
 ## How it works: Provisioning
 
-When a Machine is created, the platform provisions the bare metal server through the following steps:
+After the platform selects a BareMetalHost, it prepares the server for provisioning:
 
 1. The platform generates a user data configuration and stores it in a Kubernetes Secret on the control plane cluster.
 2. The provider sets the BareMetalHost's `userData` reference to this Secret and the image information from the configured [OSImage](../../use-platform/machines/os-images.mdx) or direct image properties.
-3. Ironic provisions the server through a series of steps: power management, PXE boot, and an in-memory installer that writes the OS to disk.
-4. The server boots into the provisioned OS and is initialized with the user data configuration.
+
+Ironic then provisions the server through power management, PXE boot, and an in-memory installer that writes the OS to disk. The server boots into the provisioned OS with the user data configuration applied.
 
 When a Machine is used as a private node for a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>, the user data includes registration scripts that automatically join the server to the tenant cluster.
 

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -73,6 +73,8 @@ The Metal3 provider can deploy the required infrastructure components on the con
 
 Bare metal provisioning and lifecycle management. Deploys the Bare Metal Operator, Ironic, an IPA image server, and MariaDB as separate workloads behind a cert-manager mTLS mesh.
 
+The values below target the metal3 chart `v0.6.0`.
+
 :::note Requires cert-manager
 The Bare Metal Operator uses admission webhooks and the components authenticate over mutual TLS, both of which require [cert-manager](https://cert-manager.io/) on the control plane cluster. Install cert-manager before enabling this component. The platform pre-checks for it and warns when it is missing.
 :::
@@ -135,6 +137,8 @@ deploy:
 <TabItem value="dhcp" label="DHCP Server">
 
 Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ironic, which may reside in a different network. When the provider also deploys Metal3, the Ironic endpoint URLs configure automatically.
+
+The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 
 **Deployment fields (NodeProvider `metal3.deploy.dhcp`):**
 

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -13,9 +13,9 @@ import Flow, {Step} from "@site/src/components/Flow";
 <FeatureTable names="auto-nodes-metal3" />
 
 The Metal3 provider allows you to provision bare metal servers as Machines using [Metal3](https://metal3.io/) and [Ironic](https://ironicbaremetal.org/).
-When a Machine is requested, the platform claims an available `BareMetalHost` resource, configures it with the requested OS image and user data, and Ironic handles the PXE boot and OS installation on the physical server.
+When a Machine is requested, the platform claims an available `BareMetalHost` resource and configures it with the requested OS image and user data. Ironic then handles the PXE boot and OS installation on the physical server.
 
-This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a control plane cluster. Machines can be used as private nodes for tenant clusters or provisioned independently.
+This enables you to offer different configurations of bare metal servers, all managed through BareMetalHost resources on a <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>. Machines can be used as private nodes for tenant clusters or provisioned independently.
 
 ```mermaid
 flowchart LR
@@ -51,7 +51,7 @@ Node types let you organize bare metal servers based on type, location, or other
 3. Ironic provisions the server through a series of steps (power management, PXE boot, in-memory installer)
 4. The server boots into the provisioned OS and is initialized
 
-When the Machine is deleted, the platform powers the server off, removes the provisioned image and user data, restores the original network annotations, and returns the BareMetalHost to its original state, making it available for reuse.
+When the Machine is deleted, the platform powers the server off and clears its image, user data, and network data references. It restores pre-existing managed DHCP annotations and makes the BareMetalHost available for reuse.
 
 ## How it works: Provisioning
 
@@ -62,26 +62,30 @@ When a Machine is created, the platform provisions the bare metal server through
 3. Ironic provisions the server through a series of steps: power management, PXE boot, and an in-memory installer that writes the OS to disk.
 4. The server boots into the provisioned OS and is initialized with the user data configuration.
 
-When a Machine is used as a private node for a tenant cluster, the user data includes registration scripts that automatically join the server to the tenant cluster.
+When a Machine is used as a private node for a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>, the user data includes registration scripts that automatically join the server to the tenant cluster.
 
 ## Infrastructure deployment
 
-The Metal3 provider can deploy the required infrastructure components on the control plane cluster. Each component can be individually enabled and customized with Helm values. Metal3 and Ironic may also be managed yourself. Disable the respective component and the provider uses whatever is already deployed.
+The Metal3 provider can deploy the required infrastructure components on the control plane cluster. Each component can be individually enabled and customized with Helm values. You can also manage Metal3 and Ironic separately. When you enable the bundled DHCP server with external Ironic, configure `proxy.ironicHttpUrl` and either `proxy.ironicApiUrl` or `proxy.apiAdvertiseUrl`.
 
 <Tabs>
 <TabItem value="metal3" label="Metal3 & Ironic">
 
-Bare metal provisioning and lifecycle management. Deploys the Bare Metal Operator, Ironic, an IPA image server, and MariaDB as separate workloads behind a cert-manager mTLS mesh.
+Bare metal provisioning and lifecycle management. Deploys the Bare Metal Operator, Ironic, an IPA image server, and MariaDB as separate workloads.
 
-The values below target the metal3 chart `v0.6.0`.
+Install [cert-manager](https://cert-manager.io/) on the control plane cluster before enabling this component. The Bare Metal Operator uses it for admission webhooks, and internal components use it for mutual TLS (mTLS). The Platform UI checks this prerequisite and warns when it is missing.
 
-:::note Requires cert-manager
-The Bare Metal Operator uses admission webhooks and the components authenticate over mutual TLS, both of which require [cert-manager](https://cert-manager.io/) on the control plane cluster. Install cert-manager before enabling this component. The platform pre-checks for it and warns when it is missing.
+:::warning Upgrading from a Metal3 chart earlier than 0.6.0
+The default Metal3 chart version is `0.6.0`. This version replaces the legacy single-pod deployment with separate workloads and a MariaDB backend. Review this architecture and database change before upgrading an existing Metal3 deployment.
+
+To retain the legacy topology temporarily, pin `spec.metal3.deploy.metal3.version` to the version that is already deployed. The previous <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform default was `0.4.1`.
 :::
 
-:::note How the components run
-Ironic runs active/active: conductors shard host ownership over a consistent hash ring and coordinate through JSON-RPC between replicas. MariaDB is a single-replica StatefulSet. For highly available MariaDB, run your own and set `mariadb.mode: external`.
-:::
+The components use the following runtime topology:
+
+- Ironic conductors run active/active. They shard host ownership over a consistent hash ring and coordinate through JSON-RPC.
+- The managed MariaDB is a single-replica StatefulSet. For high availability, run an external MariaDB and set `mariadb.mode: external`.
+- The IPA image server serves public static boot content outside the mTLS mesh.
 
 **Helm values:**
 
@@ -89,19 +93,23 @@ Ironic runs active/active: conductors shard host ownership over a consistent has
 |---|---|---|
 | `ironic.replicas` | Number of Ironic conductors. Values greater than `1` run them active/active. | `2` |
 | `ironic.ipaAdvertiseIP` | Ironic LoadBalancer VIP advertised to the in-memory agent (IPA). Set it to enable real provisioning against physical hosts; empty keeps the Ironic API in-cluster only (for scale-out testing without a real host cycle). | `""` |
-| `ironic.service` | Applied as the Ironic Service spec, so any field can be set (for example `type: LoadBalancer`, `loadBalancerClass`, and a nested `metadata` map for annotations and labels). `name`, `namespace`, `selector`, and `ports` are managed by the chart. Empty leaves a default ClusterIP Service. | `{}` |
-| `ironic.image.repository` | Ironic container image | `quay.io/metal3-io/ironic` |
+| `ironic.service` | Applied as the Ironic Service spec, so any field can be set (for example `type: LoadBalancer`, `loadBalancerClass`, and a nested `metadata` map for annotations and labels). `name`, `namespace`, and `selector` are managed by the chart. Ports use chart defaults but can be replaced with a custom `ports` list. Empty leaves a default ClusterIP Service. | `{}` |
+| `ironic.image.registry` | Ironic container image registry. | `quay.io` |
+| `ironic.image.repository` | Ironic container image repository. | `metal3-io/ironic` |
 | `ironic.image.tag` | Ironic image tag | `release-35.0` |
 | `ipaImages.replicas` | Replicas of the IPA image server that serves the IPA kernel and initramfs. | `2` |
 | `mariadb.mode` | Database backend for Ironic: `statefulset` (single-replica managed MariaDB StatefulSet with its own PVC and cert-manager TLS) or `external` (connect to your own MariaDB). | `statefulset` |
 | `mariadb.externalHost` | Host Ironic connects to in `external` mode. Ignored otherwise. | `""` |
 | `mariadb.database` | Database name. | `ironic` |
-| `mariadb.username` / `mariadb.password` | Credentials Ironic uses. In `statefulset` mode an unset password is generated on first install and preserved across upgrades. | `""` |
+| `mariadb.username` | Database username Ironic uses. An empty value resolves to `ironic`. | `""` |
+| `mariadb.password` | Database password Ironic uses. In `statefulset` mode, an empty value generates a password on first install and preserves it across upgrades. In `external` mode, an empty value resolves to `ironic`. | Mode-dependent |
 | `mariadb.caCertSecretName` / `mariadb.caCertSecretKey` | `external` mode only. Secret and key holding the CA certificate used to verify the external MariaDB over TLS. When set, Ironic connects over TLS. | `""` / `ca.crt` |
 | `mariadb.persistence.size` | PVC size for the managed MariaDB in `statefulset` mode. | `10Gi` |
-| `bareMetalOperator.image.repository` | Bare Metal Operator image | `quay.io/metal3-io/baremetal-operator` |
+| `bareMetalOperator.image.registry` | Bare Metal Operator image registry. | `quay.io` |
+| `bareMetalOperator.image.repository` | Bare Metal Operator image repository. | `metal3-io/baremetal-operator` |
 | `bareMetalOperator.image.tag` | Bare Metal Operator tag | `v0.13.1` |
-| `ipaDownloader.image.repository` | IPA image downloader init container | `ghcr.io/loft-sh/vcluster-platform-ipa-images` |
+| `ipaDownloader.image.registry` | IPA image downloader registry. | `ghcr.io` |
+| `ipaDownloader.image.repository` | IPA image downloader repository. | `loft-sh/vcluster-platform-ipa-images` |
 | `ipaDownloader.image.tag` | IPA image downloader tag | `v0.2.2` |
 
 Set `ironic.ipaAdvertiseIP` to the VIP of the Ironic LoadBalancer Service so bare metal hosts can reach the Ironic agent endpoint during provisioning:
@@ -116,6 +124,8 @@ deploy:
         ipaAdvertiseIP: 192.168.100.10
         service:
           type: LoadBalancer
+          # The assigned address must match ipaAdvertiseIP.
+          loadBalancerIP: 192.168.100.10
 ```
 
 For highly available MariaDB, run your own database and point Ironic at it:
@@ -136,7 +146,7 @@ deploy:
 </TabItem>
 <TabItem value="dhcp" label="DHCP Server">
 
-Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ironic, which may reside in a different network. When the provider also deploys Metal3, the Ironic endpoint URLs configure automatically.
+Handles PXE and HTTP Boot by acting as a proxy between bare metal servers and Ironic, which may reside in a different network. When the provider deploys Metal3, the platform configures the boot-image endpoint. Configure `proxy.apiAdvertiseUrl` to send IPA directly to the bundled Ironic agent endpoint.
 
 The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 
@@ -147,7 +157,7 @@ The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 | `enabled` | Deploy the DHCP server. | `false` |
 | `chartRepo` | Override the Helm chart repository. | `oci://ghcr.io/loft-sh/charts` |
 | `chart` | Override the Helm chart name. | `vcluster-platform-dhcp-server` |
-| `version` | Override the Helm chart version. | Bundled version |
+| `version` | Override the Helm chart version. | `0.17.0` |
 | `helmValues` | Raw YAML passed as values to the chart. | — |
 
 **Helm values:**
@@ -160,7 +170,7 @@ The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 | `image.pullPolicy` | Image pull policy. | `Always` |
 | `imagePullSecrets` | Pull secrets for the image. | `[]` |
 | `replicas` | Number of DHCP server replicas. Only supported with a DHCP relay in front of the server, since without one every replica answers the same broadcast. Replies are stateless (addresses come from the BareMetalHost, not a lease database), so any replica can serve any client. Incompatible with `networkAttachmentDefinition.enabled`; run under `hostNetwork` or plain pod networking. | `1` |
-| `hostNetwork` | Run the pod on the host network. When `true`, the pod also runs as root and the Multus NetworkAttachmentDefinition is not attached. | `false` |
+| `hostNetwork` | Run the pod on the host network. When `true`, the pod also runs as root and the Multus NetworkAttachmentDefinition isn't attached. | `false` |
 | `podAnnotations` / `podLabels` | Extra pod metadata. | `{}` |
 | `resources` | Container resource requests and limits. | `{}` |
 | `nodeSelector` / `tolerations` / `affinity` | Pod scheduling constraints. | `{}` / `[]` / `{}` |
@@ -176,13 +186,20 @@ The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 | `dhcp.listenAddr` | DHCP listen address. Set to `$(SERVER_IP):{{ .Values.dhcp.port }}` under `hostNetwork` to avoid answering on shared bridges. Rendered with `tpl`. | `0.0.0.0:67` |
 | `tftp.port` | TFTP listen port. | `69` |
 | `tftp.listenAddr` | TFTP listen address. Set to `""` to disable TFTP entirely (HTTP Boot still works). Rendered with `tpl`. | `$(SERVER_IP):69` |
-| `http.port` / `http.listenAddr` / `http.advertiseUrl` | HTTP boot file server config. `advertiseUrl` is also the default for `proxy.apiAdvertiseUrl`. Rendered with `tpl`. | `8080` |
+| `http.port` | HTTP boot file server port. | `8080` |
+| `http.listenAddr` | HTTP boot file server listen address. Rendered with `tpl`. | `$(SERVER_IP):8080` |
+| `http.advertiseUrl` | Base URL clients use to fetch boot files. Also the default for `proxy.apiAdvertiseUrl`. Rendered with `tpl`. | `http://$(SERVER_IP):8080` |
+| `https.listenAddr` | HTTPS boot file server listen address. Set it to enable HTTPS for Redfish virtual media. Bind to `0.0.0.0` when the BMC reaches the server through an interface other than `SERVER_IP`. Rendered with `tpl`. | `""` |
+| `https.port` | HTTPS boot file server port. | `8443` |
+| `https.extraSans` | Additional IP addresses or DNS names for the proxy TLS certificate. Include the address that BMCs use for Redfish virtual media. | `[]` |
 | `provisioningService.type` | Service type exposing the DHCP, TFTP, and HTTP ports so a DHCP relay can unicast to one address instead of relying on broadcast. Usually `LoadBalancer`. Empty leaves the Service out entirely. Needed for `replicas > 1`. | `""` |
 | `provisioningService` (spec) | Interpreted as the Service spec, so any field can be set (`loadBalancerClass`, `externalTrafficPolicy`, and so on). A nested `metadata` map is lifted out and applied to the object's metadata. `ports` defaults to the DHCP, TFTP, and HTTP ports and may be overridden, but an override replaces the defaults wholesale, so it must repeat every port; `name`, `namespace`, and `selector` are always the chart's. | `{}` |
-| `proxy.callbackPort` / `proxy.callbackListenAddr` / `proxy.callbackAdvertiseUrl` | IPA callback proxy config. Rendered with `tpl`. | `8081` |
-| `proxy.apiAdvertiseUrl` | Ironic API base URL written into the IPA kernel parameters. Empty defaults to `http.advertiseUrl`, which routes IPA through this proxy. Set it to a reachable Ironic API root (a literal `IP:port`, not a cluster DNS name) to have IPA reach Ironic directly, which makes `proxy.ironicApiUrl` unnecessary. Rendered with `tpl`. | `""` |
-| `proxy.ironicHttpUrl` | Ironic HTTP endpoint the proxy forwards image and boot-file requests to. Always required. | Auto-configured when Metal3 is enabled |
-| `proxy.ironicApiUrl` | Ironic API endpoint the proxy forwards to. Optional when `proxy.apiAdvertiseUrl` is set. | Auto-configured when Metal3 is enabled |
+| `proxy.callbackPort` | IPA callback proxy port. | `8081` |
+| `proxy.callbackListenAddr` | IPA callback proxy listen address. Rendered with `tpl`. | `$(POD_IP):8081` |
+| `proxy.callbackAdvertiseUrl` | URL Ironic uses to reach the IPA callback proxy. Rendered with `tpl`. | `https://ipa-callback.<release-namespace>.svc.cluster.local` |
+| `proxy.apiAdvertiseUrl` | Ironic API base URL written into the IPA kernel parameters. Empty defaults to `http.advertiseUrl`, which routes IPA through this proxy. To bypass the proxy with bundled Metal3, first configure `ironic.ipaAdvertiseIP`, then set this value to its agent endpoint, such as `https://192.168.100.10:6388`. Port `6385` is the in-cluster mTLS endpoint and isn't directly accessible to IPA. For externally managed Ironic, use an API root reachable from the provisioning network. Setting this value makes `proxy.ironicApiUrl` unnecessary. Rendered with `tpl`. | `""` |
+| `proxy.ironicHttpUrl` | Ironic HTTP endpoint the proxy forwards image and boot-file requests to. Always required. | Set to the bundled IPA image service when Metal3 is enabled |
+| `proxy.ironicApiUrl` | Ironic API endpoint the proxy forwards to. Optional when `proxy.apiAdvertiseUrl` is set. The generated URL for the bundled charts targets a port that the Ironic Service doesn't expose, so configure the direct `proxy.apiAdvertiseUrl` path for physical host provisioning. | Generated when Metal3 is enabled |
 
 **Server flags (via `extraArgs`):**
 
@@ -193,7 +210,7 @@ The values below target the vcluster-platform-dhcp-server chart `v0.17.0`.
 | `--installer-extra-kernel-param` | Extra kernel parameter appended to the installer iPXE script. May be specified multiple times. |
 | `--callback-insecure-skip-verify` | Skip TLS verification when the callback proxy forwards to IPA. |
 | `--api-advertise-url` | Ironic API base URL written into the IPA kernel parameters. Corresponds to `proxy.apiAdvertiseUrl`; defaults to the HTTP advertise URL. |
-| `--leader-election-id` | Name of the Lease electing which replica manages the proxy certificate Secret. Required when `replicas > 1`, otherwise replicas race to create the Secret. The DHCP, TFTP, HTTP, and callback servers keep serving in every replica. |
+| `--leader-election-id` | Name of the Lease electing which replica manages the proxy certificate Secret. The chart sets this flag automatically when `replicas` is greater than `1`; don't add it through `extraArgs`. The DHCP, TFTP, HTTP, and callback servers keep serving in every replica. |
 | `--tftp-single-port` | EXPERIMENTAL. Serve every TFTP transfer from the listen port instead of a per-transfer ephemeral port, so replies survive Service NAT. Required when TFTP traffic is reached through a Service. Some client firmware may reject replies from port 69, so it is off by default. |
 
 **Per-BareMetalHost DHCP annotations:**
@@ -260,14 +277,14 @@ deploy:
 
 #### High availability and DHCP relay
 
-By default the DHCP server runs a single replica attached to the provisioning L2 through Multus, where it answers broadcast DHCP directly. This mode does not scale past one active answerer.
+By default the DHCP server runs a single replica attached to the provisioning L2 through Multus, where it answers broadcast DHCP directly. This mode doesn't scale past one active answerer.
 
 To run more than one replica, place a DHCP relay in front of the server and expose it through a Service:
 
 - Set `replicas` greater than `1`.
 - Set `provisioningService.type: LoadBalancer` so the relay has a single unicast target that also serves boot files.
 - Point the relay at the `provisioningService` address, and set `dhcp.serverIP` and `http.advertiseUrl` to that same address so clients boot through the Service instead of from whichever replica answered.
-- Set `--leader-election-id` (required for more than one replica) and add the experimental `--tftp-single-port` so TFTP replies survive the Service NAT.
+- Add the experimental `--tftp-single-port` so TFTP replies survive the Service NAT. The chart configures leader election automatically.
 - Disable Multus with `networkAttachmentDefinition.enabled: false`, since its static IPAM would hand the same VIP to every pod.
 
 ```yaml
@@ -288,7 +305,6 @@ deploy:
           annotations:
             metallb.universe.tf/loadBalancerIPs: 192.168.100.20
       extraArgs:
-        - --leader-election-id=vcluster-platform-dhcp-server
         - --tftp-single-port
 ```
 
@@ -301,23 +317,23 @@ CNI plugin that enables attaching the DHCP server to a separate provisioning net
 
 | Value | Description | Default |
 |---|---|---|
-| `namespace` | Namespace to deploy Multus into | Provider namespace |
 | `image.registry` | Container image registry | `ghcr.io` |
 | `image.repository` | Container image repository | `k8snetworkplumbingwg/multus-cni` |
-| `image.tag` | Container image tag | `snapshot-thick` |
+| `image.tag` | Container image tag | `v4.2.4-thick` |
+| `resources` | CPU and memory requests and limits for the Multus container and installer init container. | `100m` CPU and `50Mi` memory |
+
+The platform installs Multus into `metal3.clusterRef.namespace`.
 
 ```yaml
 deploy:
   multus:
     enabled: true
-    helmValues: |
-      namespace: kube-system
 ```
 
 </TabItem>
 </Tabs>
 
-The DHCP server is automatically configured based on BareMetalHost resources and platform IPAM when using network properties.
+The DHCP server reads its lease data from BareMetalHost annotations. When network properties enable platform IPAM, the provider writes the allocated address and related network settings to those annotations.
 
 ## Configuration
 
@@ -331,6 +347,8 @@ The `clusterRef` specifies the control plane cluster where the platform installs
 |---|---|---|
 | `clusterRef.cluster` | Name of the connected control plane cluster | Yes |
 | `clusterRef.namespace` | Namespace on the control plane cluster for Metal3 components and BareMetalHost resources | Yes |
+
+The cluster and namespace references are immutable after you create the provider. A connected control plane cluster can be referenced by only one Metal3 NodeProvider.
 
 :::info Ironic network access
 Ironic must have network access to the BMC addresses of the bare metal servers. Ensure the control plane cluster where Ironic is deployed can reach the BMC network (Redfish/IPMI endpoints).
@@ -354,15 +372,24 @@ spec:
     deploy:
       metal3:
         enabled: true
+        helmValues: |
+          ironic:
+            # Expose the IPA API on a provisioning-network LoadBalancer VIP.
+            ipaAdvertiseIP: 192.168.100.10
+            service:
+              type: LoadBalancer
+              loadBalancerIP: 192.168.100.10
       dhcp:
         enabled: true
         helmValues: |
           networkAttachmentDefinition:
+            # Attach the DHCP server to the provisioning network.
             vip: 192.168.100.2/24
+          proxy:
+            # Send IPA directly to the bundled non-mTLS agent endpoint.
+            apiAdvertiseUrl: https://192.168.100.10:6388
       multus:
         enabled: true
-        helmValues: |
-          namespace: kube-system
     nodeTypes:
     - name: "compute-node"
       displayName: "Compute Node"
@@ -380,6 +407,13 @@ spec:
 ## Get started
 
 This walkthrough covers the essential steps to go from a connected control plane cluster to a provisioned bare metal server.
+
+Before you begin:
+
+- Install cert-manager on the control plane cluster.
+- Connect each control plane cluster node to the provisioning network through a `br0` bridge, or replace the DHCP NetworkAttachmentDefinition configuration.
+- Configure a load balancer implementation that can assign `192.168.100.10` to the Ironic Service. Replace all example network addresses with addresses from your provisioning network.
+- Create an [OSImage](../../use-platform/machines/os-images.mdx#create-an-osimage) named `ubuntu-noble`, or change the node type to reference an existing Metal3-compatible OSImage.
 
 <Flow>
 <Step>
@@ -401,7 +435,23 @@ spec:
     deploy:
       metal3:
         enabled: true
+        helmValues: |
+          ironic:
+            # Expose the IPA API on a provisioning-network LoadBalancer VIP.
+            ipaAdvertiseIP: 192.168.100.10
+            service:
+              type: LoadBalancer
+              loadBalancerIP: 192.168.100.10
       dhcp:
+        enabled: true
+        helmValues: |
+          networkAttachmentDefinition:
+            # Attach the DHCP server to the provisioning network.
+            vip: 192.168.100.2/24
+          proxy:
+            # Send IPA directly to the bundled non-mTLS agent endpoint.
+            apiAdvertiseUrl: https://192.168.100.10:6388
+      multus:
         enabled: true
     nodeTypes:
     - name: "compute-node"
@@ -449,7 +499,7 @@ kubectl apply -f server-01-bmc-secret.yaml
 <Step>
 Create a BareMetalHost.
 
-Register the physical server by creating a BareMetalHost resource. The `bmc.address` scheme determines which driver Metal3 uses (Redfish, IPMI, etc.). The `bootMACAddress` identifies the NIC used for PXE boot.
+Register the physical server by creating a BareMetalHost resource. The `bmc.address` scheme determines which driver Metal3 uses, such as Redfish or IPMI. The `bootMACAddress` identifies the NIC used for PXE boot.
 
 ```yaml
 apiVersion: metal3.io/v1alpha1
@@ -484,15 +534,15 @@ kubectl get baremetalhost -n metal3-system
 ```
 
 ```text
-NAME        STATE       CONSUMER   ONLINE   ERROR
-server-01   available              true
+NAME        STATE       CONSUMER   ONLINE   ERROR   AGE
+server-01   available              false            5m
 ```
 </Step>
 
 <Step>
-Create a vCluster that claims the server.
+Create a tenant cluster that claims the server.
 
-Create a vCluster with private nodes configured to use the Metal3 provider. The platform provisions a Machine, which claims the BareMetalHost and installs the OS through Ironic.
+Create a tenant cluster with private nodes configured to use the Metal3 provider. The platform provisions a Machine, which claims the BareMetalHost and installs the OS through Ironic.
 
 ```yaml
 privateNodes:
@@ -517,7 +567,7 @@ Each node type specifies which BareMetalHosts it can claim and what properties t
 
 ### Select BareMetalHosts by label
 
-Use `bareMetalHosts.selector` to match BareMetalHosts by labels. Only hosts matching the selector and having sufficient resources are eligible.
+Use `bareMetalHosts.selector` to match BareMetalHosts by labels. The provider checks requested CPU and memory against the inspected BareMetalHost inventory. Other resource keys don't affect BareMetalHost selection, so use labels to select hardware such as GPUs.
 
 ```yaml
 nodeTypes:
@@ -526,7 +576,6 @@ nodeTypes:
   resources:
     cpu: "64"
     memory: 256Gi
-    nvidia.com/gpu: "4"
   bareMetalHosts:
     selector:
       matchLabels:
@@ -574,7 +623,7 @@ Checksum of the OS image for verification.
 
 **Type:** `string`
 
-Checksum algorithm. Supported values: `md5`, `sha256`, `sha512`. If omitted, the type is auto-detected.
+Checksum algorithm. Supported values are `md5`, `sha256`, `sha512`, and `auto`. If omitted, Ironic defaults to `md5`. Set it to `auto` to have Ironic detect the algorithm from the checksum.
 
 ### Network configuration
 
@@ -590,7 +639,7 @@ Example: `10.0.0.1/24`
 
 **Type:** `string` (comma-separated IP ranges)
 
-Specifies explicit IP ranges for allocation instead of CIDR-based allocation. Format: `IP1-IP2,IP3-IP4`
+Restricts allocation to explicit IP ranges. The `metal3.vcluster.com/network-cidr` property remains required because it supplies the gateway and prefix. Keep every range within that subnet. Format: `IP1-IP2,IP3-IP4`
 
 Example: `10.0.0.20-10.0.0.30,10.0.0.40-10.0.0.50`
 
@@ -604,13 +653,13 @@ DNS servers to configure on the provisioned server. Example: `8.8.8.8,8.8.4.4`
 
 **Type:** `string`
 
-Complete custom network-data configuration. When set, this overrides automatic network configuration from CIDR or IP range properties.
+Complete custom network-data configuration for the installed operating system. When set, it replaces the network-data document that the provider would generate. CIDR and IP range properties still control address allocation and provisioning DHCP.
 
 #### `vcluster.com/network-data-template-config`
 
 **Type:** `string`
 
-References a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) by name. The provider renders the template's `networkDataTemplate` into a cloud-init `network-config` document when `metal3.vcluster.com/network-data` is not set. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
+References a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) by name. The provider renders the template's `networkDataTemplate` into a cloud-init `network-config` document when `metal3.vcluster.com/network-data` isn't set. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
 
 ### Network environment
 
@@ -640,7 +689,7 @@ References [SSHKey](../../use-platform/machines/ssh-keys.mdx) resources by name.
 
 **Type:** `string`
 
-Custom cloud-init configuration merged with the generated user data. Accepts any valid cloud-config directives (`packages`, `write_files`, `runcmd`, etc.). The platform's provisioning commands are appended after any user-supplied `runcmd` entries.
+Custom cloud-init configuration merged with the generated user data. Accepts any valid cloud-config directives, including `packages`, `write_files`, and `runcmd`. The platform's provisioning commands are appended after any user-supplied `runcmd` entries.
 
 Takes precedence over `vcluster.com/user-data-template-config`.
 
@@ -648,10 +697,10 @@ Takes precedence over `vcluster.com/user-data-template-config`.
 
 **Type:** `string`
 
-References a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) by name. The provider renders the template's `cloudInitTemplate` into a cloud-config document when `vcluster.com/user-data` is not set. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
+References a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) by name. The provider renders the template's `cloudInitTemplate` into a cloud-config document when `vcluster.com/user-data` isn't set. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
 
-In all cases, the platform appends the vCluster join command and the resolved SSH keys to the cloud-config.
+The platform always merges resolved SSH keys into the cloud-config. For a tenant cluster worker, it also appends the join command. For a tenant cluster control plane machine, it appends the control plane installation commands. Independently provisioned Machines receive no tenant cluster registration command.
 
 ## Try it yourself
 
-The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/docs/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints. No physical hardware is required.
+The community and experimental [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide runs the Metal3 provisioning flow locally with KubeVirt VMs as fake bare metal servers. It sets up a [vind](/docs/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints. No physical hardware is required.

--- a/platform/administer/node-providers/metal3.mdx
+++ b/platform/administer/node-providers/metal3.mdx
@@ -654,4 +654,4 @@ In all cases, the platform appends the vCluster join command and the resolved SS
 
 ## Try it yourself
 
-The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints. No physical hardware is required.
+The [vCluster Bare Metal with KubeVirt](https://github.com/loft-sh/vcluster-bare-metal-with-kubevirt) guide lets you run the full Metal3 bare metal provisioning flow locally using KubeVirt VMs as fake bare metal servers. It sets up a [vind](/docs/vcluster/deploy/control-plane/docker-container/basics) (vCluster in Docker) cluster with KubeVirt, a Metal3 NodeProvider, and simulated BareMetalHosts with Redfish BMC endpoints. No physical hardware is required.

--- a/static/media/diagrams/metal3-provisioning-flow.svg
+++ b/static/media/diagrams/metal3-provisioning-flow.svg
@@ -1,0 +1,120 @@
+<svg viewBox="0 0 1240 498" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style><![CDATA[
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+    <marker id="arrow" markerWidth="9" markerHeight="8" refX="7" refY="4" orient="auto">
+      <polygon points="0 0, 7 4, 0 8" fill="#B4B6BD"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1240" height="498" fill="#FFFFFF"/>
+  <text x="620" y="30" font-size="24" font-weight="700" fill="#050B24"
+        text-anchor="middle">How the Metal3 provider provisions bare metal</text>
+
+  <!-- Platform intent -->
+  <rect x="28" y="70" width="582" height="210" rx="14"
+        fill="#FFE0CC" stroke="#FF6600" stroke-width="2"/>
+  <text x="48" y="96" font-size="16" font-weight="600" fill="#050B24">vCluster Platform</text>
+
+  <rect x="48" y="136" width="154" height="60" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="125" y="166" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle" dominant-baseline="middle">Machine request</text>
+
+  <rect x="320" y="124" width="270" height="84" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="455" y="148" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Metal3 provider</text>
+  <text x="455" y="174" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Selects an available host.</text>
+  <text x="455" y="194" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Sets requested provisioning data.</text>
+
+  <line x1="206" y1="166" x2="316" y2="166" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+
+  <rect x="48" y="224" width="542" height="36" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="319" y="247" font-size="14" font-weight="400" fill="#828592"
+        text-anchor="middle">Deletion clears provisioning data and returns the host to available.</text>
+
+  <!-- Kubernetes resources and controllers -->
+  <rect x="630" y="70" width="582" height="210" rx="14"
+        fill="#EAF0FC" stroke="#326CE3" stroke-width="2"/>
+  <text x="650" y="96" font-size="16" font-weight="600" fill="#050B24">Control plane cluster</text>
+
+  <rect x="650" y="124" width="171" height="84" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="735.5" y="146" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Available</text>
+  <text x="735.5" y="166" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">BareMetalHost</text>
+  <text x="735.5" y="190" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Matched by node type.</text>
+
+  <rect x="875" y="124" width="125" height="84" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="937.5" y="146" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Bare Metal</text>
+  <text x="937.5" y="166" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Operator</text>
+  <text x="937.5" y="190" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Reconciles host.</text>
+
+  <rect x="1054" y="124" width="138" height="84" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="1123" y="148" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Ironic</text>
+  <text x="1123" y="174" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Powers and boots.</text>
+  <text x="1123" y="194" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Installs the OS.</text>
+
+  <line x1="594" y1="166" x2="646" y2="166" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+  <line x1="825" y1="166" x2="871" y2="166" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+  <line x1="1004" y1="166" x2="1050" y2="166" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+
+  <rect x="650" y="224" width="430" height="36" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="865" y="247" font-size="14" font-weight="400" fill="#828592"
+        text-anchor="middle">Optional DHCP and Multus connect the provisioning network.</text>
+
+  <!-- Optional tenant-cluster outcome -->
+  <rect x="28" y="300" width="582" height="170" rx="14"
+        fill="#EAF0FC" stroke="#326CE3" stroke-width="2"/>
+  <text x="48" y="326" font-size="16" font-weight="600" fill="#050B24">Tenant cluster</text>
+
+  <rect x="48" y="348" width="542" height="90" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="319" y="374" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Worker node</text>
+  <text x="319" y="400" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">For private nodes, user data registers</text>
+  <text x="319" y="420" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">the provisioned server with the tenant cluster.</text>
+
+  <!-- Hardware remains outside the control plane cluster -->
+  <rect x="630" y="300" width="582" height="170" rx="14"
+        fill="#EDEFF3" stroke="#B4B6BD" stroke-width="2"/>
+  <text x="650" y="326" font-size="16" font-weight="600" fill="#050B24">Bare metal infrastructure</text>
+
+  <rect x="650" y="348" width="542" height="90" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="921" y="374" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Physical server</text>
+  <text x="921" y="400" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">BMC and boot NIC registered before provisioning.</text>
+  <text x="921" y="420" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Ironic installs and initializes the operating system.</text>
+
+  <line x1="1123" y1="212" x2="1123" y2="344" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+
+  <!-- Independently provisioned Machines stop at the physical-server outcome. -->
+  <line x1="646" y1="393" x2="594" y2="393" stroke="#B4B6BD" stroke-width="1.5"
+        stroke-dasharray="5,4" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Refreshes the Metal3 provider page for the microservices architecture (NodeProvider CRD, Bare Metal Operator, Ironic), corrects the checksum-type default behavior, and replaces the mermaid diagram with an accessible SVG that shows the provisioning flow end to end. Adds a new network integration page covering the three network modes (none, Neutron, Netris) for isolating tenant traffic on the metal fabric.

## Preview Link 
- https://deploy-preview-2632--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/metal3
- https://deploy-preview-2632--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/metal3-network-integration


## Internal Reference


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

