### PR TITLE
adds: auto snapshot support for standalone

### DIFF
--- a/vcluster/_fragments/snapshots-oci.mdx
+++ b/vcluster/_fragments/snapshots-oci.mdx
@@ -15,6 +15,8 @@ import Flow, { Step } from '@site/src/components/Flow';
 
 It's recommended to store your credentials to your OCI registry in a secret and reference the secret in the `vcluster.yaml` of your tenant cluster configuration. This protects the details of your credentials.
 
+For standalone deployments, the secret must be created in the project namespace where the standalone cluster is created. Standalone deployments cannot specify the namespace the secret lives in, only the secret name.
+
 <Flow>
 <Step>
   Create a Kubernetes secret of your credentials to your OCI registry.

--- a/vcluster/_fragments/snapshots-oci.mdx
+++ b/vcluster/_fragments/snapshots-oci.mdx
@@ -15,7 +15,7 @@ import Flow, { Step } from '@site/src/components/Flow';
 
 It's recommended to store your credentials to your OCI registry in a secret and reference the secret in the `vcluster.yaml` of your tenant cluster configuration. This protects the details of your credentials.
 
-For standalone deployments, the secret must be created in the project namespace where the standalone cluster is created. Standalone deployments cannot specify the namespace the secret lives in, only the secret name.
+For standalone deployments, the secret must be created in the project namespace where the standalone cluster is created. The `credential.namespace` field is still part of the schema, but standalone deployments ignore it at runtime and always read the secret from that project namespace.
 
 <Flow>
 <Step>

--- a/vcluster/_fragments/snapshots-s3-aws.mdx
+++ b/vcluster/_fragments/snapshots-s3-aws.mdx
@@ -1,5 +1,9 @@
 import Flow, { Step } from '@site/src/components/Flow';
 
+:::info Standalone deployments
+Automatic snapshots are supported for standalone deployments, with two differences: AWS pod identity authentication is not available, and the credentials secret must be created in the project namespace of the tenant cluster.
+:::
+
 #### S3 configuration options
 
 | Option  | Description  |
@@ -10,6 +14,10 @@ import Flow, { Step } from '@site/src/components/Flow';
 | `auto.storage.type.s3.credential.namespace` | Namespace of the Kubernetes secret. The secret must be deployed on the host of where the vCluster control plane pod is deployed to. |
 
 #### Authenticate with AWS Pod identity
+
+:::warning Not available for standalone
+AWS pod identity authentication is not supported for standalone deployments. Use S3 credentials stored in a Kubernetes secret instead.
+:::
 
 When using AWS S3 buckets, it is recommended to authenticate using [AWS pod identity](https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/).
 
@@ -30,13 +38,15 @@ snapshots:
           url: s3://<bucket-name>/snapshots
 ```
 
-#### Authenticate with AWS Credentials as a secret
+#### Authenticate with S3 Credentials as a secret
 
-Alternatively, you can create a Kubernetes secret with your AWS credentials.
+Alternatively, you can create a Kubernetes secret with your S3 credentials.
+
+For standalone deployments, the secret must be created in the project namespace where the tenant cluster is created. Standalone deployments cannot specify the namespace the secret lives in, only the secret name.
 
 <Flow>
 <Step>
-  Create a Kubernetes secret of your AWS credentials.
+  Create a Kubernetes secret of your S3 credentials.
 
   Create this secret on the host of where the vCluster control plane is deployed. It could be deployed in the namespace
   of the vCluster or a different namespace. If the vCluster is externally deployed, ensure the vCluster ClusterRole has permission to read the secret. The vCluster ClusterRole follows the naming pattern `vc-<vClusterName>-v-<vClusterNamespace>`.

--- a/vcluster/_fragments/snapshots-s3-aws.mdx
+++ b/vcluster/_fragments/snapshots-s3-aws.mdx
@@ -1,7 +1,7 @@
 import Flow, { Step } from '@site/src/components/Flow';
 
 :::info Standalone deployments
-Automatic snapshots are supported for standalone deployments, with two differences: AWS pod identity authentication is not available, and the credentials secret must be created in the project namespace of the tenant cluster.
+Automatic snapshots are supported for standalone deployments, with two differences: AWS pod identity authentication is not available, and the credentials secret must be created in the project namespace of the standalone cluster.
 :::
 
 #### S3 configuration options
@@ -38,11 +38,11 @@ snapshots:
           url: s3://<bucket-name>/snapshots
 ```
 
-#### Authenticate with S3 Credentials as a secret
+#### Authenticate with S3 credentials as a secret
 
 Alternatively, you can create a Kubernetes secret with your S3 credentials.
 
-For standalone deployments, the secret must be created in the project namespace where the tenant cluster is created. Standalone deployments cannot specify the namespace the secret lives in, only the secret name.
+For standalone deployments, the secret must be created in the project namespace where the standalone cluster is created. The `credential.namespace` field is still part of the schema, but standalone deployments ignore it at runtime and always read the secret from that project namespace.
 
 <Flow>
 <Step>

--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -2,7 +2,7 @@
 title: Snapshots
 sidebar_label: snapshots
 sidebar_position: 8
-sidebar_class_name: pro host-nodes private-nodes
+sidebar_class_name: pro host-nodes private-nodes standalone
 description: Learn how to configure automatic snapshots.
 ---
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
@@ -86,7 +86,7 @@ snapshots:
 
 ### S3 bucket example
 
-Snapshots can be stored in a S3 bucket.
+Snapshots can be stored in an S3 bucket.
 
 <details>
 <summary>Configure snapshots with S3</summary>

--- a/vcluster/configure/vcluster-yaml/snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/snapshots.mdx
@@ -21,7 +21,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <FeatureTable names="scheduled-snapshots" />
 
-<TenancySupport hostNodes="true" privateNodes="true" />
+<TenancySupport hostNodes="true" privateNodes="true" standalone="true" />
 
 <ProAdmonition />
 
@@ -84,12 +84,12 @@ snapshots:
         url: s3://my-bucket/path
 ```
 
-### AWS S3 bucket example
+### S3 bucket example
 
-Snapshots can be stored in an AWS S3 bucket.
+Snapshots can be stored in a S3 bucket.
 
 <details>
-<summary>Configure snapshots with AWS S3</summary>
+<summary>Configure snapshots with S3</summary>
 <SnapshotsS3AWS />
 </details>
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Documents automatic snapshot support for standalone deployments.

The S3 fragments now opens with a note that auto snapshots work on standalone, with two caveats: 
 - AWS pod identity authentication is unavailable
 - Credentials secret must live in the standalone cluster project namespace. 
 
The pod identity section carries a matching warning, and both the S3 and OCI fragments explain that standalone deployments can specify only the secret name, not its namespace. 

The S3 example section in snapshots.mdx is also retitled from "AWS S3" to "S3", since the fragment covers S3-compatible storage generally.

## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-1231


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

