### PR TITLE
docs: document kubelet image pull ceiling for in-cluster registries

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -22,17 +22,17 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 
 
-Each tenant cluster runs its own DNS service using CoreDNS. This allows pods and services inside the tenant cluster to discover each other using standard Kubernetes DNS names such as `my-service.default.svc.cluster.local`. The syncer syncs the services necessary for DNS to function as expected.
+Each <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> runs its own DNS service using CoreDNS. This allows pods and services inside the tenant cluster to discover each other using standard Kubernetes DNS names such as `my-service.default.svc.cluster.local`. The <GlossaryTerm term="syncer">syncer</GlossaryTerm> syncs the services necessary for DNS to function as expected.
 
-This setup means that applications inside the tenant cluster cannot resolve names for services that only exist in the control plane cluster. Similarly, pods in the control plane cluster cannot discover services that only exist inside a tenant cluster. DNS resolution works entirely within the boundaries of the tenant cluster unless you configure external mappings explicitly.
+This setup means that applications inside the tenant cluster cannot resolve names for services that only exist in the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>. Similarly, pods in the control plane cluster cannot discover services that only exist inside a tenant cluster. DNS resolution works entirely within the boundaries of the tenant cluster unless you configure external mappings explicitly, using [replicateServices](../../networking/replicate-services.mdx) or [resolveDNS](../../networking/resolve-dns.mdx).
 
 :::note
-CoreDNS in the tenant cluster listens on port 1053, not the DNS port 53. This avoids privilege issues, especially when multiple tenant clusters run on the same control plane cluster. Port 53 is a privileged port and typically requires elevated permissions to bind. Blocked access to port 1053 prevents DNS resolution within the tenant cluster.
+CoreDNS in the tenant cluster listens on port 1053, not the DNS port 53. This avoids privilege issues, especially when multiple tenant clusters run on the same <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster. Port 53 is a privileged port and typically requires elevated permissions to bind. Blocked access to port 1053 prevents DNS resolution within the tenant cluster.
 :::
 
 ## Deployment types
 
-CoreDNS can deploy in two methods, either as a separate pod (default) or CoreDNS components can be embedded as part of the vCluster control plane pod. 
+CoreDNS can deploy in two methods, either as a separate pod (default) or CoreDNS components can be embedded as part of the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> control plane pod. 
 Each deployment type affects how the DNS service operates, how many pods the tenant cluster requires, and whether users can access and customize 
 the CoreDNS configuration from inside the tenant cluster.
 
@@ -44,7 +44,7 @@ the CoreDNS configuration from inside the tenant cluster.
 
 ### Deploy separate CoreDNS
 
-By default, vCluster creates a dedicated CoreDNS pod. The tenant cluster deployment includes two pods: one pod for the API server and syncer, and another for CoreDNS.
+By default, vCluster creates a dedicated CoreDNS pod. The tenant cluster deployment includes two pods: one pod for the <GlossaryTerm term="api-server">API server</GlossaryTerm> and syncer, and another for CoreDNS.
 
 CoreDNS is deployed as a standard Kubernetes deployment inside the tenant cluster. Users can view and modify the CoreDNS deployment using standard Kubernetes tools. DNS configuration is accessible, and you can apply changes or troubleshoot without restarting the tenant cluster's control plane.
 

--- a/vcluster/configure/vcluster-yaml/networking/advanced.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/advanced.mdx
@@ -11,13 +11,17 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-Each vCluster has its own DNS service, which is CoreDNS by default. DNS allows pods in the tenant cluster to get the IP addresses of services that are also running in the tenant cluster. The syncer ensures that the intuitive naming logic of Kubernetes DNS names for services applies, and that users can connect to these DNS names, which map to the IP address of the synchronized services that are present in the control plane cluster.
+Each <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> has its own DNS service, which is CoreDNS by default. DNS allows pods in the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> to get the IP addresses of services that are also running in the tenant cluster. The <GlossaryTerm term="syncer">syncer</GlossaryTerm> ensures that the intuitive naming logic of Kubernetes DNS names for services applies, and that users can connect to these DNS names, which map to the IP address of the synchronized services that are present in the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>.
 
