### PR TITLE
fix(deps): group webdriverio peer updates in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,13 @@
       "groupName": "docusaurus"
     },
     {
+      "description": "Keep WebdriverIO and its assertion library together across major and minor updates to satisfy peer dependencies",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@wdio/**", "webdriverio", "expect-webdriverio"],
+      "groupName": "webdriverio",
+      "separateMajorMinor": false
+    },
+    {
       "description": "Group Go patch updates",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Keep `@wdio/*`, `webdriverio`, and `expect-webdriverio` in one Renovate group, including major and minor updates. This prevents a WebdriverIO minor update from being split from the assertion-library major version it requires.

`separateMajorMinor: false` is scoped to this group because [Renovate separates major updates even within groups by default](https://docs.renovatebot.com/configuration-options/#separatemajorminor). The weekly schedule, seven-day npm release delay, and manual merge policy remain unchanged.

Validation with Renovate 42.99.0:

- Config validator passed.
- Local extraction found all three npm manifests, including all six WDIO dependencies, and 38 dependency files overall. Extraction did not perform authenticated lookups; the live Dependency Dashboard already confirms hosted detection.
- Tested all seven package names across major, minor, and patch updates using Renovate's resolved presets and package-rule engine. All 21 combinations retain the group, schedule, release delay, and manual merge policy.
- Tested Renovate's actual branch generation with the original CLI-minor/assertion-major conflict: two branches before the rule, one `renovate/webdriverio` branch afterward.
- Unrelated npm and Docusaurus grouping checks passed.

After merge, confirm the next hosted Renovate run uses the new WebdriverIO group.


## Preview Link 
Renovate configuration only. No documentation content changes.


## Internal Reference
References DOC-1767

Follow-up to #2748.


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

