### PR TITLE
docs(observability): note which tenant clusters need a loadbalancer gateway

### DIFF
--- a/platform/maintenance/observability/install-observability-gateway.mdx
+++ b/platform/maintenance/observability/install-observability-gateway.mdx
@@ -263,7 +263,7 @@ Platform reconciles the following resources:
 | `metricsBackendCertSecretName` | No | Secret with `ca.crt`, `tls.crt`, and `tls.key` for mTLS to the backend. The gateway trusts the backend with `ca.crt` and presents the certificate and key as its client identity. |
 | `gatewayResources` | No | YAML `resources` block for the Write Gateway container. |
 | `queryProxyResources` | No | YAML `resources` block for the Query Proxy container. |
-| `serviceType` | No | Gateway Service type. Valid values are `ClusterIP`, the default, and `LoadBalancer`. |
+| `serviceType` | No | Gateway Service type. Valid values are `ClusterIP`, the default, and `LoadBalancer`. Must be `LoadBalancer` when a tenant cluster delivers metrics through this connector and its collector runs outside the Platform cluster. See [When tenant clusters require a LoadBalancer gateway](#when-tenant-clusters-require-a-loadbalancer-gateway). |
 | `serviceAnnotations` | No | YAML map of annotations applied to a `LoadBalancer` gateway Service. |
 | `grafanaUrl` | No | Grafana upstream URL used by the Platform `/grafana/` reverse proxy. |
 | `grafanaInsecureSkipVerify` | No | Set to `"true"` only to test a Grafana endpoint with an unverifiable certificate. |
@@ -354,6 +354,27 @@ adds it to the certificate as a subject alternative name before deploying the ga
 custom certificate needs that same SAN added by hand, since Platform never modifies it. See
 [Customize the gateway serving certificate](#customize-the-gateway-serving-certificate) for
 how clients trust the resulting certificate either way.
+
+### When tenant clusters require a LoadBalancer gateway
+
+A `ClusterIP` gateway is only reachable from inside the Platform cluster, so it serves
+exactly one kind of tenant cluster: one with shared nodes whose control plane runs on the
+Platform cluster itself. That tenant cluster's collector is a pod on a Platform cluster node,
+so it resolves the gateway's in-cluster Service hostname like any other pod there. A
+single-cluster install that only runs shared-nodes tenant clusters needs no load balancer.
+
+Every other tenant cluster runs its collector where that hostname doesn't resolve:
+
+- A tenant cluster on a remote connected cluster runs its collector on that cluster's nodes.
+- A tenant cluster with private nodes runs its collector on its own nodes, whichever control
+  plane cluster carries its control plane.
+- A vCluster Standalone tenant cluster runs on its own machine.
+
+Rather than hand out an address those tenant clusters can't reach, Platform refuses them the
+`metrics-writer` credential for a `ClusterIP` connector, so no credential Secret is
+delivered. Set `serviceType: LoadBalancer` on the connector to serve them. For how the refusal
+surfaces, see
+[A tenant cluster gets no metrics-writer credential](./troubleshooting.mdx#a-tenant-cluster-gets-no-metrics-writer-credential).
 
 ### Retrieve the load balancer address
 

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -38,6 +38,35 @@ If multiple connector Secrets have this label, Platform still creates per-connec
 gateway resources, but it doesn't publish the fleet-wide platform admin Grafana
 datasource. Remove the fleet label from all but one connector.
 
+## A tenant cluster gets no metrics-writer credential
+
+A tenant cluster that delivers metrics through a connector requests its `metrics-writer`
+credential from Platform. When Platform can't resolve that connector into a write endpoint the
+tenant cluster's collector could reach, it refuses the request, no credential Secret is
+delivered, and the tenant cluster logs the reason on every resync.
+
+Platform reports the same finding as an `ObservabilityConnectorUnresolved` condition on the
+tenant cluster's instance, which is where the admin who owns the connector can see it:
+
+```bash
+kubectl -n loft-p-my-project get virtualclusterinstance my-vcluster \
+  -o jsonpath='{range .status.conditions[?(@.type=="ObservabilityConnectorUnresolved")]}{.reason}{": "}{.message}{"\n"}{end}'
+```
+
+| Reason | Likely cause | Fix |
+|---|---|---|
+| `WriteGatewayInternalOnly` | The connector's gateway Service is `ClusterIP`, and this tenant cluster's collector doesn't run on the Platform cluster. | Set `serviceType: LoadBalancer` on the connector Secret. See [When tenant clusters require a LoadBalancer gateway](./install-observability-gateway.mdx#when-tenant-clusters-require-a-loadbalancer-gateway). |
+| `ObservabilityConnectorNotFound` | The connector named on the tenant cluster doesn't exist in the Platform namespace. | Create the connector, or correct the name on the tenant cluster. |
+| `ObservabilityConnectorMisconfigured` | The connector exists, but its settings can never yield a usable gateway. | See [Gateway resources aren't created](#gateway-resources-arent-created). |
+| `ObservabilityNotConfiguredOnInstance` | The tenant cluster enables observability without naming a connector. | Name a connector on the tenant cluster, or disable the integration. |
+
+The condition carries only causes an admin has to fix. A connector is shared across tenant
+clusters, so causes that clear on their own, such as a gateway still waiting for its
+LoadBalancer address, are left off the condition to keep it from flapping on every tenant
+cluster using that connector. Those appear only in the requesting tenant cluster's own log. An
+absent condition therefore means either that the connector resolves or that it's still coming
+up.
+
 ## Collector writes are rejected
 
 Check the collector exporter configuration:


### PR DESCRIPTION
**DO NOT MERGE**: Depending on https://github.com/loft-sh/loft-enterprise/pull/7963 being merged first.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
A ClusterIP gateway resolves only for a shared-nodes tenant cluster whose control plane runs on the Platform cluster itself. Every other tenant cluster runs its collector where the gateway's in-cluster hostname does not resolve, so Platform refuses it the metrics-writer credential rather than handing out an address it cannot reach.

The connector-keys table listed the serviceType values without saying when LoadBalancer is required, and nothing documented how the refusal surfaces, which left an admin with a tenant cluster that ships no metrics and no way to find out why. Name the requirement where the value is chosen, and give the ObservabilityConnectorUnresolved condition a troubleshooting section covering every reason it reports.

The default stays ClusterIP: it is correct for a single-cluster install that only runs shared-nodes tenant clusters, and flipping it would provision a cloud load balancer for installs that do not need one.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