-However, this also means that you cannot directly access host services inside the tenant cluster using DNS. Host pods can only access tenant cluster services by their synced name. vCluster offers a feature to map services from the tenant cluster to the control plane cluster and vice versa.
+However, this also means that you cannot directly access host services inside the tenant cluster using DNS. Host pods can only access tenant cluster services by their synced name. vCluster offers a feature to map services from the tenant cluster to the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster and vice versa.
 
 **Fallback to Host DNS**
 
 When you enable `fallbackHostCluster`, vCluster falls back to the control plane cluster's DNS for resolving domains. This is useful if the control plane cluster is using Istio or Dapr and the sidecar containers cannot connect to the central instance. It is also useful if you want to access the control plane cluster services from within the tenant cluster.
+
+:::note Kubelet image pulls aren't covered by this feature
+`fallbackHostCluster` changes DNS resolution for pods in the tenant cluster. It doesn't affect the kubelet, which resolves image references using the underlying node's own DNS configuration on shared nodes. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) if you need to pull images from a registry running on the control plane cluster.
+:::
 
 **`proxyKubelets`**
 

--- a/vcluster/configure/vcluster-yaml/networking/advanced.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/advanced.mdx
@@ -20,7 +20,7 @@ However, this also means that you cannot directly access host services inside th
 When you enable `fallbackHostCluster`, vCluster falls back to the control plane cluster's DNS for resolving domains. This is useful if the control plane cluster is using Istio or Dapr and the sidecar containers cannot connect to the central instance. It is also useful if you want to access the control plane cluster services from within the tenant cluster.
 
 :::note Kubelet image pulls aren't covered by this feature
-`fallbackHostCluster` changes DNS resolution for pods in the tenant cluster. It doesn't affect the kubelet, which resolves image references using the underlying node's own DNS configuration on shared nodes. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) if you need to pull images from a registry running on the control plane cluster.
+`fallbackHostCluster` changes DNS resolution for pods in the tenant cluster. It doesn't affect the container runtime, which resolves image references using the underlying node's own DNS configuration on shared nodes. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) if you need to pull images from a registry running on the control plane cluster.
 :::
 
 **`proxyKubelets`**

--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -10,7 +10,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-With open source vCluster, you need to replicate services between the control plane cluster and tenant cluster.
+With open source <GlossaryTerm term="vcluster">vCluster</GlossaryTerm>, you need to replicate services between the control plane cluster and <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>.
 
 ## Control plane cluster to tenant cluster
 
@@ -24,14 +24,18 @@ networking:
       to: my-virtual-namespace/my-virtual-service
 ```
 
-vCluster replicates the service in the tenant cluster, with the tenant cluster service pointing to the service running in the control plane cluster. Pods inside the tenant cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
+vCluster replicates the service in the tenant cluster, with the tenant cluster service pointing to the service running in the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>. Pods inside the tenant cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
 
 In the above example, when you remove the `my-host-namespace/my-host-service` service replication config from `networking.replicateServices.fromHost`,
 the tenant cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the tenant cluster.
 
+:::note Kubelet image pulls aren't covered by this feature
+`fromHost` creates a DNS record that the tenant cluster's CoreDNS resolves, so any process running inside a tenant pod, such as an application calling a private registry directly, can reach the replicated service by name. It doesn't help the kubelet pull container images referenced in a pod's `image:` field. On shared nodes, image pulls happen on the underlying node, using that node's own DNS configuration rather than the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) for how to pull images from an in-cluster registry.
+:::
+
 ## Tenant cluster to control plane cluster
 
-You can also map a tenant cluster service to a control plane cluster service. This is especially useful if you want to expose an application that runs inside the tenant cluster to other workloads running in the control plane cluster, which makes it easier to share services across vCluster instances.
+You can also map a tenant cluster service to a <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster service. This is especially useful if you want to expose an application that runs inside the tenant cluster to other workloads running in the control plane cluster, which makes it easier to share services across vCluster instances.
 
 In this example, you map the virtual service `my-virtual-service` in the namespace `my-virtual-namespace` to the host namespace service `my-host-service`
 

--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -30,7 +30,7 @@ In the above example, when you remove the `my-host-namespace/my-host-service` se
 the tenant cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the tenant cluster.
 
 :::note Kubelet image pulls aren't covered by this feature
-`fromHost` creates a DNS record that the tenant cluster's CoreDNS resolves, so any process running inside a tenant pod, such as an application calling a private registry directly, can reach the replicated service by name. It doesn't help the kubelet pull container images referenced in a pod's `image:` field. On shared nodes, image pulls happen on the underlying node, using that node's own DNS configuration rather than the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) for how to pull images from an in-cluster registry.
+`fromHost` creates a tenant cluster Service that CoreDNS resolves. A process inside a tenant pod, such as an application calling a private registry directly, can reach the replicated Service by name. It doesn't help the kubelet pull container images referenced in a pod's `image:` field. On shared nodes, the container runtime resolves image references using the underlying node's DNS configuration rather than the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx) for how to pull images from an in-cluster registry.
 :::
 
 ## Tenant cluster to control plane cluster

--- a/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -12,7 +12,7 @@ import TenancySupport from '../../../_fragments/tenancy-support.mdx';
 
 <TenancySupport hostNodes="true" />
 
-This feature enables adding custom DNS rules to the tenant cluster to allow communication with services deployed in the control plane cluster and across services in separate vCluster instances.
+This feature enables adding custom DNS rules to the <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> to allow communication with services deployed in the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster and across services in separate <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> instances.
 
 ## Examples
 
@@ -62,7 +62,7 @@ networking:
 
 ### Map a tenant cluster service to a control plane cluster service
 
-This example maps the tenant cluster's `my-namespace/my-svc` resource to the control plane cluster's `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
+This example maps the tenant cluster's `my-namespace/my-svc` resource to the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>'s `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
 
 ```yaml
 controlPlane:
@@ -75,6 +75,10 @@ networking:
       target:
         hostService: dns-test/nginx-svc
 ```
+
+:::note Kubelet image pulls aren't covered by this mapping
+This mapping is a tenant cluster CoreDNS record, so it works for a process inside a pod that resolves the hostname itself, such as an application calling a private registry directly. It doesn't help the kubelet pull container images referenced in a pod's `image:` field, since image pulls on shared nodes use the underlying node's own DNS, not the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx).
+:::
 
 ### Map services across vCluster instances
 

--- a/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -77,7 +77,7 @@ networking:
 ```
 
 :::note Kubelet image pulls aren't covered by this mapping
-This mapping is a tenant cluster CoreDNS record, so it works for a process inside a pod that resolves the hostname itself, such as an application calling a private registry directly. It doesn't help the kubelet pull container images referenced in a pod's `image:` field, since image pulls on shared nodes use the underlying node's own DNS, not the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx).
+This mapping is a tenant cluster CoreDNS record, so it works for a process inside a pod that resolves the hostname itself, such as an application calling a private registry directly. It doesn't help the kubelet pull container images referenced in a pod's `image:` field. On shared nodes, the container runtime uses the underlying node's DNS, not the tenant cluster's CoreDNS. See [Use a control plane cluster registry from a tenant cluster](../../../learn-how-to/in-cluster-registry.mdx).
 :::
 
 ### Map services across vCluster instances

