### PR TITLE
kubevirt kube-ovn networking

### DIFF
--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -10,6 +10,7 @@ toc_max_heading_level: 3
 
 import Flow, {Step} from "@site/src/components/Flow";
 import FeatureTable from '@site/src/components/FeatureTable';
+import KubeVirtNodeProvisioningFlow from '@site/static/media/diagrams/kubevirt-node-provisioning-flow.svg';
 
 <FeatureTable names="auto-nodes-kubevirt" />
 
@@ -24,34 +25,10 @@ For administrator guidance on VM disk imports and Multus networks, see [Data Vol
 This enables you to offer different "flavors" of virtual machines, for example small, medium, and large compute shapes, as nodes for your vCluster,
 all managed from a central configuration.
 
-```mermaid
-flowchart LR
-    subgraph platform["vCluster Platform"]
-        direction LR
-        NodeClaimCreate["NodeClaim (for Create)"]
-        NodeClaimDelete["NodeClaim (for Delete)"]
-        NodeType["NodeType (has VM Template)"]
-        Provision("apply VirtualMachine")
-        Destroy("delete VirtualMachine")
-    end
-
-    subgraph host_cluster["KubeVirt control plane cluster"]
-        direction TB
-        KubeVirtVM["KubeVirt VirtualMachine"]
-    end
-
-    vCluster -- "Creates" --> NodeClaimCreate
-    NodeClaimCreate -- "Claims" --> NodeType
-    NodeClaimCreate -- "Triggers" --> Provision
-
-    NodeType -- "Is used by" --> Provision
-    Provision -- "Creates" --> KubeVirtVM
-    KubeVirtVM -- "Joins as Node" --> TenantCluster["tenant cluster"]
-
-    vCluster -- "Deletes" --> NodeClaimDelete
-    NodeClaimDelete -- "Triggers" --> Destroy
-    Destroy -- "Destroys" --> KubeVirtVM
-```
+<figure>
+  <KubeVirtNodeProvisioningFlow style={{width: '100%', height: 'auto'}} role="img" aria-label="A NodeClaim references a NodeType for its VM template and requests a node from the vCluster Platform. The platform creates a KubeVirt VirtualMachine on the control plane cluster from that template, with a join-token Secret injected through cloud-init. The VM registers as a worker node in the tenant cluster using that token. Deleting the NodeClaim deletes the VirtualMachine and removes the node." />
+  <figcaption>The platform turns a NodeClaim into a KubeVirt VirtualMachine on the control plane cluster, which joins the tenant cluster as a worker node through cloud-init. Deleting the NodeClaim reverses the flow.</figcaption>
+</figure>
 
 ## Overview
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -602,7 +602,9 @@ The following properties tune the injected interface. They only take effect when
 
 **Type:** `string`
 
-Sets an in-tree binding method for the injected interface. One of `bridge`, `masquerade`, or `sriov`. Defaults to `bridge`.
+Sets the binding method for the injected interface. One of `bridge`, `masquerade`, or `sriov`. Defaults to `bridge`.
+
+KubeVirt removed several network bindings, including macvtap and slirp, from its in-tree API in v1.3, so this property now accepts only the remaining in-tree bindings and rejects any other value. Plugin-based bindings such as macvtap, passt, slirp, and custom bindings are selected through `kubevirt.vcluster.com/interface-template` instead.
 
 #### `kubevirt.vcluster.com/interface-template`
 
@@ -616,21 +618,119 @@ A partial KubeVirt interface definition merged over the default injected interfa
 
 When `"true"`, the Multus network becomes the VM's default network, and the pod network and its interface are removed, since KubeVirt rejects a VM that has both. Defaults to `"false"`.
 
-### Node environment selection
+### Network environment
 
 #### `vcluster.com/network-environment`
 
 **Type:** `string`
 
-Names the [NodeEnvironment](./overview.mdx#node-environments) whose properties merge into the NodeClaim's effective property set. The platform resolves this from the merged properties of NodeProvider, NodeType, and NodeClaim. When set, this property takes precedence over the typed `NodeClaim.spec.environmentRef` field.
+Names the [NodeEnvironment](./overview.mdx#node-environments) whose properties merge into the NodeClaim's effective property set. The platform resolves this network environment from the merged properties of NodeProvider, NodeType, and NodeClaim. When set, this property takes precedence over the typed `NodeClaim.spec.environmentRef` field.
 
-Use this to declare environment-level defaults at the provider or type level, or to keep network configuration separate from provider and type definitions.
+Use it to declare network environment defaults at the provider or type level, or to keep network configuration separate from provider and type definitions.
 
 ### SSH and user data
 
 The `vcluster.com/ssh-keys` and `vcluster.com/user-data` properties behave identically across providers. See the [metal3 reference](./metal3.mdx#ssh-and-user-data) for details.
 
 To render cloud-init from a reusable template, reference a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) with the `vcluster.com/user-data-template-config` property. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
+
+## kube-ovn networking
+
+KubeVirt VMs can attach to [kube-ovn](https://kubeovn.github.io/docs/stable/en/) networks, so each set of auto-nodes runs on its own isolated, routable overlay network with OVN-native DHCP and optional external egress.
+
+### Attach VMs to a kube-ovn network
+
+A VM joins a kube-ovn network the way it joins any additional network: through a Multus `NetworkAttachmentDefinition`, made the VM's default network, with an interface binding. This works against any kube-ovn network — one you created yourself, one another system manages, or one the platform provisioned for you. To have the platform create the network, see [Provision a kube-ovn network](#provision-a-kube-ovn-network).
+
+By default, the integration uses the `managedtap` interface binding instead of `bridge`. The `bridge` binding makes KubeVirt run its own DHCP inside the launcher pod, which answers the guest before kube-ovn can, shadowing OVN-native DHCP so the VM never receives the address and gateway the subnet serves. `managedtap` avoids this. The binding is overridable, so you can set a different one where it fits your network.
+
+The attachment is driven by these KubeVirt properties (see [Network configuration](#network-configuration)):
+
+- `kubevirt.vcluster.com/network-attachment-definition` — the kube-ovn Multus NAD to attach to.
+- `kubevirt.vcluster.com/multus-default` — `"true"` so the kube-ovn network is the VM's default network.
+- `kubevirt.vcluster.com/interface-template` — `{"binding":{"name":"managedtap"}}` to use the managedtap binding.
+
+When the NodeEnvironment carries the `kube-ovn.vcluster.com/subnet` property, the platform fills these in automatically, each only when you have not set it yourself. Set any of them explicitly on the NodeType or NodeClaim to override the default.
+
+- [`kubevirt.vcluster.com/network-attachment-definition`](#kubevirt-vcluster-com-network-attachment-definition) points at the `NetworkAttachmentDefinition` named after the subnet in the provider namespace (`<provider-namespace>/<subnet>`).
+- `kubevirt.vcluster.com/multus-default` becomes `"true"`.
+- `kubevirt.vcluster.com/interface-template` selects the `managedtap` binding, for the reason described above.
+
+#### Register the managedtap binding
+
+Registering `managedtap` is required if you use it, which the integration does by default. The binding must be registered on the `KubeVirt` resource on the control plane cluster, and it requires KubeVirt v1.4 or later. If the default `managedtap` binding is not registered, provisioning fails. Override the binding on the NodeType or NodeClaim if you do not want to register it.
+
+Register the binding through the KubeVirt provider's `deploy.kubevirt.helmValues`. The platform renders `kubevirt.spec` verbatim into the `KubeVirt` resource `.spec`, so add the network binding under it:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: NodeProvider
+metadata:
+  name: kubevirt-provider
+spec:
+  kubeVirt:
+    deploy:
+      kubevirt:
+        enabled: true
+        helmValues: |
+          kubevirt:
+            spec:
+              configuration:
+                network:
+                  binding:
+                    managedtap:
+                      domainAttachmentType: managedTap
+```
+
+If KubeVirt is managed outside the provider, register the same binding on your existing `KubeVirt` resource instead.
+
+:::note Verify the binding registration
+The network binding registration follows the KubeVirt API, not a vCluster schema. Confirm the exact fields for your KubeVirt version against the [KubeVirt network binding plugin documentation](https://kubevirt.io/user-guide/network/network_binding_plugins/).
+:::
+
+### Provision a kube-ovn network
+
+Instead of pointing VMs at an existing kube-ovn network, you can have the platform create one for you. Set `kube-ovn.vcluster.com/vpc` on the [NodeEnvironment](./overview.mdx#node-environments) to provision the kube-ovn resources on the control plane cluster. This property gates provisioning: without it, the platform creates nothing. Provisioning runs as part of the NodeEnvironment's infrastructure lifecycle, so the network exists before any VM uses the environment and is removed when the environment is deleted.
+
+A VM attaches to a network provisioned this way through the same [attachment properties](#attach-vms-to-a-kube-ovn-network). When the NodeEnvironment carries `kube-ovn.vcluster.com/subnet`, those attachment defaults are filled in automatically.
+
+#### `kube-ovn.vcluster.com/vpc`
+
+**Type:** `string`
+
+Name of the kube-ovn `Vpc`. Setting it enables provisioning and creates the VPC, subnet, and `NetworkAttachmentDefinition`. When the VPC does not exist, the platform creates it. A pre-existing VPC is only modified when this NodeEnvironment manages it.
+
+#### `kube-ovn.vcluster.com/subnet`
+
+**Type:** `string`
+**Required:** Yes, when `kube-ovn.vcluster.com/vpc` is set.
+
+Name of the kube-ovn `Subnet` provisioned inside the VPC. The platform also creates a `NetworkAttachmentDefinition` of the same name in the provider namespace that VMs attach to.
+
+#### `kube-ovn.vcluster.com/subnet-cidr`
+
+**Type:** `string` (IPv4 CIDR)
+**Required:** Yes, when `kube-ovn.vcluster.com/vpc` is set.
+
+CIDR block for the subnet. Only IPv4 is supported; an IPv6 or dual-stack CIDR is rejected. The subnet's CIDR is immutable, so changing it on a live environment requires recreating the subnet.
+
+#### `kube-ovn.vcluster.com/external-subnet`
+
+**Type:** `string`
+
+Name of a pre-existing external `Subnet`. Setting it wires the VPC's external connectivity and default route, using the external subnet's gateway as the next hop. The platform never creates or deletes this external subnet. Required for egress.
+
+#### `kube-ovn.vcluster.com/egress-enabled`
+
+**Type:** `string` (`"true"` or `"false"`)
+
+When `"true"`, the platform creates the egress source NAT objects (`OvnEip` and `OvnSnatRule`) so VMs on the subnet can reach external networks. Requires `kube-ovn.vcluster.com/external-subnet`. Defaults to `"false"`. Disabling egress after it was enabled is not supported.
+
+The platform labels every object it provisions with `kube-ovn.vcluster.com/node-environment`, set to the NodeEnvironment's UID, and removes those objects by that label when the NodeEnvironment is deleted. Objects it did not create, such as a pre-existing VPC or the external subnet, are left untouched.
+
+### kube-ovn cloud-controller-manager
+
+Provisioning a kube-ovn network and attaching VMs to it gives them a VPC and overlay connectivity. To expose `LoadBalancer` services and direct pod routing on that same VPC, deploy the kube-ovn cloud-controller-manager in the tenant cluster. See [kube-ovn cloud-controller-manager](/docs/vcluster/deploy/worker-nodes/private-nodes/kube-ovn) for setup. The integration here builds the VPC and wires the VMs onto it; the cloud-controller-manager then provides LoadBalancer services and pod routing on top of it.
 
 ## Netris integration
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -634,7 +634,7 @@ The `vcluster.com/ssh-keys` and `vcluster.com/user-data` properties behave ident
 
 To render cloud-init from a reusable template, reference a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) with the `vcluster.com/user-data-template-config` property. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
 
-## kube-ovn networking
+## Networking with kube-ovn
 
 KubeVirt VMs can attach to [kube-ovn](https://kubeovn.github.io/docs/stable/en/) networks, so each set of auto-nodes runs on its own isolated, routable overlay network with OVN-native DHCP and optional external egress.
 
@@ -728,7 +728,7 @@ When `"true"`, the platform creates the egress source NAT objects (`OvnEip` and 
 
 The platform labels every object it provisions with `kube-ovn.vcluster.com/node-environment`, set to the NodeEnvironment's UID, and removes those objects by that label when the NodeEnvironment is deleted. Objects it did not create, such as a pre-existing VPC or the external subnet, are left untouched.
 
-### kube-ovn cloud-controller-manager
+### Expose services with the kube-ovn cloud-controller-manager
 
 Provisioning a kube-ovn network and attaching VMs to it gives them a VPC and overlay connectivity. To expose `LoadBalancer` services and direct pod routing on that same VPC, deploy the kube-ovn cloud-controller-manager in the tenant cluster. See [kube-ovn cloud-controller-manager](/docs/vcluster/deploy/worker-nodes/private-nodes/kube-ovn) for setup. The integration here builds the VPC and wires the VMs onto it; the cloud-controller-manager then provides LoadBalancer services and pod routing on top of it.
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -3,6 +3,8 @@ title: KubeVirt
 sidebar_label: KubeVirt
 sidebar_position: 3
 sidebar_class_name: free
+toc_min_heading_level: 2
+toc_max_heading_level: 3
 ---
 
 
@@ -44,7 +46,7 @@ flowchart LR
 
     NodeType -- "Is used by" --> Provision
     Provision -- "Creates" --> KubeVirtVM
-    KubeVirtVM -- "Joins as Node" --> Node["vCluster"]
+    KubeVirtVM -- "Joins as Node" --> TenantCluster["tenant cluster"]
 
     vCluster -- "Deletes" --> NodeClaimDelete
     NodeClaimDelete -- "Triggers" --> Destroy
@@ -634,21 +636,21 @@ The `vcluster.com/ssh-keys` and `vcluster.com/user-data` properties behave ident
 
 To render cloud-init from a reusable template, reference a [MachineConfigTemplate](../../use-platform/machines/machine-config-templates.mdx) with the `vcluster.com/user-data-template-config` property. See [Machine Config Templates](../../use-platform/machines/machine-config-templates.mdx) for the template syntax and available variables.
 
-## Networking with kube-ovn
+## Integrate with kube-ovn
 
 KubeVirt VMs can attach to [kube-ovn](https://kubeovn.github.io/docs/stable/en/) networks, so each set of auto-nodes runs on its own isolated, routable overlay network with OVN-native DHCP and optional external egress.
 
 ### Attach VMs to a kube-ovn network
 
-A VM joins a kube-ovn network the way it joins any additional network: through a Multus `NetworkAttachmentDefinition`, made the VM's default network, with an interface binding. This works against any kube-ovn network — one you created yourself, one another system manages, or one the platform provisioned for you. To have the platform create the network, see [Provision a kube-ovn network](#provision-a-kube-ovn-network).
+A VM joins a kube-ovn network the same way it joins any other network, through a Multus `NetworkAttachmentDefinition` that's set as the VM's default network with an interface binding. This works whether you created the kube-ovn network yourself, another system manages it, or the platform provisioned it for you. To have the platform create the network, see [Provision a kube-ovn network](#provision-a-kube-ovn-network).
 
 By default, the integration uses the `managedtap` interface binding instead of `bridge`. The `bridge` binding makes KubeVirt run its own DHCP inside the launcher pod, which answers the guest before kube-ovn can, shadowing OVN-native DHCP so the VM never receives the address and gateway the subnet serves. `managedtap` avoids this. The binding is overridable, so you can set a different one where it fits your network.
 
 The attachment is driven by these KubeVirt properties (see [Network configuration](#network-configuration)):
 
-- `kubevirt.vcluster.com/network-attachment-definition` — the kube-ovn Multus NAD to attach to.
-- `kubevirt.vcluster.com/multus-default` — `"true"` so the kube-ovn network is the VM's default network.
-- `kubevirt.vcluster.com/interface-template` — `{"binding":{"name":"managedtap"}}` to use the managedtap binding.
+- `kubevirt.vcluster.com/network-attachment-definition`: the kube-ovn Multus NAD to attach to.
+- `kubevirt.vcluster.com/multus-default`: `"true"` so the kube-ovn network is the VM's default network.
+- `kubevirt.vcluster.com/interface-template`: `{"binding":{"name":"managedtap"}}` to use the managedtap binding.
 
 When the NodeEnvironment carries the `kube-ovn.vcluster.com/subnet` property, the platform fills these in automatically, each only when you have not set it yourself. Set any of them explicitly on the NodeType or NodeClaim to override the default.
 
@@ -658,7 +660,7 @@ When the NodeEnvironment carries the `kube-ovn.vcluster.com/subnet` property, th
 
 #### Register the managedtap binding
 
-Registering `managedtap` is required if you use it, which the integration does by default. The binding must be registered on the `KubeVirt` resource on the control plane cluster, and it requires KubeVirt v1.4 or later. If the default `managedtap` binding is not registered, provisioning fails. Override the binding on the NodeType or NodeClaim if you do not want to register it.
+The integration uses `managedtap` by default, and registering it is required whenever you use it. The binding must be registered on the `KubeVirt` resource on the control plane cluster, and it requires KubeVirt v1.4 or later. If the default `managedtap` binding is not registered, provisioning fails. Override the binding on the NodeType or NodeClaim if you do not want to register it.
 
 Register the binding through the KubeVirt provider's `deploy.kubevirt.helmValues`. The platform renders `kubevirt.spec` verbatim into the `KubeVirt` resource `.spec`, so add the network binding under it:
 
@@ -690,7 +692,7 @@ The network binding registration follows the KubeVirt API, not a vCluster schema
 
 ### Provision a kube-ovn network
 
-Instead of pointing VMs at an existing kube-ovn network, you can have the platform create one for you. Set `kube-ovn.vcluster.com/vpc` on the [NodeEnvironment](./overview.mdx#node-environments) to provision the kube-ovn resources on the control plane cluster. This property gates provisioning: without it, the platform creates nothing. Provisioning runs as part of the NodeEnvironment's infrastructure lifecycle, so the network exists before any VM uses the environment and is removed when the environment is deleted.
+Instead of pointing VMs at an existing kube-ovn network, you can have the platform create one for you. Set `kube-ovn.vcluster.com/vpc` on the [NodeEnvironment](./overview.mdx#node-environments) to provision the kube-ovn resources on the control plane cluster. This property gates provisioning. Without it, the platform creates nothing. Provisioning runs as part of the NodeEnvironment's infrastructure lifecycle, so the network exists before any VM uses the environment and is removed when the environment is deleted.
 
 A VM attaches to a network provisioned this way through the same [attachment properties](#attach-vms-to-a-kube-ovn-network). When the NodeEnvironment carries `kube-ovn.vcluster.com/subnet`, those attachment defaults are filled in automatically.
 

--- a/platform/administer/node-providers/kubevirt.mdx
+++ b/platform/administer/node-providers/kubevirt.mdx
@@ -730,7 +730,7 @@ The platform labels every object it provisions with `kube-ovn.vcluster.com/node-
 
 ### Expose services with the kube-ovn cloud-controller-manager
 
-Provisioning a kube-ovn network and attaching VMs to it gives them a VPC and overlay connectivity. To expose `LoadBalancer` services and direct pod routing on that same VPC, deploy the kube-ovn cloud-controller-manager in the tenant cluster. See [kube-ovn cloud-controller-manager](/docs/vcluster/deploy/worker-nodes/private-nodes/kube-ovn) for setup. The integration here builds the VPC and wires the VMs onto it; the cloud-controller-manager then provides LoadBalancer services and pod routing on top of it.
+Provisioning a kube-ovn network and attaching VMs to it gives them a VPC and overlay connectivity. To expose `LoadBalancer` services and direct pod routing on that same VPC, deploy the kube-ovn cloud-controller-manager in the tenant cluster. See [kube-ovn cloud-controller-manager](/docs/vcluster/next/deploy/worker-nodes/private-nodes/kube-ovn) for setup. The integration here builds the VPC and wires the VMs onto it; the cloud-controller-manager then provides LoadBalancer services and pod routing on top of it.
 
 ## Netris integration
 

--- a/static/media/diagrams/kubevirt-node-provisioning-flow.svg
+++ b/static/media/diagrams/kubevirt-node-provisioning-flow.svg
@@ -1,0 +1,74 @@
+<svg viewBox="0 0 1160 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style><![CDATA[
+      text { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    ]]></style>
+    <marker id="arrow" markerWidth="9" markerHeight="8" refX="7" refY="4" orient="auto">
+      <polygon points="0 0, 7 4, 0 8" fill="#B4B6BD"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1160" height="320" fill="#FFFFFF"/>
+  <text x="580" y="30" font-size="24" font-weight="700" fill="#050B24"
+        text-anchor="middle">How the KubeVirt provider provisions a node</text>
+
+  <!-- vCluster Platform -->
+  <rect x="28" y="56" width="350" height="230" rx="14"
+        fill="#FFE0CC" stroke="#FF6600" stroke-width="2"/>
+  <text x="48" y="82" font-size="16" font-weight="600" fill="#050B24">vCluster Platform</text>
+
+  <rect x="48" y="135" width="310" height="90" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="203" y="163" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">NodeClaim</text>
+  <text x="203" y="185" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Requests a node on create.</text>
+  <text x="203" y="203" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Triggers VM deletion on removal.</text>
+
+  <rect x="48" y="235" width="310" height="36" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="203" y="258" font-size="14" font-weight="400" fill="#828592"
+        text-anchor="middle">References a NodeType for the VM template.</text>
+
+  <!-- KubeVirt control plane cluster -->
+  <rect x="408" y="56" width="350" height="230" rx="14"
+        fill="#EAF0FC" stroke="#326CE3" stroke-width="2"/>
+  <text x="428" y="82" font-size="16" font-weight="600" fill="#050B24">KubeVirt control plane cluster</text>
+
+  <rect x="428" y="135" width="310" height="90" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="583" y="163" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">VirtualMachine</text>
+  <text x="583" y="185" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">Created from the NodeType template.</text>
+  <text x="583" y="203" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">cloud-init injects a join-token Secret.</text>
+
+  <rect x="428" y="231" width="310" height="44" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5" stroke-dasharray="5,4"/>
+  <text x="583" y="249" font-size="14" font-weight="400" fill="#828592"
+        text-anchor="middle">Deleting the NodeClaim</text>
+  <text x="583" y="265" font-size="14" font-weight="400" fill="#828592"
+        text-anchor="middle">deletes this VirtualMachine.</text>
+
+  <!-- Tenant cluster -->
+  <rect x="788" y="56" width="344" height="184" rx="14"
+        fill="#EAF0FC" stroke="#326CE3" stroke-width="2"/>
+  <text x="808" y="82" font-size="16" font-weight="600" fill="#050B24">Tenant cluster</text>
+
+  <rect x="808" y="135" width="304" height="90" rx="8"
+        fill="#FFFFFF" stroke="#B4B6BD" stroke-width="1.5"/>
+  <text x="960" y="163" font-size="16" font-weight="600" fill="#050B24"
+        text-anchor="middle">Worker node</text>
+  <text x="960" y="185" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">The VM registers using its</text>
+  <text x="960" y="203" font-size="14" font-weight="400" fill="#050B24"
+        text-anchor="middle">injected join token.</text>
+
+  <!-- Arrows -->
+  <line x1="358" y1="180" x2="424" y2="180" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+  <line x1="738" y1="180" x2="804" y2="180" stroke="#B4B6BD" stroke-width="1.5"
+        marker-end="url(#arrow)"/>
+</svg>

--- a/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
@@ -205,7 +205,7 @@ surface.
    subnets named in `loadBalancers.externalSubnet` and
    `loadBalancers.backendSubnet` must already exist. The KubeVirt node provider
    creates these through NodeEnvironment properties. See [kube-ovn
-   networking](/docs/platform/administer/node-providers/kubevirt#networking-with-kube-ovn).
+   networking](/docs/platform/next/administer/node-providers/kubevirt#networking-with-kube-ovn).
 
 4. **Provider network, uplink, and the external segment.** Configure a
    `ProviderNetwork` with the node uplink NIC, a `Vlan`, and the external
@@ -218,7 +218,7 @@ surface.
    VPC to reach external networks, for example to pull images. Enable it through
    the NodeEnvironment's `kube-ovn.vcluster.com/egress-enabled` property. See
    [kube-ovn
-   networking](/docs/platform/administer/node-providers/kubevirt#networking-with-kube-ovn).
+   networking](/docs/platform/next/administer/node-providers/kubevirt#networking-with-kube-ovn).
 
 6. **A kube-ovn build that has the `RouterLBRule` CRD.** The integration drives
    the `RouterLBRule` custom resource, which kube-ovn versions up to and including

--- a/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
@@ -14,10 +14,10 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx';
 <ProAdmonition/>
 
 vCluster ships an embedded cloud-controller-manager (CCM). Its kube-ovn
-integration lets a private-nodes tenant cluster whose nodes run on a kube-ovn
-network, for example KubeVirt VM nodes on the control plane cluster, route
-traffic through the tenant's kube-ovn VPC. It layers two capabilities onto that
-VPC:
+integration lets a private-nodes tenant cluster route traffic through the
+tenant's kube-ovn VPC. This works when the tenant's nodes run on a kube-ovn
+network, for example KubeVirt VM nodes on the control plane cluster. It layers
+two capabilities onto that VPC:
 
 - **Direct pod routing**, so the tenant VPC router reaches pod IPs directly and
   preserves the client source IP.
@@ -109,8 +109,8 @@ the route controller reads.
 ## LoadBalancer services
 
 When a tenant creates a `type: LoadBalancer` Service, the integration allocates a
-VIP from a kube-ovn external subnet (an `OvnEip`) and programs the tenant VPC's
-router to forward that VIP to the Service backends (a `RouterLBRule`). It then
+VIP from a kube-ovn external subnet (an `OvnEip`). It programs the tenant VPC's
+router to forward that VIP to the Service backends (a `RouterLBRule`), then
 publishes the allocated VIP back onto the Service as its ingress address.
 Deleting the Service, or changing it away from `type: LoadBalancer`, tears the
 kube-ovn resources back down.
@@ -205,20 +205,20 @@ surface.
    subnets named in `loadBalancers.externalSubnet` and
    `loadBalancers.backendSubnet` must already exist. The KubeVirt node provider
    creates these through NodeEnvironment properties. See [kube-ovn
-   networking](/docs/platform/next/administer/node-providers/kubevirt#networking-with-kube-ovn).
+   networking](/docs/platform/next/administer/node-providers/kubevirt#integrate-with-kube-ovn).
 
 4. **Provider network, uplink, and the external segment.** Configure a
    `ProviderNetwork` with the node uplink NIC, a `Vlan`, and the external
    `Subnet` that the VIPs are allocated from. The external subnet's name must
    match kube-ovn's `--external-gateway-switch` flag, which defaults to
-   `external`, and the VPC must have `enableExternal: true` so it gets an LRP and
-   gateway chassis onto that segment.
+   `external`. The VPC must also have `enableExternal: true` so it gets an LRP
+   and gateway chassis onto that segment.
 
 5. **Egress out of the custom VPC configured.** Tenant nodes need egress from the
    VPC to reach external networks, for example to pull images. Enable it through
    the NodeEnvironment's `kube-ovn.vcluster.com/egress-enabled` property. See
    [kube-ovn
-   networking](/docs/platform/next/administer/node-providers/kubevirt#networking-with-kube-ovn).
+   networking](/docs/platform/next/administer/node-providers/kubevirt#integrate-with-kube-ovn).
 
 6. **A kube-ovn build that has the `RouterLBRule` CRD.** The integration drives
    the `RouterLBRule` custom resource, which kube-ovn versions up to and including

--- a/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
@@ -167,10 +167,10 @@ example source-IP allowlists, logging, geo-routing, or mTLS by IP.
 :::warning In-place changes don't self-converge
 Switching an already-created LoadBalancer Service to direct-to-pod routing, by
 flipping `podRoutes.enabled` while the Service exists, doesn't converge on its
-own. Node routing leaves a stale v1 `Endpoints` object, created by kube-ovn's own
+own. Node routing leaves a stale v1 Endpoints object, created by kube-ovn's own
 RouterLBRule controller, that emptying `RouterLBRule.spec.endpoints` doesn't
 clear. kube-ovn unions it with the pod backends, giving a mixed datapath for a few
-minutes until the stale `Endpoints` is removed.
+minutes until the stale Endpoints is removed.
 
 Recreate the LoadBalancer Service after changing `podRoutes.enabled` rather than
 relying on an in-place change.
@@ -205,7 +205,7 @@ surface.
    subnets named in `loadBalancers.externalSubnet` and
    `loadBalancers.backendSubnet` must already exist. The KubeVirt node provider
    creates these through NodeEnvironment properties. See [kube-ovn
-   networking](/docs/platform/administer/node-providers/kubevirt#kube-ovn-networking).
+   networking](/docs/platform/administer/node-providers/kubevirt#networking-with-kube-ovn).
 
 4. **Provider network, uplink, and the external segment.** Configure a
    `ProviderNetwork` with the node uplink NIC, a `Vlan`, and the external
@@ -218,7 +218,7 @@ surface.
    VPC to reach external networks, for example to pull images. Enable it through
    the NodeEnvironment's `kube-ovn.vcluster.com/egress-enabled` property. See
    [kube-ovn
-   networking](/docs/platform/administer/node-providers/kubevirt#kube-ovn-networking).
+   networking](/docs/platform/administer/node-providers/kubevirt#networking-with-kube-ovn).
 
 6. **A kube-ovn build that has the `RouterLBRule` CRD.** The integration drives
    the `RouterLBRule` custom resource, which kube-ovn versions up to and including

--- a/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
+++ b/vcluster/deploy/worker-nodes/private-nodes/kube-ovn.mdx
@@ -1,0 +1,231 @@
+---
+title: kube-ovn integration
+sidebar_label: kube-ovn
+sidebar_position: 3.6
+description: Route directly to tenant pod IPs and expose LoadBalancer services on kube-ovn VIPs for private-nodes tenant clusters, without an external load balancer or MetalLB.
+sidebar_class_name: pro private-nodes
+---
+
+import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx';
+
+<TenancySupport privateNodes="true" />
+
+<ProAdmonition/>
+
+vCluster ships an embedded cloud-controller-manager (CCM). Its kube-ovn
+integration lets a private-nodes tenant cluster whose nodes run on a kube-ovn
+network, for example KubeVirt VM nodes on the control plane cluster, route
+traffic through the tenant's kube-ovn VPC. It layers two capabilities onto that
+VPC:
+
+- **Direct pod routing**, so the tenant VPC router reaches pod IPs directly and
+  preserves the client source IP.
+- **LoadBalancer services**, so `type: LoadBalancer` Services get an externally
+  reachable VIP without an external load balancer, cloud provider, or MetalLB.
+
+The direct-to-pod LoadBalancer builds on direct pod routing. The integration
+only writes into kube-ovn objects the operator has already created, namely the
+VPC and its subnets. It never creates or manages the VPC or the subnets
+themselves. See [Prerequisites](#prerequisites) for the kube-ovn topology that
+must already exist.
+
+## Configuration
+
+The entire user-facing surface lives under
+`controlPlane.advanced.cloudControllerManager` in `vcluster.yaml`. It's a
+vCluster Pro feature.
+
+```yaml title="vcluster.yaml"
+controlPlane:
+  advanced:
+    cloudControllerManager:
+      # The embedded CCM must be running
+      enabled: true
+      kubeOvn:
+        # Turn on the kube-ovn integration
+        enabled: true
+        # The custom VPC the integration operates on
+        vpc: vmlb-vpc
+        loadBalancers:
+          # Subnet the LoadBalancer VIPs are allocated from
+          externalSubnet: vmlb-external
+          # A real subnet in the VPC (see the table below)
+          backendSubnet: vmlb-vms
+        podRoutes:
+          # Add direct pod routing and route LoadBalancer VIPs straight to pods
+          enabled: false
+```
+
+Two switches control the integration:
+
+- `kubeOvn.enabled` turns the integration on. This is also what enables
+  LoadBalancer services.
+- `kubeOvn.podRoutes.enabled` adds direct pod routing and switches LoadBalancer
+  services to route directly to pods. Left at its default `false`, LoadBalancer
+  services route through nodes instead.
+
+Each field:
+
+| Key | Meaning |
+|---|---|
+| `cloudControllerManager.enabled` | Gates the embedded CCM. Must be `true`, because the kube-ovn integration runs inside it. |
+| `kubeOvn.enabled` | Enables the kube-ovn integration. Requires `privateNodes.enabled: true` (see [Prerequisites](#prerequisites)) or the config is rejected. |
+| `kubeOvn.vpc` | Name of the existing kube-ovn `Vpc` to operate on. Shared by both `loadBalancers` and `podRoutes`. |
+| `kubeOvn.loadBalancers.externalSubnet` | Name of the kube-ovn `Subnet` the VIPs are allocated from. Each LoadBalancer VIP is an `OvnEip` on this subnet. |
+| `kubeOvn.loadBalancers.backendSubnet` | Name of a real `Subnet` inside `vpc`. It selects which kube-ovn load balancer the VIP is placed on, and it's stamped as the generated Service's `ovn.kubernetes.io/logical_switch`. The value just needs to be a real subnet in the VPC. Only required (and only used) when `podRoutes.enabled` is set; node routing ignores it. |
+| `kubeOvn.podRoutes.enabled` | Adds direct pod routing and routes LoadBalancer VIPs straight to pods. Defaults to `false`, which routes through nodes. When set, it additionally requires `networking.podCIDR` and `loadBalancers.backendSubnet`, or the config is rejected. See [Direct pod routing](#direct-pod-routing). |
+
+:::note Configure from the Platform UI
+The same fields are available in vCluster Platform. On a tenant cluster in
+private nodes mode, the networking settings expose the kube-ovn integration and
+write the same `controlPlane.advanced.cloudControllerManager.kubeOvn` values. The
+form appears only for tenant clusters running vCluster 0.37 or later.
+:::
+
+### RBAC
+
+When `kubeOvn.enabled` is set, vCluster deploys the RBAC the integration needs in
+the control plane cluster.
+
+## Direct pod routing
+
+Set `podRoutes.enabled: true`. The integration's route controller programs one
+`Vpc` static route per node podCIDR, read from `Node.Spec.PodCIDRs`, so the
+tenant VPC router can reach pod IPs directly. This removes the extra kube-proxy
+hop and preserves the client source IP end to end.
+
+These static routes are the foundation that the direct-to-pod LoadBalancer builds
+on. The routes don't depend on any `type: LoadBalancer` Service, or on
+`externalSubnet` and `backendSubnet`. Direct pod routing runs inside the kube-ovn
+integration, reached through `podRoutes.enabled` with `kubeOvn.enabled`, not as a
+separate component.
+
+Enabling `podRoutes.enabled` also requires `networking.podCIDR` and
+`loadBalancers.backendSubnet` in `vcluster.yaml`. The pod CIDR is the cluster
+CIDR that kube-controller-manager splits into the per-node `Node.Spec.PodCIDRs`
+the route controller reads.
+
+## LoadBalancer services
+
+When a tenant creates a `type: LoadBalancer` Service, the integration allocates a
+VIP from a kube-ovn external subnet (an `OvnEip`) and programs the tenant VPC's
+router to forward that VIP to the Service backends (a `RouterLBRule`). It then
+publishes the allocated VIP back onto the Service as its ingress address.
+Deleting the Service, or changing it away from `type: LoadBalancer`, tears the
+kube-ovn resources back down.
+
+The `OvnEip` and `RouterLBRule` share a Service-UID-derived name (`vlb-<uid>`).
+How the VIP reaches its backends depends on `podRoutes.enabled`.
+
+### Node routing (default)
+
+With `podRoutes.enabled: false`, the CCM service controller drives the
+LoadBalancer. For each `type: LoadBalancer` Service the integration creates:
+
+- an `OvnEip` on `externalSubnet` whose allocated IP becomes the VIP, and
+- a `RouterLBRule` that DNATs the VIP to the tenant node internal IPs, targeting
+  the Service `NodePort`.
+
+Traffic path:
+
+1. The client sends traffic to the VIP.
+2. The tenant VPC router DNATs the VIP to a node IP and `NodePort`.
+3. kube-proxy on that node performs the second hop to a backend pod.
+
+Because kube-proxy does the final hop, the client source IP is lost. The pod sees
+the node's address. This mode requires each Service port to have a `NodePort`
+allocated, which is the default for `type: LoadBalancer`. Use it when you don't
+need the client source IP.
+
+### Direct-to-pod routing
+
+With `podRoutes.enabled: true`, the LoadBalancer builds on [direct pod
+routing](#direct-pod-routing) and sends traffic straight to pods, preserving the
+client source IP. It replaces the node-routing service load balancer with two
+cooperating pieces:
+
+- The PodLBReconciler reconciles each Service into an `OvnEip` and a pod-mode
+  `RouterLBRule` with empty endpoints and selector. It stamps the generated
+  Service with `backendSubnet` as its `logical_switch`, so kube-ovn places the
+  VIP on the VPC's load balancer.
+- The EndpointSliceReplicator copies the tenant Service's EndpointSlices into the
+  control plane cluster namespace to supply the pod-IP backends.
+
+Traffic path:
+
+1. The client sends traffic to the VIP.
+2. The tenant VPC router DNATs the VIP straight to a pod IP, using the per-node
+   podCIDR routes to find the next hop.
+3. The backend pod receives the traffic and sees the real client source IP.
+
+Node routing and direct-to-pod routing don't run at the same time. Enabling
+`podRoutes.enabled` switches the LoadBalancer from one to the other. Use
+direct-to-pod routing when the workload needs the real client source IP, for
+example source-IP allowlists, logging, geo-routing, or mTLS by IP.
+
+:::warning In-place changes don't self-converge
+Switching an already-created LoadBalancer Service to direct-to-pod routing, by
+flipping `podRoutes.enabled` while the Service exists, doesn't converge on its
+own. Node routing leaves a stale v1 `Endpoints` object, created by kube-ovn's own
+RouterLBRule controller, that emptying `RouterLBRule.spec.endpoints` doesn't
+clear. kube-ovn unions it with the pod backends, giving a mixed datapath for a few
+minutes until the stale `Endpoints` is removed.
+
+Recreate the LoadBalancer Service after changing `podRoutes.enabled` rather than
+relying on an in-place change.
+:::
+
+## Prerequisites
+
+This feature sits on top of a specific kube-ovn topology on the control plane
+cluster. Everything below must already exist and be healthy before you enable the
+integration. The integration writes into these objects but doesn't create them.
+
+### Configure kube-ovn
+
+The cluster administrator must have the following in place on the control plane cluster.
+These are configured directly on kube-ovn and are outside the vCluster config
+surface.
+
+1. **kube-ovn deployed in secondary (non-primary CNI) mode.** The primary CNI,
+   for example flannel, keeps pod networking, services, and DNS. kube-ovn only
+   serves the tenant VPC overlay subnets and the external segment through Multus
+   secondary interfaces. On the kube-ovn install this requires `NON_PRIMARY_CNI:
+   true`, and `CNI_CONFIG_PRIORITY: "20"` so kube-ovn's conflist sorts after
+   `00-multus` and `10-flannel` rather than becoming the cluster CNI. The
+   `install-cni` step writes a conflist unconditionally with no non-primary
+   branch, so the priority is what keeps it out of the primary datapath.
+
+2. **Custom VPCs enabled.** Set `ENABLE_EXTERNAL_VPC: true` on the kube-ovn
+   install. Without it, the controller silently refuses to reconcile any `Vpc`
+   other than the default, and the tenant VPC objects reconcile to nothing.
+
+3. **The VPC and its subnets exist.** The `Vpc` named in `kubeOvn.vpc` and the
+   subnets named in `loadBalancers.externalSubnet` and
+   `loadBalancers.backendSubnet` must already exist. The KubeVirt node provider
+   creates these through NodeEnvironment properties. See [kube-ovn
+   networking](/docs/platform/administer/node-providers/kubevirt#kube-ovn-networking).
+
+4. **Provider network, uplink, and the external segment.** Configure a
+   `ProviderNetwork` with the node uplink NIC, a `Vlan`, and the external
+   `Subnet` that the VIPs are allocated from. The external subnet's name must
+   match kube-ovn's `--external-gateway-switch` flag, which defaults to
+   `external`, and the VPC must have `enableExternal: true` so it gets an LRP and
+   gateway chassis onto that segment.
+
+5. **Egress out of the custom VPC configured.** Tenant nodes need egress from the
+   VPC to reach external networks, for example to pull images. Enable it through
+   the NodeEnvironment's `kube-ovn.vcluster.com/egress-enabled` property. See
+   [kube-ovn
+   networking](/docs/platform/administer/node-providers/kubevirt#kube-ovn-networking).
+
+6. **A kube-ovn build that has the `RouterLBRule` CRD.** The integration drives
+   the `RouterLBRule` custom resource, which kube-ovn versions up to and including
+   1.16 don't ship. Use a kube-ovn build that includes it.
+
+## Related
+
+- [Private nodes overview](./overview.mdx)
+- [Join manually provisioned nodes](./join.mdx)
+- [Node requirements](./node-requirements.mdx)


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Documents the new kube-ovn integration for KubeVirt auto-nodes: attaching VMs to a kube-ovn network with the `managedtap` binding, having the platform provision the VPC/subnet/egress resources, and exposing tenant `LoadBalancer` services and direct pod routing through the embedded cloud-controller-manager's kube-ovn support.

## Preview Link 
<!-- The preview link or links to the documents-->
- https://deploy-preview-2633--vcluster-docs-site.netlify.app/docs/platform/next/administer/node-providers/kubevirt
- https://deploy-preview-2633--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/worker-nodes/private-nodes/kube-ovn

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

