### PR TITLE
docs(stacks): Update for v2 certified stacks and the new run:ai

### DIFF
--- a/platform/integrations/certified-stacks/index.mdx
+++ b/platform/integrations/certified-stacks/index.mdx
@@ -1,57 +1,35 @@
 ---
-title: Certified Stacks
+title: NVIDIA Run:ai integration
 sidebar_label: Overview
 sidebar_position: 1
 ---
 
-Certified Stacks are tested, versioned, one-command deployments of a vCluster plus a complete
-application stack. Each stack handles provisioning, dependency orchestration, and configuration
-automatically, so platform teams can go from zero to a fully configured tenant cluster environment
-without manual integration work.
+import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
 
-Stacks are maintained in the [certified-stacks](https://github.com/loft-sh/certified-stacks)
-repository. The repo contains full documentation, usage instructions, and architecture details
-for each stack.
+[NVIDIA Run:ai](https://www.run.ai/) manages AI workloads and GPU resources on Kubernetes.
+vCluster gives each team an isolated tenant cluster while NVIDIA Run:ai manages workloads across the GPU infrastructure.
 
-## Why use certified stacks
+Use the [NVIDIA Run:ai documentation](https://docs.run.ai/) for installation, configuration, and workload management.
 
-Deploying applications on top of Kubernetes involves stitching together multiple
-components — operators, controllers, CRDs, Helm charts — and getting the sequencing and
-configuration right across all of them. Certified Stacks eliminate that gap by providing
-pre-built, tested configurations that work out of the box.
+## Use NVIDIA Run:ai with vCluster
 
-- **Tenant isolation out of the box.** Stacks ship with pre-built configurations for both private and
-  shared node models, so platform teams can match their worker node architecture to their security
-  and performance requirements without custom integration work.
-- **Built on validated reference architectures.** Each stack extends partner-published reference
-  architectures with additional deployment flexibility and tenancy options.
-- **Forkable and extensible.** Every stack is a starting point, not a black box. Fork the repo,
-  modify Helm values, swap components, or adapt the orchestration to your environment.
+Use vCluster when teams need separate Kubernetes APIs and workloads must use shared GPU infrastructure.
+Each team works in its own tenant cluster. NVIDIA Run:ai schedules their workloads on GPUs in the control plane cluster.
 
-## Worker node models
+Choose a worker node model that matches tenant trust and access requirements:
 
-Each stack supports two worker node models:
+- Use private nodes for untrusted tenants or tenants with compliance requirements.
+- Use shared nodes for trusted tenants, such as internal development, testing, and CI/CD teams.
+- Use standalone mode for one team with a dedicated GPU pool.
 
-| Model | Description | Use case |
-|-------|-------------|----------|
-| **Private nodes** | Each tenant gets a dedicated tenant cluster with private auto-provisioned nodes. Full isolation of control plane, GPU operators, drivers, and networking. | Untrusted tenants, strict compliance requirements |
-| **Shared nodes** | Tenants share Control Plane Cluster nodes via label-based assignment. Each tenant gets its own tenant cluster with a separate Kubernetes API and workload scheduling. | Trusted tenants, cost-efficient shared infrastructure |
+<SharedNodesSuitability />
 
-## Available stacks
+For shared nodes, enable NetworkPolicy and verify that your CNI enforces it.
 
-| Stack | Components |
-|-------|-----------|
-| **NVIDIA Run:ai** | vCluster, NVIDIA GPU Operator, NVIDIA Run:ai |
-| **Slinky (Slurm)** | vCluster, NVIDIA GPU Operator, Slurm via Slinky operator |
+## Legacy certified stacks
 
-## Get started
+vCluster previously provided Certified Stacks with prebuilt configurations for NVIDIA Run:ai and Slinky (Slurm).
+These configurations remain available for existing deployments and reference use.
 
-For detailed setup instructions, prerequisites, and configuration options, see the
-[certified-stacks repository](https://github.com/loft-sh/certified-stacks).
-
-## Build your own stack
-
-Certified Stacks are designed to be customized. You can fork the repository and adapt any stack
-to your environment, or use the existing stacks as a reference for building your own. See the
-[repository README](https://github.com/loft-sh/certified-stacks) for code style conventions and
-module structure.
+- [NVIDIA Run:ai legacy certified stack](./runai.mdx)
+- [Certified Stacks repository](https://github.com/loft-sh/certified-stacks)

--- a/platform/integrations/certified-stacks/runai.mdx
+++ b/platform/integrations/certified-stacks/runai.mdx
@@ -1,15 +1,17 @@
 ---
-title: NVIDIA Run:ai
-sidebar_label: NVIDIA Run:ai
+title: NVIDIA Run:ai legacy certified stack
+sidebar_label: Legacy certified stack
 sidebar_position: 2
 ---
 
-[NVIDIA Run:ai](https://www.run.ai/) is a GPU orchestration platform that schedules and manages AI and
-machine learning workloads across Kubernetes clusters. vCluster is a certified Kubernetes Distribution for hosting NVIDIA Run:ai that lets platform teams
-share GPU infrastructure across isolated tenants without provisioning separate physical clusters for each team.
+import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
 
-Compatibility has been verified with the following versions.
+This page documents the legacy NVIDIA Run:ai Certified Stack.
+Use the [NVIDIA Run:ai integration overview](./index.mdx) for current guidance.
 
+## Compatibility
+
+This Certified Stack was verified with these versions:
 
 | Component | Version |
 |-----------|---------|
@@ -19,25 +21,17 @@ Compatibility has been verified with the following versions.
 
 ## Deployment models
 
-vCluster supports all three deployment models with NVIDIA Run:ai:
+The legacy stack supports three worker node models:
 
 | Model | Description | Use case |
 |-------|-------------|----------|
-| **Shared nodes** | Tenants share Control Plane Cluster nodes with label-based scheduling. Each tenant gets a separate tenant cluster with its own Kubernetes API. | Trusted tenants, cost-efficient GPU sharing |
-| **Private nodes** | Each tenant gets a dedicated tenant cluster with auto-provisioned private nodes. | Untrusted tenants, strict compliance requirements |
-| **Standalone** | A single-tenant deployment where NVIDIA Run:ai manages the full node pool within one tenant cluster. | Single team, dedicated GPU pool |
+| **Shared nodes** | Tenants share control plane cluster nodes with label-based scheduling. Each tenant has a separate Kubernetes API. | Trusted tenants and internal GPU sharing |
+| **Private nodes** | Each tenant has a tenant cluster with auto-provisioned private nodes. | Untrusted tenants and compliance requirements |
+| **Standalone** | NVIDIA Run:ai manages the full node pool in one tenant cluster. | One team with a dedicated GPU pool |
+
+<SharedNodesSuitability />
 
 ## Installation
 
-The NVIDIA Run:ai certified stack provisions a vCluster together with the NVIDIA GPU Operator and NVIDIA Run:ai
-in a single, tested deployment. See the
-[certified-stacks repository](https://github.com/loft-sh/certified-stacks) for prerequisites,
-configuration options, and step-by-step setup instructions.
-<br/>
-<div style={{ display: "flex", justifyContent: "center" }}>
-  <img
-    src={require("@site/static/media/diagrams/certified-stacks.png").default}
-    alt="NVIDIA Run:ai certified stack"
-    style={{ width: "60%", height: "60%" }}
-  />
-</div>
+The legacy stack provisions a tenant cluster with NVIDIA GPU Operator and NVIDIA Run:ai.
+See the [Certified Stacks repository](https://github.com/loft-sh/certified-stacks) for prerequisites and configuration details.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENGNODE-858


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