--- a/vcluster/learn-how-to/in-cluster-registry.mdx
+++ b/vcluster/learn-how-to/in-cluster-registry.mdx
@@ -1,0 +1,88 @@
+---
+title: Use a control plane cluster registry from a tenant cluster
+sidebar_label: In-cluster registry access
+description: Pull images from a private registry running on the control plane cluster, from application code and from pod specs.
+sidebar_class_name: host-nodes private-nodes
+---
+
+import TenancySupport from '../_fragments/tenancy-support.mdx';
+
+<TenancySupport hostNodes="true" privateNodes="true" />
+
+A private OCI registry often runs as a `ClusterIP` Service on the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, reachable at an in-cluster FQDN such as `registry.ns.svc.cluster.local`. Whether a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> can reach it depends on who's doing the pulling.
+
+## Two ways a pod pulls an image
+
+A pod reaches the registry in one of two ways, and only one of them is helped by DNS changes inside the tenant cluster.
+
+**Application-level access.** Code running inside a pod, such as `crane`, `skopeo`, or a custom client using `go-containerregistry`, resolves the registry's hostname itself, through the pod's own DNS configuration.
+
+**Image pulls done by the kubelet.** When a pod spec references an image with `image: registry.ns.svc.cluster.local/my-image:tag`, the kubelet resolves that hostname and pulls the image through containerd, not the pod.
+
+`replicateServices.fromHost` only changes DNS resolution inside the tenant cluster's pod network, so it solves the first case and doesn't help with the second.
+
+## Application-level access
+
+Configure [`replicateServices.fromHost`](../configure/vcluster-yaml/networking/replicate-services.mdx) to map the registry's Service into the tenant cluster:
+
+```yaml title="vcluster.yaml"
+networking:
+  replicateServices:
+    fromHost:
+    - from: registry-ns/registry
+      to: my-virtual-namespace/registry
+```
+
+The tenant cluster's CoreDNS now resolves `registry.my-virtual-namespace` to the <GlossaryTerm term="control-plane">control plane</GlossaryTerm> cluster's registry Service. A pod that calls the registry directly, rather than through a pod spec's `image:` field, can reach it by that name. The tenant pod performs the pull itself, end to end.
+
+## Image pulls done by the kubelet
+
+On shared nodes there's no tenant kubelet. The underlying node's kubelet does the pulling, using the node's own `/etc/resolv.conf`, typically pointed at systemd-resolved rather than the tenant cluster's CoreDNS. `fromHost` doesn't change this, because it only affects the pod's DNS, not the node's.
+
+This is an upstream Kubernetes constraint, not a vCluster limitation. containerd can't depend on cluster DNS to pull images, including CoreDNS's own image, without a bootstrap circularity. Use one of the following instead.
+
+### NodePort
+
+Change the registry Service to `NodePort` and reference it by node hostname and port:
+
+```yaml title="registry-service.yaml"
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: registry-ns
+spec:
+  type: NodePort
+  ports:
+  - port: 5000
+    nodePort: 30500
+```
+
+```yaml title="Pod spec"
+image: <node-hostname>:30500/my-image:tag
+```
+
+This is the simplest option, but it changes every image reference to a node hostname and a non-standard port, and ties the reference to a specific node.
+
+### Redirect containerd with hosts.toml
+
+Keep the FQDN in image references, and redirect containerd to the registry at the OS layer instead of through DNS. Create `/etc/containerd/certs.d/registry.ns.svc.cluster.local/hosts.toml` on each node:
+
+```toml title="hosts.toml"
+server = "https://registry.ns.svc.cluster.local"
+
+[host."http://10.96.0.50:5000"]
+  capabilities = ["pull", "resolve"]
+```
+
+Point the `host` entry at the registry's `ClusterIP` or `NodePort` address instead of its FQDN. Resolving that FQDN from the node is exactly what fails, so the mirror entry needs an address the node can reach without it. Deploy a DaemonSet that writes this file to each node, so the configuration survives node scaling. containerd reads `hosts.toml` on each pull, so no restart or reload is needed. This is the cleanest option when preserving the FQDN in image references matters, and it follows containerd's own [registry host model](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+
+### Ingress with a resolvable hostname
+
+Expose the registry through an Ingress controller, using a hostname that resolves from the node's own DNS, such as a public or internal DNS zone the node already trusts. Reference that hostname in image specs instead of the in-cluster FQDN. This avoids per-node file management, at the cost of routing registry traffic through the ingress path.
+
+## Private nodes and vind
+
+The kubelet DNS ceiling above is specific to shared nodes, where tenant workloads run on the control plane cluster's own nodes and share its kubelet. With private nodes, each tenant cluster has its own kubelet running on its own dedicated nodes, so image pull redirection is a node-join setting rather than a DNS or DaemonSet workaround. Configure it through [`privateNodes.joinNode.containerd.registry`](../configure/vcluster-yaml/private-nodes/README.mdx#privateNodes-joinNode-containerd-registry) for nodes joined through kubeadm.
+
+vind doesn't use that setting. Its Docker driver serves images to worker node containers through a host-cache registry proxy instead. See [Deploy vind with restricted network access](../deploy/control-plane/docker-container/air-gapped.mdx) for how vind handles image pulls in a restricted-network environment.

--- a/vcluster/learn-how-to/in-cluster-registry.mdx
+++ b/vcluster/learn-how-to/in-cluster-registry.mdx
@@ -11,15 +11,19 @@ import TenancySupport from '../_fragments/tenancy-support.mdx';
 
 A private OCI registry often runs as a `ClusterIP` Service on the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>, reachable at an in-cluster FQDN such as `registry.ns.svc.cluster.local`. Whether a <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> can reach it depends on who's doing the pulling.
 
+:::note Registry authentication
+The options in this guide provide network reachability but don't provide registry credentials. For kubelet pulls, configure [`imagePullSecrets`](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) in the tenant workload namespace. Application-level clients need their own supported credential configuration.
+:::
+
 ## Two ways a pod pulls an image
 
 A pod reaches the registry in one of two ways, and only one of them is helped by DNS changes inside the tenant cluster.
 
 **Application-level access.** Code running inside a pod, such as `crane`, `skopeo`, or a custom client using `go-containerregistry`, resolves the registry's hostname itself, through the pod's own DNS configuration.
 
-**Image pulls done by the kubelet.** When a pod spec references an image with `image: registry.ns.svc.cluster.local/my-image:tag`, the kubelet resolves that hostname and pulls the image through containerd, not the pod.
+**Image pulls done by the kubelet.** When a pod spec references an image with `image: registry.ns.svc.cluster.local/my-image:tag`, the kubelet asks containerd to pull it. containerd resolves the hostname outside the pod.
 
-`replicateServices.fromHost` only changes DNS resolution inside the tenant cluster's pod network, so it solves the first case and doesn't help with the second.
+`replicateServices.fromHost` creates a tenant cluster Service that applications in tenant pods can resolve and reach. It doesn't configure DNS or registry access for the underlying nodes, so it solves the first case but not the second.
 
 ## Application-level access
 
@@ -37,13 +41,13 @@ The tenant cluster's CoreDNS now resolves `registry.my-virtual-namespace` to the
 
 ## Image pulls done by the kubelet
 
-On shared nodes there's no tenant kubelet. The underlying node's kubelet does the pulling, using the node's own `/etc/resolv.conf`, typically pointed at systemd-resolved rather than the tenant cluster's CoreDNS. `fromHost` doesn't change this, because it only affects the pod's DNS, not the node's.
+On shared nodes there's no tenant kubelet. The underlying node's kubelet asks its container runtime to pull the image. The runtime uses the node's DNS configuration rather than the tenant cluster's CoreDNS. `fromHost` doesn't change the node's configuration.
 
 This is an upstream Kubernetes constraint, not a vCluster limitation. containerd can't depend on cluster DNS to pull images, including CoreDNS's own image, without a bootstrap circularity. Use one of the following instead.
 
 ### NodePort
 
-Change the registry Service to `NodePort` and reference it by node hostname and port:
+Change the existing registry Service to `NodePort`. Preserve its selector and any other settings when you update it. This example assumes the registry pods use the `app: registry` label:
 
 ```yaml title="registry-service.yaml"
 apiVersion: v1
@@ -53,20 +57,47 @@ metadata:
   namespace: registry-ns
 spec:
   type: NodePort
+  selector:
+    app: registry
   ports:
   - port: 5000
+    targetPort: 5000
     nodePort: 30500
 ```
+
+Ensure the registry presents a trusted TLS certificate that is valid for `<node-hostname>`. containerd uses HTTPS for registry endpoints by default. If the registry serves plain HTTP or its certificate doesn't match the node hostname, use the containerd host configuration in the next section.
 
 ```yaml title="Pod spec"
 image: <node-hostname>:30500/my-image:tag
 ```
 
-This is the simplest option, but it changes every image reference to a node hostname and a non-standard port, and ties the reference to a specific node.
+Kubernetes exposes the same NodePort on every eligible node. Use a stable node address or hostname that the nodes themselves can resolve. This option changes every image reference to a node address and a non-standard port.
 
 ### Redirect containerd with hosts.toml
 
-Keep the FQDN in image references, and redirect containerd to the registry at the OS layer instead of through DNS. Create `/etc/containerd/certs.d/registry.ns.svc.cluster.local/hosts.toml` on each node:
+Keep the FQDN in image references, and redirect containerd to the registry at the OS layer instead of through DNS.
+
+First, verify that the containerd CRI plugin loads registry host configurations from `/etc/containerd/certs.d`. For containerd 2.x, `/etc/containerd/config.toml` needs this configuration:
+
+```toml title="containerd 2.x"
+version = 3
+
+[plugins."io.containerd.cri.v1.images".registry]
+  config_path = "/etc/containerd/certs.d"
+```
+
+For containerd 1.x, use the following configuration instead:
+
+```toml title="containerd 1.x"
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+```
+
+Restart containerd after adding or changing `config_path`. Follow your node maintenance procedure when restarting the runtime. You can skip the restart if `config_path` already has the correct value.
+
+Create `/etc/containerd/certs.d/registry.ns.svc.cluster.local/hosts.toml` on each node:
 
 ```toml title="hosts.toml"
 server = "https://registry.ns.svc.cluster.local"
@@ -75,7 +106,9 @@ server = "https://registry.ns.svc.cluster.local"
   capabilities = ["pull", "resolve"]
 ```
 
-Point the `host` entry at the registry's `ClusterIP` or `NodePort` address instead of its FQDN. Resolving that FQDN from the node is exactly what fails, so the mirror entry needs an address the node can reach without it. Deploy a DaemonSet that writes this file to each node, so the configuration survives node scaling. containerd reads `hosts.toml` on each pull, so no restart or reload is needed. This is the cleanest option when preserving the FQDN in image references matters, and it follows containerd's own [registry host model](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
+Point the `host` entry at the registry's `ClusterIP` or `NodePort` address instead of its FQDN. The mirror entry needs an address the node can reach without resolving the registry FQDN.
+
+Deploy a DaemonSet that writes this file to each node, so the configuration also reaches newly scaled nodes. After you configure `config_path`, containerd loads `hosts.toml` changes without a restart. This approach preserves the FQDN in image references and follows containerd's [registry host model](https://github.com/containerd/containerd/blob/main/docs/hosts.md).
 
 ### Ingress with a resolvable hostname
 


### PR DESCRIPTION
# Content Description
Adds a how-to guide distinguishing application-level registry access (works via `replicateServices.fromHost`/`resolveDNS`) from kubelet image pulls (which use the node's own DNS and aren't covered by either feature), and cross-links it from the DNS-mapping pages that stop short of the kubelet.

## Preview Link
https://deploy-preview-2644--vcluster-docs-site.netlify.app/docs/vcluster/next/learn-how-to/in-cluster-registry

## Internal Reference
Closes DOC-1470

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs