### PR TITLE
fix(netlify): add redirects for legacy vcluster.pro docs pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -172,6 +172,651 @@ command = """
   from = "/pro/docs/install-cli"
   to = "/docs/platform/install/quick-start-guide"
 
+# legacy-docs-vcluster-pro decommission: vcluster.pro/pro/docs/* is served here
+# via a dashboard-level proxy rule (not in this repo). These redirects take
+# precedence over that proxy so callers get a real 301 to current docs instead
+# of stale vCluster.Pro content. Mapping generated from every indexable page
+# under loft-sh/legacy-docs-vcluster-pro docs/pages/.
+[[redirects]]
+  from = "/pro/docs/admin/audit"
+  to = "/docs/platform/configure/platform-configs/audit"
+
+[[redirects]]
+  from = "/pro/docs/admin/billing-and-licensing"
+  to = "/docs/platform/"
+
+[[redirects]]
+  from = "/pro/docs/admin/config"
+  to = "/docs/platform/configure/platform-configs/overview"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/custom-branding"
+  to = "/docs/platform/configure/platform-configs/custom-branding"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/high-availability"
+  to = "/docs/platform/maintenance/reliability-scaling/high-availability"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/install-with-helm"
+  to = "/docs/platform/install/helm"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/metrics"
+  to = "/docs/platform/maintenance/monitoring/metrics"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/offline-installations"
+  to = "/docs/platform/install/air-gapped/with-offline-license-key"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/oidc-provider"
+  to = "/docs/platform/administer/authentication/oidc-provider"
+
+[[redirects]]
+  from = "/pro/docs/admin/guides/reset-admin-password"
+  to = "/docs/platform/administer/authentication/reset-admin-password"
+
+[[redirects]]
+  from = "/pro/docs/admin/uninstall"
+  to = "/docs/platform/maintenance/uninstall"
+
+[[redirects]]
+  from = "/pro/docs/admin/upgrade-loft"
+  to = "/docs/platform/maintenance/upgrade-migrate/upgrade"
+
+[[redirects]]
+  from = "/pro/docs/api/authentication"
+  to = "/docs/platform/administer/authentication/access-keys"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/apps"
+  to = "/docs/platform/api/resources/apps"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/clusteraccess"
+  to = "/docs/platform/api/resources/clusteraccess"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/clusters/clusterconnect"
+  to = "/docs/platform/api/resources/clusters/clusters"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/clusters/clusters"
+  to = "/docs/platform/api/resources/clusters/clusters"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/config"
+  to = "/docs/platform/api/resources/config"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/devpodworkspaceinstance/devpodworkspaceinstance"
+  to = "/docs/platform/api/use-api"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/devpodworkspacetemplate"
+  to = "/docs/platform/api/use-api"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/directclusterendpointtoken"
+  to = "/docs/platform/api/resources/directclusterendpointtoken"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/ownedaccesskey"
+  to = "/docs/platform/api/resources/ownedaccesskey"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/clusters"
+  to = "/docs/platform/api/resources/project/clusters"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/importspace"
+  to = "/docs/platform/api/resources/project/importspace"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/importvcluster"
+  to = "/docs/platform/use-platform/virtual-clusters/add-virtual-clusters"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/members"
+  to = "/docs/platform/api/resources/project/members"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/migratespaceinstance"
+  to = "/docs/platform/api/resources/project/migratespaceinstance"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/migratevirtualclusterinstance"
+  to = "/docs/platform/api/resources/project/migratevirtualclusterinstance"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/project"
+  to = "/docs/platform/api/resources/project/project"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/project/templates"
+  to = "/docs/platform/api/resources/project/templates"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/runner/accesskey"
+  to = "/docs/platform/api/use-api"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/runner/runner"
+  to = "/docs/platform/api/use-api"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/self"
+  to = "/docs/platform/api/resources/self"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/sharedsecret"
+  to = "/docs/platform/api/resources/sharedsecret"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/team"
+  to = "/docs/platform/api/resources/team"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/user"
+  to = "/docs/platform/api/resources/user"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/virtualclusterinstance/kubeconfig"
+  to = "/docs/platform/api/resources/virtualclusterinstance/kubeconfig"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/virtualclusterinstance/virtualclusterinstance"
+  to = "/docs/platform/api/resources/virtualclusterinstance/virtualclusterinstance"
+
+[[redirects]]
+  from = "/pro/docs/api/resources/virtualclustertemplate"
+  to = "/docs/platform/api/resources/virtualclustertemplate"
+
+[[redirects]]
+  from = "/pro/docs/api/use-api"
+  to = "/docs/platform/api/use-api"
+
+[[redirects]]
+  from = "/pro/docs/apps/create"
+  to = "/docs/platform/administer/templates/create-templates"
+
+[[redirects]]
+  from = "/pro/docs/apps/parameters"
+  to = "/docs/platform/use-platform/apps/use-parameters"
+
+[[redirects]]
+  from = "/pro/docs/apps/use-in-templates"
+  to = "/docs/platform/use-platform/apps/use-in-templates"
+
+[[redirects]]
+  from = "/pro/docs/apps/use-on-demand"
+  to = "/docs/platform/use-platform/apps/use-on-demand"
+
+[[redirects]]
+  from = "/pro/docs/apps/versioning"
+  to = "/docs/platform/use-platform/apps/updating"
+
+[[redirects]]
+  from = "/pro/docs/apps/what-are-apps"
+  to = "/docs/platform/understand/what-are-apps"
+
+[[redirects]]
+  from = "/pro/docs/cli"
+  to = "/docs/vcluster/cli"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_connect"
+  to = "/docs/vcluster/cli/vcluster_connect"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_create"
+  to = "/docs/vcluster/cli/vcluster_create"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_delete"
+  to = "/docs/vcluster/cli/vcluster_delete"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_disconnect"
+  to = "/docs/vcluster/cli/vcluster_disconnect"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_get"
+  to = "/docs/vcluster/cli/vcluster_describe"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_get_service-cidr"
+  to = "/docs/vcluster/cli/vcluster_describe"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_import"
+  to = "/docs/vcluster/cli/vcluster_platform_add_vcluster"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_list"
+  to = "/docs/vcluster/cli/vcluster_list"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_login"
+  to = "/docs/vcluster/cli/vcluster_login"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_logout"
+  to = "/docs/vcluster/cli/vcluster_logout"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pause"
+  to = "/docs/vcluster/cli/vcluster_pause"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro"
+  to = "/docs/vcluster/cli/vcluster_platform"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro_generate"
+  to = "/docs/vcluster/cli/vcluster_platform_connect"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro_generate_admin-kube-config"
+  to = "/docs/vcluster/cli/vcluster_platform_connect_cluster"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro_reset"
+  to = "/docs/vcluster/cli/vcluster_platform_reset"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro_reset_password"
+  to = "/docs/vcluster/cli/vcluster_platform_reset_password"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_pro_start"
+  to = "/docs/vcluster/cli/vcluster_platform_start"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_resume"
+  to = "/docs/vcluster/cli/vcluster_resume"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_telemetry"
+  to = "/docs/vcluster/cli/vcluster_telemetry"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_telemetry_disable"
+  to = "/docs/vcluster/cli/vcluster_telemetry_disable"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_telemetry_enable"
+  to = "/docs/vcluster/cli/vcluster_telemetry_enable"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_ui"
+  to = "/docs/vcluster/cli/vcluster_ui"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_upgrade"
+  to = "/docs/vcluster/cli/vcluster_upgrade"
+
+[[redirects]]
+  from = "/pro/docs/cli/vcluster_version"
+  to = "/docs/vcluster/cli/vcluster_version"
+
+[[redirects]]
+  from = "/pro/docs/clusters/agent-config"
+  to = "/docs/platform/administer/clusters/advanced/agent-config"
+
+[[redirects]]
+  from = "/pro/docs/clusters/cluster-troubleshooting"
+  to = "/docs/platform/troubleshoot/tsnet-connectivity"
+
+[[redirects]]
+  from = "/pro/docs/clusters/cluster-upgrades"
+  to = "/docs/platform/administer/clusters/advanced/cluster-upgrades"
+
+[[redirects]]
+  from = "/pro/docs/clusters/connect-cluster"
+  to = "/docs/platform/administer/clusters/connect-cluster"
+
+[[redirects]]
+  from = "/pro/docs/clusters/guides/monitoring"
+  to = "/docs/platform/maintenance/monitoring/overview"
+
+[[redirects]]
+  from = "/pro/docs/clusters/guides/policies"
+  to = "/docs/platform/administer/clusters/advanced/policies"
+
+[[redirects]]
+  from = "/pro/docs/clusters/ingress-suffix"
+  to = "/docs/platform/administer/clusters/advanced/ingress-suffix"
+
+[[redirects]]
+  from = "/pro/docs/clusters/multi-region-mode"
+  to = "/docs/platform/administer/clusters/advanced/regional-cluster-endpoints"
+
+[[redirects]]
+  from = "/pro/docs/clusters/what-are-clusters"
+  to = "/docs/platform/understand/what-are-clusters"
+
+[[redirects]]
+  from = "/pro/docs/features/centralized_admission_control"
+  to = "/docs/vcluster/configure/vcluster-yaml/policies/admission-control"
+
+[[redirects]]
+  from = "/pro/docs/features/cross_vcluster_coredns_plugin"
+  to = "/docs/vcluster/configure/vcluster-yaml/networking/resolve-dns"
+
+[[redirects]]
+  from = "/pro/docs/features/embedded_etcd"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded"
+
+[[redirects]]
+  from = "/pro/docs/features/generic_resource_patches"
+  to = "/docs/vcluster/configure/vcluster-yaml/sync/patching/README"
+
+[[redirects]]
+  from = "/pro/docs/features/hardened_security"
+  to = "/docs/vcluster/security/README"
+
+[[redirects]]
+  from = "/pro/docs/features/high_availability"
+  to = "/docs/vcluster/deploy/control-plane/kubernetes-pod/high-availability"
+
+[[redirects]]
+  from = "/pro/docs/features/integrated_coredns"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/components/coredns"
+
+[[redirects]]
+  from = "/pro/docs/features/isolated_control_planes"
+  to = "/docs/vcluster/introduction/architecture"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/domain"
+  to = "/docs/platform/configure/installation-options/domain"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/explore"
+  to = "/docs/platform/introduction/how-platform-works"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/install"
+  to = "/docs/platform/install/quick-start-guide"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/single-sign-on"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/troubleshooting"
+  to = "/docs/platform/use-platform/troubleshooting/troubleshooting"
+
+[[redirects]]
+  from = "/pro/docs/getting-started/upgrade-to-pro"
+  to = "/docs/platform/use-platform/virtual-clusters/add-virtual-clusters"
+
+[[redirects]]
+  from = "/pro/docs/guides/aggregating-metrics"
+  to = "/docs/platform/maintenance/monitoring/aggregating-metrics"
+
+[[redirects]]
+  from = "/pro/docs/guides/gitops"
+  to = "/docs/platform/install/gitops"
+
+[[redirects]]
+  from = "/pro/docs/guides/host-kyverno"
+  to = "/docs/vcluster/configure/vcluster-yaml/policies/admission-control"
+
+[[redirects]]
+  from = "/pro/docs/guides/managing-permissions"
+  to = "/docs/platform/administer/users-permissions/overview"
+
+[[redirects]]
+  from = "/pro/docs/guides/preview-environments"
+  to = "/docs/vcluster/third-party-integrations/github-actions/preview-environments"
+
+[[redirects]]
+  from = "/pro/docs/guides/rancher-integration"
+  to = "/docs/vcluster/third-party-integrations/rancher/install-rancher-integration"
+
+[[redirects]]
+  from = "/pro/docs/"
+  to = "/docs/platform/"
+
+[[redirects]]
+  from = "/pro/docs/licenses/Unknown"
+  to = "/docs/platform/"
+
+[[redirects]]
+  from = "/pro/docs/licenses/vcluster-pro"
+  to = "/docs/platform/"
+
+[[redirects]]
+  from = "/pro/docs/load-testing/results"
+  to = "/docs/vcluster/deploy/control-plane/sizing-and-performance"
+
+[[redirects]]
+  from = "/pro/docs/load-testing/setup"
+  to = "/docs/vcluster/deploy/control-plane/benchmark-methodology"
+
+[[redirects]]
+  from = "/pro/docs/projects/argocd"
+  to = "/docs/platform/integrations/argocd/legacy"
+
+[[redirects]]
+  from = "/pro/docs/projects/clusters"
+  to = "/docs/platform/administer/projects/allowed/clusters"
+
+[[redirects]]
+  from = "/pro/docs/projects/create"
+  to = "/docs/platform/administer/projects/create"
+
+[[redirects]]
+  from = "/pro/docs/projects/members"
+  to = "/docs/platform/administer/users-permissions/permissions/project"
+
+[[redirects]]
+  from = "/pro/docs/projects/quotas"
+  to = "/docs/platform/administer/projects/quotas"
+
+[[redirects]]
+  from = "/pro/docs/projects/rancher"
+  to = "/docs/vcluster/third-party-integrations/rancher/install-rancher-integration"
+
+[[redirects]]
+  from = "/pro/docs/projects/secrets"
+  to = "/docs/platform/administer/secrets/project/create"
+
+[[redirects]]
+  from = "/pro/docs/projects/templates"
+  to = "/docs/platform/administer/projects/allowed/templates"
+
+[[redirects]]
+  from = "/pro/docs/projects/what-are-projects"
+  to = "/docs/platform/understand/what-are-projects"
+
+[[redirects]]
+  from = "/pro/docs/secrets/create-global-secrets"
+  to = "/docs/platform/administer/secrets/global/create"
+
+[[redirects]]
+  from = "/pro/docs/secrets/create-project-secrets"
+  to = "/docs/platform/administer/secrets/project/create"
+
+[[redirects]]
+  from = "/pro/docs/secrets/delete-global-secrets"
+  to = "/docs/platform/administer/secrets/global/delete"
+
+[[redirects]]
+  from = "/pro/docs/secrets/delete-project-secrets"
+  to = "/docs/platform/administer/secrets/project/delete"
+
+[[redirects]]
+  from = "/pro/docs/secrets/hashicorp-vault"
+  to = "/docs/platform/integrations/hashicorp-vault"
+
+[[redirects]]
+  from = "/pro/docs/secrets/retrieve-project-secrets"
+  to = "/docs/platform/administer/secrets/project/retrieve"
+
+[[redirects]]
+  from = "/pro/docs/secrets/secret-sync"
+  to = "/docs/platform/use-platform/secrets/secret-sync"
+
+[[redirects]]
+  from = "/pro/docs/secrets/use-in-projects"
+  to = "/docs/platform/administer/secrets/project/create"
+
+[[redirects]]
+  from = "/pro/docs/secrets/what-are-secrets"
+  to = "/docs/platform/understand/what-are-secrets"
+
+[[redirects]]
+  from = "/pro/docs/users/access-keys"
+  to = "/docs/platform/administer/authentication/access-keys"
+
+[[redirects]]
+  from = "/pro/docs/users/create-teams"
+  to = "/docs/platform/administer/users-permissions/managing-teams/create"
+
+[[redirects]]
+  from = "/pro/docs/users/create-users"
+  to = "/docs/platform/administer/users-permissions/managing-users/create"
+
+[[redirects]]
+  from = "/pro/docs/users/github"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/gitlab"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/google"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/guides/admin"
+  to = "/docs/platform/administer/users-permissions/overview"
+
+[[redirects]]
+  from = "/pro/docs/users/impersonate"
+  to = "/docs/platform/administer/users-permissions/managing-users/impersonate"
+
+[[redirects]]
+  from = "/pro/docs/users/ldap"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/loft-management-roles"
+  to = "/docs/platform/administer/users-permissions/overview"
+
+[[redirects]]
+  from = "/pro/docs/users/microsoft"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/multiple-sso"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/okta"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/openid-connect"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/other-dex"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/saml"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/sso-group-sync"
+  to = "/docs/platform/configure/platform-configs/single-sign-on"
+
+[[redirects]]
+  from = "/pro/docs/users/suspend-users"
+  to = "/docs/platform/administer/users-permissions/managing-users/suspend"
+
+[[redirects]]
+  from = "/pro/docs/users/what-are-users-and-teams"
+  to = "/docs/platform/understand/what-are-users-and-teams"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/apps"
+  to = "/docs/platform/use-platform/apps/use-on-demand"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/argocd"
+  to = "/docs/platform/integrations/argocd/legacy"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/central-hostpath-mapper"
+  to = "/docs/platform/maintenance/logging/central-hostpath-mapper"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/create"
+  to = "/docs/platform/use-platform/virtual-clusters/create/create-no-template"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/custom-links"
+  to = "/docs/platform/use-platform/virtual-clusters/key-features/custom-links"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/github-actions"
+  to = "/docs/vcluster/third-party-integrations/github-actions/pull-requests"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/gitlab-ci"
+  to = "/docs/platform/integrations/gitlab-ci"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/import-vclusters"
+  to = "/docs/platform/use-platform/virtual-clusters/add-virtual-clusters"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/ingress-access"
+  to = "/docs/vcluster/key-features/ingress-access"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/isolation"
+  to = "/docs/vcluster/key-features/isolation"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/manage-access"
+  to = "/docs/platform/use-platform/virtual-clusters/manage-access"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/prevent-deletion"
+  to = "/docs/platform/use-platform/virtual-clusters/key-features/prevent-deletion"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/rancher"
+  to = "/docs/vcluster/third-party-integrations/rancher/install-rancher-integration"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/retrieve-kube-config"
+  to = "/docs/platform/use-platform/virtual-clusters/retrieve-kube-config"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/sleep-mode"
+  to = "/docs/platform/use-platform/virtual-clusters/key-features/sleep-mode"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/templates"
+  to = "/docs/platform/use-platform/virtual-clusters/create/create-with-template"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/virtual-cluster-config"
+  to = "/docs/vcluster/configure/what-is-vcluster-yaml"
+
+[[redirects]]
+  from = "/pro/docs/virtual-clusters/what-are-virtual-clusters"
+  to = "/docs/vcluster/introduction/what-are-virtual-clusters"
+
 [[redirects]]
   from = "/schemas/config"
   to = "/docs/vcluster/configure/vcluster-yaml/"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Adds ~160 redirects for legacy vcluster.pro docs pages to their current equivalent under `/docs/platform/` or `/docs/vcluster/`, as part of decommissioning `loft-sh/legacy-docs-vcluster-pro`. Extends the existing `/pro/docs/install-cli` precedent already in `netlify.toml`.

`www.vcluster.com/pro/docs/*` currently proxies to the legacy Docusaurus site's content via a dashboard-level Netlify rule (not in any repo). These explicit redirects take precedence over that proxy, so all previously indexed paths now 301 to real, current content instead of serving stale vCluster.Pro pages.

## Preview Link
No content pages changed — `netlify.toml` only. Redirects can be spot-checked on the deploy preview, e.g. `<preview-url>/pro/docs/getting-started/install` should redirect to `/docs/platform/install/quick-start-guide`.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1735

Related: companion PR loft-sh/legacy-docs-vcluster-pro#16 (the actual site decommission), and [DEVOPS-1444](https://linear.app/loft/issue/DEVOPS-1444/fix-vclusterpro-domain-redirect-doubles-pro-prefix-404s-on-every) (separate dashboard-level fix for the bare vcluster.pro domain redirect, not part of this PR).

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs
