### PR TITLE
docs(platform): rework upgrade docs and correct helm guidance

### DIFF
--- a/platform/_partials/install/upgrade.mdx
+++ b/platform/_partials/install/upgrade.mdx
@@ -8,7 +8,7 @@ Upgrade the platform
 - Test the upgrade in a non-production environment before applying it to your production setup.
 :::
 
-Upgrade the platform via:
+Upgrade the platform using:
 
 <Tabs
   defaultValue="cli"
@@ -46,3 +46,7 @@ helm upgrade $RELEASE_NAME vcluster-platform -n $RELEASE_NAMESPACE --repository-
 
 </TabItem>
 </Tabs>
+
+:::note Server-side apply with Helm 4
+Helm 4 keeps the apply method a release was created with, so upgrades need no extra flags. If you switch a release to server-side apply with `--server-side=true`, the upgrade fails with a conflict on any field the platform has written itself. The most common one is `data.config` in the `loft-manager-config` secret after you edit the config in the UI. Add `--force-conflicts` to let Helm take ownership of those fields. Either way, keep the `config` section of your values file in sync with changes made in the UI. The upgrade replaces the secret with the values from the file.
+:::

--- a/platform/administer/clusters/advanced/external-database/deploy.mdx
+++ b/platform/administer/clusters/advanced/external-database/deploy.mdx
@@ -563,7 +563,7 @@ Install the platform:
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
+  --context [[GLOBAL:CLUSTER_CONTEXT]] \\
   --values platform-ha-values.yaml \\
   --no-tunnel`
   }

--- a/platform/administer/clusters/advanced/external-database/restore.mdx
+++ b/platform/administer/clusters/advanced/external-database/restore.mdx
@@ -23,7 +23,6 @@ import PageVariables from "@site/src/components/PageVariables";
   CURRENT_DB_INSTANCE_ID="mariadb-ha-platform"
   NEW_DB_INSTANCE_ID="mariadb-ha-platform-restored"
   SNAPSHOT_NAME="kine-backup-YYYY-MM-DD"
-  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 This procedure describes how to restore the Kine database from an RDS snapshot to
@@ -212,7 +211,7 @@ restored database.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
   -f platform-ha-values.yaml`
   }

--- a/platform/administer/clusters/advanced/external-database/restore.mdx
+++ b/platform/administer/clusters/advanced/external-database/restore.mdx
@@ -23,6 +23,7 @@ import PageVariables from "@site/src/components/PageVariables";
   CURRENT_DB_INSTANCE_ID="mariadb-ha-platform"
   NEW_DB_INSTANCE_ID="mariadb-ha-platform-restored"
   SNAPSHOT_NAME="kine-backup-YYYY-MM-DD"
+  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 This procedure describes how to restore the Kine database from an RDS snapshot to
@@ -211,7 +212,7 @@ restored database.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
   -f platform-ha-values.yaml`
   }

--- a/platform/administer/clusters/advanced/external-database/restore.mdx
+++ b/platform/administer/clusters/advanced/external-database/restore.mdx
@@ -178,7 +178,9 @@ Update the `dataSource` in the values file to point to the new RDS endpoint:
 
 ## Step 5 - Upgrade the platform
 
-Apply the updated values file.
+Apply the updated values file. The upgrade reapplies `replicaCount` from the
+values file, so this also brings the platform back up, now pointing at the
+restored database.
 
 <Tabs
   defaultValue="cli"
@@ -193,7 +195,7 @@ Apply the updated values file.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
+  --context [[GLOBAL:CLUSTER_CONTEXT]] \\
   --values platform-ha-values.yaml \\
   --upgrade \\
   --no-tunnel`
@@ -211,8 +213,7 @@ Apply the updated values file.
   --repo "https://charts.loft.sh/" \\
   --version [[VAR:CHART_VERSION:4.8.0]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
-  -f platform-ha-values.yaml \\
-  --server-side=true --force-conflicts`
+  -f platform-ha-values.yaml`
   }
   language="bash"
 />
@@ -220,18 +221,7 @@ Apply the updated values file.
   </TabItem>
 </Tabs>
 
-## Step 6 - Scale up the platform
-
-The Helm upgrade keeps replicas at zero because it does not override the manual
-scale-down. Scale the deployment back up.
-
-<InterpolatedCodeBlock
-  code={
-`kubectl --context [[GLOBAL:CLUSTER_CONTEXT]] \\
-  scale deployment -n vcluster-platform loft --replicas=3`
-  }
-  language="bash"
-/>
+## Step 6 - Wait for the platform to come back up
 
 Wait for all pods to become ready:
 

--- a/platform/administer/clusters/advanced/external-database/upgrade.mdx
+++ b/platform/administer/clusters/advanced/external-database/upgrade.mdx
@@ -47,7 +47,7 @@ the transition automatically.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
+  --context [[GLOBAL:CLUSTER_CONTEXT]] \\
   --values platform-ha-values.yaml \\
   --upgrade \\
   --no-tunnel`
@@ -65,13 +65,13 @@ the transition automatically.
   --repo "https://charts.loft.sh/" \\
   --version [[VAR:CHART_VERSION:4.8.0]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
-  -f platform-ha-values.yaml \\
-  --server-side=true --force-conflicts`
+  -f platform-ha-values.yaml`
   }
   language="bash"
 />
 
-The `--server-side=true --force-conflicts` flags are required because the platform chart manages CRDs that may conflict during upgrades.
+If you use Helm 4 with `--server-side=true`, see the note on server-side apply
+conflicts in [Upgrade vCluster Platform](../../../../maintenance/upgrade-migrate/upgrade.mdx).
 
   </TabItem>
 </Tabs>

--- a/platform/administer/clusters/advanced/external-database/upgrade.mdx
+++ b/platform/administer/clusters/advanced/external-database/upgrade.mdx
@@ -20,7 +20,6 @@ import PageVariables from "@site/src/components/PageVariables";
   DB_VPC_ID="vpc-xxxxxxxxx"
   DB_SG_ID="sg-xxxxxxxxx"
   CLUSTER_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-ha"
-  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 This procedure describes how to upgrade vCluster Platform with minimal downtime.
@@ -64,7 +63,7 @@ the transition automatically.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
   -f platform-ha-values.yaml`
   }

--- a/platform/administer/clusters/advanced/external-database/upgrade.mdx
+++ b/platform/administer/clusters/advanced/external-database/upgrade.mdx
@@ -20,6 +20,7 @@ import PageVariables from "@site/src/components/PageVariables";
   DB_VPC_ID="vpc-xxxxxxxxx"
   DB_SG_ID="sg-xxxxxxxxx"
   CLUSTER_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-ha"
+  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 This procedure describes how to upgrade vCluster Platform with minimal downtime.
@@ -63,7 +64,7 @@ the transition automatically.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:CLUSTER_CONTEXT]] \\
   -f platform-ha-values.yaml`
   }

--- a/platform/administer/clusters/advanced/multi-region/deploy.mdx
+++ b/platform/administer/clusters/advanced/multi-region/deploy.mdx
@@ -715,7 +715,7 @@ Install the platform on each cluster using its values file.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[VAR:US_REGION_CONTEXT:arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1]] \\
+  --context [[VAR:US_REGION_CONTEXT:arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1]] \\
   --values [[GLOBAL:US_VALUES_FILE]] \\
   --no-tunnel`
   }
@@ -728,7 +728,7 @@ Install the platform on each cluster using its values file.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[VAR:EU_REGION_CONTEXT:arn:aws:eks:eu-west-1:123456789012:cluster/platform-multi-region-eu-west-1]] \\
+  --context [[VAR:EU_REGION_CONTEXT:arn:aws:eks:eu-west-1:123456789012:cluster/platform-multi-region-eu-west-1]] \\
   --values [[GLOBAL:EU_VALUES_FILE]] \\
   --no-tunnel`
   }
@@ -1004,13 +1004,12 @@ Use the vCluster CLI to add each cluster as a connected cluster. Generate an acc
   code={
 `vcluster platform add cluster [[GLOBAL:US_CLUSTER_NAME]] \\
   --namespace vcluster-agent \\
-  --display-name [[VAR:DISPLAY_NAME:my-cluster]] \\
-  --values 'https://[[GLOBAL:PLATFORM_URL]]/clusters/agent-values/[[GLOBAL:US_CLUSTER_NAME]]?token=[[GLOBAL:ACCESS_TOKEN]]'`
+  --display-name [[VAR:DISPLAY_NAME:my-cluster]]`
   }
   language="bash"
 />
 
-Repeat on the second cluster, substituting `EU_CLUSTER_NAME` for the cluster name and providing a new `DISPLAY_NAME`.
+The CLI fetches the agent values for the cluster from the platform itself, so you don't pass a values URL. Repeat on the second cluster, substituting `EU_CLUSTER_NAME` for the cluster name and providing a new `DISPLAY_NAME`.
 
   </TabItem>
   <TabItem value="helm">

--- a/platform/administer/clusters/advanced/multi-region/recover.mdx
+++ b/platform/administer/clusters/advanced/multi-region/recover.mdx
@@ -32,7 +32,6 @@ The commands in this runbook reference your cluster context ARNs, the failed reg
   FAILED_REGION_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1"
   FAILED_REGION_VALUES_FILE="platform-us-east-1-values.yaml"
   FAILED_REGION_HEALTH_CHECK_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>
@@ -155,7 +154,7 @@ The recovery steps depend on the failure cause.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
   -f [[GLOBAL:FAILED_REGION_VALUES_FILE]]`
   }

--- a/platform/administer/clusters/advanced/multi-region/recover.mdx
+++ b/platform/administer/clusters/advanced/multi-region/recover.mdx
@@ -138,7 +138,7 @@ The recovery steps depend on the failure cause.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
+  --context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
   --values [[GLOBAL:FAILED_REGION_VALUES_FILE]] \\
   --upgrade \\
   --no-tunnel`
@@ -156,8 +156,7 @@ The recovery steps depend on the failure cause.
   --repo "https://charts.loft.sh/" \\
   --version [[VAR:CHART_VERSION:4.8.0]] \\
   --kube-context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
-  -f [[GLOBAL:FAILED_REGION_VALUES_FILE]] \\
-  --server-side=true --force-conflicts`
+  -f [[GLOBAL:FAILED_REGION_VALUES_FILE]]`
   }
   language="bash"
 />
@@ -165,15 +164,8 @@ The recovery steps depend on the failure cause.
   </TabItem>
 </Tabs>
 
-Then scale up if needed:
-
-<InterpolatedCodeBlock
-  code={
-`kubectl --context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
-  scale deployment -n vcluster-platform loft --replicas=[[VAR:REPLICA_COUNT:3]]`
-  }
-  language="bash"
-/>
+Re-applying the values file restores `replicaCount` from the file, so no
+separate scale-up is needed.
 
 **If the EKS cluster itself is down**, follow the AWS documentation to restore
 the cluster or create a replacement, then redeploy the platform using the

--- a/platform/administer/clusters/advanced/multi-region/recover.mdx
+++ b/platform/administer/clusters/advanced/multi-region/recover.mdx
@@ -32,6 +32,7 @@ The commands in this runbook reference your cluster context ARNs, the failed reg
   FAILED_REGION_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1"
   FAILED_REGION_VALUES_FILE="platform-us-east-1-values.yaml"
   FAILED_REGION_HEALTH_CHECK_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>
@@ -154,7 +155,7 @@ The recovery steps depend on the failure cause.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:FAILED_REGION_CONTEXT]] \\
   -f [[GLOBAL:FAILED_REGION_VALUES_FILE]]`
   }

--- a/platform/administer/clusters/advanced/multi-region/restore.mdx
+++ b/platform/administer/clusters/advanced/multi-region/restore.mdx
@@ -41,7 +41,6 @@ This runbook references AWS resource IDs, cluster context ARNs, and file names s
   NEW_DB_INSTANCE_ID="mariadb-multi-region-restored"
   FIRST_REGION_VALUES_FILE="platform-us-east-1-values.yaml"
   SECOND_REGION_VALUES_FILE="platform-eu-west-1-values.yaml"
-  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>
@@ -236,14 +235,14 @@ vcluster platform start \\
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[GLOBAL:FIRST_REGION_VALUES_FILE]]
 
 helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
   -f [[GLOBAL:SECOND_REGION_VALUES_FILE]]`
   }

--- a/platform/administer/clusters/advanced/multi-region/restore.mdx
+++ b/platform/administer/clusters/advanced/multi-region/restore.mdx
@@ -42,7 +42,6 @@ This runbook references AWS resource IDs, cluster context ARNs, and file names s
   FIRST_REGION_VALUES_FILE="platform-us-east-1-values.yaml"
   SECOND_REGION_VALUES_FILE="platform-eu-west-1-values.yaml"
   CHART_VERSION="4.8.0"
-  REPLICA_COUNT="3"
 />
 
 </details>
@@ -197,7 +196,9 @@ endpoint:
 
 ## Step 5 - Upgrade both regions
 
-Apply the updated values files to both regions.
+Apply the updated values files to both regions. The upgrade reapplies
+`replicaCount` from the values files, so this also brings both regions back up,
+now pointing at the restored database.
 
 <Tabs
   defaultValue="cli"
@@ -212,14 +213,14 @@ Apply the updated values files to both regions.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
+  --context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   --values [[GLOBAL:FIRST_REGION_VALUES_FILE]] \\
   --upgrade \\
   --no-tunnel
 
 vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
+  --context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
   --values [[GLOBAL:SECOND_REGION_VALUES_FILE]] \\
   --upgrade \\
   --no-tunnel`
@@ -237,16 +238,14 @@ vcluster platform start \\
   --repo "https://charts.loft.sh/" \\
   --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
-  -f [[GLOBAL:FIRST_REGION_VALUES_FILE]] \\
-  --server-side=true --force-conflicts
+  -f [[GLOBAL:FIRST_REGION_VALUES_FILE]]
 
 helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
   --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
-  -f [[GLOBAL:SECOND_REGION_VALUES_FILE]] \\
-  --server-side=true --force-conflicts`
+  -f [[GLOBAL:SECOND_REGION_VALUES_FILE]]`
   }
   language="bash"
 />
@@ -254,21 +253,7 @@ helm upgrade loft vcluster-platform --install --create-namespace --repository-co
   </TabItem>
 </Tabs>
 
-## Step 6 - Scale up both regions
-
-The Helm upgrade keeps replicas at zero because it doesn't override the manual
-scale-down. Scale both regions back up.
-
-<InterpolatedCodeBlock
-  code={
-`kubectl --context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
-  scale deployment -n vcluster-platform loft --replicas=[[GLOBAL:REPLICA_COUNT]]
-
-kubectl --context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
-  scale deployment -n vcluster-platform loft --replicas=[[GLOBAL:REPLICA_COUNT]]`
-  }
-  language="bash"
-/>
+## Step 6 - Wait for both regions to come back up
 
 Wait for all pods to become ready:
 

--- a/platform/administer/clusters/advanced/multi-region/restore.mdx
+++ b/platform/administer/clusters/advanced/multi-region/restore.mdx
@@ -41,7 +41,7 @@ This runbook references AWS resource IDs, cluster context ARNs, and file names s
   NEW_DB_INSTANCE_ID="mariadb-multi-region-restored"
   FIRST_REGION_VALUES_FILE="platform-us-east-1-values.yaml"
   SECOND_REGION_VALUES_FILE="platform-eu-west-1-values.yaml"
-  CHART_VERSION="4.8.0"
+  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>

--- a/platform/administer/clusters/advanced/multi-region/upgrade.mdx
+++ b/platform/administer/clusters/advanced/multi-region/upgrade.mdx
@@ -34,7 +34,6 @@ The commands in this runbook reference your cluster context ARNs. Set them below
 <PageVariables
   FIRST_REGION_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1"
   SECOND_REGION_CONTEXT="arn:aws:eks:eu-west-1:123456789012:cluster/platform-multi-region-eu-west-1"
-  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>
@@ -119,7 +118,7 @@ values file, set `replicaCount: 0` in the copy, and pass the copy:
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]] \\
   --set replicaCount=0`
@@ -164,7 +163,7 @@ so the region continues serving traffic during the upgrade.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
   -f [[VAR:SECOND_REGION_VALUES_FILE:platform-eu-west-1-values.yaml]]`
   }
@@ -220,7 +219,7 @@ release values then still record `replicaCount: 0` until the next upgrade.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[GLOBAL:CHART_VERSION]] \\
+  --version [[VAR:CHART_VERSION:__PLATFORM_VERSION__]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]]`
   }

--- a/platform/administer/clusters/advanced/multi-region/upgrade.mdx
+++ b/platform/administer/clusters/advanced/multi-region/upgrade.mdx
@@ -34,6 +34,7 @@ The commands in this runbook reference your cluster context ARNs. Set them below
 <PageVariables
   FIRST_REGION_CONTEXT="arn:aws:eks:us-east-1:123456789012:cluster/platform-multi-region-us-east-1"
   SECOND_REGION_CONTEXT="arn:aws:eks:eu-west-1:123456789012:cluster/platform-multi-region-eu-west-1"
+  CHART_VERSION="__PLATFORM_VERSION__"
 />
 
 </details>
@@ -118,7 +119,7 @@ values file, set `replicaCount: 0` in the copy, and pass the copy:
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]] \\
   --set replicaCount=0`
@@ -163,7 +164,7 @@ so the region continues serving traffic during the upgrade.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
   -f [[VAR:SECOND_REGION_VALUES_FILE:platform-eu-west-1-values.yaml]]`
   }
@@ -219,7 +220,7 @@ release values then still record `replicaCount: 0` until the next upgrade.
 `helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
   --namespace vcluster-platform \\
   --repo "https://charts.loft.sh/" \\
-  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --version [[GLOBAL:CHART_VERSION]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]]`
   }

--- a/platform/administer/clusters/advanced/multi-region/upgrade.mdx
+++ b/platform/administer/clusters/advanced/multi-region/upgrade.mdx
@@ -80,9 +80,11 @@ Wait for all pods to stop before proceeding.
 
 ## Step 2 - Upgrade the first region
 
-Upgrade the first region with the updated values file. The deployment stays at
-zero replicas after the upgrade because the tool doesn't override the manual
-scale-down.
+Upgrade the first region with the updated values file, overriding
+`replicaCount` to `0`. Helm reapplies `replicaCount` from your values on every
+upgrade. Without the override, this region would come back up on the new
+version while the other region still runs the old one. The override keeps it
+scaled down until Step 4.
 
 <Tabs
   defaultValue="cli"
@@ -93,12 +95,15 @@ scale-down.
 >
   <TabItem value="cli">
 
+The CLI takes a single values file and has no `--set` flag. Copy the region's
+values file, set `replicaCount: 0` in the copy, and pass the copy:
+
 <InterpolatedCodeBlock
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
-  --values [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]] \\
+  --context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
+  --values [[VAR:FIRST_REGION_SCALED_DOWN_VALUES_FILE:platform-us-east-1-values-scaled-down.yaml]] \\
   --upgrade \\
   --no-tunnel`
   }
@@ -116,7 +121,7 @@ scale-down.
   --version [[VAR:CHART_VERSION:4.8.0]] \\
   --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
   -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]] \\
-  --server-side=true --force-conflicts`
+  --set replicaCount=0`
   }
   language="bash"
 />
@@ -142,7 +147,7 @@ so the region continues serving traffic during the upgrade.
   code={
 `vcluster platform start \\
   --namespace vcluster-platform \\
-  --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
+  --context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
   --values [[VAR:SECOND_REGION_VALUES_FILE:platform-eu-west-1-values.yaml]] \\
   --upgrade \\
   --no-tunnel`
@@ -160,8 +165,7 @@ so the region continues serving traffic during the upgrade.
   --repo "https://charts.loft.sh/" \\
   --version [[VAR:CHART_VERSION:4.8.0]] \\
   --kube-context [[GLOBAL:SECOND_REGION_CONTEXT]] \\
-  -f [[VAR:SECOND_REGION_VALUES_FILE:platform-eu-west-1-values.yaml]] \\
-  --server-side=true --force-conflicts`
+  -f [[VAR:SECOND_REGION_VALUES_FILE:platform-eu-west-1-values.yaml]]`
   }
   language="bash"
 />
@@ -181,17 +185,49 @@ Wait for the rollout to complete.
 
 ## Step 4 - Scale up the first region
 
-Bring the first region back online.
+Bring the first region back online by running the upgrade again with its
+normal values file. This restores `replicaCount` in both the Helm release
+values and the deployment. You can use `kubectl scale` instead, but the Helm
+release values then still record `replicaCount: 0` until the next upgrade.
 
-Replace the replica count with the `replicaCount` value from the region's values file.
+<Tabs
+  defaultValue="cli"
+  values={[
+    { label: "vCluster CLI", value: "cli" },
+    { label: "Helm", value: "helm" },
+  ]}
+>
+  <TabItem value="cli">
 
 <InterpolatedCodeBlock
   code={
-`kubectl --context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
-  scale deployment -n vcluster-platform loft --replicas=[[VAR:REPLICA_COUNT:3]]`
+`vcluster platform start \\
+  --namespace vcluster-platform \\
+  --context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
+  --values [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]] \\
+  --upgrade \\
+  --no-tunnel`
   }
   language="bash"
 />
+
+  </TabItem>
+  <TabItem value="helm">
+
+<InterpolatedCodeBlock
+  code={
+`helm upgrade loft vcluster-platform --install --create-namespace --repository-config='' \\
+  --namespace vcluster-platform \\
+  --repo "https://charts.loft.sh/" \\
+  --version [[VAR:CHART_VERSION:4.8.0]] \\
+  --kube-context [[GLOBAL:FIRST_REGION_CONTEXT]] \\
+  -f [[VAR:FIRST_REGION_VALUES_FILE:platform-us-east-1-values.yaml]]`
+  }
+  language="bash"
+/>
+
+  </TabItem>
+</Tabs>
 
 Wait for all pods to become ready.
 

--- a/platform/install/air-gapped/with-offline-license-key.mdx
+++ b/platform/install/air-gapped/with-offline-license-key.mdx
@@ -17,7 +17,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 <FeatureTable names="air-gapped-mode" />
 
 
-This guide walks you through installing vCluster Platform and deploying tenant clusters in environments without internet access, referred to as air-gapped environments. It covers setting up a private OCI-compliant registry, populating it with container images and Helm charts, configuring vCluster Platform and agents to pull from the registry, and deploying tenant clusters securely and offline.
+This guide walks you through installing <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform and deploying tenant clusters in environments without internet access, referred to as air-gapped environments. It covers setting up a private OCI-compliant registry, populating it with container images and Helm charts, configuring vCluster Platform and agents to pull from the registry, and deploying tenant clusters securely and offline.
 
 If you want to run a dedicated offline license service in-cluster, see [With Offline License Server](./with-offline-license-server.mdx).
 
@@ -30,7 +30,7 @@ There are several artifacts that are typically accessed using an internet connec
 - **vCluster Helm chart** - This Helm chart is typically accessed through the vCluster Labs charts repository and is used for deploying tenant clusters.
 - **Images used in the Helm charts**  - These images are typically accessed through different container registries.
 
-After populating the registry with the artifacts, install vCluster Platform, connect control plane clusters and then deploy tenant clusters. Each step requires additional configuration to use your private registry.
+After populating the registry with the artifacts, install vCluster Platform, connect <GlossaryTerm term="control-plane">control plane</GlossaryTerm> clusters and then deploy tenant clusters. Each step requires additional configuration to use your private registry.
 
 ## Prerequisites
 
@@ -87,7 +87,7 @@ Contact sales@loft.sh to purchase a license key or request a trial license key f
 <details>
 <summary>Network and resource prerequisites </summary>
 
-- **Control plane cluster access to platform domain** - Connected control plane clusters must reach the domain where vCluster Platform is hosted.
+- **<GlossaryTerm term="control-plane-cluster">Control plane cluster</GlossaryTerm> access to platform domain** - Connected control plane clusters must reach the domain where vCluster Platform is hosted.
 
 - **vCluster Platform Pod Resource Requirements**
 
@@ -730,6 +730,11 @@ vCluster Platform exclusively supports the default `secret` backend for storing 
   </Step>
 </Flow>
 
+:::info Upgrading later
+When you're ready to upgrade vCluster Platform or connected control plane
+clusters, see [Upgrade in an air-gapped environment](../../maintenance/upgrade-migrate/upgrade-air-gapped.mdx).
+:::
+
 ## Deploy tenant clusters in air-gapped environments
 
 With your vCluster Platform now installed and configured for air-gapped environments, you can deploy tenant clusters. The platform automatically uses your configured private registry settings.
@@ -751,7 +756,7 @@ After you complete the platform setup, stay on this page if you need to complete
 
 ### Tenant cluster configuration {#virtual-cluster-configuration}
 
-The `vcluster.yaml` file defines all configuration settings for your tenant cluster deployment.
+The `vcluster.yaml` file defines all configuration settings for your <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> deployment.
 
 <details>
   <summary>Use a private registry without credentials</summary>

--- a/platform/install/air-gapped/with-offline-license-server.mdx
+++ b/platform/install/air-gapped/with-offline-license-server.mdx
@@ -11,7 +11,7 @@ import FeatureTable from '@site/src/components/FeatureTable';
 
 <FeatureTable names="air-gapped-mode" />
 
-This guide explains how to deploy the offline license server and expose it through an ingress. It also covers configuring vCluster Platform with `LICENSE_SERVER` and exporting usage data.
+This guide explains how to deploy the offline license server and expose it through an ingress. It also covers configuring <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform with `LICENSE_SERVER` and exporting usage data.
 
 ## Overview
 
@@ -98,7 +98,7 @@ Use one of these endpoint styles depending on your network setup:
 - In-cluster: `http://license-server.license-server.svc.cluster.local/license/v2`
 - Ingress or load balancer: `https://<license-server-host>/license/v2`
 
-## Expose the license server via ingress
+## Expose the license server using ingress
 
 If the platform doesn't run in the same Kubernetes cluster as the license server, or you want a stable DNS endpoint, expose the license server through an ingress.
 
