### PR TITLE
Fix link to auto nodes in src/data/features.yaml

### DIFF
--- a/platform/maintenance/observability/configure-edge-collectors.mdx
+++ b/platform/maintenance/observability/configure-edge-collectors.mdx
@@ -3,6 +3,7 @@ title: Configure edge collectors
 sidebar_label: Configure collectors
 sidebar_position: 5
 description: Configure OpenTelemetry Collectors to send fleet metrics to the vCluster observability Write Gateway.
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/observability/configure-metrics-access.mdx
+++ b/platform/maintenance/observability/configure-metrics-access.mdx
@@ -3,6 +3,7 @@ title: Configure metrics access
 sidebar_label: Configure access
 sidebar_position: 4
 description: Create metrics-writer and metrics-reader access keys for the Fleet Observability gateway.
+sidebar_class_name: pro
 ---
 
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";

--- a/platform/maintenance/observability/gpu-observability-templates.mdx
+++ b/platform/maintenance/observability/gpu-observability-templates.mdx
@@ -3,6 +3,7 @@ title: Deploy GPU observability with Argo CD
 sidebar_label: GPU observability templates
 sidebar_position: 7
 description: Overview of the GPU observability Argo CD templates that vCluster Platform ships, the order to deploy them in, which DCGM metric family each produces, and how to tear the stack down.
+sidebar_class_name: pro
 ---
 
 When the [Argo CD integration](../../integrations/argocd/overview.mdx) is enabled,

--- a/platform/maintenance/observability/install-observability-gateway.mdx
+++ b/platform/maintenance/observability/install-observability-gateway.mdx
@@ -3,6 +3,7 @@ title: Install the observability gateway
 sidebar_label: Install gateway
 sidebar_position: 3
 description: Create the Fleet Observability connector that deploys the Write Gateway and Query Proxy.
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/observability/labels-reference.mdx
+++ b/platform/maintenance/observability/labels-reference.mdx
@@ -3,6 +3,7 @@ title: Fleet Observability labels reference
 sidebar_label: Labels reference
 sidebar_position: 9
 description: Reference for vcluster_platform labels stamped by the Fleet Observability Write Gateway.
+sidebar_class_name: pro
 ---
 
 The Write Gateway owns the full `vcluster_platform_*` label namespace. These labels are

--- a/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
+++ b/platform/maintenance/observability/nvsentinel-gpu-observability.mdx
@@ -3,6 +3,7 @@ title: Observe GPU nodes with NVSentinel
 sidebar_label: NVSentinel GPU observability
 sidebar_position: 8
 description: Deploy NVIDIA NVSentinel with the bundled Argo CD template to detect, quarantine, and remediate GPU node faults, and understand dry-run mode and teardown cleanup.
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/observability/overview.mdx
+++ b/platform/maintenance/observability/overview.mdx
@@ -3,6 +3,7 @@ title: Fleet Observability
 sidebar_label: Overview
 sidebar_position: 1
 description: Monitor tenant clusters across your vCluster Platform fleet with an observability gateway, scoped access keys, and platform-owned metric labels.
+sidebar_class_name: pro
 ---
 
 import FleetObservabilityArchitecture from '@site/static/media/diagrams/fleet-observability-architecture.svg';

--- a/platform/maintenance/observability/query-fleet-metrics.mdx
+++ b/platform/maintenance/observability/query-fleet-metrics.mdx
@@ -3,6 +3,7 @@ title: Query fleet metrics
 sidebar_label: Query metrics
 sidebar_position: 6
 description: Query fleet metrics through the Fleet Observability Query Proxy with scoped headers and platform-owned labels.
+sidebar_class_name: pro
 ---
 
 import Tabs from "@theme/Tabs";

--- a/platform/maintenance/observability/quickstart.mdx
+++ b/platform/maintenance/observability/quickstart.mdx
@@ -3,6 +3,7 @@ title: Fleet Observability quickstart
 sidebar_label: Quickstart
 sidebar_position: 2
 description: Deploy the default Fleet Observability pipeline end to end with Argo CD, from the metrics backend to your first query.
+sidebar_class_name: pro
 ---
 
 import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -3,6 +3,7 @@ title: Troubleshooting Fleet Observability
 sidebar_label: Troubleshooting
 sidebar_position: 10
 description: Diagnose common Fleet Observability gateway, access-key, collector, and query-proxy problems.
+sidebar_class_name: pro
 ---
 
 Use this page to diagnose the Fleet Observability path from edge collectors through the

