### PR TITLE
test: cover platform generation before release dispatch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,37 @@
 
 This directory contains GitHub Actions workflows for the vCluster documentation.
 
+## Test release scripts and the Platform generator
+
+`test-release-scripts.yml` runs the release-script bats suites, shellcheck,
+and `go test ./hack/platform/...`. It also runs the receiver's Platform
+generator against the committed vendor tree, writing docs to a temporary
+folder. Changes to Go dependencies, vendored code, Platform generator code,
+release scripts, or either workflow trigger these checks.
+
+This catches incompatible dependency updates before a release dispatch.
+For example, `external-types` v0.1.0-alpha.4 removed Argo types still used by
+`loft-sh/api`. PR #2726 introduced that failure; PR #2745 restored the
+compatible dependency. The shell tests mock Go and cannot catch such errors.
+
+Run the same generator checks from the repository root with the Go version
+in `go.mod`:
+
+```bash
+export GOFLAGS=-mod=vendor
+go test ./hack/platform/...
+export EVENT_TYPE=platform-released
+export TARGET_FOLDER="$(mktemp -d)/platform-generator"
+bash hack/release/run-generator.sh
+```
+
+When diagnosing `handle-source-release`, check the dispatch version, the
+classifier's `skip` output, and the bump step's `pinned at` notices. Platform
+dispatches change the API pins before generation, so the committed pins may
+differ from the failed build. A green run that skips an alpha or stale release
+does not test the generator. The PR check covers the committed dependencies;
+the receiver still validates newly released API versions after bumping them.
+
 ## Sync next branch (`sync-next-branch.yml`)
 Keeps `next` branch in sync with `main` by auto-merging or creating PRs when conflicts exist. Runs on push to main, daily, or manually. Never syncs in reverse (next → main is manual only).
 

--- a/.github/workflows/test-release-scripts.yml
+++ b/.github/workflows/test-release-scripts.yml
@@ -4,14 +4,19 @@ name: test-release-scripts
 # bats coverage alongside each script, but nothing ran those suites in CI, so
 # a regression could only be caught by a live release failing. That is how
 # the proxy-propagation breakage recurred across DEVOPS-904, DEVOPS-1008 and
-# DEVOPS-1041. This workflow runs the bats suites and shellcheck on every PR
-# that touches the release scripts, turning the receiver's logic into a
-# reviewable, test-gated unit.
+# DEVOPS-1041. Test the real Platform generator as well as the shell routing.
+# A dependency update can pass the mocked bats tests while removing types the
+# generator needs, as external-types v0.1.0-alpha.4 did in #2726.
 on:
   pull_request:
     branches: [ main ]
     paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'vendor/**'
+      - 'hack/platform/**'
       - 'hack/release/**'
+      - '.github/workflows/handle-source-release.yml'
       - '.github/workflows/test-release-scripts.yml'
   workflow_dispatch:
 
@@ -35,3 +40,28 @@ jobs:
 
       - name: Run release-script bats suites
         run: bats hack/release/*.bats
+
+  platform-generator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOFLAGS: -mod=vendor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test Platform generator packages
+        run: go test ./hack/platform/...
+
+      - name: Generate Platform docs
+        env:
+          EVENT_TYPE: platform-released
+          TARGET_FOLDER: ${{ runner.temp }}/platform-generator
+        run: bash hack/release/run-generator.sh


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Platform release generation failed after #2726 removed Argo types from the selected external-types dependency. #2745 restored the compatible dependency; this change adds a real Platform Go test and generator run to PR CI so the same dependency regression is caught before release dispatch.

The existing release-test workflow now runs on Go dependency, vendor, generator, and receiver changes. It uses the committed vendor tree and writes generated docs to a temporary directory.

Validation:

- The new Go test command reproduces all seven original Argo compile errors at docs SHA 1c2c635.
- Current main passes the Platform tests and generates 185 files, including Argo references.
- A separate checkout passed the real API/agentapi bump to v4.12.0, Platform tests, and full generation with the restored external-types dependency.
- All 61 release bats tests pass; shellcheck, actionlint, and zizmor pass.

The failures resolved v4.12.0-rc.11 and v4.12.0 after the release bump. The nearby successful Platform runs skipped stale or alpha releases. No upstream API or tag change is needed.


## Preview Link 
CI and workflow documentation only. No published product docs change.


## Internal Reference
Closes DEVOPS-1522


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

