### PR TITLE
docs(observability): document tenant control plane backing store metrics

### DIFF
--- a/platform/maintenance/observability/configure-edge-collectors.mdx
+++ b/platform/maintenance/observability/configure-edge-collectors.mdx
@@ -165,6 +165,53 @@ On a cluster with the GPU stack deployed, this template also scrapes GPU metrics
 extra configuration. See
 [The cluster-collector template scrapes GPU metrics automatically](./gpu-observability-templates.mdx#the-cluster-collector-template-scrapes-gpu-metrics-automatically).
 
+On a tenant cluster, this template also scrapes the tenant control plane's backing store.
+See [Tenant backing store metrics](#tenant-backing-store-metrics) below.
+
+## Tenant backing store metrics
+
+The `otel-deploy` collector scrapes the tenant control plane's backing store with no extra
+configuration. vCluster serves these metrics on the tenant control plane's HTTPS proxy, the
+same target the collector already scrapes for tenant API server metrics, so the collector
+reaches them with its own ServiceAccount token and the tenant cluster's CA.
+
+| Scrape job | Path | Backing store |
+|---|---|---|
+| `vcluster-etcd` | `/metrics/etcd` | Embedded etcd. |
+| `vcluster-kine` | `/metrics/kine` | Embedded or external database. Requires vCluster v0.35.0 or later. |
+
+The tenant cluster's own RBAC authorizes these scrapes. The template grants the collector's
+ServiceAccount `get` on both paths, so no action is needed unless you replace the bundled
+ClusterRole.
+
+Deployed etcd and external etcd aren't covered. vCluster serves no metrics route for either,
+so no scrape job collects them.
+
+To query the collected series, see
+[Query fleet metrics](./query-fleet-metrics.mdx#example-queries).
+
+### One backing store job is always down
+
+A tenant cluster has one backing store, so only one of the two jobs ever returns data. The
+path for the other backing store doesn't exist on that tenant cluster, so its job reports
+`up == 0` and logs a scrape failure on every scrape interval, for the lifetime of the tenant
+cluster. This is expected, and a failing job doesn't affect the others on the collector.
+
+Prometheus generates `up` itself rather than reading it from the target, so
+`metric_relabel_configs` can't drop it at the collector. Exclude both backing store jobs
+from any general `up == 0` alert:
+
+```promql
+up{job!~"vcluster-etcd|vcluster-kine"} == 0
+```
+
+Then alert on the job that matches the tenant cluster's backing store. For a tenant cluster
+on embedded etcd:
+
+```promql
+up{job="vcluster-etcd"} == 0
+```
+
 ## Configure collectors manually
 
 To configure a collector yourself instead of using the bundled template, or to customize

--- a/platform/maintenance/observability/query-fleet-metrics.mdx
+++ b/platform/maintenance/observability/query-fleet-metrics.mdx
@@ -343,6 +343,51 @@ avg by (vcluster_platform_project, vcluster_platform_instance, gpu) (
 )
 ```
 
+### Tenant control plane backing store
+
+The bundled collectors scrape the tenant control plane's backing store, described in
+[Tenant backing store metrics](./configure-edge-collectors.mdx#tenant-backing-store-metrics).
+Tenant clusters on embedded etcd report etcd's own series; tenant clusters on a database
+backing store report kine's series.
+
+Backing store reachability across the fleet:
+
+```promql
+min by (vcluster_platform_project, vcluster_platform_instance) (
+  etcd_server_has_leader
+)
+```
+
+Database size by tenant cluster:
+
+```promql
+max by (vcluster_platform_project, vcluster_platform_instance) (
+  etcd_mvcc_db_total_size_in_bytes
+)
+```
+
+Write-ahead log fsync latency, an early sign of a slow backing store disk:
+
+```promql
+histogram_quantile(0.99,
+  sum by (vcluster_platform_project, vcluster_platform_instance, le) (
+    rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])
+  )
+)
+```
+
+Leader elections, which should be rare on a healthy tenant control plane:
+
+```promql
+sum by (vcluster_platform_project, vcluster_platform_instance) (
+  increase(etcd_server_leader_changes_seen_total[1h])
+)
+```
+
+Only one of the two backing store jobs returns data for any given tenant cluster, so
+scope these queries to tenant clusters you know use that backing store. See
+[One backing store job is always down](./configure-edge-collectors.mdx#one-backing-store-job-is-always-down).
+
 ## Query failures
 
 If a query is rejected, check:

--- a/platform/maintenance/observability/troubleshooting.mdx
+++ b/platform/maintenance/observability/troubleshooting.mdx
@@ -161,6 +161,35 @@ Set requests and limits on the affected template:
 Prometheus is the most likely to be OOMKilled, because its memory grows with active series
 count.
 
+## Tenant backing store metrics are missing
+
+A tenant cluster has one backing store, so one of the two scrape jobs is always down by
+design. Confirm which job applies before assuming something is broken. See
+[One backing store job is always down](./configure-edge-collectors.mdx#one-backing-store-job-is-always-down).
+
+| Symptom | Likely cause |
+|---|---|
+| `up{job="vcluster-kine"} == 0` on a tenant cluster with embedded etcd | Expected. The `/metrics/kine` path doesn't exist on that tenant cluster. |
+| `up{job="vcluster-etcd"} == 0` on a tenant cluster with a database backing store | Expected. The `/metrics/etcd` path doesn't exist on that tenant cluster. |
+| Both jobs down | The tenant cluster uses deployed or external etcd, which vCluster serves no metrics route for. |
+| Both jobs down, and the tenant API server job is also down | Not backing store specific. The collector can't reach the tenant control plane proxy at all. |
+| Scrape returns `403` | The collector's ServiceAccount lacks `get` on the non-resource path. Restore the bundled ClusterRole. |
+
+Check the collector's view of the jobs:
+
+```bash
+TENANT_CLUSTER_CONTEXT=my-vcluster
+kubectl --context "$TENANT_CLUSTER_CONTEXT" logs -n observability deploy/otel-deploy | grep "Failed to scrape"
+```
+
+:::note `kubectl get --raw` can't reach these paths
+`kubectl get --raw /metrics/etcd` against a platform kubeconfig doesn't reach the tenant
+control plane, so it can't confirm or rule out a backing store problem. Non-resource paths
+aren't forwarded to the tenant cluster's proxy; Platform answers them itself and returns its
+own web UI's HTML. Read the paths from inside the tenant cluster instead, with a tenant
+ServiceAccount that holds the non-resource grant.
+:::
+
 ## Platform API outage
 
 The gateway and query proxy fail closed when Platform authorization is unavailable.


### PR DESCRIPTION
**DO NOT MERGE**: Depending on https://github.com/loft-sh/loft-enterprise/pull/7989 being merged first.



<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
The bundled cluster-collector template now scrapes the tenant control plane's backing store, so document what it collects, how to query it, and how to tell its one expected failure apart from a real one.

Readers need the always-down job called out explicitly. Because the jobs ship ungated, every tenant cluster has one permanently failing target, and without this note the reasonable conclusion is that the collector is broken. The same property makes a general up == 0 alert unusable, so the collectors page gives the exclusion query and the per-backing-store alert to use instead.

The kubectl get --raw caveat is in troubleshooting because the obvious diagnostic is actively misleading, not merely unsupported: a platform kubeconfig answers non-resource paths from Platform itself and returns the Platform web UI's HTML, so the command appears to succeed while saying nothing about the tenant cluster.

Deployed and external etcd are stated as uncovered on both pages, since vCluster serves no metrics route for either.

The kine series are described generically. Verification so far covers a tenant cluster on embedded etcd, where all four documented etcd queries return data.


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Part of ENGPLAT-954


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

