### PR TITLE
docs: trigger vmetal-docs lifecycle sync from platform release process

### DIFF
--- a/.claude/skills/platform-docs-releaser/SKILL.md
+++ b/.claude/skills/platform-docs-releaser/SKILL.md
@@ -291,6 +291,19 @@ Copy from previous version, update version numbers. Include cross-version tests 
 
 This PR is small, reviewable, and safe to merge by anyone with merge rights.
 
+#### 7. After merge — trigger vmetal-docs lifecycle sync
+
+vMetal has no version or support window of its own — it ships as part of vCluster Platform and follows the same lifecycle. Its docs site (`vmetal-docs`) keeps a generated copy of `docs/_partials/platform_supported_versions.mdx` at `docs/reference/lifecycle-policy.mdx`, synced by its `generate-lifecycle-docs` workflow.
+
+Once the config flip PR is merged (release/EOS/EOL dates for the new row are final at that point), dispatch that workflow:
+
+```bash
+gh api repos/loft-sh/vmetal-docs/dispatches \
+  -f event_type=platform-released
+```
+
+This opens a PR in vmetal-docs regenerating `lifecycle-policy.mdx` from the current `platform_supported_versions.mdx`. It is not required to merge that PR before this one — it lands independently in vmetal-docs. If the dispatch is skipped or fails, a weekly scheduled run in that workflow catches the drift within a week.
+
 ## Files Modified Summary
 
 | File | Changes | Phase |
@@ -303,6 +316,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 | `netlify.toml` | Add redirect for new lastVersion; remove redirect for previous lastVersion | Release day |
 | `hack/test-platform-X.Y.hurl` | New test file | Release day |
 | Platform support dates file (`docs/_partials/platform_supported_versions.mdx`) | Release/EOL dates + Default vCluster Version column | User adds, AI verifies |
+| `vmetal-docs` `docs/reference/lifecycle-policy.mdx` | Regenerated via `repository_dispatch` (external repo) | After Release day merge |
 
 ## Division of Responsibilities
 
@@ -313,6 +327,7 @@ This PR is small, reviewable, and safe to merge by anyone with merge rights.
 - ✅ **Update netlify redirect** - `netlify.toml`
 - ✅ **Create hurl test** - Including cross-version tests
 - ✅ **Verify Default vCluster Version column** - Check the new row in `platform_supported_versions.mdx` matches `DefaultVClusterVersion` in `loft-enterprise` ([DOC-1658](https://linear.app/loft/issue/DOC-1658))
+- ✅ **Trigger vmetal-docs lifecycle sync** - After the config flip PR merges, dispatch `loft-sh/vmetal-docs`'s `generate-lifecycle-docs` workflow (see Part 5, item 7)
 
 ### User Handles (Items 2, 6-8):
 - **Create versioned docs** - `npm run docusaurus docs:version:platform X.Y.Z`

--- a/.claude/skills/platform-docs-releaser/references/release-checklist.md
+++ b/.claude/skills/platform-docs-releaser/references/release-checklist.md
@@ -198,6 +198,11 @@ This is the release-day action. All heavy work was done at rc-1.
 - [ ] Merge config flip PR
 - [ ] Monitor production deployment
 - [ ] Verify version appears in dropdown
+- [ ] Trigger vmetal-docs lifecycle sync (vMetal has no version of its own — it follows Platform's lifecycle):
+  ```bash
+  gh api repos/loft-sh/vmetal-docs/dispatches -f event_type=platform-released
+  ```
+  Opens a PR in vmetal-docs regenerating `docs/reference/lifecycle-policy.mdx` from `docs/_partials/platform_supported_versions.mdx`. Independent of this PR — no need to wait on it before merging here.
 
 ## Part 7: Final Review
 
@@ -243,6 +248,7 @@ Ready for: Build & Test
 | `hack/test-platform-X.Y.hurl` | SEO/redirect/cross-version tests | AI |
 | Platform support dates file | Support dates & compat | User |
 | `platform_versioned_docs/version-X.Y.Z/` | Versioned docs | User |
+| `vmetal-docs` `docs/reference/lifecycle-policy.mdx` | Regenerated via cross-repo dispatch | AI (post-merge) |
 | `platform_versions.json` | Version list | Auto |
 
 ## Common Issues Checklist


### PR DESCRIPTION
# Content Description
Add a step to the `platform-docs-releaser` skill: after the Platform docs config flip PR merges on release day, dispatch vmetal-docs' `generate-lifecycle-docs` workflow so its lifecycle policy page (synced from `platform_supported_versions.mdx`) picks up the finalized release/EOS/EOL dates. Companion to [loft-sh/vmetal-docs#60](https://github.com/loft-sh/vmetal-docs/pull/60).

## Preview Link
N/A — skill/process documentation only, no rendered docs content changed.

## Internal Reference
Related to DOC-1753

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs