### PR TITLE
docs(stacks): document Stacks in the platform docs

### DIFF
--- a/platform/integrations/certified-stacks/index.mdx
+++ b/platform/integrations/certified-stacks/index.mdx
@@ -9,9 +9,15 @@ application stack. Each stack handles provisioning, dependency orchestration, an
 automatically, so platform teams can go from zero to a fully configured tenant cluster environment
 without manual integration work.
 
-Stacks are maintained in the [certified-stacks](https://github.com/loft-sh/certified-stacks)
+Certified Stacks are maintained in the [certified-stacks](https://github.com/loft-sh/certified-stacks)
 repository. The repo contains full documentation, usage instructions, and architecture details
 for each stack.
+
+:::note not the same as Stacks
+Certified Stacks are reference deployments maintained in a public repository. They are
+distinct from [Stacks](../../use-platform/stacks/index.mdx), the platform feature for
+deploying dependency-ordered application bundles from a `StackTemplate`.
+:::
 
 ## Why use certified stacks
 

--- a/platform/use-platform/stacks/_category_.json
+++ b/platform/use-platform/stacks/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Stacks",
+  "position": "3.25",
+  "className": "pro",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/platform/use-platform/stacks/create-a-stack-template.mdx
+++ b/platform/use-platform/stacks/create-a-stack-template.mdx
@@ -1,0 +1,144 @@
+---
+title: Create a stack template
+sidebar_label: Create a stack template
+sidebar_position: 2
+---
+
+A `StackTemplate` declares the parameters a stack accepts and the tasks it deploys. It is
+cluster-scoped and reusable: many `StackInstance` resources, in different projects and
+against different destinations, can reference the same template.
+
+## Declare parameters
+
+Parameters use the same schema as [App parameters](../apps/use-parameters.mdx).
+
+```yaml
+spec:
+  parameters:
+    - variable: appVersion
+      type: string
+      required: true
+      defaultValue: "1.4.0"
+      label: Application version
+      validation: '^[0-9]+\.[0-9]+\.[0-9]+$'
+    - variable: replicas
+      type: number
+      defaultValue: 2
+      label: Replica count
+```
+
+Values supplied on the instance are read in task payloads as `{{ .Values.<variable> }}`.
+
+## Declare tasks
+
+Each task deploys one application and names the tasks it waits for.
+
+```yaml
+spec:
+  tasks:
+    - name: namespace
+      timeout: 5m
+      app:
+        templateRef:
+          name: demo-namespace
+
+    - name: database
+      dependsOn: [namespace]
+      app:
+        templateRef:
+          name: demo-postgres
+```
+
+A task starts only once every task in its `dependsOn` list reaches readiness. Tasks with
+no dependency relationship run in parallel. The graph must be acyclic and every name in a
+`dependsOn` list must match a declared task.
+
+### Task names
+
+Task names must be valid DNS labels and unique within the stack.
+
+There is one extra restriction: **a task that declares outputs must use letters and digits
+only**. Outputs are referenced as `{{ .Outputs.<task>.<output> }}`, and the template syntax
+cannot address a name containing a hyphen. A task that declares no outputs may contain
+hyphens freely.
+
+```yaml
+# Valid: declares outputs, name is letters and digits only.
+- name: database
+  outputs:
+    - name: password
+      fromSecret: { namespace: demo, name: demo-postgres, key: password }
+
+# Valid: contains a hyphen, but declares no outputs.
+- name: ingress-ready
+  app:
+    templateRef: { name: demo-ingress-ready }
+```
+
+### Timeouts
+
+Each task has a timeout. The default is 10 minutes and is set stack-wide through
+`spec.defaults.taskTimeout` on the instance; a task overrides it with its own `timeout`.
+A task that does not reach readiness within its timeout is marked `Failed`.
+
+```yaml
+spec:
+  defaults:
+    taskTimeout: 15m
+  tasks:
+    - name: gpu-operator
+      timeout: 25m
+      app:
+        templateRef: { name: gpu-operator }
+```
+
+Set timeouts against what a component realistically takes. Operators that wait on node
+readiness or pull large images need considerably more than the default.
+
+## Publish outputs
+
+`publishedOutputs` selects which captured task outputs the stack exposes to its consumers,
+optionally under a different name. Only values already captured by a task can be published;
+nothing extra is read from the destination.
+
+```yaml
+spec:
+  publishedOutputs:
+    - name: databasePassword
+      fromTask:
+        task: database
+        output: password
+```
+
+See [Parameters and outputs](./parameters-and-outputs.mdx) for how these are read back.
+
+## Conditional tasks are not supported
+
+A task cannot be skipped based on a parameter. There is no `when` or `enabled` field, and
+a stack always resolves to its full task set.
+
+The supported pattern is to select a different application by interpolating the
+`templateRef` name, pointing at an application that does nothing when the feature is not
+wanted:
+
+```yaml
+- name: gpu
+  dependsOn: [namespace]
+  app:
+    templateRef:
+      name: 'gpu-operator{{ if eq .Values.gpuProvider "gke" }}-skip{{ end }}'
+```
+
+This requires a no-op application to exist under the resolved name. The task still runs and
+still reports a phase; only its payload changes.
+
+## Validate before you rely on it
+
+Several rules are enforced at admission rather than at deploy time, so a malformed template
+is rejected on apply:
+
+- Exactly one of `argoCDApplication` or `app` per task.
+- Exactly one of `template` or `templateRef` per task payload.
+- Exactly one of `fromSecret` or `fromResource` per output.
+- Every `dependsOn` entry names a declared task, and the graph is acyclic.
+- Every `publishedOutputs` entry names an existing task and one of its declared outputs.

--- a/platform/use-platform/stacks/deploy-a-stack.mdx
+++ b/platform/use-platform/stacks/deploy-a-stack.mdx
@@ -1,0 +1,171 @@
+---
+title: Deploy a stack
+sidebar_label: Deploy a stack
+sidebar_position: 5
+---
+
+import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
+import Label from "@site/src/components/Label";
+
+A `StackInstance` deploys one stack into one destination. It lives in a project namespace
+and either references a cluster-scoped `StackTemplate` or carries its definition inline.
+
+## Deploy from a template
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: StackInstance
+metadata:
+  name: demo-app
+  namespace: loft-p-demo
+spec:
+  displayName: Demo application
+  templateRef:
+    name: demo-app
+  parameters: |
+    appVersion: "1.4.0"
+    replicas: 3
+  destination:
+    virtualCluster:
+      name: demo-tenant
+```
+
+Values for the template's declared parameters go on the instance. A missing required
+parameter, or a value that fails a parameter's validation, leaves the instance blocked with
+the reason `TemplateInvalid`.
+
+## Define a stack inline
+
+An instance can carry its own definition instead of referencing a template. The `template`
+field has the same shape as a `StackTemplate` spec:
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: StackInstance
+metadata:
+  name: demo-app
+  namespace: loft-p-demo
+spec:
+  template:
+    tasks:
+      - name: namespace
+        app:
+          templateRef: { name: demo-namespace }
+      - name: database
+        dependsOn: [namespace]
+        app:
+          templateRef: { name: demo-postgres }
+  destination:
+    virtualCluster:
+      name: demo-tenant
+```
+
+Use a template when several instances share a definition. Use an inline definition for a
+one-off stack that nothing else reuses.
+
+## Choose a destination
+
+A stack deploys into either a tenant cluster or a connected cluster. Exactly one of the two
+must be set.
+
+```yaml
+# Into a tenant cluster.
+destination:
+  virtualCluster:
+    name: demo-tenant
+
+# Into a connected cluster.
+destination:
+  cluster:
+    name: production-eu
+```
+
+The two are resolved differently, and the difference matters:
+
+| Destination | Resolved as | Scope |
+|-------------|-------------|-------|
+| `virtualCluster` | `VirtualClusterInstance` | **The instance's own namespace.** The tenant cluster must be in the same project as the stack. |
+| `cluster` | `Cluster` | Cluster-scoped. Any connected cluster. |
+
+:::warning a stack cannot target a tenant cluster in another project
+`destination.virtualCluster` is looked up in the `StackInstance`'s own namespace. There is
+no cross-project form of this field. To deploy the same stack into tenant clusters in
+several projects, create one `StackInstance` per project, all referencing the same
+`StackTemplate`.
+:::
+
+### The destination is immutable
+
+The destination cannot be changed after the instance is created. If the named destination
+does not exist, the instance is blocked with the reason `DestinationNotFound` and stays
+blocked until that destination is created. A stack cannot be retargeted; create a new
+instance instead.
+
+While a destination is being torn down, the instance reports `DestinationDeleting` and
+applications are not applied, because a recreated application would hold up the
+destination's own deletion.
+
+## Deploy from the UI
+
+There is no global "create stack" action, and stacks are not deployed from the stack
+templates page. You create a stack from the destination it deploys into, so the destination
+is fixed by where you start.
+
+### Into a tenant cluster
+
+<Flow id="deploy-stack-vcluster">
+  <Step>
+    From the project drop-down menu, select the project holding the tenant cluster.
+  </Step>
+  <Step>
+    Click <NavStep>Tenant Clusters</NavStep> and open the tenant cluster.
+  </Step>
+  <Step>
+    Open the <Label>Config</Label> tab, then the <Label>Stacks</Label> section. It lists the
+    stacks already deployed to this tenant cluster.
+  </Step>
+  <Step>
+    Add a stack. The destination is locked to this tenant cluster and the namespace is fixed,
+    so there is no destination or project to choose.
+  </Step>
+  <Step>
+    Choose a stack template or define the stack inline, fill in the template's parameters,
+    then confirm.
+  </Step>
+</Flow>
+
+### Into a connected cluster
+
+<Flow id="deploy-stack-cluster">
+  <Step>
+    Click <NavStep>Clusters</NavStep> and open the cluster.
+  </Step>
+  <Step>
+    Open the <Label>Stacks</Label> tab. It lists the stacks already deployed to this cluster.
+  </Step>
+  <Step>
+    Add a stack. The cluster is fixed by context, but you choose the project that provides the
+    namespace for the `StackInstance`.
+  </Step>
+  <Step>
+    Choose a stack template or define the stack inline, fill in the template's parameters,
+    then confirm.
+  </Step>
+</Flow>
+
+Each stack is shown as a card with its task graph, per-task status, and published outputs.
+Day-2 actions on a stack are **Edit**, which opens the YAML sheet, **Show Yaml**, and
+**Delete**.
+
+## Manage stack templates
+
+Stack templates are managed separately from the stacks that use them. Click
+<NavStep>Stacks &amp; Apps</NavStep> to list, create, and edit `StackTemplate` resources.
+Deploying is done from a destination, as above.
+
+:::note the nav item is named for what you can access
+The sidebar entry is labeled **Stacks &amp; Apps** for users who can list stack templates,
+and **Apps** for those who cannot. If you see only **Apps**, your role does not grant access
+to stacks. See [Access and permissions](./index.mdx#access-and-permissions).
+:::

--- a/platform/use-platform/stacks/index.mdx
+++ b/platform/use-platform/stacks/index.mdx
@@ -1,0 +1,124 @@
+---
+title: Stacks
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+A stack deploys several applications into one destination in dependency order. Each
+application is a task, tasks declare which other tasks they wait for, and the platform
+rolls them out in that order. A task can pass a captured value, such as a generated
+password or a load balancer address, to a task that runs later.
+
+Use a stack when a single [App](../apps/use-on-demand.mdx) is not enough because the
+components have to land in a specific order, or because one component needs a value that
+another component only produces at deploy time.
+
+## StackTemplate and StackInstance
+
+Stacks are built from two resources.
+
+| Resource | Scope | Purpose |
+|----------|-------|---------|
+| `StackTemplate` | Cluster-scoped | A reusable, parameterized blueprint: declared parameters and a task graph. It has no controller of its own and is resolved when an instance reconciles. |
+| `StackInstance` | Namespaced (project) | One deployment of a stack into one destination. It either references a `StackTemplate` or carries its definition inline. |
+
+A `StackTemplate` is passive. Nothing happens until a `StackInstance` references it and
+supplies values for its parameters.
+
+## Example
+
+This stack creates a namespace, deploys a database, then deploys an application that
+needs the password the database generated.
+
+```mermaid
+flowchart LR
+  namespace["namespace<br/>(Healthy)"] --> database["database<br/>(Healthy)"]
+  database -->|"password"| app["app<br/>(Progressing)"]
+```
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: StackTemplate
+metadata:
+  name: demo-app
+spec:
+  displayName: Demo application
+  parameters:
+    - variable: appVersion
+      type: string
+      required: true
+      defaultValue: "1.4.0"
+      label: Application version
+  tasks:
+    - name: namespace
+      app:
+        templateRef:
+          name: demo-namespace
+
+    - name: database
+      dependsOn: [namespace]
+      app:
+        templateRef:
+          name: demo-postgres
+      outputs:
+        - name: password
+          fromSecret:
+            namespace: demo
+            name: demo-postgres
+            key: password
+
+    - name: app
+      dependsOn: [database]
+      app:
+        templateRef:
+          name: demo-frontend
+        parameters:
+          version: "{{ .Values.appVersion }}"
+          databasePassword: "{{ .Outputs.database.password }}"
+
+  publishedOutputs:
+    - name: databasePassword
+      fromTask:
+        task: database
+        output: password
+```
+
+Note the two kinds of reference. `{{ .Values.appVersion }}` reads a stack parameter, and
+`{{ .Outputs.database.password }}` reads a value captured from the `database` task after
+that task became healthy. See [Parameters and outputs](./parameters-and-outputs.mdx).
+
+## Access and permissions
+
+Stacks are an administrator feature. The built-in **Project Admin** role
+(`loft-management-project-admin`) grants full access to `stackinstances` and the
+`stackinstances/outputs` subresource. The built-in **Project User** and **Project Viewer**
+roles do not include either resource, so users holding those roles cannot create stacks,
+list them, or read their outputs.
+
+Licensing is applied per task type rather than to stacks as a whole:
+
+| Task type | Required license feature |
+|-----------|--------------------------|
+| `app` | Apps |
+| `argoCDApplication` | Argo CD integration |
+
+If a license does not cover the features a stack's tasks need, the instance is blocked
+with the reason `FeatureNotAllowed` and nothing is deployed.
+
+## Certified templates
+
+With an Apps-bearing license, the platform seeds a set of certified NVIDIA Run:ai
+`StackTemplate` resources, labeled `vcluster.com/certified: "true"`. They cover the
+self-hosted control plane model and the shared central control plane model. These are
+separate from
+[Certified Stacks](../../integrations/certified-stacks/index.mdx), the reference
+deployments maintained in a public repository.
+
+## Next steps
+
+- [Create a stack template](./create-a-stack-template.mdx)
+- [Task types](./task-types.mdx)
+- [Parameters and outputs](./parameters-and-outputs.mdx)
+- [Deploy a stack](./deploy-a-stack.mdx)
+- [Lifecycle and status](./lifecycle.mdx)
+- [Declare stacks in vcluster.yaml](./vcluster-yaml.mdx)

--- a/platform/use-platform/stacks/lifecycle.mdx
+++ b/platform/use-platform/stacks/lifecycle.mdx
@@ -1,0 +1,108 @@
+---
+title: Lifecycle and status
+sidebar_label: Lifecycle and status
+sidebar_position: 6
+---
+
+A stack reports status at two levels: an aggregate phase for the instance, and a phase for
+each task.
+
+## Instance phases
+
+| Phase | Meaning |
+|-------|---------|
+| `Pending` | A prerequisite is missing and needs manual intervention. |
+| `Progressing` | At least one task is still rolling out. |
+| `Healthy` | Every task reached readiness. |
+| `Degraded` | At least one task failed. |
+| `Deleting` | The instance is being torn down. |
+
+## Task phases
+
+| Phase | Meaning |
+|-------|---------|
+| `Pending` | Not yet materialized. |
+| `Waiting` | Waiting on its dependencies. |
+| `Progressing` | The child application is rolling out. |
+| `Blocked` | Waiting on a prerequisite that somebody has to fix. |
+| `Healthy` | The child application reached readiness. |
+| `Failed` | The child application failed or timed out. |
+
+Each task status also carries its `type` (`app` or `argoCDApplication`), a machine-readable
+`reason`, a human-readable `message`, and `lastTransitionTime`. Argo CD Application tasks
+additionally report `synced` and `health`.
+
+Task status is reported for tasks that have not been materialized yet, so the full task set
+is visible from the moment the stack resolves. The task list is empty only when the instance
+stopped before it could work out its task set, such as when the template does not resolve.
+
+## The Ready condition
+
+The instance carries a `Ready` condition. When the stack is not progressing normally, its
+reason says why:
+
+| Reason | Meaning | Action |
+|--------|---------|--------|
+| `Invalid` | The spec itself is malformed. | Edit the stack. |
+| `TemplateNotFound` | `templateRef` names a `StackTemplate` that does not exist. | Create the template, or fix the reference. |
+| `TemplateInvalid` | The template exists but cannot be rendered: a missing parameter, a failed validation, or a substitution error. | Edit the stack. Nothing is retried until you do. |
+| `NoTasks` | The stack resolved to no tasks at all. | Edit the stack. |
+| `FeatureNotAllowed` | The license does not cover a feature the stack's tasks need. | Change the license. |
+| `DestinationNotFound` | `destination` names a cluster or tenant cluster that does not exist. | Create the destination. The destination is immutable, so this clears only when it exists. |
+| `DestinationDeleting` | The destination is being torn down. | Wait, or deploy elsewhere. |
+| `OutputsConflict` | A Secret the instance does not own already holds the name its task outputs are stored under. | Remove or rename the conflicting Secret. |
+| `Progressing` | Tasks are still rolling out. | Wait. |
+| `Degraded` | At least one task failed. | Inspect the failing task. |
+
+`TemplateInvalid` is a permanent user error. The controller reports it and waits rather than
+retrying quickly, so a stack in this state stays there until it is edited.
+
+## Retry
+
+A stack can be retried without recreating the instance. Retrying is requested by setting the
+`platform.vcluster.com/stack-retry` annotation on the `StackInstance`, either to a single
+task name or to `all`:
+
+```yaml
+metadata:
+  annotations:
+    platform.vcluster.com/stack-retry: "all"
+```
+
+The controller removes the annotation once it has acted on it, so the annotation's presence
+is what "a retry is in flight" means. There is no status field reporting it.
+
+In the UI, retry is available from the stack card. Requesting a retry needs the `update`
+verb on the `StackInstance`.
+
+:::note per-task retry is limited to Argo CD Application tasks
+A single task can be retried only when it is in the `Failed` phase **and** its type is not
+`app`. An `app` task that failed cannot be retried on its own; retry the whole stack with
+`all` instead.
+:::
+
+## Template drift and orphaned applications
+
+When a task is removed from a stack's resolved task set, for example because the template
+changed, the application it deployed becomes an orphan. `prunePolicy` on the instance
+controls what happens to it:
+
+| Policy | Behavior |
+|--------|----------|
+| `Retain` | The orphaned application is left in place. This is the default, and the behavior when the field is empty. |
+| `Prune` | The orphaned application is deleted. |
+
+```yaml
+spec:
+  prunePolicy: Prune
+```
+
+With `Prune`, orphans are deleted in reverse-dependency order, so an application that
+something still depends on is never deleted first. The dependency edges captured when the
+task left the resolved set are carried forward for exactly this purpose.
+
+:::warning Retain is the default
+Changing a template so that a task disappears does not remove what that task deployed. The
+application keeps running, unmanaged by the stack. Set `prunePolicy: Prune` if you want
+removals from the template to reach the destination.
+:::

--- a/platform/use-platform/stacks/parameters-and-outputs.mdx
+++ b/platform/use-platform/stacks/parameters-and-outputs.mdx
@@ -1,0 +1,199 @@
+---
+title: Parameters and outputs
+sidebar_label: Parameters and outputs
+sidebar_position: 4
+---
+
+Stack payloads read two kinds of value, and they behave differently.
+
+| Reference | Reads | Available |
+|-----------|-------|-----------|
+| `{{ .Values.<name> }}` | A stack parameter, supplied on the instance | Immediately, before any task runs |
+| `{{ .Outputs.<task>.<output> }}` | A value captured from a task's destination | Only after that task became healthy |
+
+Parameters are filled in first. Outputs are filled in later, once the task that produces
+them has run and its value has been captured. That ordering is the reason the two behave
+differently in the sections below.
+
+## Parameters
+
+Parameters are declared on the template and supplied on the instance. Inside a task payload
+they support the full template syntax, including conditionals and functions:
+
+```yaml
+- name: backend
+  app:
+    templateRef:
+      name: demo-backend
+    parameters:
+      version: "{{ .Values.appVersion }}"
+      fqdn: '{{ if .Values.domain }}{{ .Values.domain }}{{ else }}{{ .Values.tenant }}.example.com{{ end }}'
+```
+
+## Declare an output
+
+A task declares the values it captures from its destination. Each output reads from exactly
+one source: a Secret key, or a single field of a single resource.
+
+### From a Secret
+
+```yaml
+- name: database
+  outputs:
+    - name: password
+      fromSecret:
+        namespace: demo
+        name: demo-postgres
+        key: password
+```
+
+### From a resource
+
+```yaml
+- name: ingress
+  outputs:
+    - name: address
+      fromResource:
+        apiVersion: v1
+        kind: Service
+        namespace: ingress-nginx
+        name: ingress-nginx-controller
+        jsonPath: "{.status.loadBalancer.ingress[0].ip}"
+```
+
+`jsonPath` uses kubectl template syntax and must select exactly one scalar value. The
+namespace must be a namespace the stack deploys into, and cluster-scoped resources cannot
+be read.
+
+Output names must be letters and digits only, and unique within the task. The task that
+declares them is subject to the same restriction. See
+[Task names](./create-a-stack-template.mdx#task-names).
+
+## Read an output in a later task
+
+```yaml
+- name: app
+  dependsOn: [database]
+  app:
+    templateRef:
+      name: demo-frontend
+    parameters:
+      databasePassword: "{{ .Outputs.database.password }}"
+```
+
+The reference must sit inside a task that depends, directly or transitively, on the task
+producing the value. Otherwise there is no guarantee the value has been captured.
+
+### Output references must be plain substitutions
+
+Because outputs are filled in after the rest of the template has rendered, an output can
+only be read as a plain substitution. Pipelines and functions are rejected when the stack is
+applied, not silently ignored:
+
+```yaml
+# Rejected on apply.
+databasePassword: "{{ .Outputs.database.password | quote }}"
+caBundle: "{{ .Outputs.ca.cert | b64enc | nindent 4 }}"
+
+# Correct.
+databasePassword: "{{ .Outputs.database.password }}"
+```
+
+This is the one place where output references and parameter references differ in what they
+accept. `{{ .Values.x | quote }}` is fine; `{{ .Outputs.t.x | quote }}` is not.
+
+Two further restrictions apply to any string that reads `.Outputs`:
+
+- It must not also declare a template with `define` or `block`.
+- An action that reads `.Outputs` must not contain the literal text `{{`.
+
+### The reserved `<%` sequence
+
+A task payload must not contain the literal text `<%`, which is reserved. Applying a stack
+whose payload contains it is rejected.
+
+### What you see in the stored resource
+
+When a stack is applied, the platform rewrites output references into an internal form that
+uses different delimiters:
+
+```yaml
+# What you write:
+databasePassword: "{{ .Outputs.database.password }}"
+
+# What you see when reading the stored StackInstance back:
+databasePassword: "<% .Outputs.database.password %>"
+```
+
+This is expected. Always author using `{{ }}`, and never write `<%` yourself.
+
+## Publish outputs
+
+`publishedOutputs` selects the captured task outputs the stack exposes, optionally renaming
+them:
+
+```yaml
+spec:
+  publishedOutputs:
+    - name: databasePassword
+      fromTask:
+        task: database
+        output: password
+    - name: ingressAddress
+      fromTask:
+        task: ingress
+        output: address
+```
+
+## Read published outputs
+
+Published output values live in a platform-managed Secret. They are never written to the
+instance's `status`. They are read either in the UI, on the stack's detail view, or through
+the `stackinstances/outputs` subresource of the management API, which requires the `get`
+verb on that subresource:
+
+```bash
+kubectl get --raw \
+  "/apis/management.loft.sh/v1/namespaces/loft-p-demo/stackinstances/demo-app/outputs"
+```
+
+There is no CLI command for reading stack outputs.
+
+Each published output reports a `state`:
+
+| State | Meaning |
+|-------|---------|
+| `Available` | The value is captured and returned. |
+| `Pending` | No value can be served yet. |
+| `Failed` | The value cannot be produced. |
+
+The `reason` distinguishes a stack that has to be edited from one that may still come good
+on its own. `OutputNotDeclared` and `NoSource` mean the stack is wrong and must be fixed.
+`NotCaptured`, `TaskFailed`, and `SourceChanged` describe a value that is not ready yet or
+no longer matches the stack's declarations.
+
+:::note an Available output can still carry a reason
+An output can be `Available` with the reason `TaskFailed`. This means the task producing the
+value failed **after** the value was captured, so what you are being served is the last good
+value rather than a current one.
+:::
+
+## Handle sensitive values
+
+Whether an output is treated as sensitive is decided by **the source you read it from**, not
+by what the value contains:
+
+| Source | `sensitive` |
+|--------|-------------|
+| `fromSecret` | `true` |
+| `fromResource` | `false` |
+
+:::warning read secret values with fromSecret
+A credential captured through `fromResource` is reported as not sensitive and is displayed
+in plain text wherever outputs are shown. To have a value treated as sensitive, read it from
+a Secret with `fromSecret`.
+:::
+
+Masking in the UI is a display affordance, not an access control. Anyone permitted to read
+the outputs subresource can read the real value regardless of how it is displayed. The
+actual boundary is RBAC on `stackinstances/outputs`.

--- a/platform/use-platform/stacks/task-types.mdx
+++ b/platform/use-platform/stacks/task-types.mdx
@@ -1,0 +1,111 @@
+---
+title: Task types
+sidebar_label: Task types
+sidebar_position: 3
+---
+
+Every task deploys exactly one of two things: a platform App, or an Argo CD Application.
+A task sets exactly one of `app` or `argoCDApplication`. Setting both, or neither, is
+rejected at admission.
+
+The choice determines which license feature the stack needs:
+
+| Task payload | Child resource | Required license feature |
+|--------------|----------------|--------------------------|
+| `app` | App instance | Apps |
+| `argoCDApplication` | Argo CD Application | Argo CD integration |
+
+A stack may mix both types. It then requires both features, and is blocked with the reason
+`FeatureNotAllowed` if the license covers only one.
+
+## App tasks
+
+An `app` task deploys a platform [App](../apps/use-on-demand.mdx) into the stack's
+destination.
+
+### Reference an existing App
+
+Use `templateRef` to deploy an App that already exists in the platform, and pass values to
+its parameters:
+
+```yaml
+- name: database
+  dependsOn: [namespace]
+  app:
+    templateRef:
+      name: demo-postgres
+    parameters:
+      storageClass: "{{ .Values.storageClass }}"
+      replicas: "{{ .Values.replicas }}"
+```
+
+### Define an App inline
+
+Use `template` to define the chart and values in the stack itself, without creating a
+separate App first:
+
+```yaml
+- name: database
+  dependsOn: [namespace]
+  app:
+    template:
+      metadata:
+        labels:
+          example.com/component: database
+      spec:
+        displayName: Demo database
+        releaseName: demo-postgres
+        namespace: demo
+        helm:
+          chart:
+            name: postgresql
+            version: "16.2.1"
+            repository: https://charts.bitnami.com/bitnami
+          values: |
+            auth:
+              database: demo
+```
+
+:::note parameters belong to templateRef only
+`parameters` is valid only alongside `templateRef`. Admission rejects `parameters` on a
+task that defines its App inline, because those values belong in the definition itself.
+:::
+
+An inline App definition carries the chart, values, and deploy options. Where the App runs,
+who owns it, and who can see it come from the stack, so the destination, owner, and access
+fields do not appear on the task.
+
+## Argo CD Application tasks
+
+An `argoCDApplication` task deploys an Argo CD Application. It requires the
+[Argo CD integration](../../integrations/argocd/overview.mdx) to be configured.
+
+```yaml
+- name: monitoring
+  dependsOn: [namespace]
+  argoCDApplication:
+    templateRef:
+      name: kube-prometheus
+```
+
+As with App tasks, `template` defines the Application inline instead:
+
+```yaml
+- name: monitoring
+  argoCDApplication:
+    template:
+      spec:
+        source:
+          repoURL: https://github.com/example/manifests
+          path: monitoring
+          targetRevision: "{{ .Values.manifestRevision }}"
+```
+
+### Readiness and health
+
+Argo CD Application tasks report two extra pieces of status that App tasks do not:
+`synced`, and `health` mirroring the child Argo CD health value. The task's own `phase`
+stays type-agnostic: `Healthy` and `Failed` describe the task's resolved readiness rather
+than Argo CD specific state, so a stack that mixes both task types reports consistently.
+
+See [Lifecycle and status](./lifecycle.mdx).

--- a/platform/use-platform/stacks/vcluster-yaml.mdx
+++ b/platform/use-platform/stacks/vcluster-yaml.mdx
@@ -1,0 +1,72 @@
+---
+title: Declare stacks in vcluster.yaml
+sidebar_label: Stacks in vcluster.yaml
+sidebar_position: 7
+---
+
+A stack can be declared inside a tenant cluster's own `vcluster.yaml`, under the top-level
+`deploy.stacks` key, instead of being created as a `StackInstance` through the platform API.
+
+```yaml
+deploy:
+  stacks:
+    - name: monitoring
+      template:
+        tasks:
+          - name: install
+            argoCDApplication:
+              templateRef:
+                name: kube-prometheus
+```
+
+The platform turns each entry into a `StackInstance` that the tenant cluster owns.
+
+## Behavior
+
+**The destination is fixed.** A stack declared this way always deploys into the tenant
+cluster that declares it. There is no `destination` field, and one of these stacks cannot
+target another cluster.
+
+**Names are derived.** The generated `StackInstance` is named `<tenant-cluster>-<stack>`,
+truncated to 63 characters. Choose stack names that stay distinct after truncation.
+
+**The stack's lifecycle follows the tenant cluster's.** The instances are owned by the
+tenant cluster, so removing an entry from `deploy.stacks` or deleting the tenant cluster
+takes the stack with it.
+
+## Parsing is strict
+
+The `deploy.stacks` subtree is parsed on its own with strict unmarshalling. A misspelled
+field is a hard error rather than a silently dropped value, so the tenant cluster fails to
+apply instead of deploying something different from what was written.
+
+Large integer values survive the round trip without being converted through a floating point
+type, so a parameter value such as a port number or a byte count is passed through exactly.
+
+## Reference a template
+
+An entry can reference an existing cluster-scoped `StackTemplate` rather than defining the
+task graph inline:
+
+```yaml
+deploy:
+  stacks:
+    - name: platform-baseline
+      templateRef:
+        name: demo-app
+      parameters:
+        appVersion: "1.4.0"
+```
+
+## When to use this
+
+Use `deploy.stacks` when the stack is part of what defines a tenant cluster, so that
+creating the tenant cluster from a template also brings up its applications. Use a
+[`StackInstance`](./deploy-a-stack.mdx) when the stack has an independent lifecycle, when it
+targets a connected cluster, or when it should be deployed and removed without editing the
+tenant cluster's configuration.
+
+:::note this key is understood by the platform
+`deploy.stacks` is acted on by vCluster Platform. A tenant cluster running standalone,
+without the platform, does not deploy stacks declared here.
+:::


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link or links to the documents-->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-
Fixes ENGNODE-858

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

