### PR TITLE
fix(scripts): stop wrap-glossary-terms.js from corrupting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,5 +116,9 @@ The script will:
 - Only wrap terms that exist in `src/data/glossary.yaml`
 - Only wrap the first occurrence of each term in a document
 - Respect the glossary type setting (vcluster, platform, or both)
-- Skip terms in front matter, code blocks, links, and HTML/JSX tags
+- Skip terms in front matter, code spans, fenced code (including longer
+  backtick and tilde fences), table rows, link text, link destinations, link
+  reference definitions, bare URL autolinks, MDX comments (`{/* ... */}`),
+  ESM and brace expressions, HTML/JSX tags, and interactive or code-oriented
+  JSX children such as `<Link>`, `<code>`, and `<CodeBlock>`
 - Preserve the original case of matched terms

--- a/scripts/wrap-glossary-terms.js
+++ b/scripts/wrap-glossary-terms.js
@@ -26,14 +26,6 @@ const path = require('path');
 const yaml = require('js-yaml');
 const glob = require('glob');
 
-// Check if a file/directory argument was provided
-const target = process.argv[2];
-if (!target) {
-  console.error('Error: Please provide a file or directory to process.');
-  console.error('Usage: node scripts/wrap-glossary-terms.js <file-or-directory>');
-  process.exit(1);
-}
-
 // Load the glossary data
 const glossaryPath = path.join(__dirname, '../src/data/glossary.yaml');
 const glossaryData = yaml.load(fs.readFileSync(glossaryPath, 'utf8'));
@@ -78,6 +70,479 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function positionInRanges(position, ranges) {
+  return ranges.some(({ start, end }) => position >= start && position < end);
+}
+
+// Return line-oriented fenced code ranges. Closing fences must use the same
+// character and at least as many markers as the opening fence. This preserves
+// triple-backtick examples nested inside a four-backtick fence.
+function findFencedCodeRanges(content) {
+  const ranges = [];
+  let fence = null;
+  let lineStart = 0;
+
+  while (lineStart <= content.length) {
+    const newline = content.indexOf('\n', lineStart);
+    const lineEnd = newline === -1 ? content.length : newline;
+    const rangeEnd = newline === -1 ? content.length : newline + 1;
+    const line = content.substring(lineStart, lineEnd);
+    const markerMatch = line.match(/^[ \t]*(?:>[ \t]*)*(`{3,}|~{3,})(.*)$/);
+
+    if (fence) {
+      if (markerMatch) {
+        const marker = markerMatch[1];
+        const remainder = markerMatch[2];
+        if (
+          marker[0] === fence.character &&
+          marker.length >= fence.length &&
+          remainder.trim() === ''
+        ) {
+          ranges.push({ start: fence.start, end: rangeEnd });
+          fence = null;
+        }
+      }
+    } else if (markerMatch) {
+      const marker = markerMatch[1];
+      const remainder = markerMatch[2];
+      // Backticks aren't allowed in the info string of a backtick fence.
+      if (marker[0] !== '`' || !remainder.includes('`')) {
+        fence = {
+          start: lineStart,
+          character: marker[0],
+          length: marker.length,
+        };
+      }
+    }
+
+    if (newline === -1) {
+      break;
+    }
+    lineStart = newline + 1;
+  }
+
+  if (fence) {
+    ranges.push({ start: fence.start, end: content.length });
+  }
+
+  return ranges;
+}
+
+// Match inline code spans by delimiter length. An unmatched run is literal
+// text, and runs inside fenced code are ignored.
+function findInlineCodeRanges(content, fencedRanges) {
+  const ranges = [];
+
+  for (let i = 0; i < content.length;) {
+    const fencedRange = fencedRanges.find(({ start, end }) => i >= start && i < end);
+    if (fencedRange) {
+      i = fencedRange.end;
+      continue;
+    }
+
+    if (content[i] !== '`') {
+      i++;
+      continue;
+    }
+
+    let runLength = 1;
+    while (content[i + runLength] === '`') {
+      runLength++;
+    }
+
+    let closingStart = -1;
+    for (let j = i + runLength; j < content.length;) {
+      const skippedFence = fencedRanges.find(({ start, end }) => j >= start && j < end);
+      if (skippedFence) {
+        j = skippedFence.end;
+        continue;
+      }
+      if (content[j] !== '`') {
+        j++;
+        continue;
+      }
+
+      let closingLength = 1;
+      while (content[j + closingLength] === '`') {
+        closingLength++;
+      }
+      if (closingLength === runLength) {
+        closingStart = j;
+        break;
+      }
+      j += closingLength;
+    }
+
+    if (closingStart !== -1) {
+      const end = closingStart + runLength;
+      ranges.push({ start: i, end });
+      i = end;
+    } else {
+      i += runLength;
+    }
+  }
+
+  return ranges;
+}
+
+function findMdxCommentRanges(content) {
+  const ranges = [];
+  const pattern = /\{\/\*[\s\S]*?\*\/\}/g;
+  let match;
+  while ((match = pattern.exec(content)) !== null) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
+}
+
+// Find HTML/JSX tags without treating a `>` inside a quoted attribute or JSX
+// expression as the end of the tag. Code and comment ranges are excluded by
+// the caller so examples containing tag-like text don't affect the scan.
+function findHtmlJsxTags(content, excludedRanges) {
+  const tags = [];
+
+  for (let i = 0; i < content.length;) {
+    const excluded = excludedRanges.find(({ start, end }) => i >= start && i < end);
+    if (excluded) {
+      i = excluded.end;
+      continue;
+    }
+
+    if (content[i] !== '<') {
+      i++;
+      continue;
+    }
+
+    // Protect HTML comments as tag-like markup even though they don't have a
+    // name or participate in element nesting.
+    if (content.startsWith('<!--', i)) {
+      const commentEnd = content.indexOf('-->', i + 4);
+      const end = commentEnd === -1 ? content.length : commentEnd + 3;
+      tags.push({ start: i, end, name: null, closing: false, selfClosing: true });
+      i = end;
+      continue;
+    }
+
+    let cursor = i + 1;
+    let closing = false;
+    if (content[cursor] === '/') {
+      closing = true;
+      cursor++;
+    }
+
+    // Fragments (`<>` and `</>`) are valid JSX tags without names.
+    let name = null;
+    if (content[cursor] === '>') {
+      tags.push({
+        start: i,
+        end: cursor + 1,
+        name,
+        closing,
+        selfClosing: !closing,
+      });
+      i = cursor + 1;
+      continue;
+    }
+
+    const nameMatch = content.substring(cursor).match(/^[A-Za-z][A-Za-z0-9_.:-]*/);
+    if (!nameMatch) {
+      i++;
+      continue;
+    }
+    name = nameMatch[0];
+    cursor += name.length;
+
+    let quote = null;
+    let escaped = false;
+    let braceDepth = 0;
+    let lineComment = false;
+    let blockComment = false;
+
+    while (cursor < content.length) {
+      const ch = content[cursor];
+      const next = content[cursor + 1];
+
+      if (lineComment) {
+        if (ch === '\n') {
+          lineComment = false;
+        }
+      } else if (blockComment) {
+        if (ch === '*' && next === '/') {
+          blockComment = false;
+          cursor++;
+        }
+      } else if (quote) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === quote) {
+          quote = null;
+        }
+      } else if (braceDepth > 0 && ch === '/' && next === '/') {
+        lineComment = true;
+        cursor++;
+      } else if (braceDepth > 0 && ch === '/' && next === '*') {
+        blockComment = true;
+        cursor++;
+      } else if (ch === '"' || ch === "'" || (braceDepth > 0 && ch === '`')) {
+        quote = ch;
+      } else if (ch === '{') {
+        braceDepth++;
+      } else if (ch === '}' && braceDepth > 0) {
+        braceDepth--;
+      } else if (ch === '>' && braceDepth === 0) {
+        const beforeClose = content.substring(i, cursor).trimEnd();
+        const end = cursor + 1;
+        tags.push({
+          start: i,
+          end,
+          name,
+          closing,
+          selfClosing: !closing && beforeClose.endsWith('/'),
+        });
+        i = end;
+        break;
+      }
+      cursor++;
+    }
+
+    // An apparent tag without a real closing `>` is just prose. Advance past
+    // its `<` so later valid tags can still be found.
+    if (cursor >= content.length) {
+      i++;
+    }
+  }
+
+  return tags;
+}
+
+function isProtectedElementName(name) {
+  return /^(?:a|link|button|code|pre|codeblock|summary|td|th|h[1-6]|glossaryterm)$/i.test(name);
+}
+
+// Protect child content where inserting the interactive GlossaryTerm component
+// would either corrupt code semantics, nest interactive elements, or reproduce
+// the table/title rendering problems handled for Markdown syntax above.
+function findProtectedElementRanges(tags) {
+  const ranges = [];
+  const openElements = [];
+
+  for (const tag of tags) {
+    if (!tag.name || !isProtectedElementName(tag.name)) {
+      continue;
+    }
+    const normalizedName = tag.name.toLowerCase();
+
+    if (!tag.closing && !tag.selfClosing) {
+      openElements.push({ ...tag, normalizedName });
+      continue;
+    }
+    if (!tag.closing) {
+      continue;
+    }
+
+    for (let i = openElements.length - 1; i >= 0; i--) {
+      if (openElements[i].normalizedName === normalizedName) {
+        ranges.push({ start: openElements[i].start, end: tag.end });
+        openElements.splice(i, 1);
+        break;
+      }
+    }
+  }
+
+  return ranges;
+}
+
+function scanJavaScriptBalance(text, state) {
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (state.lineComment) {
+      continue;
+    }
+    if (state.blockComment) {
+      if (ch === '*' && next === '/') {
+        state.blockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (state.quote) {
+      if (state.escaped) {
+        state.escaped = false;
+      } else if (ch === '\\') {
+        state.escaped = true;
+      } else if (ch === state.quote) {
+        state.quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      state.lineComment = true;
+      i++;
+    } else if (ch === '/' && next === '*') {
+      state.blockComment = true;
+      i++;
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      state.quote = ch;
+    } else if (ch === '{') {
+      state.braces++;
+    } else if (ch === '}') {
+      state.braces--;
+    } else if (ch === '(') {
+      state.parens++;
+    } else if (ch === ')') {
+      state.parens--;
+    } else if (ch === '[') {
+      state.brackets++;
+    } else if (ch === ']') {
+      state.brackets--;
+    } else if (ch === ';') {
+      state.sawSemicolon = true;
+    }
+  }
+  state.lineComment = false;
+}
+
+// Protect complete top-level MDX ESM declarations, including multiline
+// imports and exported component definitions with internal blank lines.
+function findMdxEsmRanges(content, excludedRanges) {
+  const ranges = [];
+  const lines = [];
+  let lineStart = 0;
+
+  while (lineStart <= content.length) {
+    const newline = content.indexOf('\n', lineStart);
+    const lineEnd = newline === -1 ? content.length : newline;
+    lines.push({
+      start: lineStart,
+      end: newline === -1 ? content.length : newline + 1,
+      text: content.substring(lineStart, lineEnd),
+    });
+    if (newline === -1) {
+      break;
+    }
+    lineStart = newline + 1;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (
+      positionInRanges(lines[i].start, excludedRanges) ||
+      !/^\s*(?:import|export)\b/.test(lines[i].text)
+    ) {
+      continue;
+    }
+
+    const start = lines[i].start;
+    let end = lines[i].end;
+    const state = {
+      braces: 0,
+      parens: 0,
+      brackets: 0,
+      quote: null,
+      escaped: false,
+      lineComment: false,
+      blockComment: false,
+      sawSemicolon: false,
+    };
+
+    for (let j = i; j < lines.length; j++) {
+      scanJavaScriptBalance(lines[j].text, state);
+      end = lines[j].end;
+
+      const balanced =
+        state.braces === 0 &&
+        state.parens === 0 &&
+        state.brackets === 0 &&
+        !state.quote &&
+        !state.blockComment;
+      const nextLineIsBoundary =
+        j + 1 >= lines.length || lines[j + 1].text.trim() === '';
+
+      if (balanced && (state.sawSemicolon || nextLineIsBoundary)) {
+        i = j;
+        break;
+      }
+    }
+    ranges.push({ start, end });
+  }
+
+  return ranges;
+}
+
+// Find MDX brace expressions while respecting JavaScript strings and
+// comments. Code, ESM, and MDX comment ranges are excluded by the caller.
+function findMdxExpressionRanges(content, excludedRanges) {
+  const ranges = [];
+
+  for (let i = 0; i < content.length;) {
+    const excluded = excludedRanges.find(({ start, end }) => i >= start && i < end);
+    if (excluded) {
+      i = excluded.end;
+      continue;
+    }
+
+    if (content[i] !== '{' || content[i - 1] === '\\') {
+      i++;
+      continue;
+    }
+
+    const start = i;
+    let depth = 1;
+    let quote = null;
+    let escaped = false;
+    let lineComment = false;
+    let blockComment = false;
+    i++;
+
+    while (i < content.length && depth > 0) {
+      const ch = content[i];
+      const next = content[i + 1];
+
+      if (lineComment) {
+        if (ch === '\n') {
+          lineComment = false;
+        }
+      } else if (blockComment) {
+        if (ch === '*' && next === '/') {
+          blockComment = false;
+          i++;
+        }
+      } else if (quote) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === quote) {
+          quote = null;
+        }
+      } else if (ch === '/' && next === '/') {
+        lineComment = true;
+        i++;
+      } else if (ch === '/' && next === '*') {
+        blockComment = true;
+        i++;
+      } else if (ch === '"' || ch === "'" || ch === '`') {
+        quote = ch;
+      } else if (ch === '{') {
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+      }
+      i++;
+    }
+
+    if (depth === 0) {
+      ranges.push({ start, end: i });
+    }
+  }
+
+  return ranges;
+}
+
 // Function to check if a position is inside a code block, link, front matter, or existing GlossaryTerm
 function isInProtectedArea(content, position, term) {
   // Check if inside front matter (between --- markers at the start of file)
@@ -88,93 +553,155 @@ function isInProtectedArea(content, position, term) {
     }
   }
   
-  // Check if inside an import statement
+  // Check if inside a single-line import or export statement. Complete
+  // multiline ESM blocks are checked below.
   const lineStart = content.lastIndexOf('\n', position) + 1;
   const lineEnd = content.indexOf('\n', position);
   const currentLine = content.substring(lineStart, lineEnd === -1 ? content.length : lineEnd);
-  if (currentLine.trim().startsWith('import ')) {
+  if (/^(?:import|export)\b/.test(currentLine.trim())) {
     return true;
   }
-  
+
   // Check if inside a markdown header (# ## ### etc.)
   const headerPattern = /^#{1,6}\s/;
   if (headerPattern.test(currentLine.trim())) {
     return true;
   }
-  
+
+  // Check if inside a markdown table row (GlossaryTerm breaks table cell rendering)
+  if (currentLine.trim().startsWith('|')) {
+    return true;
+  }
+
+  // Check if on a link reference definition line: [label]: url "title".
+  // Whitespace after the colon is optional.
+  if (/^\[[^\]]+\]:/.test(currentLine.trim())) {
+    return true;
+  }
+
+  // A reference destination may appear on the line after a bare [label]:.
+  if (lineStart > 0) {
+    const previousLineEnd = lineStart - 1;
+    const previousLineStart = content.lastIndexOf('\n', previousLineEnd - 1) + 1;
+    const previousLine = content.substring(previousLineStart, previousLineEnd);
+    if (/^\[[^\]]+\]:\s*$/.test(previousLine.trim())) {
+      return true;
+    }
+  }
+
   // Check if inside an admonition title (:::note, :::warning, :::tip, :::info, :::caution, :::danger)
   const admonitionPattern = /^:::(note|warning|tip|info|caution|danger)\s/;
   if (admonitionPattern.test(currentLine.trim())) {
     return true;
   }
   
-  // Check if inside code blocks (backticks)
-  let insideCode = false;
-  let backticksCount = 0;
-  
-  for (let i = 0; i < position; i++) {
-    if (content[i] === '`') {
-      if (content[i + 1] === '`' && content[i + 2] === '`') {
-        // Triple backticks
-        insideCode = !insideCode;
-        i += 2;
-      } else if (!insideCode) {
-        // Single backtick
-        backticksCount++;
-      }
-    }
-  }
-  
-  if (insideCode || backticksCount % 2 === 1) {
+  const fencedCodeRanges = findFencedCodeRanges(content);
+  const inlineCodeRanges = findInlineCodeRanges(content, fencedCodeRanges);
+  if (
+    positionInRanges(position, fencedCodeRanges) ||
+    positionInRanges(position, inlineCodeRanges)
+  ) {
     return true;
   }
-  
+
+  // Check if inside an MDX comment: {/* ... */}
+  const mdxCommentRanges = findMdxCommentRanges(content);
+  if (positionInRanges(position, mdxCommentRanges)) {
+    return true;
+  }
+
+  const htmlJsxTags = findHtmlJsxTags(content, [
+    ...fencedCodeRanges,
+    ...inlineCodeRanges,
+    ...mdxCommentRanges,
+  ]);
+  if (positionInRanges(position, htmlJsxTags)) {
+    return true;
+  }
+
+  const protectedElementRanges = findProtectedElementRanges(htmlJsxTags);
+  if (positionInRanges(position, protectedElementRanges)) {
+    return true;
+  }
+
+  // Check MDX ESM declarations and brace expressions. Inserting JSX into a
+  // JavaScript string or expression makes the MDX module invalid.
+  const mdxEsmRanges = findMdxEsmRanges(content, [
+    ...fencedCodeRanges,
+    ...inlineCodeRanges,
+    ...mdxCommentRanges,
+    ...protectedElementRanges,
+  ]);
+  if (positionInRanges(position, mdxEsmRanges)) {
+    return true;
+  }
+  const mdxExpressionRanges = findMdxExpressionRanges(content, [
+    ...fencedCodeRanges,
+    ...inlineCodeRanges,
+    ...mdxCommentRanges,
+    ...protectedElementRanges,
+    ...mdxEsmRanges,
+  ]);
+  if (positionInRanges(position, mdxExpressionRanges)) {
+    return true;
+  }
+
   // Check if inside a link [text](url) or [text][ref]
   const beforeContent = content.substring(0, position);
   const afterContent = content.substring(position + term.length);
+
+  // Check GFM bare URL autolinks. Inserting JSX into the URL token prevents
+  // Docusaurus from recognizing it and corrupts the destination.
+  const positionOnLine = position - lineStart;
+  const beforeOnLine = currentLine.substring(0, positionOnLine);
+  const urlStart = Math.max(
+    beforeOnLine.lastIndexOf('https://'),
+    beforeOnLine.lastIndexOf('http://')
+  );
+  if (urlStart !== -1 && !/\s/.test(beforeOnLine.substring(urlStart))) {
+    return true;
+  }
   
-  // Check for markdown link pattern
+  // Check for markdown link text: [text](url)
   const linkPattern = /\[[^\]]*$/;
   if (linkPattern.test(beforeContent) && /^[^\]]*\]/.test(afterContent)) {
     return true;
   }
-  
-  // Check if already inside a GlossaryTerm
-  const glossaryPattern = /<GlossaryTerm[^>]*>/;
-  let lastGlossaryOpen = beforeContent.lastIndexOf('<GlossaryTerm');
-  let lastGlossaryClose = beforeContent.lastIndexOf('</GlossaryTerm>');
-  
-  if (lastGlossaryOpen > lastGlossaryClose && lastGlossaryOpen !== -1) {
-    return true;
-  }
-  
-  // Check if the term is part of a GlossaryTerm tag itself
-  const tagContext = content.substring(Math.max(0, position - 50), position + term.length + 50);
-  if (tagContext.includes('<GlossaryTerm') || tagContext.includes('</GlossaryTerm>')) {
-    return true;
-  }
-  
-  // Check if inside HTML/JSX tags (between < and >)
-  let insideTag = false;
-  for (let i = 0; i < position; i++) {
-    if (content[i] === '<') {
-      insideTag = true;
-    } else if (content[i] === '>') {
-      insideTag = false;
+
+  // Check for markdown link destination: [text](url) or [text](url "title").
+  // A term inside the URL/path breaks the link target. Track paren depth from
+  // the nearest "](" so destinations with balanced parens (rare but valid,
+  // e.g. Wikipedia-style URLs) aren't mistaken for a closed link, and stop at
+  // a line break since destinations here never span lines.
+  const linkDestStart = beforeContent.lastIndexOf('](');
+  if (linkDestStart !== -1) {
+    const between = content.substring(linkDestStart + 2, position);
+    let depth = 0;
+    let stillInDestination = true;
+    let escaped = false;
+    for (const ch of between) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '\n') {
+        stillInDestination = false;
+        break;
+      } else if (ch === '(') {
+        depth++;
+      } else if (ch === ')') {
+        if (depth === 0) {
+          stillInDestination = false;
+          break;
+        }
+        depth--;
+      }
+    }
+    if (stillInDestination) {
+      return true;
     }
   }
-  
-  if (insideTag) {
-    return true;
-  }
-  
-  // Also check if we're currently inside an unclosed tag
-  const lastOpenTag = content.lastIndexOf('<', position);
-  const lastCloseTag = content.lastIndexOf('>', position);
-  if (lastOpenTag > lastCloseTag) {
-    return true;
-  }
-  
+
   return false;
 }
 
@@ -245,61 +772,78 @@ function processFile(filePath) {
   return 0;
 }
 
-// Determine if target is a file or directory
-const targetPath = path.resolve(target);
-let mdxFiles = [];
+module.exports = {
+  escapeRegExp,
+  isInProtectedArea,
+  shouldProcessTerm,
+  processFile,
+};
 
-try {
-  const stats = fs.statSync(targetPath);
-  
-  if (stats.isFile()) {
-    // Single file
-    if (targetPath.endsWith('.mdx') || targetPath.endsWith('.md')) {
-      mdxFiles = [targetPath];
-    } else {
-      console.error('Error: File must be an MDX or MD file.');
-      process.exit(1);
-    }
-  } else if (stats.isDirectory()) {
-    // Directory - find all MDX files recursively
-    const pattern = path.join(targetPath, '**/*.mdx');
-    mdxFiles = glob.sync(pattern, {
-      ignore: [
-        '**/node_modules/**',
-        '**/build/**',
-        '**/.docusaurus/**',
-        '**/.vscode/**'
-      ]
-    });
-    
-    // Also include .md files if needed
-    const mdPattern = path.join(targetPath, '**/*.md');
-    const mdFiles = glob.sync(mdPattern, {
-      ignore: [
-        '**/node_modules/**',
-        '**/build/**',
-        '**/.docusaurus/**',
-        '**/.vscode/**'
-      ]
-    });
-    
-    mdxFiles = [...mdxFiles, ...mdFiles];
+if (require.main === module) {
+  // Check if a file/directory argument was provided
+  const target = process.argv[2];
+  if (!target) {
+    console.error('Error: Please provide a file or directory to process.');
+    console.error('Usage: node scripts/wrap-glossary-terms.js <file-or-directory>');
+    process.exit(1);
   }
-} catch (error) {
-  console.error(`Error: Cannot access "${target}": ${error.message}`);
-  process.exit(1);
+
+  // Determine if target is a file or directory
+  const targetPath = path.resolve(target);
+  let mdxFiles = [];
+
+  try {
+    const stats = fs.statSync(targetPath);
+
+    if (stats.isFile()) {
+      // Single file
+      if (targetPath.endsWith('.mdx') || targetPath.endsWith('.md')) {
+        mdxFiles = [targetPath];
+      } else {
+        console.error('Error: File must be an MDX or MD file.');
+        process.exit(1);
+      }
+    } else if (stats.isDirectory()) {
+      // Directory - find all MDX files recursively
+      const pattern = path.join(targetPath, '**/*.mdx');
+      mdxFiles = glob.sync(pattern, {
+        ignore: [
+          '**/node_modules/**',
+          '**/build/**',
+          '**/.docusaurus/**',
+          '**/.vscode/**'
+        ]
+      });
+
+      // Also include .md files if needed
+      const mdPattern = path.join(targetPath, '**/*.md');
+      const mdFiles = glob.sync(mdPattern, {
+        ignore: [
+          '**/node_modules/**',
+          '**/build/**',
+          '**/.docusaurus/**',
+          '**/.vscode/**'
+        ]
+      });
+
+      mdxFiles = [...mdxFiles, ...mdFiles];
+    }
+  } catch (error) {
+    console.error(`Error: Cannot access "${target}": ${error.message}`);
+    process.exit(1);
+  }
+
+  if (mdxFiles.length === 0) {
+    console.log('No MDX/MD files found to process.');
+    process.exit(0);
+  }
+
+  console.log(`Processing ${mdxFiles.length} file(s)...`);
+
+  let processedCount = 0;
+  mdxFiles.forEach(filePath => {
+    processedCount += processFile(filePath);
+  });
+
+  console.log(`\n✅ Complete! Modified ${processedCount} file(s) with glossary terms.`);
 }
-
-if (mdxFiles.length === 0) {
-  console.log('No MDX/MD files found to process.');
-  process.exit(0);
-}
-
-console.log(`Processing ${mdxFiles.length} file(s)...`);
-
-let processedCount = 0;
-mdxFiles.forEach(filePath => {
-  processedCount += processFile(filePath);
-});
-
-console.log(`\n✅ Complete! Modified ${processedCount} file(s) with glossary terms.`);

--- a/tests/wrap-glossary-terms.test.js
+++ b/tests/wrap-glossary-terms.test.js
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for scripts/wrap-glossary-terms.js.
+ *
+ * Uses Node's built-in test runner (node --test); no extra dependencies.
+ * Run: node --test tests/wrap-glossary-terms.test.js
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isInProtectedArea } = require('../scripts/wrap-glossary-terms.js');
+
+// Finds the first case-insensitive match of `term` in `content` and asserts
+// whether isInProtectedArea considers that position protected.
+function checkTerm(content, term) {
+  const index = content.toLowerCase().indexOf(term.toLowerCase());
+  assert.notEqual(index, -1, `fixture must contain "${term}"`);
+  return isInProtectedArea(content, index, term);
+}
+
+test('does not protect a plain prose mention', () => {
+  const content = 'The tenant cluster scales down its workloads.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a markdown table row', () => {
+  const content = '| Method | Behavior |\n| --- | --- |\n| Manual | Pauses the vcluster CLI. |\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside an indented markdown table row', () => {
+  const content = '  | Method | Behavior |\n  | Manual | Pauses the vcluster CLI. |\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term in markdown link text', () => {
+  const content = 'See [the vcluster CLI](../cli/overview.mdx) for details.';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a markdown link destination', () => {
+  const content = 'See [Configure auto sleep](../configure/vcluster-yaml/sleep.mdx) for details.';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a link destination with balanced parens', () => {
+  const content = 'See [docs](https://example.test/foo_(bar)/k3s/reference) for details.';
+  assert.equal(checkTerm(content, 'k3s'), true);
+});
+
+test('protects a term after an escaped parenthesis in a link destination', () => {
+  const content = 'See [docs](https://example.test/foo_\\)/k3s/reference) for details.';
+  assert.equal(checkTerm(content, 'k3s'), true);
+});
+
+test('does not protect prose that follows a closed link on the same line', () => {
+  const content = 'See [Configure auto sleep](../configure/vcluster-yaml/sleep.mdx) for tenant cluster details.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a link reference definition', () => {
+  const content = 'See [the repo][repo] for details.\n\n[repo]: https://github.com/loft-sh/vcluster-selinux\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a link reference definition without whitespace', () => {
+  const content = '[repo]:https://github.com/loft-sh/vcluster-selinux\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a multiline link reference destination', () => {
+  const content = '[repo]:\n  https://github.com/loft-sh/vcluster-selinux\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a GFM bare URL autolink', () => {
+  const content = 'Workflow: https://github.com/loft-demos/k8s-image-mirror/actions';
+  assert.equal(checkTerm(content, 'k8s'), true);
+});
+
+test('does not protect prose following a bare URL on the same line', () => {
+  const content = 'See https://example.test/docs before the tenant cluster description.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a code span', () => {
+  const content = 'Run `vcluster --version` in a terminal.';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term already inside a GlossaryTerm tag', () => {
+  const content = 'The <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> is ready.';
+  assert.equal(checkTerm(content, 'tenant cluster'), true);
+});
+
+test('does not protect a later, distinct term near a closed GlossaryTerm tag', () => {
+  const content = 'The <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> and the syncer work together.';
+  assert.equal(checkTerm(content, 'syncer'), false);
+});
+
+test('protects a term inside frontmatter', () => {
+  const content = '---\ntitle: About vcluster\n---\n\nBody text.\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term in a markdown heading', () => {
+  const content = '## Configure vcluster\n\nBody text.\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a four-backtick fence', () => {
+  const content = '````yaml\nkey: vcluster\n````\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('does not protect prose following a four-backtick fence', () => {
+  const content = '````yaml\nkey: value\n````\n\nThe tenant cluster scales down its workloads.\n';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a single-line MDX comment', () => {
+  const content = '{/* mentions vcluster internally */}\n\nBody text.\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a multiline MDX comment', () => {
+  const content = [
+    '{/*',
+    'One possible usage for adding annotations to all the vCluster components.',
+    '*/}',
+    '',
+    'Body text about vCluster elsewhere.',
+  ].join('\n');
+  const firstIndex = content.indexOf('vCluster');
+  assert.equal(isInProtectedArea(content, firstIndex, 'vCluster'), true);
+});
+
+test('does not protect a visible mention after an MDX comment', () => {
+  const content = [
+    '{/*',
+    'One possible usage for adding annotations to all the vCluster components.',
+    '*/}',
+    '',
+    'Body text about vCluster elsewhere.',
+  ].join('\n');
+  const lastIndex = content.lastIndexOf('vCluster');
+  assert.equal(isInProtectedArea(content, lastIndex, 'vCluster'), false);
+});
+
+test('protects a triple-backtick example nested inside a four-backtick fence', () => {
+  const content = [
+    '````md',
+    '```yaml',
+    'name: vcluster',
+    '```',
+    '````',
+  ].join('\n');
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('does not protect prose after a nested fenced example', () => {
+  const content = [
+    '````md',
+    '```yaml',
+    'name: value',
+    '```',
+    '````',
+    '',
+    'The tenant cluster is visible prose.',
+  ].join('\n');
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('allows a longer backtick run to close a shorter opening fence', () => {
+  const content = '```yaml\nname: value\n````\n\nThe tenant cluster is visible prose.\n';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a tilde fence', () => {
+  const content = '~~~yaml\nname: vcluster\n~~~\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('does not protect prose following a tilde fence', () => {
+  const content = '~~~yaml\nname: value\n~~~\n\nThe tenant cluster is visible prose.\n';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a fenced blockquote', () => {
+  const content = '> ~~~yaml\n> name: vcluster\n> ~~~\n';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a variable-length inline code span', () => {
+  const content = 'Use ``vcluster `literal` output`` here.';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('does not protect prose following a variable-length inline code span', () => {
+  const content = 'Use ``a `literal` output`` before the tenant cluster description.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('does not treat an unmatched backtick as an inline code span', () => {
+  const content = 'An unmatched ` marker appears before tenant cluster prose.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside an exported MDX value', () => {
+  const content = 'export const label = "vCluster Platform";\n\nVisible prose.';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term inside a multiline exported MDX component', () => {
+  const content = [
+    'export const Example = () => {',
+    '  const label = "vCluster Platform";',
+    '',
+    '  return <span>{label}</span>;',
+    '};',
+    '',
+    'Visible prose.',
+  ].join('\n');
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('does not protect prose after an exported MDX component', () => {
+  const content = [
+    'export const Example = () => {',
+    '  return <span>Example</span>;',
+    '};',
+    '',
+    'The tenant cluster is visible prose.',
+  ].join('\n');
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside a standalone MDX expression', () => {
+  const content = '{enabled ? "vCluster" : "other"}\n\nVisible prose.';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('does not protect prose after a standalone MDX expression', () => {
+  const content = '{enabled ? "enabled" : "disabled"} then tenant cluster prose.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term inside an HTML code element', () => {
+  const content = 'Use <code>vcluster.yaml</code> for configuration.';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a Docusaurus CodeBlock component', () => {
+  const content = '<CodeBlock>vcluster create demo</CodeBlock>';
+  assert.equal(checkTerm(content, 'vcluster'), true);
+});
+
+test('protects a term inside a Docusaurus Link component', () => {
+  const content = '<Link to="/docs/platform">vCluster Platform</Link>';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term inside a raw anchor', () => {
+  const content = '<a href="/docs/platform">vCluster Platform</a>';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term inside a details summary', () => {
+  const content = '<details><summary>Configure vCluster</summary>Visible prose.</details>';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term inside a JSX heading', () => {
+  const content = '<h3>Configure vCluster</h3>\n\nVisible prose.';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('does not protect prose after a protected JSX element', () => {
+  const content = '<Link to="/docs/platform">Platform docs</Link> describe the tenant cluster.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects a term after a greater-than sign in a double-quoted JSX attribute', () => {
+  const content = '<Component label="value > vCluster" />';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term after a greater-than sign in a single-quoted JSX attribute', () => {
+  const content = "<Component label='value > vCluster' />";
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('protects a term in a JSX expression after a greater-than operator', () => {
+  const content = '<Component label={count > 0 ? "vCluster" : "none"} />';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});
+
+test('does not protect prose following a tag with a quoted greater-than sign', () => {
+  const content = '<Component label="done > now" /> The tenant cluster is visible prose.';
+  assert.equal(checkTerm(content, 'tenant cluster'), false);
+});
+
+test('protects paired JSX children when an attribute contains a greater-than sign', () => {
+  const content = '<Link title="x > y" to="/docs">vCluster</Link>';
+  assert.equal(checkTerm(content, 'vCluster'), true);
+});


### PR DESCRIPTION
# Content Description
Fixes `scripts/wrap-glossary-terms.js` inserting `<GlossaryTerm>` wraps inside markdown table cells, link destinations/reference definitions, MDX comments, fenced code (4+ backtick and tilde fences, nested fences), variable-length inline code spans, MDX ESM/expression blocks, and JSX attributes containing a literal `>`. Replaces the old single-pass scanning with range-based detection matching CommonMark's fence/code-span rules, and adds 49 regression tests.

## Preview Link
No content pages changed (script/test/README only), so there's no docs preview for this PR.

## Internal Reference
Closes DOC-1731

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

@netlify /docs