### PR TITLE
fix(deps): resolve webdriverio assertion peer conflict

### DIFF
--- a/tests/wdio/package-lock.json
+++ b/tests/wdio/package-lock.json
@@ -11,7 +11,7 @@
         "@wdio/local-runner": "^9.21.0",
         "@wdio/mocha-framework": "^9.21.0",
         "@wdio/spec-reporter": "^8.29.0",
-        "expect-webdriverio": "^5.5.0"
+        "expect-webdriverio": "^6.0.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1807,42 +1807,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@vitest/pretty-format": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
-      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/@wdio/globals": {
-      "version": "9.31.3",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.31.3.tgz",
-      "integrity": "sha512-ZzmRKUlwUBahNoNxHbAzst+9dNInEjLQc7Z3c86OhDRxAf3Ivw8k2rc56UCbyYiZnkd1dOpuA91zFiTrUNNORw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^6.0.9",
-        "webdriverio": "^9.28.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@wdio/cli/node_modules/@wdio/logger": {
       "version": "9.29.1",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
@@ -1871,75 +1835,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/expect-webdriverio": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-6.0.10.tgz",
-      "integrity": "sha512-VBaMl4U6orgn3uzM7n65Gd48legqi37GoP0mklR+3f7vs/cC1s4hQVmGoiqz9aBcISVF37dAynP3aoi0R0CDow==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/snapshot": "^4.1.10",
-        "deep-eql": "^5.0.2",
-        "expect": "^30.4.1",
-        "jest-matcher-utils": "^30.4.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@wdio/globals": "^9.0.0",
-        "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.28.0"
-      },
-      "peerDependenciesMeta": {
-        "@wdio/globals": {
-          "optional": false
-        },
-        "@wdio/logger": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/cli/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@wdio/cli/node_modules/tinyrainbow": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@wdio/config": {
@@ -2084,18 +1979,17 @@
       }
     },
     "node_modules/@wdio/globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha512-i38o7wlipLllNrk2hzdDfAmk6nrqm3lR2MtAgWgtHbwznZAKkB84KpkNFfmUXw5Kg3iP1zKlSjwZpKqenuLc+Q==",
+      "version": "9.31.3",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.31.3.tgz",
+      "integrity": "sha512-ZzmRKUlwUBahNoNxHbAzst+9dNInEjLQc7Z3c86OhDRxAf3Ivw8k2rc56UCbyYiZnkd1dOpuA91zFiTrUNNORw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
       "peerDependencies": {
-        "expect-webdriverio": "^5.3.4",
-        "webdriverio": "^9.0.0"
+        "expect-webdriverio": "^6.0.9",
+        "webdriverio": "^9.28.0"
       },
       "peerDependenciesMeta": {
         "expect-webdriverio": {
@@ -2136,57 +2030,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@vitest/pretty-format": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
-      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@vitest/snapshot": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
-      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.11",
-        "@vitest/utils": "4.1.11",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/globals": {
-      "version": "9.31.3",
-      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.31.3.tgz",
-      "integrity": "sha512-ZzmRKUlwUBahNoNxHbAzst+9dNInEjLQc7Z3c86OhDRxAf3Ivw8k2rc56UCbyYiZnkd1dOpuA91zFiTrUNNORw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20.0"
-      },
-      "peerDependencies": {
-        "expect-webdriverio": "^6.0.9",
-        "webdriverio": "^9.28.0"
-      },
-      "peerDependenciesMeta": {
-        "expect-webdriverio": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
       }
     },
     "node_modules/@wdio/local-runner/node_modules/@wdio/logger": {
@@ -2251,55 +2094,6 @@
       },
       "engines": {
         "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/expect-webdriverio": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-6.0.10.tgz",
-      "integrity": "sha512-VBaMl4U6orgn3uzM7n65Gd48legqi37GoP0mklR+3f7vs/cC1s4hQVmGoiqz9aBcISVF37dAynP3aoi0R0CDow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/snapshot": "^4.1.10",
-        "deep-eql": "^5.0.2",
-        "expect": "^30.4.1",
-        "jest-matcher-utils": "^30.4.1"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@wdio/globals": "^9.0.0",
-        "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.28.0"
-      },
-      "peerDependenciesMeta": {
-        "@wdio/globals": {
-          "optional": false
-        },
-        "@wdio/logger": {
-          "optional": false
-        },
-        "webdriverio": {
-          "optional": false
-        }
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@wdio/local-runner/node_modules/tinyrainbow": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@wdio/logger": {
@@ -4166,24 +3960,24 @@
       }
     },
     "node_modules/expect-webdriverio": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.5.0.tgz",
-      "integrity": "sha512-2K7RMnmdZqOlo1jitOg/mAJDwv1HumInQdDLil+wQe5xol0ZdGLp6UsT+DB++vqVemc4ZOeAW+5z/EN3zNFvXQ==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-6.0.10.tgz",
+      "integrity": "sha512-VBaMl4U6orgn3uzM7n65Gd48legqi37GoP0mklR+3f7vs/cC1s4hQVmGoiqz9aBcISVF37dAynP3aoi0R0CDow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/snapshot": "^4.0.12",
+        "@vitest/snapshot": "^4.1.10",
         "deep-eql": "^5.0.2",
-        "expect": "^30.2.0",
-        "jest-matcher-utils": "^30.2.0"
+        "expect": "^30.4.1",
+        "jest-matcher-utils": "^30.4.1"
       },
       "engines": {
-        "node": ">=18 || >=20 || >=22"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@wdio/globals": "^9.0.0",
         "@wdio/logger": "^9.0.0",
-        "webdriverio": "^9.0.0"
+        "webdriverio": "^9.28.0"
       },
       "peerDependenciesMeta": {
         "@wdio/globals": {
@@ -4198,26 +3992,27 @@
       }
     },
     "node_modules/expect-webdriverio/node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4233,9 +4028,9 @@
       "license": "MIT"
     },
     "node_modules/expect-webdriverio/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/tests/wdio/package.json
+++ b/tests/wdio/package.json
@@ -10,6 +10,6 @@
     "@wdio/local-runner": "^9.21.0",
     "@wdio/mocha-framework": "^9.21.0",
     "@wdio/spec-reporter": "^8.29.0",
-    "expect-webdriverio": "^5.5.0"
+    "expect-webdriverio": "^6.0.9"
   }
 }


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Bump `expect-webdriverio` to `^6.0.9` so WebdriverIO updates can resolve their peer dependencies. Refresh the lockfile for `expect-webdriverio` and `@wdio/globals`, removing duplicate nested copies.

The [upstream v5 to v6 migration guide](https://github.com/webdriverio/expect-webdriverio/blob/v6.0.0/docs/Migrations.md) does not require changes to the assertions used by this suite.

Validation: `npm ci` passed with lifecycle scripts enabled; `npm ls` reports a valid dependency tree; all five configured WDIO packages load; the four assertion types used by the specs pass positive and negative smoke checks. Fresh resolution reproduced `ERESOLVE` with the original manifest and passed with the fixed manifest. A separate copy regenerated the fixed lockfile without changes using `npm install --package-lock-only`. The next hosted Renovate run remains post-merge verification. BrowserStack tests were not run locally.


## Preview Link 
Dependency-only change. No documentation content changes.


## Internal Reference
Closes DOC-1767


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

