### PR TITLE
test(redirects): cover vcluster domain routing

### DIFF
--- a/hack/test-domain-redirects.hurl
+++ b/hack/test-domain-redirects.hurl
@@ -27,17 +27,17 @@ header "Location" == "/enterprise-demo?source=hurl"
 GET {{VCLUSTER_COM_URL}}/pro/docs
 HTTP 302
 [Asserts]
-header "Location" contains "/pro/docs/getting-started/explore"
+header "Location" == "/pro/docs/getting-started/explore"
 
 GET {{VCLUSTER_COM_URL}}/pro/docs/getting-started/install
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/platform/install/quick-start-guide"
+header "Location" == "{{VCLUSTER_COM_URL}}/docs/platform/install/quick-start-guide"
 
 GET {{VCLUSTER_COM_URL}}/pro/docs/virtual-clusters/create
 HTTP 301
 [Asserts]
-header "Location" contains "/docs/platform/use-platform/virtual-clusters/create/create-no-template"
+header "Location" == "{{VCLUSTER_COM_URL}}/docs/platform/use-platform/virtual-clusters/create/create-no-template"
 
 # vcluster.com control routes
 GET {{VCLUSTER_COM_URL}}/docs/

--- a/hack/test-domain-redirects.hurl
+++ b/hack/test-domain-redirects.hurl
@@ -1,0 +1,106 @@
+# Cross-domain redirect tests
+# Usage:
+# hurl --test \
+#   --variable VCLUSTER_COM_URL=https://www.vcluster.com \
+#   --variable VCLUSTER_APEX_URL=https://vcluster.com \
+#   --variable VCLUSTER_PRO_URL=https://vcluster.pro \
+#   --variable VCLUSTER_PRO_WWW_URL=https://www.vcluster.pro \
+#   hack/test-domain-redirects.hurl
+
+# vcluster.com marketing redirects
+GET {{VCLUSTER_COM_URL}}/pro
+HTTP 301
+[Asserts]
+header "Location" == "/enterprise-demo"
+
+GET {{VCLUSTER_COM_URL}}/pro/
+HTTP 301
+[Asserts]
+header "Location" == "/enterprise-demo"
+
+GET {{VCLUSTER_COM_URL}}/pro?source=hurl
+HTTP 301
+[Asserts]
+header "Location" == "/enterprise-demo?source=hurl"
+
+# vcluster.com Pro docs redirects
+GET {{VCLUSTER_COM_URL}}/pro/docs
+HTTP 302
+[Asserts]
+header "Location" contains "/pro/docs/getting-started/explore"
+
+GET {{VCLUSTER_COM_URL}}/pro/docs/getting-started/install
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/platform/install/quick-start-guide"
+
+GET {{VCLUSTER_COM_URL}}/pro/docs/virtual-clusters/create
+HTTP 301
+[Asserts]
+header "Location" contains "/docs/platform/use-platform/virtual-clusters/create/create-no-template"
+
+# vcluster.com control routes
+GET {{VCLUSTER_COM_URL}}/docs/
+HTTP 200
+
+GET {{VCLUSTER_COM_URL}}/docs/v0.33
+HTTP 302
+[Asserts]
+header "Location" contains "vcluster-v0-33--vcluster-docs-site.netlify.app/docs/vcluster/"
+
+GET {{VCLUSTER_COM_URL}}/docs/v4.7
+HTTP 302
+[Asserts]
+header "Location" contains "platform-v4-7--vcluster-docs-site.netlify.app/docs/platform/"
+
+GET {{VCLUSTER_COM_URL}}/releases/en/changelog
+HTTP 302
+[Asserts]
+header "Location" == "/releases/changelog"
+
+GET {{VCLUSTER_COM_URL}}/pricing
+HTTP 200
+
+GET {{VCLUSTER_COM_URL}}/robots.txt
+HTTP 200
+
+# vcluster.pro preserves the incoming path
+GET {{VCLUSTER_PRO_URL}}/
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/"
+
+GET {{VCLUSTER_PRO_URL}}/pro
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/pro"
+
+GET {{VCLUSTER_PRO_URL}}/pro/
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/pro/"
+
+GET {{VCLUSTER_PRO_URL}}/pro/docs/getting-started/install
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/pro/docs/getting-started/install"
+
+GET {{VCLUSTER_PRO_URL}}/pro/docs/virtual-clusters/create
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/pro/docs/virtual-clusters/create"
+
+GET {{VCLUSTER_PRO_URL}}/docs/getting-started/install
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/docs/getting-started/install"
+
+GET {{VCLUSTER_PRO_URL}}/pro/docs/getting-started/install?source=hurl
+HTTP 302
+[Asserts]
+header "Location" == "{{VCLUSTER_APEX_URL}}/pro/docs/getting-started/install?source=hurl"
+
+GET {{VCLUSTER_PRO_WWW_URL}}/pro/docs/getting-started/install
+HTTP 301
+[Asserts]
+header "Location" == "{{VCLUSTER_PRO_URL}}/pro/docs/getting-started/install"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds one production Hurl suite for `vcluster.com` and `vcluster.pro` redirects. It covers marketing routes, legacy Pro docs, slash variants, query strings, archived docs, releases, and control routes.

## Preview Link 
<!-- The preview link or links to the documents-->
Not applicable. This PR adds a redirect test under `hack/`.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DEVOPS-1444
References DOC-1735


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs