### PR TITLE
docs(DOC-1772): version-lock partial imports in versioned docs

### DIFF
--- a/platform_versioned_docs/version-4.10.0/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform_versioned_docs/version-4.10.0/maintenance/upgrade-migrate/upgrade.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import PartialAdminUpgrade from "@site/platform/_partials/install/upgrade.mdx";
+import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 
 You can upgrade vCluster Platform using either the vCluster CLI or Helm. 
 

--- a/platform_versioned_docs/version-4.10.0/reference/platform-cli.mdx
+++ b/platform_versioned_docs/version-4.10.0/reference/platform-cli.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 description: Task-oriented entry point for vCluster platform CLI commands, with UI-to-CLI equivalents for common Platform tasks
 ---
 
-import PlatformCliCommands from '@site/platform/_partials/reference/platform-cli-commands.mdx';
+import PlatformCliCommands from '../_partials/reference/platform-cli-commands.mdx';
 
 This page is a Platform-focused entry point to the `vcluster platform` CLI. It groups commands by task and links each one to its full flag reference.
 

--- a/platform_versioned_docs/version-4.11.0/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform_versioned_docs/version-4.11.0/maintenance/upgrade-migrate/upgrade.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import PartialAdminUpgrade from "@site/platform/_partials/install/upgrade.mdx";
+import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 
 You can upgrade vCluster Platform using either the vCluster CLI or Helm. 
 

--- a/platform_versioned_docs/version-4.11.0/reference/platform-cli.mdx
+++ b/platform_versioned_docs/version-4.11.0/reference/platform-cli.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 description: Task-oriented entry point for vCluster platform CLI commands, with UI-to-CLI equivalents for common Platform tasks
 ---
 
-import PlatformCliCommands from '@site/platform/_partials/reference/platform-cli-commands.mdx';
+import PlatformCliCommands from '../_partials/reference/platform-cli-commands.mdx';
 
 This page is a Platform-focused entry point to the `vcluster platform` CLI. It groups commands by task and links each one to its full flag reference.
 

--- a/platform_versioned_docs/version-4.12.0/reference/platform-cli.mdx
+++ b/platform_versioned_docs/version-4.12.0/reference/platform-cli.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 description: Task-oriented entry point for vCluster platform CLI commands, with UI-to-CLI equivalents for common Platform tasks
 ---
 
-import PlatformCliCommands from '@site/platform/_partials/reference/platform-cli-commands.mdx';
+import PlatformCliCommands from '../_partials/reference/platform-cli-commands.mdx';
 
 This page is a Platform-focused entry point to the `vcluster platform` CLI. It groups commands by task and links each one to its full flag reference.
 

--- a/platform_versioned_docs/version-4.9.0/maintenance/upgrade-migrate/upgrade.mdx
+++ b/platform_versioned_docs/version-4.9.0/maintenance/upgrade-migrate/upgrade.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import PartialAdminUpgrade from "@site/platform/_partials/install/upgrade.mdx";
+import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 
 You can upgrade vCluster Platform using either the vCluster CLI or Helm. 
 

--- a/vcluster_versioned_docs/version-0.35.0/deploy/control-plane/binary/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/deploy/control-plane/binary/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import PageVariables from '@site/src/components/PageVariables';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 

--- a/vcluster_versioned_docs/version-0.35.0/deploy/worker-nodes/host-nodes/overview.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/deploy/worker-nodes/host-nodes/overview.mdx
@@ -7,7 +7,7 @@ slug: /deploy/worker-nodes/host-nodes
 ---
 
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../../../_partials/admonitions/shared-nodes-suitability.mdx';
 
 <TenancySupport hostNodes="true" />
 

--- a/vcluster_versioned_docs/version-0.35.0/deploy/worker-nodes/private-nodes/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/deploy/worker-nodes/private-nodes/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition />
 

--- a/vcluster_versioned_docs/version-0.35.0/production-guide/cicd-platform.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/production-guide/cicd-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 6
 description: Ephemeral isolated clusters for CI/CD pipelines with automatic cleanup. Extends the Internal Kubernetes Platform model with sleep mode and auto-deletion.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated, ephemeral Kubernetes environments for CI/CD pipelines. Each pipeline run gets its own tenant cluster. No shared state, no cross-pipeline interference, no cleanup scripts. Clusters are created on demand and deleted automatically after the job finishes.
 

--- a/vcluster_versioned_docs/version-0.35.0/production-guide/enterprise-ai-factory.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/production-guide/enterprise-ai-factory.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 description: Build an internal AI platform for your organization's teams. Day 0, Day 1, and Day 2 path for enterprise AI platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Give every team in your organization a production-grade AI environment without the overhead of managing separate clusters. Production ML teams get private GPU nodes and full isolation. Dev and experiment teams share a node pool and provision on demand. Platform keeps everything governed, audited, and within budget.
 

--- a/vcluster_versioned_docs/version-0.35.0/production-guide/internal-k8s-platform.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/production-guide/internal-k8s-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 5
 description: Provide isolated, long-running tenant clusters for internal engineering teams and services. Day 0, Day 1, and Day 2 path for internal Kubernetes platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated Kubernetes environments for internal engineering teams, business units, and the services they own. Clusters are long-running and may carry internal production traffic. Tenant isolation gives each team its own control plane and prevents noisy-neighbor effects across teams. Shared nodes avoid standing up separate infrastructure per team.
 

--- a/vcluster_versioned_docs/version-0.35.0/quick-start/shared-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.35.0/quick-start/shared-nodes.mdx
@@ -10,7 +10,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
 import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 You're running a Kubernetes cluster and want to give internal teams or CI pipelines their own isolated Kubernetes environments. You don't want to spin up new infrastructure for each one.
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/control-plane/binary/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/control-plane/binary/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import PageVariables from '@site/src/components/PageVariables';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/host-nodes/overview.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/host-nodes/overview.mdx
@@ -7,7 +7,7 @@ slug: /deploy/worker-nodes/host-nodes
 ---
 
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../../../_partials/admonitions/shared-nodes-suitability.mdx';
 
 <TenancySupport hostNodes="true" />
 

--- a/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/deploy/worker-nodes/private-nodes/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition />
 

--- a/vcluster_versioned_docs/version-0.36.0/production-guide/choose-worker-node-model.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/production-guide/choose-worker-node-model.mdx
@@ -7,7 +7,7 @@ description: Decide between shared and private worker nodes for a customer-facin
 
 import GlossaryTerm from '@site/src/components/GlossaryTerm';
 import ChooseWorkerNodeModelDecision from '@site/static/media/diagrams/choose-worker-node-model-decision.svg';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Shared and private nodes aren't interchangeable settings you tune for cost or performance. They're a security boundary decision, and vCluster locks it at deployment time. Make this decision before you pick a [production path](./overview.mdx) or deploy a worker node model, not after.
 

--- a/vcluster_versioned_docs/version-0.36.0/production-guide/cicd-platform.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/production-guide/cicd-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 description: Ephemeral isolated clusters for CI/CD pipelines with automatic cleanup. Extends the Internal Kubernetes Platform model with sleep mode and auto-deletion.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated, ephemeral Kubernetes environments for CI/CD pipelines. Each pipeline run gets its own <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. No shared state, no cross-pipeline interference, no cleanup scripts. Clusters are created on demand and deleted automatically after the job finishes.
 

--- a/vcluster_versioned_docs/version-0.36.0/production-guide/enterprise-ai-factory.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/production-guide/enterprise-ai-factory.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 description: Build an internal AI platform for your organization's teams. Day 0, Day 1, and Day 2 path for enterprise AI platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Give every team in your organization a production-grade AI environment without the overhead of managing separate clusters. Production ML teams get private GPU nodes and full isolation. Dev and experiment teams share a node pool and provision on demand. Platform keeps everything governed, audited, and within budget.
 

--- a/vcluster_versioned_docs/version-0.36.0/production-guide/internal-k8s-platform.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/production-guide/internal-k8s-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 6
 description: Provide isolated, long-running tenant clusters for internal engineering teams and services. Day 0, Day 1, and Day 2 path for internal Kubernetes platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated Kubernetes environments for internal engineering teams, business units, and the services they own. Clusters are long-running and may carry internal production traffic. <GlossaryTerm term="multi-tenancy">Tenant isolation</GlossaryTerm> gives each team its own control plane and prevents noisy-neighbor effects across teams. Shared nodes avoid standing up separate infrastructure per team.
 

--- a/vcluster_versioned_docs/version-0.36.0/quick-start/shared-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.36.0/quick-start/shared-nodes.mdx
@@ -10,7 +10,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
 import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 You're running a Kubernetes cluster and want to give internal teams or CI pipelines their own isolated Kubernetes environments. You don't want to spin up new infrastructure for each one.
 

--- a/vcluster_versioned_docs/version-0.37.0/deploy/control-plane/binary/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/deploy/control-plane/binary/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 2
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import PageVariables from '@site/src/components/PageVariables';
 import InterpolatedCodeBlock from '@site/src/components/InterpolatedCodeBlock';
 

--- a/vcluster_versioned_docs/version-0.37.0/deploy/worker-nodes/host-nodes/overview.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/deploy/worker-nodes/host-nodes/overview.mdx
@@ -7,7 +7,7 @@ slug: /deploy/worker-nodes/host-nodes
 ---
 
 import TenancySupport from '../../../_fragments/tenancy-support.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../../../_partials/admonitions/shared-nodes-suitability.mdx';
 
 <TenancySupport hostNodes="true" />
 

--- a/vcluster_versioned_docs/version-0.37.0/deploy/worker-nodes/private-nodes/security/fips.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/deploy/worker-nodes/private-nodes/security/fips.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 sidebar_class_name: pro
 ---
 
-import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition />
 

--- a/vcluster_versioned_docs/version-0.37.0/production-guide/choose-worker-node-model.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/production-guide/choose-worker-node-model.mdx
@@ -7,7 +7,7 @@ description: Decide between shared and private worker nodes for a customer-facin
 
 import GlossaryTerm from '@site/src/components/GlossaryTerm';
 import ChooseWorkerNodeModelDecision from '@site/static/media/diagrams/choose-worker-node-model-decision.svg';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Shared and private nodes aren't interchangeable settings you tune for cost or performance. They're a security boundary decision, and vCluster locks it at deployment time. Make this decision before you pick a [production path](./overview.mdx) or deploy a worker node model, not after.
 

--- a/vcluster_versioned_docs/version-0.37.0/production-guide/cicd-platform.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/production-guide/cicd-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 7
 description: Ephemeral isolated clusters for CI/CD pipelines with automatic cleanup. Extends the Internal Kubernetes Platform model with sleep mode and auto-deletion.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated, ephemeral Kubernetes environments for CI/CD pipelines. Each pipeline run gets its own <GlossaryTerm term="tenant-cluster">tenant cluster</GlossaryTerm>. No shared state, no cross-pipeline interference, no cleanup scripts. Clusters are created on demand and deleted automatically after the job finishes.
 

--- a/vcluster_versioned_docs/version-0.37.0/production-guide/enterprise-ai-factory.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/production-guide/enterprise-ai-factory.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 description: Build an internal AI platform for your organization's teams. Day 0, Day 1, and Day 2 path for enterprise AI platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Give every team in your organization a production-grade AI environment without the overhead of managing separate clusters. Production ML teams get private GPU nodes and full isolation. Dev and experiment teams share a node pool and provision on demand. Platform keeps everything governed, audited, and within budget.
 

--- a/vcluster_versioned_docs/version-0.37.0/production-guide/internal-k8s-platform.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/production-guide/internal-k8s-platform.mdx
@@ -5,7 +5,7 @@ sidebar_position: 6
 description: Provide isolated, long-running tenant clusters for internal engineering teams and services. Day 0, Day 1, and Day 2 path for internal Kubernetes platforms.
 ---
 
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 Provide isolated Kubernetes environments for internal engineering teams, business units, and the services they own. Clusters are long-running and may carry internal production traffic. <GlossaryTerm term="multi-tenancy">Tenant isolation</GlossaryTerm> gives each team its own control plane and prevents noisy-neighbor effects across teams. Shared nodes avoid standing up separate infrastructure per team.
 

--- a/vcluster_versioned_docs/version-0.37.0/quick-start/shared-nodes.mdx
+++ b/vcluster_versioned_docs/version-0.37.0/quick-start/shared-nodes.mdx
@@ -10,7 +10,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import InstallCLIFragment from '../_partials/deploy/install-cli.mdx';
 import ProductionNextStep from '../_fragments/production-next-step.mdx';
 import DefaultK8sVersion from '../_fragments/default-k8s-version.mdx';
-import SharedNodesSuitability from '@site/vcluster/_partials/admonitions/shared-nodes-suitability.mdx';
+import SharedNodesSuitability from '../_partials/admonitions/shared-nodes-suitability.mdx';
 
 You're running a Kubernetes cluster and want to give internal teams or CI pipelines their own isolated Kubernetes environments. You don't want to spin up new infrastructure for each one.
 


### PR DESCRIPTION
# Content Description

Fixes an import bug affecting every archived doc version: several pages import a partial with an absolute `@site/<product>/_partials/...` path instead of a relative one, so the archived page silently renders today's live partial content instead of a version-locked snapshot. Found and partially fixed while reviewing the Platform 4.12 docs backport (PR #2754), scope broadened after a full spot-check turned up three more affected partials.

Fixes:

- `PartialAdminUpgrade` (install instructions) in `version-4.9.0`, `version-4.10.0`, `version-4.11.0` (`version-4.12.0` and main already fixed in #2754 and #2712)
- `PlatformCliCommands` in `version-4.10.0`, `version-4.11.0`, `version-4.12.0`
- `ProAdmonition` in both `fips.mdx` pages across `version-0.35.0`, `version-0.36.0`, `version-0.37.0`
- `SharedNodesSuitability` across the production-guide, quick-start, and worker-nodes pages that use it, in `version-0.35.0`, `version-0.36.0`, `version-0.37.0`

Cross-product imports (a platform page importing a vCluster partial, or vice versa) are left as absolute/live imports on purpose — those intentionally track the other, independently-versioned product's current content, and have no matching version-locked copy to point at.

## Preview Link

- [Upgrade vCluster Platform (4.11.0)](https://deploy-preview-2761--vcluster-docs-site.netlify.app/docs/platform/4.11.0/maintenance/upgrade-migrate/upgrade)
- [Platform CLI Reference (4.12.0)](https://deploy-preview-2761--vcluster-docs-site.netlify.app/docs/platform/4.12.0/reference/platform-cli)
- [FIPS Compliance (0.37.0)](https://deploy-preview-2761--vcluster-docs-site.netlify.app/docs/vcluster/0.37.0/deploy/worker-nodes/private-nodes/security/fips)
- [Shared Nodes Quickstart (0.37.0)](https://deploy-preview-2761--vcluster-docs-site.netlify.app/docs/vcluster/0.37.0/quick-start/shared-nodes)

## Internal Reference

Closes DOC-1772

AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

<!-- Do not change the line below -->
@netlify /docs