--- a/platform/understand/what-are-apps.mdx
+++ b/platform/understand/what-are-apps.mdx
@@ -2,6 +2,7 @@
 title: What are Apps
 sidebar_label: What Are Apps
 sidebar_position: 6
+sidebar_class_name: free
 ---
 import FeatureTable from '@site/src/components/FeatureTable';
 

--- a/platform/use-platform/namespaces/create/create-with-template.mdx
+++ b/platform/use-platform/namespaces/create/create-with-template.mdx
@@ -2,6 +2,7 @@
 title: Create Namespace from Templates
 sidebar_label: Create from Template
 sidebar_position: 1
+sidebar_class_name: free
 ---
 
 import Tabs from '@theme/Tabs';
@@ -22,7 +23,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 Once you have created a namespace template you can then refer to that template when
 creating a new namespace. All template configurations will be automatically applied to the
 newly created namespace. Namespaces referring to templates can be created in the UI
-or via the vCluster CLI.
+or using the vCluster CLI.
 
 <Tabs
     defaultValue="ui"
@@ -39,7 +40,7 @@ or via the vCluster CLI.
   </Tabs>
 
 
-## Template Version Strings
+## Template version strings
 
 Regardless of how you create a namespace from a template, either by the UI or the CLI, vCluster Platform
 allows you to provide a template version string. If you do not provide this string, the latest

--- a/scripts/sync-feature-tables.js
+++ b/scripts/sync-feature-tables.js
@@ -81,9 +81,12 @@ function resolveFilePath(filePath) {
     return filePath;
   }
 
-  // Try README.mdx
+  // Try treating the URL's final path segment as a directory containing an
+  // index page: <dir>/<basename-without-extension>/README.mdx
+  // e.g. .../sync/patching.mdx -> .../sync/patching/README.mdx
   const dir = path.dirname(filePath);
-  const readmePath = path.join(dir, 'README.mdx');
+  const base = path.basename(filePath, path.extname(filePath));
+  const readmePath = path.join(dir, base, 'README.mdx');
   if (fs.existsSync(readmePath)) {
     return readmePath;
   }

--- a/src/data/features.yaml
+++ b/src/data/features.yaml
@@ -46,6 +46,7 @@ features:
     name: "Sync Patches"
     description: "Sync Patches provide an option to alter the vCluster sync process by defining patches applied to objects during sync."
     category: "vCluster Pro Distro"
+    docs_url: "/docs/vcluster/configure/vcluster-yaml/sync/patching"
   vcp-distro-embedded-etcd:
     name: "Embedded etcd"
     description: "Embedded etcd is as lightweight as k3s+sqlite but optimized for HA and scalability designed for production workloads."

--- a/src/data/features.yaml
+++ b/src/data/features.yaml
@@ -147,7 +147,7 @@ features:
     name: "Private Nodes Auto Nodes"
     description: "Private Nodes Auto Nodes automatically scales up and down and provisions private nodes for virtual clusters."
     category: "vCluster Pro Distro"
-    docs_url: "/docs/vcluster/configure/vcluster-yaml/private-nodes"
+    docs_url: "/docs/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes"
   standalone:
     name: "Standalone"
     description: "Standalone is an alternative deployment model, where vCluster is installed directly onto bare-metal or VM nodes."

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/kube-vip.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/kube-vip.mdx
@@ -3,7 +3,7 @@ title: Kube-vip
 sidebar_label: kubeVip
 sidebar_position: 4
 description: Configure embedded kube-vip for tenant cluster control plane.
-sidebar_class_name: private-nodes
+sidebar_class_name: pro private-nodes
 ---
 
 import KubeVipConfig from '../../../../../_partials/config/controlPlane/advanced/kubeVip.mdx'
@@ -52,8 +52,8 @@ controlPlane:
 
 ### Configuration options
 
-- **`interface`** - The network interface on which the VIP is announced (e.g., `eth0`, `ens192`). When using in conjunction with Multus, this is normally `net1`.
-- **`gateway`** - The gateway address in CIDR notation (e.g., `10.100.0.1/24`). This is used to configure policy-based routing for the VIP and must include the subnet prefix.
+- **`interface`** - The network interface on which the VIP is announced (for example, `eth0`, `ens192`). When using in conjunction with Multus, this is normally `net1`.
+- **`gateway`** - The gateway address in CIDR notation (for example, `10.100.0.1/24`). This is used to configure policy-based routing for the VIP and must include the subnet prefix.
 
 ## Example
 
@@ -108,8 +108,8 @@ networking:
 
 ## Limitations
 
-- The network interface specified must exist on the vCluster control plane instances (e.g. through Multus)
-- The VIP must be routable from the worker nodes (layer 3), e.g. through the specified gateway
+- The network interface specified must exist on the vCluster control plane instances (for example, through Multus)
+- The VIP must be routable from the worker nodes (layer 3), for example through the specified gateway
 - Embedded Kube-vip currently only supports ARP mode. Other features such as BGP are not supported or configurable.
 
 ## Security considerations

--- a/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/README.mdx
@@ -9,6 +9,10 @@ slug: /configure/vcluster-yaml/private-nodes
 import PrivateNodesYaml from '../../../_fragments/private-nodes.mdx'
 import PrivateNodes from '../../../_partials/config/privateNodes.mdx'
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
+import FeatureTable from '@site/src/components/FeatureTable';
+
+<FeatureTable names="vcp-distro-private-nodes,private-nodes-vpn" />
+
 
 <TenancySupport privateNodes="true" standalone="true"/>
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/auto-nodes.mdx
@@ -2,11 +2,16 @@
 title: Auto Nodes
 sidebar_label: autoNodes
 sidebar_position: 1
+sidebar_class_name: free private-nodes
 ---
 
 import AutoNodes from '../../../_fragments/deploy/auto-nodes.mdx';
 import AutoNodesScheduling from '../../../_fragments/deploy/auto-nodes-scheduling.mdx';
 import PrivateNodesAutoNodes from '../../../_partials/config/privateNodes/autoNodes.mdx';
+import FeatureTable from '@site/src/components/FeatureTable';
+
+<FeatureTable names="private-nodes-auto-nodes" />
+
 
 
 

--- a/vcluster/configure/vcluster-yaml/private-nodes/vpn.mdx
+++ b/vcluster/configure/vcluster-yaml/private-nodes/vpn.mdx
@@ -2,7 +2,7 @@
 title: vCluster VPN
 sidebar_label: vpn
 sidebar_position: 2
-sidebar_class_name: private-nodes 
+sidebar_class_name: free private-nodes
 ---
 
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';

--- a/vcluster/third-party-integrations/pod-identity/_category_.json
+++ b/vcluster/third-party-integrations/pod-identity/_category_.json
@@ -2,5 +2,5 @@
     "label": "Pod Identity",
     "position": "4",
     "collapsible": false,
-    "className": "pro"
+    "className": "free"
   }

--- a/vcluster/third-party-integrations/rancher/install-rancher-integration.mdx
+++ b/vcluster/third-party-integrations/rancher/install-rancher-integration.mdx
@@ -2,7 +2,7 @@
 title: Install the Rancher integration in vCluster
 sidebar_label: Rancher Integration
 sidebar_position: 1
-sidebar_class_name: pro
+sidebar_class_name: free
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Started as a one-line fix: the "Private Nodes Auto Nodes" row in [the features table](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/) linked to the private nodes page instead of the auto nodes page. Fixing that link surfaced a build error (the target page had no canonical `FeatureTable`), which led to a full audit of the feature-table system. Scope expanded to:

- **Root fix:** `auto-nodes.mdx` now has its canonical `<FeatureTable>`.
- **Sync script bug:** `scripts/sync-feature-tables.js` resolved directory-index `docs_url`s (e.g. `.../private-nodes`) against the parent directory's `README.mdx` instead of the target directory's, silently misplacing the `Private Nodes` and `Private Nodes VPN` feature tables onto the general vcluster.yaml overview page. Fixed the resolver and re-synced.
- **Missing `docs_url`:** added for `vcp-distro-sync-patches` (page existed, wasn't registered).
- **Sidebar tier badges:** added missing/incorrect `free`/`pro` badges on 15 pages found out of sync with `plans/*.yaml` (private-nodes auto-nodes/vpn, `kube-vip.mdx`, `what-are-apps.mdx`, `create-with-template.mdx`, and the 10 pages under `platform/maintenance/observability/`, which relied on category-level `className` that doesn't propagate to child pages).
- **DOC-1733:** fixed two additional mislabeled Enterprise tags found via Linear/Slack during this pass — `install-rancher-integration.mdx` and the `pod-identity` category were both marked `pro` with no license-gated feature behind either (the new Rancher operator is Apache-2.0/ungated; pod identity is standard Kubernetes SA config). Both relabeled `free`.

`npm run validate-feature-tables` passes clean.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1733

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
