### PR TITLE
chore(ci): pin docs-backport-action to v1.3.1

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Backport Docusaurus Changes
-        uses: loft-sh/docs-backport-action@v1
+        uses: loft-sh/docs-backport-action@v1.3.1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
`.github/workflows/backport-docs.yml` pins `loft-sh/docs-backport-action@v1`, a floating tag that currently resolves to a commit predating [#117](https://github.com/loft-sh/docs-backport-action/pull/117) (backport file deletions and renames to versioned docs) and [#128](https://github.com/loft-sh/docs-backport-action/pull/128) (read file content from the merge commit rather than head, so 3-way-merge reconciliation on main isn't missed). As a result, any backport PR that deletes or renames a source file currently leaves the old file behind, orphaned, in every versioned docs folder it touches.

Pins to `v1.3.1`, the latest `v1.x` release, which includes both fixes. Verified via `git log`/`git tag` on the action's own repo that `v1` predates `5e342fa` (the deletion/rename feature) and that `v1.3.1` includes it.

## Preview Link 
<!-- The preview link or links to the documents-->
N/A — CI workflow change, no docs content affected.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
No Linear ticket. Found while planning backports for #2664.


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs