### PR TITLE
fix(redirects): add redirect for removed design-principles page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1920,6 +1920,12 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
   to = "/docs/vcluster/introduction/architecture#worker-nodes"
   status = 301
 
+# DOC-1735: design-principles.mdx deleted in #1889 but missed a redirect
+[[redirects]]
+  from = "/docs/vcluster/introduction/design-principles"
+  to = "/docs/vcluster/introduction/architecture"
+  status = 301
+
 [[redirects]]
   from = "/docs/platform/understand/what-are-virtual-clusters"
   to = "/docs/vcluster/introduction/what-is-vcluster"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds a missing 301 redirect for `/docs/vcluster/introduction/design-principles`, which has 404'd since the page was deleted in #1889. Its sibling deletion in that same PR (`tenancy-model.mdx`) got a redirect; this one was missed.

## Preview Link 
N/A (redirect-only change to netlify.toml)

## Internal Reference
Part of DOC-1735 (the other issue in that ticket, about Pro pages, is left for devops)

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs