### PR TITLE
docs(vcluster): regroup production paths by goal on overview page

### DIFF
--- a/vcluster/production-guide/inference-provider.mdx
+++ b/vcluster/production-guide/inference-provider.mdx
@@ -9,6 +9,8 @@ import InferenceProviderArchitecture from '@site/static/img/production-paths/inf
 
 Build managed inference endpoints on your GPU infrastructure. Customers interact with your product API and model endpoints. Platform and <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> form the operations layer your team runs behind it.
 
+**Customer access model:** External customers, through provider-managed product APIs and model endpoints. **Worker-node model:** Private nodes for dedicated or customer-controlled serving, shared nodes for provider-owned models with API-only access. See [Choose a worker node model](./choose-worker-node-model.mdx).
+
 **Minimum stack:**
 
 - [vCluster Platform](/docs/platform/install/quick-start-guide) as the management plane.

--- a/vcluster/production-guide/overview.mdx
+++ b/vcluster/production-guide/overview.mdx
@@ -19,20 +19,32 @@ Shared and private nodes are a security boundary decision, locked at deployment 
 
 ## What are you building?
 
-| You are building | Where to start | Worker-node model |
+Find the goal that matches your platform, then choose the desired outcome. The linked production path takes you from architecture decisions through Day 2 operations.
+
+### Offer AI or Kubernetes infrastructure to customers
+
+| Desired outcome | Start here | Worker-node guidance |
 | --- | --- | --- |
-| Managed inference endpoints on GPU infrastructure for customers | [Inference Provider: Managed Model Serving](./inference-provider.mdx) | Private nodes |
-| A managed Kubernetes service for paying customers on GPU infrastructure | [AI Cloud: Managed Kubernetes Service](./ai-cloud.mdx) | Private nodes |
-| An internal AI platform for your organization's R&D and engineering teams | [Enterprise AI Factory](./enterprise-ai-factory.mdx) | Private nodes for production ML teams; shared nodes for trusted internal dev/experiment tiers |
-| A unified GPU operations layer across multiple compute sources or suppliers | [Distributed Compute Aggregation](./distributed-compute.mdx) | Private nodes |
-| A shared Kubernetes platform for internal engineering teams and services | [Internal Kubernetes Platform](./internal-k8s-platform.mdx) | Shared nodes, trusted internal tenants only |
-| Ephemeral isolated clusters for CI/CD pipelines with automatic cleanup | [CI/CD Platform](./cicd-platform.mdx) | Shared nodes, trusted internal tenants only |
-| A dedicated cluster stack per enterprise customer | [Single-Tenant Per Customer](./single-tenant.mdx) | Private nodes |
-| Tenant workloads at distributed edge sites from a central control plane | [Edge Distribution](./edge-distribution.mdx) | Private nodes |
+| Serve models through managed endpoints while your team operates the Kubernetes infrastructure | [Inference Provider: Managed Model Serving](./inference-provider.mdx) | Private nodes for dedicated or customer-controlled serving. Shared nodes may suit provider-owned models with API-only access |
+| Give customers isolated, GPU-backed Kubernetes environments through your product | [AI Cloud: Managed Kubernetes Service](./ai-cloud.mdx) | Private nodes for external customer workloads |
+| Give each enterprise customer a dedicated cluster stack for node-level, regulated, or sovereign isolation | [Single-Tenant Per Customer](./single-tenant.mdx) | Private nodes for node-level customer isolation |
 
-Not sure which model your offering needs? [Choose a worker node model](./choose-worker-node-model.mdx) walks through the customer-access questions that decide it.
+### Build a platform for internal teams
 
-If you are not sure which path fits, start with [Architecture](../introduction/architecture.mdx) and [Building a GPU cloud platform](../introduction/gpu-cloud-platform.mdx).
+| Desired outcome | Start here | Worker-node guidance |
+| --- | --- | --- |
+| Standardize governed GPU environments across production, development, and experiment tiers | [Enterprise AI Factory](./enterprise-ai-factory.mdx) | Private nodes for production. Shared nodes for trusted development and experiment tiers |
+| Give trusted engineering teams long-running, isolated Kubernetes environments | [Internal Kubernetes Platform](./internal-k8s-platform.mdx) | Shared nodes for trusted team workloads only |
+| Give each CI/CD pipeline an ephemeral, isolated Kubernetes environment with automatic cleanup | [CI/CD Platform](./cicd-platform.mdx) | Shared nodes for trusted pipeline workloads only |
+
+### Operate compute across providers or locations
+
+| Desired outcome | Start here | Worker-node guidance |
+| --- | --- | --- |
+| Manage GPU capacity from multiple compute sources through one operations layer | [Distributed Compute Aggregation](./distributed-compute.mdx) | Private nodes for dedicated tenant capacity at each site |
+| Manage tenant workloads at distributed edge sites from a central control plane | [Edge Distribution](./edge-distribution.mdx) | Private nodes for dedicated tenant capacity at edge sites |
+
+Not sure where to start? Use [Choose a worker node model](./choose-worker-node-model.mdx) to decide between shared and private nodes. If no production path fits, review [Architecture](../introduction/architecture.mdx) and [Building a GPU cloud platform](../introduction/gpu-cloud-platform.mdx).
 
 ## What production-ready means
 
@@ -51,10 +63,10 @@ Each quick start validates a specific deployment model. Use this table to connec
 
 | If you completed | You have proven | Production paths to consider |
 | --- | --- | --- |
-| [Docker (vind)](../quick-start/docker.mdx) | Local or CI cluster behavior | Use vind for CI only. Choose a path above based on your production use case. |
+| [Docker (vind)](../quick-start/docker.mdx) | Local development, testing, or CI cluster behavior | Use vind to validate cluster behavior, then choose a production path for deployment. |
 | [Shared Nodes](../quick-start/shared-nodes.mdx) | Tenant clusters on an existing Kubernetes cluster | [Internal Kubernetes Platform](./internal-k8s-platform.mdx), [CI/CD Platform](./cicd-platform.mdx), or [Enterprise AI Factory](./enterprise-ai-factory.mdx) (shared tier) |
-| [Private Nodes](../quick-start/private-nodes.mdx) | Tenant clusters with dedicated worker nodes | [Inference Provider](./inference-provider.mdx), [AI Cloud](./ai-cloud.mdx), [Enterprise AI Factory](./enterprise-ai-factory.mdx) (production tier), [Single-Tenant Per Customer](./single-tenant.mdx) |
-| [Standalone](../quick-start/standalone.mdx) | Control plane cluster on bare metal or VMs | [Inference Provider](./inference-provider.mdx), [AI Cloud](./ai-cloud.mdx), [Distributed Compute Aggregation](./distributed-compute.mdx), [Enterprise AI Factory](./enterprise-ai-factory.mdx) (on-premises) |
+| [Private Nodes](../quick-start/private-nodes.mdx) | Tenant clusters with dedicated worker nodes | [Inference Provider](./inference-provider.mdx), [AI Cloud](./ai-cloud.mdx), [Enterprise AI Factory](./enterprise-ai-factory.mdx) (production tier), [Distributed Compute Aggregation](./distributed-compute.mdx), [Single-Tenant Per Customer](./single-tenant.mdx), or [Edge Distribution](./edge-distribution.mdx) |
+| [Standalone](../quick-start/standalone.mdx) | Control plane cluster on bare metal or VMs | [Inference Provider](./inference-provider.mdx), [AI Cloud](./ai-cloud.mdx), [Distributed Compute Aggregation](./distributed-compute.mdx), [Enterprise AI Factory](./enterprise-ai-factory.mdx) (on-premises), or [Edge Distribution](./edge-distribution.mdx) |
 
 ## Day 2 operations reference
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Restructures the "What are you building?" table on the production guide overview into three goal-based sections (offer infrastructure to customers, build for internal teams, operate compute across sites), adds worker-node guidance for the inference-provider path's shared-nodes exception, and syncs matching wording onto inference-provider.mdx.

## Preview Link 
<!-- Netlify will post the preview link on this PR -->
https://deploy-preview-2723--vcluster-docs-site.netlify.app/docs/vcluster/next/production-guide/overview#what-are-you-building

## Internal Reference
Closes DOC-1754

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs