### PR TITLE
fix(ci): follow the docs backport action v1 tag

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Backport Docusaurus Changes
-        uses: loft-sh/docs-backport-action@a56a443f5ad542602526ac06f3804d24e3cd010b # v1.3.2
+        uses: loft-sh/docs-backport-action@v1
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,12 @@
       "groupName": "github-actions"
     },
     {
+      "description": "Follow compatible docs-backport-action releases through its floating major tag",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["loft-sh/docs-backport-action"],
+      "pinDigests": false
+    },
+    {
       "description": "npm gets a longer stabilization window (more yanked/compromised releases)",
       "matchManagers": ["npm"],
       "minimumReleaseAge": "7 days"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Use `loft-sh/docs-backport-action@v1` so compatible action releases reach docs backports without a consumer update. Add a Renovate exception for this action so digest pinning does not replace the floating tag.

Validation: `actionlint` and strict Renovate config validation pass. A test using Renovate's real workflow extractor, preset resolver, and rule matcher confirms only this action stops being digest-pinned. `v1` currently resolves to the same commit as `v1.3.2`. Zizmor reports the expected `unpinned-uses` finding for this internal tag, plus the same three findings present on main.


## Preview Link 
Not applicable; workflow configuration only.


## Internal Reference
Related: https://github.com/loft-sh/docs-backport-action/pull/145


AI review: mention `@claude` in a comment to request a review or changes. See [CONTRIBUTING.md](https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#ai-assisted-pr-review) for available commands.

> FORK LIMITATION: `@claude` does not work on pull requests opened from forks. GitHub Actions cannot access the required secrets for fork-originated PRs. To use AI review, push your branch directly to this repository.

<!-- Do not change the line below -->
@netlify /docs