@@ -178,7 +178,7 @@ env:
 insecureSkipVerify: true
 ```
 
-Apply the updated values through your normal upgrade flow (for example, `helm upgrade`).
+Apply the updated values through your normal upgrade flow (for example, `helm upgrade`). See [Upgrade in an air-gapped environment](../../maintenance/upgrade-migrate/upgrade-air-gapped.mdx) to upgrade vCluster Platform itself.
 
 ## Export usage data
 

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -25,7 +25,7 @@ This guide details installing the platform using GitOps practices, specifically 
 
 ### ArgoCD
 
-ArgoCD needs to be installed and configured on the control plane cluster. Follow the [Argo CD Installation Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install it.
+ArgoCD needs to be installed and configured on the <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm>. Follow the [Argo CD Installation Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install it.
 
 ### Resource requirements
 
@@ -36,7 +36,7 @@ ArgoCD needs to be installed and configured on the control plane cluster. Follow
 
 :::note Required labels for manual namespace creation
 
-If you are manually creating the vCluster namespace as part of your GitOps workflow, ensure you  apply the following labels:
+If you are manually creating the <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> namespace as part of your GitOps workflow, ensure you  apply the following labels:
 
   ```yaml
   metadata:
@@ -451,8 +451,8 @@ The following table summarizes fields that commonly cause drift for each Platfor
 
 | Resource type | Common drift fields | Description |
 |---------------|---------------------|-------------|
-| **Project** | `status`, `spec.access`, `spec.quotas`, `spec.requireTemplate`, `spec.requirePreset`, `metadata.finalizers`, `metadata.annotations` | Status, default access rules, empty objects get defaults, finalizers and tracking annotations auto-added |
-| **Team** | `status`, `spec.access`, `metadata.finalizers`, `metadata.annotations` | Status, default access rules, finalizers and tracking annotations auto-added |
+| **Project** | `status`, `spec.access`, `spec.quotas`, `spec.requireTemplate`, `spec.requirePreset`, `metadata.finalizers`, `metadata.annotations` | Status, default access rules, empty objects get defaults, finalizers, and tracking annotations auto-added |
+| **Team** | `status`, `spec.access`, `metadata.finalizers`, `metadata.annotations` | Status, default access rules, finalizers, and tracking annotations auto-added |
 | **VirtualClusterTemplate** | `status`, `spec.template.metadata`, `spec.template.instanceTemplate.metadata`, `spec.template.spaceTemplate.metadata`, `spec.template.accessPoint.ingress`, `metadata.annotations` | Empty nested objects, tracking annotations like `loft.sh/last-applied-parameter-defaults` |
 | **SpaceTemplate** | `status`, `spec.template.metadata` | Status and metadata defaults |
 | **SharedSecret** | `status` | Status field updates |
@@ -635,6 +635,11 @@ If resources continue showing as out-of-sync:
 3. **Compare live vs desired state**: Use `kubectl get <resource> -o yaml` to see the full live state
 4. **Check for webhooks**: Mutating admission webhooks may modify resources after apply
 
+## Upgrade
+
+To upgrade a GitOps-managed platform deployment, update the chart version in
+your `Application` or `HelmRelease` manifest. Let your GitOps tool apply it
+rather than running `helm upgrade` directly. See [Upgrade a GitOps-managed deployment](../maintenance/upgrade-migrate/upgrade.mdx#upgrade-a-gitops-managed-deployment).
 
 ## Login
 

--- a/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
@@ -21,10 +21,12 @@ the install guide for the version you're upgrading to. This is the same
 used during install. See [Populate images to private registry](../../install/air-gapped/with-offline-license-key.mdx#populate-images-to-private-registry)
 and [Populate the Helm charts to a private registry](../../install/air-gapped/with-offline-license-key.mdx#populate-the-helm-charts-to-a-private-registry)
 for the full walkthrough, including multi-platform images and insecure
-registries. In short, for the platform chart and images:
+registries.
 
-```bash title="Re-populate the registry for the target version"
-export PLATFORM_VERSION=4.12.0 # Replace with the target version
+### Platform images and chart
+
+```bash title="Mirror the platform images and chart"
+export PLATFORM_VERSION=__PLATFORM_VERSION__ # Replace with the target version
 export REGISTRY=ecr.io/myteam # Replace with your private registry
 
 wget -O images.txt https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/images.txt
@@ -39,12 +41,29 @@ helm pull vcluster-platform --repo https://charts.loft.sh --version ${PLATFORM_V
 helm push vcluster-platform-${PLATFORM_VERSION}.tgz oci://${REGISTRY}/charts
 ```
 
-:::info Upgrading tenant clusters too
-If you're also moving tenant clusters to a new vCluster version, repeat the
-same workflow for the `vcluster` images and chart using `VCLUSTER_VERSION`.
-Then update the image reference on any air-gapped <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> templates.
-See [Pull and push images for vCluster](../../install/air-gapped/with-offline-license-key.mdx#pull-and-push-images-for-vcluster).
-:::
+### vCluster images and chart
+
+Do this only if you're also moving <GlossaryTerm term="tenant-cluster">tenant clusters</GlossaryTerm> to a new vCluster
+version. Both projects publish a release file named `images.txt`, so these
+commands save the vCluster list as `vcluster-images.txt` and pass it to both
+scripts explicitly. The scripts default to `images.txt`, which at this point
+still holds the platform list from the previous step.
+
+```bash title="Mirror the vCluster images and chart"
+export VCLUSTER_VERSION=__VCLUSTER_VERSION__ # Replace with the target vCluster version
+
+wget -O vcluster-images.txt https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/images.txt
+
+./download-images.sh --image-list vcluster-images.txt --images vcluster-images.tar.gz
+./push-images.sh --registry ${REGISTRY} --images vcluster-images.tar.gz --image-list vcluster-images.txt
+
+helm pull vcluster --repo https://charts.loft.sh --version ${VCLUSTER_VERSION}
+helm push vcluster-${VCLUSTER_VERSION}.tgz oci://${REGISTRY}/charts
+```
+
+After mirroring, update the chart version on any tenant cluster templates that
+pin a vCluster version. For the optional image sets covering other Kubernetes
+distributions and versions, see [Pull and push images for vCluster](../../install/air-gapped/with-offline-license-key.mdx#pull-and-push-images-for-vcluster).
 
 ## Step 2 - Upgrade the platform deployment
 
@@ -61,9 +80,9 @@ this upgrade. Update it in `vcluster-platform.yaml` as well, so later upgrades
 don't revert to the old image.
 
 ```bash title="Upgrade the platform using helm"
-export PLATFORM_VERSION=4.12.0 # Replace with the target version
+export PLATFORM_VERSION=__PLATFORM_VERSION__ # Replace with the target version
 export REGISTRY=ecr.io/myteam # Replace with your private registry
-PLATFORM_NAMESPACE=vcluster-platform # Replace if the platform is installed to a different namespace
+export PLATFORM_NAMESPACE=vcluster-platform # Replace if the platform is installed to a different namespace
 
 helm upgrade vcluster-platform oci://${REGISTRY}/charts/vcluster-platform:${PLATFORM_VERSION} \
   --version ${PLATFORM_VERSION} \

--- a/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
@@ -1,0 +1,95 @@
+---
+title: Upgrade in an air-gapped environment
+sidebar_label: Upgrade in an Air-Gapped Environment
+sidebar_position: 3
+description: Steps for upgrading vCluster Platform in air-gapped, offline, or VPC environments with restricted network connectivity.
+---
+
+This page covers upgrading <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform when it was installed in an
+air-gapped environment (see [With Offline License Key](../../install/air-gapped/with-offline-license-key.mdx)
+or [With Offline License Server](../../install/air-gapped/with-offline-license-server.mdx)).
+Unlike the [regular upgrade](./upgrade.mdx), an air-gapped upgrade starts by
+re-populating your private registry with the target version's images and Helm
+chart. Your <GlossaryTerm term="control-plane-cluster">control plane cluster</GlossaryTerm> has no route to the public registries
+vCluster Labs publishes to, so it can only pull what you've mirrored.
+
+## Step 1 - Populate the registry with the target version
+
+On a machine with internet access, repeat the registry-population steps from
+the install guide for the version you're upgrading to. This is the same
+`download-images.sh`, `push-images.sh`, `helm pull`, and `helm push` workflow
+used during install. See [Populate images to private registry](../../install/air-gapped/with-offline-license-key.mdx#populate-images-to-private-registry)
+and [Populate the Helm charts to a private registry](../../install/air-gapped/with-offline-license-key.mdx#populate-the-helm-charts-to-a-private-registry)
+for the full walkthrough, including multi-platform images and insecure
+registries. In short, for the platform chart and images:
+
+```bash title="Re-populate the registry for the target version"
+export PLATFORM_VERSION=4.12.0 # Replace with the target version
+export REGISTRY=ecr.io/myteam # Replace with your private registry
+
+wget -O images.txt https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/images.txt
+wget -O download-images.sh https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/download-images.sh
+wget -O push-images.sh https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/push-images.sh
+chmod +x ./download-images.sh ./push-images.sh
+
+./download-images.sh --image-list images.txt --images loft-images.tar.gz
+./push-images.sh --registry ${REGISTRY} --images loft-images.tar.gz --image-list images.txt
+
+helm pull vcluster-platform --repo https://charts.loft.sh --version ${PLATFORM_VERSION}
+helm push vcluster-platform-${PLATFORM_VERSION}.tgz oci://${REGISTRY}/charts
+```
+
+:::info Upgrading tenant clusters too
+If you're also moving tenant clusters to a new vCluster version, repeat the
+same workflow for the `vcluster` images and chart using `VCLUSTER_VERSION`.
+Then update the image reference on any air-gapped <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> templates.
+See [Pull and push images for vCluster](../../install/air-gapped/with-offline-license-key.mdx#pull-and-push-images-for-vcluster).
+:::
+
+## Step 2 - Upgrade the platform deployment
+
+Run `helm upgrade` against the chart version you just pushed, reusing your
+existing `vcluster-platform.yaml` values file. That file already points the
+platform and its agents at your private registry, so those settings carry
+over automatically. The relevant keys are `imageRef`,
+`env.DEFAULT_IMAGE_REGISTRY`, `env.DEFAULT_VCLUSTER_CHART_REPO`, and
+`agentValues.env`, as set up under [Configure and install vCluster Platform and agent](../../install/air-gapped/with-offline-license-key.mdx#configure-install-platform-agent).
+
+One value doesn't carry over. `imageRef.tag` pins the image to the version you
+installed, and it overrides the chart version. The command below sets it for
+this upgrade. Update it in `vcluster-platform.yaml` as well, so later upgrades
+don't revert to the old image.
+
+```bash title="Upgrade the platform using helm"
+export PLATFORM_VERSION=4.12.0 # Replace with the target version
+export REGISTRY=ecr.io/myteam # Replace with your private registry
+PLATFORM_NAMESPACE=vcluster-platform # Replace if the platform is installed to a different namespace
+
+helm upgrade vcluster-platform oci://${REGISTRY}/charts/vcluster-platform:${PLATFORM_VERSION} \
+  --version ${PLATFORM_VERSION} \
+  --namespace ${PLATFORM_NAMESPACE} \
+  --values vcluster-platform.yaml \
+  --set imageRef.tag=${PLATFORM_VERSION}
+```
+
+If you use Helm 4 with `--server-side=true`, see the note on server-side apply
+conflicts in [Upgrade vCluster Platform](./upgrade.mdx).
+
+:::warning
+vCluster Platform exclusively supports the default `secret` backend for
+storing Helm releases. Alternative `HELM_DRIVER` configurations (such as
+`configmap` or `sql`) are not supported.
+:::
+
+## Step 3 - Verify the deployment
+
+Confirm the platform and agent deployments are running the target image from
+your private registry:
+
+```bash title="Verify the deployed image"
+kubectl get deployment -n ${PLATFORM_NAMESPACE} loft \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+The platform automatically upgrades connected agents to the same version once
+the platform upgrade completes, pulling from the same private registry.

--- a/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade-air-gapped.mdx
@@ -5,6 +5,8 @@ sidebar_position: 3
 description: Steps for upgrading vCluster Platform in air-gapped, offline, or VPC environments with restricted network connectivity.
 ---
 
+import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
+
 This page covers upgrading <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform when it was installed in an
 air-gapped environment (see [With Offline License Key](../../install/air-gapped/with-offline-license-key.mdx)
 or [With Offline License Server](../../install/air-gapped/with-offline-license-server.mdx)).
@@ -25,21 +27,25 @@ registries.
 
 ### Platform images and chart
 
-```bash title="Mirror the platform images and chart"
-export PLATFORM_VERSION=__PLATFORM_VERSION__ # Replace with the target version
-export REGISTRY=ecr.io/myteam # Replace with your private registry
+<InterpolatedCodeBlock
+  title="Mirror the platform images and chart"
+  code={
+`export PLATFORM_VERSION=[[VAR:PLATFORM_VERSION:__PLATFORM_VERSION__]]
+export REGISTRY=[[VAR:REGISTRY:ecr.io/myteam]]
 
-wget -O images.txt https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/images.txt
-wget -O download-images.sh https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/download-images.sh
-wget -O push-images.sh https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/push-images.sh
+wget -O images.txt https://github.com/loft-sh/loft/releases/download/v\${PLATFORM_VERSION}/images.txt
+wget -O download-images.sh https://github.com/loft-sh/loft/releases/download/v\${PLATFORM_VERSION}/download-images.sh
+wget -O push-images.sh https://github.com/loft-sh/loft/releases/download/v\${PLATFORM_VERSION}/push-images.sh
 chmod +x ./download-images.sh ./push-images.sh
 
 ./download-images.sh --image-list images.txt --images loft-images.tar.gz
-./push-images.sh --registry ${REGISTRY} --images loft-images.tar.gz --image-list images.txt
+./push-images.sh --registry \${REGISTRY} --images loft-images.tar.gz --image-list images.txt
 
-helm pull vcluster-platform --repo https://charts.loft.sh --version ${PLATFORM_VERSION}
-helm push vcluster-platform-${PLATFORM_VERSION}.tgz oci://${REGISTRY}/charts
-```
+helm pull vcluster-platform --repo https://charts.loft.sh --version \${PLATFORM_VERSION}
+helm push vcluster-platform-\${PLATFORM_VERSION}.tgz oci://\${REGISTRY}/charts`
+  }
+  language="bash"
+/>
 
 ### vCluster images and chart
 
@@ -49,17 +55,22 @@ commands save the vCluster list as `vcluster-images.txt` and pass it to both
 scripts explicitly. The scripts default to `images.txt`, which at this point
 still holds the platform list from the previous step.
 
-```bash title="Mirror the vCluster images and chart"
-export VCLUSTER_VERSION=__VCLUSTER_VERSION__ # Replace with the target vCluster version
+<InterpolatedCodeBlock
+  title="Mirror the vCluster images and chart"
+  code={
+`export VCLUSTER_VERSION=[[VAR:VCLUSTER_VERSION:__VCLUSTER_VERSION__]]
+export REGISTRY=[[VAR:REGISTRY:ecr.io/myteam]]
 
-wget -O vcluster-images.txt https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/images.txt
+wget -O vcluster-images.txt https://github.com/loft-sh/vcluster/releases/download/v\${VCLUSTER_VERSION}/images.txt
 
 ./download-images.sh --image-list vcluster-images.txt --images vcluster-images.tar.gz
-./push-images.sh --registry ${REGISTRY} --images vcluster-images.tar.gz --image-list vcluster-images.txt
+./push-images.sh --registry \${REGISTRY} --images vcluster-images.tar.gz --image-list vcluster-images.txt
 
-helm pull vcluster --repo https://charts.loft.sh --version ${VCLUSTER_VERSION}
-helm push vcluster-${VCLUSTER_VERSION}.tgz oci://${REGISTRY}/charts
-```
+helm pull vcluster --repo https://charts.loft.sh --version \${VCLUSTER_VERSION}
+helm push vcluster-\${VCLUSTER_VERSION}.tgz oci://\${REGISTRY}/charts`
+  }
+  language="bash"
+/>
 
 After mirroring, update the chart version on any tenant cluster templates that
 pin a vCluster version. For the optional image sets covering other Kubernetes
@@ -79,17 +90,21 @@ installed, and it overrides the chart version. The command below sets it for
 this upgrade. Update it in `vcluster-platform.yaml` as well, so later upgrades
 don't revert to the old image.
 
-```bash title="Upgrade the platform using helm"
-export PLATFORM_VERSION=__PLATFORM_VERSION__ # Replace with the target version
-export REGISTRY=ecr.io/myteam # Replace with your private registry
-export PLATFORM_NAMESPACE=vcluster-platform # Replace if the platform is installed to a different namespace
+<InterpolatedCodeBlock
+  title="Upgrade the platform using helm"
+  code={
+`export PLATFORM_VERSION=[[VAR:PLATFORM_VERSION:__PLATFORM_VERSION__]]
+export REGISTRY=[[VAR:REGISTRY:ecr.io/myteam]]
+export PLATFORM_NAMESPACE=[[VAR:PLATFORM_NAMESPACE:vcluster-platform]]
 
-helm upgrade vcluster-platform oci://${REGISTRY}/charts/vcluster-platform:${PLATFORM_VERSION} \
-  --version ${PLATFORM_VERSION} \
-  --namespace ${PLATFORM_NAMESPACE} \
-  --values vcluster-platform.yaml \
-  --set imageRef.tag=${PLATFORM_VERSION}
-```
+helm upgrade vcluster-platform oci://\${REGISTRY}/charts/vcluster-platform:\${PLATFORM_VERSION} \\
+  --version \${PLATFORM_VERSION} \\
+  --namespace \${PLATFORM_NAMESPACE} \\
+  --values vcluster-platform.yaml \\
+  --set imageRef.tag=\${PLATFORM_VERSION}`
+  }
+  language="bash"
+/>
 
 If you use Helm 4 with `--server-side=true`, see the note on server-side apply
 conflicts in [Upgrade vCluster Platform](./upgrade.mdx).

--- a/platform/maintenance/upgrade-migrate/upgrade-v3-to-v4.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade-v3-to-v4.mdx
@@ -1,0 +1,143 @@
+---
+title: Upgrade from v3 to v4
+sidebar_label: Upgrade v3 to v4
+sidebar_position: 5
+description: Steps for upgrading vCluster Platform from a v3.x release to v4.0, including breaking changes and required configuration.
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+:::info Who needs this page
+This page only applies if you're upgrading <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform from a v3.x release to
+v4.0. If you're already running v4.0 or later, use the [regular upgrade instructions](./upgrade.mdx)
+instead.
+:::
+
+Before attempting this major upgrade, upgrade to the latest v3.x version first.
+Review the [older upgrade docs](https://loft.sh/docs/admin/upgrade-loft) on how
+to upgrade. Upgrade using the CLI and not the UI, since there are known issues
+upgrading versions through the UI.
+
+## Pre-upgrade recommendations
+
+1. Read through the v4.0 release notes. Review the [release notes for v4.0](https://github.com/loft-sh/loft-enterprise/releases/tag/v4.0.0) to read the updates in the release and understand any behavior changes.
+
+2. vCluster versions are required on tenant clusters and <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm> templates. One of the breaking changes in v4.0 is the requirement of a vCluster version defined on your tenant cluster. Previously, if you deployed a tenant cluster without editing the version field, the version wasn't set in the `spec` of the resource. With each upgrade of the platform, these tenant clusters were automatically upgraded to the latest default vCluster version. Due to the [breaking changes introduced in v0.20](https://roadmap.vcluster.com/changelog/vcluster-v020-ga), automatic upgrades of the vCluster version are no longer supported. You must set a vCluster version in the spec of each tenant cluster and tenant cluster template.
+
+    Confirm that the resource YAML includes the versions of your tenant clusters and tenant cluster templates before upgrading.
+    Otherwise, your tenant clusters might encounter errors that require you to define these versions after the upgrade.
+    The platform can't detect which version you upgraded from, so it can't set the correct version automatically. You must determine and set it manually.
+
+3. Define the vCluster version on existing tenant clusters. In the UI, edit each tenant cluster or tenant cluster template and type the version in the version field. The resource YAML automatically updates the spec to include it. If the resource YAML already has `spec.template.helmRelease.chart.version` set, the version is defined.
+    ```yaml title="Example of spec"
+    spec:
+        template:
+            helmRelease:
+              chart:
+                version: 0.19.7
+    ```
+
+## Download the latest vCluster CLI
+
+With the deprecation of the Loft CLI, review the [Loft CLI to vCluster CLI Migration docs](https://vcluster.com/docs/vcluster/reference/migrations/loft-cli-vcluster-cli-migration).
+
+## Required changes in your platform configuration before upgrading
+
+v4.0 adds the ability to change the prefix of the namespaces created for projects. In previous versions the prefix was `loft-p-`, and in v4.0.0 the new default is `p-`. Because the default changed, you must set the previous prefix in the platform configuration as part of the upgrade command. Future upgrades reuse the configuration values, so you only need to set it once.
+
+### Append the project prefix to upgrade commands
+
+<Tabs
+  defaultValue="cli"
+  values={[
+    { label: 'CLI', value: 'cli', },
+    { label: 'Helm', value: 'helm', },
+  ]
+}>
+<TabItem value="cli">
+
+To upgrade from v3 to v4 using the vCluster CLI, run the following. The command pins v4.0.0, the target of this upgrade:
+
+:::info Platform Namespace
+The following steps assume the existing installation is in the default namespace `loft`. The default namespace for v4 is vcluster-platform, so we specify the namespace in the steps.
+:::
+
+```bash
+PLATFORM_NAMESPACE="loft" # Update if the platform is installed to a different namespace
+PLATFORM_VERSION="4.0.0"
+
+vcluster platform start --upgrade --namespace $PLATFORM_NAMESPACE --version=$PLATFORM_VERSION --values=<(cat <<EOF
+config:
+  projectNamespacePrefix: loft-p-
+EOF
+)
+```
+
+</TabItem>
+<TabItem value="helm">
+
+To upgrade from v3 to v4 using `helm`, run the following. The command pins v4.0.0, the target of this upgrade:
+
+```bash
+PLATFORM_RELEASE_NAME="loft" # Update if the Helm release has a different name
+PLATFORM_NAMESPACE="loft" # Update if the platform is installed to a different namespace
+PLATFORM_VERSION="4.0.0"
+
+helm upgrade $PLATFORM_RELEASE_NAME vcluster-platform -n $PLATFORM_NAMESPACE --repository-config '' --repo https://charts.loft.sh \
+  --version $PLATFORM_VERSION \
+  --reuse-values \
+  -f <(cat <<EOF
+config:
+  projectNamespacePrefix: loft-p-
+EOF
+)
+```
+
+</TabItem>
+</Tabs>
+
+### Add the project prefix to your values file
+
+If you upgrade the Platform with another method, an alternative is to extend your config file and include the project prefix requirement for this upgrade.
+
+```
+config:
+  projectNamespacePrefix: loft-p-
+```
+
+## Post-upgrade recommendations
+
+### Migrate vCluster Platform OIDC provider clients
+
+vCluster Platform can be used as an OIDC provider. Formerly, to add clients to the vCluster Platform OIDC provider a user would add them to the `oidc.clients` array field
+in the vCluster Platform config. This could be done either through the `Admin > Config` UI or through editing the `loft-manager-config` secret found in the namespace vCluster Platform
+is installed in. Editing this config causes loft to restart, which should be unnecessary for adding OIDC platform clients. Therefore, managing vCluster Platform OIDC clients has
+been moved to its own UI, and the clients their own objects. You can manage these OIDC clients through the OIDC Provider tab of the admin page or through Kubernetes Secrets.
+See [Adding OIDC Clients to vCluster Platform OIDC Using Secrets](../../administer/authentication/oidc-provider.mdx#adding-oidc-clients-to-vcluster-platform-oidc-using-secrets). The `oidc.clients` field
+is deprecated in vCluster Platform version 4.0 and is removed in version 5.0.
+
+### Migrate OIDC clients from admin config to new OIDC clients
+
+1. Navigate to `Admin > OIDC Provider`.
+2. Select `Add Client`.
+3. In a separate tab navigate to `Admin > Config`.
+4. Copy over the `name`, `clientID`, and `clientSecrets` fields from the first element of `oidc.clients` to the open editor on the `OIDC Provider` page.
+5. Copy each value from the `oidc.clients.redirectURIs` list to the `Allowed redirect URIs` editor field on the OIDC Provider page. Separate each URI by a newline.
+6. Select "Save".
+7. Repeat steps 1-6 for all clients.
+8. Copy the `oidc.clients` to a safe location. These can be discarded once all steps have been successful.
+9. Delete the `oidc.clients` field. This causes vCluster Platform to restart.
+10. Validate OIDC clients function normally.
+
+## Troubleshoot
+
+### Forgot the project prefix
+
+If you accidentally performed the upgrade without setting the `projectNamespacePrefix`, then the pod of the platform is in a `CrashLoopBackoff` with a log similar to:
+
+```bash
+cmd/main.go:107 error executing root command    {"component": "loft", "error": "init (4): set default project namespace prefix: seems like you have upgraded the platform from an earlier version that uses 'loft-p-' as a project namespace prefix. This has been changed to be 'p-' in the current version. Please set 'projectNamespacePrefix: loft-p-' in the platform config to get rid of this error"}
+```
+
+Follow the instructions on how to [append the project prefix](#append-the-project-prefix-to-upgrade-commands) and upgrade again.

--- a/platform/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade.mdx
@@ -32,8 +32,11 @@ The `vcluster-platform.yaml` file is optional and defines Helm values to use whe
 
 If you installed the platform using GitOps (see [Install with ArgoCD](../../install/gitops.mdx)),
 upgrade by updating the chart version in your GitOps manifests and letting
+<!-- vale off -->
+{/* Vale reads the lowercase command name as the Helm project. It is the command, so it stays lowercase. */}
 your GitOps tool apply it, rather than running `vcluster platform start` or
 `helm upgrade` directly against the cluster.
+<!-- vale on -->
 
 <Tabs
   defaultValue="argocd"
@@ -47,6 +50,8 @@ your GitOps tool apply it, rather than running `vcluster platform start` or
 Update `spec.source.targetRevision` on the platform `Application` to the
 target version, then sync.
 
+<!-- vale off -->
+{/* Vale reads the chart and resource name in this block as prose. */}
 ```yaml title="Update the platform Application" {8}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -59,6 +64,7 @@ spec:
     chart: vcluster-platform
     repoURL: "https://charts.loft.sh"
 ```
+<!-- vale on -->
 
 Commit the change to the repository ArgoCD watches. With automated sync
 enabled, ArgoCD applies the new chart version on its next sync. To apply it

--- a/platform/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrade vCluster Platform
 sidebar_label: Upgrade vCluster Platform 
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 
@@ -9,11 +9,14 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import PartialAdminUpgrade from "@site/platform/_partials/install/upgrade.mdx";
 
-You can upgrade vCluster Platform using either the vCluster CLI or Helm. 
+Upgrade <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform using the vCluster CLI, Helm, or GitOps, matching
+however you originally installed it. If you installed in an air-gapped
+environment, see [Upgrade in an air-gapped environment](./upgrade-air-gapped.mdx)
+instead of the steps below.
 
 :::warning
-If you are using vCluster Platform version earlier than v4.0, you should upgrade to 
-v4.0 first by following instructions [here](#upgrade-old-version).
+If you are using a vCluster Platform version earlier than v4.0, upgrade to
+v4.0 first by following the [v3 to v4 upgrade instructions](./upgrade-v3-to-v4.mdx).
 :::
 
 Platform 4.12 also removes the resources that deployed apps before this release. If you have any apps deployed, see [Upgrade to Platform 4.12](#upgrade-to-4-12) after completing the upgrade steps below.
@@ -25,137 +28,84 @@ The `$PLATFORM_VERSION` environment variable specifies the vCluster Platform ver
 The `vcluster-platform.yaml` file is optional and defines Helm values to use when upgrading the vCluster Platform deployment.
 :::
 
-## Upgrade from pre v4.0 to v4.0 {#upgrade-old-version}
+## Upgrade a GitOps-managed deployment
 
-Before attempting to perform this major upgrade, upgrade to the latest v3.x version. 
-Review the [older upgrade docs](https://loft.sh/docs/admin/upgrade-loft) on how to upgrade. It is recommended to upgrade using the CLI and not the UI as there are known issues to upgrade versions through the UI.
-
-### Pre-upgrade recommendations 
-
-1. Read through the v4.0 release notes. Review the [release notes for v4.0](https://github.com/loft-sh/loft-enterprise/releases/tag/v4.0.0) to read the updates in the release and understand any behavior changes. 
-
-2. vCluster versions are required on tenant clusters and tenant cluster templates One of the breaking changes in v4.0 is the requirement of a vCluster version defined on your tenant cluster. Previously if you deployed a vCluster version or used a vCluster version without editing the version field, the version was not set in the `spec` of the resource. With each upgrade of the Platform,
-the vCluster would automatically upgrade these tenant clusters to the latest default vCluster version. Due to the [breaking changes introduced in v0.20](https://roadmap.vcluster.com/changelog/vcluster-v020-ga), 
-automatic upgrades of vCluster version are no longer supported and a vCluster version must be set in the spec of a tenant cluster or tenant cluster template. 
-
-    Confirm that the resource yaml includes the versions of your tenant clusters and tenant cluster templates before upgrading.
-    Otherwise, your tenant clusters might encounter errors that require you to define these versions after the upgrade. 
-    Because it is not known which version you upgraded from, it cannot set the correct version automatically, and you must manually determine and set it.
-
-3. Define the vCluster version on existing tenant clusters. In the UI, for each tenant cluster, edit the configuration and type the version of the tenant cluster or tenant cluster template in the textbox and the resource yaml automatically updates the spec to include the version. If the resource yaml of your tenant cluster or tenant cluster template has `spec.template.helmRelease.chart.version` set, then the tenant cluster version is defined.
-    ```yaml title="Example of spec"
-    spec:
-        template:
-            helmRelease:
-            chart:
-                version: 0.19.7
-    ```
-
-### Download the latest vCluster CLI
-
-With the deprecation of the Loft CLI, review the [Loft CLI to vCluster CLI Migration docs](https://vcluster.com/docs/vcluster/reference/migrations/loft-cli-vcluster-cli-migration).
-
-### Required changes in your platform configuration before upgrading
-
-A new feature has been added to support the ability to change the prefix of the namespace created for projects. In previous versions, the 
-prefix was `loft-p`, but in v4.0.0, the new default is `p-`. Due to the change in defaults, the previous prefix needs to be set in the Platform configuration as 
-part of the upgrade command. Since future upgrades reuse the values of the configuration, you only need to apply it once.
-
-#### Append the project prefix to upgrade commands
+If you installed the platform using GitOps (see [Install with ArgoCD](../../install/gitops.mdx)),
+upgrade by updating the chart version in your GitOps manifests and letting
+your GitOps tool apply it, rather than running `vcluster platform start` or
+`helm upgrade` directly against the cluster.
 
 <Tabs
-  defaultValue="cli"
+  defaultValue="argocd"
   values={[
-    { label: 'CLI', value: 'cli', },
-    { label: 'Helm', value: 'helm', },
-  ]
-}>
-<TabItem value="cli">
+    { label: "ArgoCD", value: "argocd" },
+    { label: "Flux", value: "flux" },
+  ]}
+>
+<TabItem value="argocd">
 
-To upgrade the Platform from v3 to v4 via vCluster CLI, run. Update `$PLATFORM_VERSION` with a valid vCluster Platform version.
+Update `spec.source.targetRevision` on the platform `Application` to the
+target version, then sync.
 
-:::info Platform Namespace
-The following steps assume the existing installation is in the default namespace `loft`. The default namespace for v4 is vcluster-platform, so we specify the namespace in the steps.
-:::
-
-```bash
-PLATFORM_NAMESPACE="loft" # Update if the platform is installed to a different namespace
-PLATFORM_VERSION="" # Specify a version or it upgrades to latest stable version
-
-vcluster platform start --upgrade --namespace $PLATFORM_NAMESPACE --version=$PLATFORM_VERSION --values=<(cat <<EOF
-config:
-  projectNamespacePrefix: loft-p-
-EOF
-)
+```yaml title="Update the platform Application" {8}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vcluster-platform
+  namespace: argocd
+spec:
+  source:
+    targetRevision: "4.12.0" # Replace with the target version
+    chart: vcluster-platform
+    repoURL: "https://charts.loft.sh"
 ```
+
+Commit the change to the repository ArgoCD watches. With automated sync
+enabled, ArgoCD applies the new chart version on its next sync. To apply it
+right away instead of waiting, trigger a sync:
+
+```bash title="Trigger a sync"
+argocd app sync vcluster-platform
+```
+
+The platform creates and updates its own CRDs when it starts, so the
+`Application` needs no CRD-specific sync options.
 
 </TabItem>
-<TabItem value="helm">
+<TabItem value="flux">
 
-To upgrade vCluster Platform from v3 to v4 via `helm`, run. Update `$PLATFORM_VERSION` with a valid vCluster Platform version.
+Update `spec.chart.spec.version` on the platform `HelmRelease` to the target
+version, then reconcile.
 
-```bash
-PLATFORM_RELEASE_NAME="loft" # Update if the Helm release has a different name
-PLATFORM_NAMESPACE="loft" # Update if the platform is installed to a different namespace
-PLATFORM_VERSION="" # Specify a version or it upgrades to latest stable version
-
-helm upgrade $PLATFORM_RELEASE_NAME vcluster-platform -n $PLATFORM_NAMESPACE --repository-config '' --repo https://charts.loft.sh \
-  --version $PLATFORM_VERSION \
-  --reuse-values \
-  -f <(cat <<EOF
-config:
-  projectNamespacePrefix: loft-p-
-EOF
-)
+```yaml title="Update the platform HelmRelease" {9}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vcluster-platform
+  namespace: vcluster-platform
+spec:
+  chart:
+    spec:
+      version: "4.12.0" # Replace with the target version
+      chart: vcluster-platform
+      sourceRef:
+        kind: HelmRepository
+        name: vcluster-platform
 ```
+
+Commit the change to the repository Flux watches. Flux applies the new chart
+version on its next reconciliation. To apply it right away instead of
+waiting, trigger a reconciliation:
+
+```bash title="Trigger a reconciliation"
+flux reconcile helmrelease vcluster-platform -n vcluster-platform
+```
+
+The platform creates and updates its own CRDs when it starts, so the
+`HelmRelease` needs no CRD policy settings.
 
 </TabItem>
 </Tabs>
-
-#### Add the project prefix to your values file
-
-If you upgrade the Platform with another method, an alternative method is to extend your config file and include the project prefix requirement for this upgrade.
-
-```
-config:
-  projectNamespacePrefix: loft-p-
-```
-
-### Post-upgrade recommendations
-
-#### Migrate vCluster Platform OIDC provider clients
-
-vCluster Platform can be used as an OIDC provider. Formerly, to add clients to the vCluster Platform OIDC provider a user woulld add them to the `oidc.clients` array field
-in the vCluster Platform config. This could be done either through the `Admin > Config` UI or through editing the `loft-manager-config` secret found in the namespace vCluster Platform
-is installed in. Editing this config causes loft to restart which should be unnecessary for adding OIDC platform clients. Therefore, managing vCluster Platform OIDC clients has
-been moved to its own UI and the clients their own objects. These new OIDC clients can be managed either through the OIDC Provider tab of the admin page or through Kubernetes Secrets,
-see [Adding OIDC Clients to vCluster Platform OIDC Using Secrets](/docs/platform/administer/authentication/oidc-provider#adding-oidc-clients-to-vcluster-platform-oidc-using-secrets). The `oidc.clients` field
-is deprecated in vCluster Platform version 4.0 and is removed in version 5.0.
-
-#### Migrate OIDC clients from admin config to new OIDC clients
-
-1. Navigate to `Admin > OIDC Provider`.
-2. Select `Add Client`.
-3. In a separate tab navigate to `Admin > Config`.
-4. Copy over the `name`, `clientID`, and `clientSecrets` fields from the first element of `oidc.clients` to the open editor on the `OIDC Provider` page.
-5. Copy each value from the `oidc.clients.redirectURIs` list to the `Allowed redirect URIs` editor field on the OIDC Provider page. Separate each URI by a newline.
-6. Select "Save".
-7. Repeat steps 1-6 for all clients.
-8. Copy the `oidc.clients` to a safe location. These can be discard once all steps have been successful.
-9. Delete the `oidc.clients` field. This causes vCluster Platform to restart.
-10. Validate OIDC clients function normally.
-
-### Troubleshoot 
-
-#### Forgot the project prefix
-
-If you accidentially performed the upgrade without setting the `projectNamespacePrefix`, then the pod of the platform is in a `CrashLoopBackoff` with a log similar to:
-
-```bash
-cmd/main.go:107 error executing root command    {"component": "loft", "error": "init (4): set default project namespace prefix: seems like you have upgraded the platform from an earlier version that uses 'loft-p-' as a project namespace prefix. This has been changed to be 'p-' in the current version. Please set 'projectNamespacePrefix: loft-p-' in the platform config to get rid of this error"}
-```
-
-Follow the instructions on how to [append the project prefix](#append-the-project-prefix-to-upgrade-commands) and upgrade again. 
 
 ## Upgrade to Platform 4.12 {#upgrade-to-4-12}
 

--- a/platform/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade.mdx
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import PartialAdminUpgrade from "@site/platform/_partials/install/upgrade.mdx";
+import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 
 Upgrade <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> Platform using the vCluster CLI, Helm, or GitOps, matching
 however you originally installed it. If you installed in an air-gapped

--- a/platform/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform/maintenance/upgrade-migrate/upgrade.mdx
@@ -107,6 +107,36 @@ The platform creates and updates its own CRDs when it starts, so the
 </TabItem>
 </Tabs>
 
+## Verify the upgrade
+
+These checks apply to every upgrade method. Replace `vcluster-platform` with
+your platform namespace if you installed it elsewhere.
+
+Wait for the rollout to finish.
+
+```bash title="Wait for the rollout"
+kubectl rollout status deployment/loft -n vcluster-platform
+```
+
+Confirm the deployment runs the version you upgraded to.
+
+```bash title="Check the running image"
+kubectl get deployment -n vcluster-platform loft \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+The platform upgrades connected agents automatically once its own upgrade
+completes, so you don't upgrade them separately. To check one, run the same
+command against the connected cluster's context, using the namespace the agent
+is installed in.
+
+If the rollout doesn't finish, inspect the pod and its logs.
+
+```bash title="Inspect the platform pod"
+kubectl get pods -n vcluster-platform -l app=loft
+kubectl logs -n vcluster-platform -l app=loft --tail=50
+```
+
 ## Upgrade to Platform 4.12 {#upgrade-to-4-12}
 
 If you have apps deployed on a cluster, tenant cluster, or space, upgrading to Platform 4.12 doesn't disrupt them. Each app's underlying Helm release keeps running exactly as before. What changes is how the platform manages that release. Platform 4.12 removes the old resources that used to represent a deployed app:


### PR DESCRIPTION
# Content Description

Closes the gaps in DOC-272 by adding upgrade paths that match the install paths we document (GitOps and air-gapped), splitting the legacy v3 to v4 migration onto its own page, and correcting several inaccuracies found while verifying the pages against the chart and CLI source. Also closes DOC-1772, a version-locking bug in this same page's install partial import found while reviewing the DOC-1770/Platform 4.12 docs backport.

## Preview Link

- [Upgrade vCluster Platform](https://deploy-preview-2712--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/upgrade-migrate/upgrade)
- [Upgrade in an air-gapped environment](https://deploy-preview-2712--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/upgrade-migrate/upgrade-air-gapped) (new)
- [Upgrade from v3 to v4](https://deploy-preview-2712--vcluster-docs-site.netlify.app/docs/platform/next/maintenance/upgrade-migrate/upgrade-v3-to-v4) (new)
- [Upgrade Platform with an External Database](https://deploy-preview-2712--vcluster-docs-site.netlify.app/docs/platform/next/administer/clusters/advanced/external-database/upgrade)
- [Upgrade a Multi-Region Platform Deployment](https://deploy-preview-2712--vcluster-docs-site.netlify.app/docs/platform/next/administer/clusters/advanced/multi-region/upgrade)

## Internal Reference

Closes DOC-272
Closes DOC-1772

---

## What changed

### New coverage

- **GitOps upgrades.** The main upgrade page now has an "Upgrade a GitOps-managed deployment" section with ArgoCD and Flux tabs. We document a GitOps install path but had no matching upgrade guidance.
- **Air-gapped upgrades.** New page covering registry re-population for the target version, then the upgrade itself. Same gap: documented install path, no upgrade path.
- **A verification step.** The main upgrade page now ends with a "Verify the upgrade" section covering all three methods. None of them previously told the reader how to confirm the upgrade landed, or what to inspect when it didn't.
- **v3 to v4 migration** moved to its own page, positioned last in the section. It was the bulk of the main upgrade page and no longer applies to most readers. This also gives us a pattern to reuse for a v4 to v5 page when that lands.

### Accuracy fixes

These were found by checking the pages against `loft-sh/loft-enterprise` and `loft-sh/vcluster-pro`, and confirmed by running chart 4.11.1 to 4.11.2 upgrades on Helm 4.2.1 in kind.

| Issue | Impact |
| --- | --- |
| `--server-side=true --force-conflicts` documented as required "because the platform chart manages CRDs" | The chart templates no CRDs. The binary creates them at startup, outside Helm. The flags are Helm 4 only, so the commands would have failed for anyone on Helm 3. Neither the CLI nor the platform UI passes them. Removed from 9 places and replaced with an accurate note about when server-side apply genuinely conflicts. |
| `vcluster platform start --kube-context` | No such flag. The real flag is `--context`. Corrected in 10 invocations that would have failed outright. |
| `vcluster platform add cluster --values <url>` | No such flag. The CLI fetches agent values from the platform itself. |
| "The Helm upgrade keeps replicas at zero because it doesn't override the manual scale-down" | Wrong under both client-side and server-side apply. In the multi-region runbook this meant a region could come back up on the new version while the other still ran the old one. Rewrote the scale-down and scale-up steps in the multi-region and external database runbooks. |
| Air-gapped upgrade left `imageRef.tag` at the installed version | A pinned tag overrides the chart version, so bumping the chart alone deploys new manifests with the old image. |
| Air-gapped tenant cluster mirroring was prose-only, pointing at the install guide | Now inline. Both projects publish a release file named `images.txt` and both mirroring scripts default to that filename, so following the guide in order silently re-pushed the platform list. The vCluster list is now saved as `vcluster-images.txt` and passed explicitly. |
| Malformed YAML in the tenant cluster version example | `chart` was nested as a sibling of `helmRelease`, so the example did not produce the `spec.template.helmRelease.chart.version` path it described. |
| `PartialAdminUpgrade` imported via an absolute `@site/platform/_partials/...` path (DOC-1772) | Every archived `platform_versioned_docs/version-*/` snapshot of this page silently rendered today's live install partial instead of a version-locked copy. Switched to a relative import, matching sibling pages such as `administer/connector/database.mdx`. `version-4.12.0` was already fixed directly in PR #2754; `version-4.9.0`/`4.10.0`/`4.11.0` remain open follow-up work tracked in DOC-1772. |

### Notes for reviewers

- The server-side apply and replicaCount findings both existed in pages this PR did not otherwise need to touch. They are corrected here rather than left inconsistent, which is why the diff reaches the multi-region and external database runbooks.
- The ArgoCD and Flux guidance is the one part not verified against a live cluster. It follows the documented behavior of each tool and reuses the manifest shapes already in our install docs.

## Validation

- `vale` clean on all changed files, apart from two known false positives on a `helm upgrade` code span and a YAML resource name.
- `hack/cli-drift` and `hack/config-drift` both report zero drift. Both flag errors above were surfaced by `cli-drift`.
- `npm run build` passes, with sidebar ordering, pagination, and all new cross-links verified in the built output.

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


