### PR TITLE
graceful node drain on deprovisioning

### DIFF
--- a/platform/administer/node-providers/overview.mdx
+++ b/platform/administer/node-providers/overview.mdx
@@ -186,6 +186,10 @@ You can restrict the node types a project's NodeClaims may use with [`spec.allow
   <NodeClaimsDiagram style={{width: '100%', height: 'auto'}} role="img" aria-label="Node claims diagram" />
 </figure>
 
+:::info Graceful drain on deprovisioning
+When a NodeClaim is deleted, the platform first deletes the corresponding tenant cluster Node so its workloads evict gracefully, then waits until the Node is gone before destroying the underlying machine. If the drain does not complete within 30 minutes, the platform stops waiting on it and proceeds with teardown. If the tenant cluster is unreachable, the drain is skipped. Set the `vcluster.com/skip-node-drain` annotation on the NodeClaim to waive the drain and destroy the machine immediately, which is also what a force delete does.
+:::
+
 ## Node environments
 
 Node environments are optional and scoped to a single tenant cluster and node provider. Some node providers require one-time setup before they can create nodes. For example, a tenant cluster in AWS using the Terraform provider needs a VPC, routing tables, and subnets before deploying any nodes.

--- a/platform/administer/node-providers/overview.mdx
+++ b/platform/administer/node-providers/overview.mdx
@@ -166,7 +166,7 @@ Karpenter always tries to find the cheapest node and automatically provisions or
 
 ### Capacity
 
-Capacity is the number of available nodes for a given node type. The appropriate limit depends on the scenario. For bare-metal, for example, you may want to cap the number of usable machines.
+Capacity is the number of available nodes for a given node type. The appropriate limit depends on the scenario. For bare metal, for example, you may want to cap the number of usable machines.
 
 Depending on the provider, capacity is set manually or discovered automatically:
 * *Terraform*: set using `maxCapacity`, otherwise unlimited
@@ -187,7 +187,7 @@ You can restrict the node types a project's NodeClaims may use with [`spec.allow
 </figure>
 
 :::info Graceful drain on deprovisioning
-When a NodeClaim is deleted, the platform first deletes the corresponding tenant cluster Node so its workloads evict gracefully, then waits until the Node is gone before destroying the underlying machine. If the drain does not complete within 30 minutes, the platform stops waiting on it and proceeds with teardown. If the tenant cluster is unreachable, the drain is skipped. Set the `vcluster.com/skip-node-drain` annotation on the NodeClaim to waive the drain and destroy the machine immediately, which is also what a force delete does.
+When a NodeClaim is deleted, the platform first deletes the corresponding tenant cluster Node so its workloads evict gracefully. It then waits until the Node is gone before destroying the underlying machine. If the drain doesn't complete within 30 minutes, the platform stops waiting and proceeds with teardown. This is the same backstop that applies when the tenant cluster stays unreachable for that long. To skip the drain and destroy the machine immediately, set the `vcluster.com/skip-node-drain` annotation on the NodeClaim. Or click **Force delete** in the platform to do the same.
 :::
 
 ## Node environments


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

