### PR TITLE
docs: fix unsupported ??= operator and add missing pro label

### DIFF
--- a/platform/configure/platform-configs/single-sign-on.mdx
+++ b/platform/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.10.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.10.0/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.11.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.11.0/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.12.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.12.0/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.8.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.8.0/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/platform_versioned_docs/version-4.9.0/configure/platform-configs/single-sign-on.mdx
+++ b/platform_versioned_docs/version-4.9.0/configure/platform-configs/single-sign-on.mdx
@@ -2,6 +2,7 @@
 title: "SSO Providers"
 sidebar_label: "SSO Providers"
 sidebar_position: 1
+sidebar_class_name: pro
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";

--- a/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/patching/README.mdx
@@ -157,8 +157,8 @@ patches:
   - path: ""
     expression: |
       (value => {
-        value.metadata ??= {};
-        value.metadata.annotations ??= {};
+        if (!value.metadata) value.metadata = {};
+        if (!value.metadata.annotations) value.metadata.annotations = {};
         value.metadata.annotations["patched-by"] = "vcluster";
         return value;
       })(value)

--- a/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/configure/vcluster-yaml/sync/patching/README.mdx
@@ -157,8 +157,8 @@ patches:
   - path: ""
     expression: |
       (value => {
-        value.metadata ??= {};
-        value.metadata.annotations ??= {};
+        if (!value.metadata) value.metadata = {};
+        if (!value.metadata.annotations) value.metadata.annotations = {};
         value.metadata.annotations["patched-by"] = "vcluster";
         return value;
       })(value)

--- a/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/configure/vcluster-yaml/sync/patching/README.mdx
@@ -157,8 +157,8 @@ patches:
   - path: ""
     expression: |
       (value => {
-        value.metadata ??= {};
-        value.metadata.annotations ??= {};
+        if (!value.metadata) value.metadata = {};
+        if (!value.metadata.annotations) value.metadata.annotations = {};
         value.metadata.annotations["patched-by"] = "vcluster";
         return value;
       })(value)

--- a/vcluster_versioned_docs/version-0.37.0/configure/vcluster-yaml/sync/patching/README.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/configure/vcluster-yaml/sync/patching/README.mdx
@@ -157,8 +157,8 @@ patches:
   - path: ""
     expression: |
       (value => {
-        value.metadata ??= {};
-        value.metadata.annotations ??= {};
+        if (!value.metadata) value.metadata = {};
+        if (!value.metadata.annotations) value.metadata.annotations = {};
         value.metadata.annotations["patched-by"] = "vcluster";
         return value;
       })(value)


### PR DESCRIPTION
# Content Description
Fixes an empty-path patch example that used `??=`, which the vendored goja JS engine doesn't support (throws a SyntaxError at runtime). Also adds the missing `pro` sidebar label to the SSO Providers page, which documents Pro-only features but had no `sidebar_class_name`.

## Preview Link
<!-- The preview link or links to the documents-->
Netlify will post the deploy preview link as a comment on this PR.

## Internal Reference
Closes DOC-1722
Closes DOC-1726


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs