### PR TITLE
fix(accessibility): Button props, labeled inputs, non-text contrast

### DIFF
--- a/platform/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform/administer/users-permissions/managing-users/impersonate.mdx
@@ -83,7 +83,7 @@ how vCluster Platform UI appears for the newly created user:
   </Step>
   <Step>
     Find the user `Anna` in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"
@@ -150,7 +150,7 @@ After configuring the cluster access for test user Anna, verify that she can acc
   </Step>
   <Step>
     Find the user Anna in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"

--- a/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.11.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -83,7 +83,7 @@ how vCluster Platform UI appears for the newly created user:
   </Step>
   <Step>
     Find the user `Anna` in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"
@@ -150,7 +150,7 @@ After configuring the cluster access for test user Anna, verify that she can acc
   </Step>
   <Step>
     Find the user Anna in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"

--- a/platform_versioned_docs/version-4.12.0/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform_versioned_docs/version-4.12.0/administer/users-permissions/managing-users/impersonate.mdx
@@ -83,7 +83,7 @@ how vCluster Platform UI appears for the newly created user:
   </Step>
   <Step>
     Find the user `Anna` in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"
@@ -150,7 +150,7 @@ After configuring the cluster access for test user Anna, verify that she can acc
   </Step>
   <Step>
     Find the user Anna in the list of users and click the{" "}
-    <Button>
+    <Button aria-label="Impersonate user">
       <svg
         viewBox="64 64 896 896"
         focusable="false"

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
 
-export default function Button({ children }) {
-  return <button>{children}</button>;
+export default function Button({ children, ...props }) {
+  return <button {...props}>{children}</button>;
 }

--- a/src/components/Icon/styles.module.css
+++ b/src/components/Icon/styles.module.css
@@ -10,7 +10,7 @@
 }
 
 .checkmark {
-  color: #f27506; /* Orange in light mode - matches FeatureTable */
+  color: #cc5100; /* Orange in light mode - matches FeatureTable; WCAG AA non-text contrast */
 }
 
 .cross {

--- a/src/components/InterpolatedCodeBlock/index.js
+++ b/src/components/InterpolatedCodeBlock/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import { useLocation } from '@docusaurus/router';
 import { useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
@@ -9,6 +9,8 @@ const LATEST_VERSIONS = {
   platform: '4.11.2',
   vcluster: '0.36.1',
 };
+
+const varInputId = (instanceId, key) => `var-${instanceId}-${key.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
 /**
  * InterpolatedCodeBlock - Interactive code block with editable variables
@@ -56,6 +58,7 @@ const LATEST_VERSIONS = {
  * @param {string} title - Optional title for the code block
  */
 const InterpolatedCodeBlock = ({ code = '', language = 'bash', title }) => {
+  const instanceId = useId();
   // Get global variables from page store
   const globalVariables = usePageVariables();
   const location = useLocation();
@@ -169,7 +172,8 @@ const InterpolatedCodeBlock = ({ code = '', language = 'bash', title }) => {
             }}
           >
             <label
-              style={{ 
+              htmlFor={varInputId(instanceId, key)}
+              style={{
                 minWidth: '150px',
                 color: 'var(--ifm-font-color-base)', /* Regular text color */
                 fontSize: '0.9rem',
@@ -180,11 +184,12 @@ const InterpolatedCodeBlock = ({ code = '', language = 'bash', title }) => {
               {key}
             </label>
             <input
+              id={varInputId(instanceId, key)}
               type="text"
               value={values[key] || ''}
               onChange={(e) => setValues(prev => ({ ...prev, [key]: e.target.value }))}
               placeholder={defaultValue}
-              style={{ 
+              style={{
                 backgroundColor: 'rgba(255, 255, 255, 0.7)',
                 border: '1px solid var(--ifm-color-emphasis-300)',
                 borderRadius: 'var(--ifm-global-radius)',

--- a/src/components/PageVariables/index.js
+++ b/src/components/PageVariables/index.js
@@ -1,5 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useId } from 'react';
 import { setPageVariables, updatePageVariable, usePageVariables } from './PageVariablesContext';
+
+const varInputId = (instanceId, key) => `var-${instanceId}-${key.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
 /**
  * PageVariables - Define global variables for use across multiple code blocks
@@ -29,6 +31,7 @@ import { setPageVariables, updatePageVariable, usePageVariables } from './PageVa
  * @param {Object} props - All props become available as page variables
  */
 const PageVariables = (props) => {
+  const instanceId = useId();
   // Initialize variables IMMEDIATELY (synchronously) before first render
   // Use a ref to ensure this only happens once
   const initializedRef = React.useRef(false);
@@ -78,6 +81,7 @@ const PageVariables = (props) => {
           }}
         >
           <label
+            htmlFor={varInputId(instanceId, key)}
             style={{
               minWidth: '200px',
               color: 'var(--ifm-font-color-base)',
@@ -89,6 +93,7 @@ const PageVariables = (props) => {
             {key}
           </label>
           <input
+            id={varInputId(instanceId, key)}
             type="text"
             value={currentValues[key] || defaultValue}
             onChange={(e) => updatePageVariable(key, e.target.value)}

--- a/src/css/content/config-fields.scss
+++ b/src/css/content/config-fields.scss
@@ -191,7 +191,7 @@ body .markdown .config-field {
       font-weight: 700;
       letter-spacing: 0.3px;
       color: #fff;
-      background: #f27506;
+      background: #cc5100;
       border-radius: 3px;
       line-height: 110%;
       text-indent: 0;


### PR DESCRIPTION
<!--
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it.
In this case, follow the instructions from vale and fix the linting issues.
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

Three accessibility fixes bundled together since they're small and independent:

- **DOC-1412**: `Button` didn't spread props, so `aria-label` never reached the underlying `<button>`. Icon-only buttons had no accessible name (WCAG 4.1.2). Fixed the component and added `aria-label` to the two live icon-only `<Button>` call sites, both in `impersonate.mdx`. (Several other icon-only `<Button>` usages exist in the tree, but they're all in partial files nothing imports — left untouched as dead code.)
- **DOC-1413**: `InterpolatedCodeBlock` and `PageVariables` inputs had no programmatic label (WCAG 1.3.1, 3.3.2). Added `id`/`htmlFor` pairing via `useId()`, scoped per component instance rather than just the variable name — several pages reuse the same variable name (e.g. `NAMESPACE`) across multiple code blocks, and a bare `var-<name>` id would have produced duplicate DOM ids across those blocks.
- **DOC-1414**: `#f27506` (checkmark icon, PRO badge) measures ~2.87:1 against white, below the WCAG 1.4.11 non-text-contrast floor of 3:1. Used `#CC5100` (brand pressed-orange) instead of the ticket's literal `#FF6600` suggestion — recalculated both and `#FF6600` measures ~2.94:1 (still fails 3:1; the ticket's cited 3.09:1 doesn't hold up), while `#CC5100` measures ~4.43:1.

All three verified against a production `npm run build` (grepped the rendered static HTML for the `aria-label`, `id`/`for` pairing across multiple `InterpolatedCodeBlock` instances, and the new hex values in compiled CSS).

## Preview Link
Netlify will post a preview link on this PR.

## Internal Reference
Closes DOC-1412
Closes DOC-1413
Closes DOC-1414

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs